### PR TITLE
fix(deepseek): make tool_choice violations actually retryable

### DIFF
--- a/packages/test/src/test/ai-provider-api/DeepSeek_ToolCalling.test.ts
+++ b/packages/test/src/test/ai-provider-api/DeepSeek_ToolCalling.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  assertToolChoiceHonored,
+  DeepSeekToolChoiceNotHonoredError,
+  isForcingToolChoice,
+} from "@workglow/deepseek/ai";
+import { RetryableJobError } from "@workglow/job-queue";
+import { describe, expect, it } from "vitest";
+
+describe("isForcingToolChoice", () => {
+  it("returns false for undefined, auto, and none", () => {
+    expect(isForcingToolChoice(undefined)).toBe(false);
+    expect(isForcingToolChoice("auto")).toBe(false);
+    expect(isForcingToolChoice("none")).toBe(false);
+  });
+
+  it("returns true for required and a named function", () => {
+    expect(isForcingToolChoice("required")).toBe(true);
+    expect(isForcingToolChoice("get_weather")).toBe(true);
+  });
+});
+
+describe("assertToolChoiceHonored", () => {
+  it("throws DeepSeekToolChoiceNotHonoredError when required and no calls were made", () => {
+    expect(() => assertToolChoiceHonored("required", [], "m")).toThrow(
+      DeepSeekToolChoiceNotHonoredError
+    );
+  });
+
+  it("does not throw when required and at least one valid call was made", () => {
+    expect(() => assertToolChoiceHonored("required", ["get_weather"], "m")).not.toThrow();
+  });
+
+  it("throws with a diagnostic message when a named function was not called", () => {
+    let caught: unknown;
+    try {
+      assertToolChoiceHonored("get_weather", ["send_email"], "m");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DeepSeekToolChoiceNotHonoredError);
+    const message = (caught as Error).message;
+    expect(message).toContain('expected a call to "get_weather"');
+    expect(message).toContain("called: send_email");
+  });
+
+  it("throws an error that is an instance of RetryableJobError", () => {
+    let caught: unknown;
+    try {
+      assertToolChoiceHonored("required", [], "m");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RetryableJobError);
+  });
+});

--- a/packages/test/src/test/ai/AiJob_classifyProviderError.test.ts
+++ b/packages/test/src/test/ai/AiJob_classifyProviderError.test.ts
@@ -10,6 +10,7 @@ import {
   ImageGenerationProviderError,
   ProviderUnsupportedFeatureError,
 } from "@workglow/ai";
+import { DeepSeekToolChoiceNotHonoredError } from "@workglow/deepseek/ai";
 import { PermanentJobError, RetryableJobError } from "@workglow/job-queue";
 import { describe, expect, it } from "vitest";
 
@@ -30,5 +31,14 @@ describe("classifyProviderError mapping for image-generation errors", () => {
     const err = new ImageGenerationProviderError("m", "rate limited");
     const classified = classifyProviderError(err, "ImageGenerateTask", "TEST_PROVIDER");
     expect(classified).toBeInstanceOf(RetryableJobError);
+  });
+});
+
+describe("classifyProviderError mapping for tool-choice errors", () => {
+  it("passes DeepSeekToolChoiceNotHonoredError through as RetryableJobError", () => {
+    const err = new DeepSeekToolChoiceNotHonoredError("deepseek-v4-pro", "required", "no calls");
+    const classified = classifyProviderError(err, "ToolCallingTask", "DEEPSEEK");
+    expect(classified).toBeInstanceOf(RetryableJobError);
+    expect(classified).toBe(err);
   });
 });

--- a/providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts
@@ -12,6 +12,7 @@ import type {
 } from "@workglow/ai";
 import { accumulateOpenAIChatStream, buildOpenAITools } from "@workglow/ai/provider-utils";
 import { filterValidToolCalls, toOpenAIMessages } from "@workglow/ai/worker";
+import { RetryableJobError } from "@workglow/job-queue";
 import { getClient, getModelName, resolveMaxTokens } from "./DeepSeek_Client";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
 
@@ -20,10 +21,12 @@ import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
  *
  * Retryable: the model was *asked* for the call and simply didn't produce one,
  * which is nondeterministic rather than structurally impossible — a re-roll is
- * a legitimate remedy, so the job-queue retry policy applies.
+ * a legitimate remedy, so the job-queue retry policy applies. Extending
+ * {@link RetryableJobError} is what lets {@link classifyProviderError} pass the
+ * error through unchanged instead of wrapping it as a `PermanentJobError`.
  */
-export class DeepSeekToolChoiceNotHonoredError extends Error {
-  public readonly retryable = true;
+export class DeepSeekToolChoiceNotHonoredError extends RetryableJobError {
+  public static override type = "DeepSeekToolChoiceNotHonoredError";
   constructor(
     public readonly modelId: string,
     public readonly requestedToolChoice: string,
@@ -40,7 +43,7 @@ export class DeepSeekToolChoiceNotHonoredError extends Error {
  * Whether `toolChoice` demands a call — i.e. `"required"` (any tool) or a
  * specific function name. `undefined` / `"auto"` / `"none"` demand nothing.
  */
-function isForcingToolChoice(toolChoice: string | undefined): toolChoice is string {
+export function isForcingToolChoice(toolChoice: string | undefined): toolChoice is string {
   return toolChoice !== undefined && toolChoice !== "auto" && toolChoice !== "none";
 }
 
@@ -73,7 +76,7 @@ function mapDeepSeekToolChoice(toolChoice: string | undefined): "auto" | "none" 
  * Only calls that survived {@link filterValidToolCalls} count — a hallucinated
  * function name does not satisfy the request.
  */
-function assertToolChoiceHonored(
+export function assertToolChoiceHonored(
   toolChoice: string,
   calledNames: readonly string[],
   modelId: string

--- a/providers/deepseek/src/ai/index.ts
+++ b/providers/deepseek/src/ai/index.ts
@@ -16,6 +16,11 @@ export {
 export * from "./common/DeepSeek_Constants";
 export * from "./common/DeepSeek_ModelSchema";
 export * from "./common/DeepSeek_ModelSearch";
+export {
+  DeepSeekToolChoiceNotHonoredError,
+  assertToolChoiceHonored,
+  isForcingToolChoice,
+} from "./common/DeepSeek_ToolCalling";
 export * from "./registerDeepSeek";
 
 import { DEEPSEEK_RUN_FN_SPECS } from "./common/DeepSeek_Capabilities";


### PR DESCRIPTION
## Root cause

`DeepSeekToolChoiceNotHonoredError` (in `providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts`) extended plain `Error` and set `public readonly retryable = true`, but nothing consumed that field. `classifyProviderError` in `packages/ai/src/job/AiJob.ts` only special-cases `ImageGenerationProviderError` for the `retryable` flag; every other unknown throw falls through to the default `PermanentJobError` branch. So the DeepSeek error was wrapped as permanent and the job never retried — defeating the entire point of the class.

## Fix

- Extend `RetryableJobError` from `@workglow/job-queue` instead of plain `Error`. The `retryable = true` flag is now inherited from `RetryableJobError`'s constructor, and — importantly — `classifyProviderError`'s existing early guard passes any `RetryableJobError` instance through unchanged, so the queue's retry policy applies.
- Export `isForcingToolChoice` and `assertToolChoiceHonored` so they can be unit-tested.
- Re-export `DeepSeekToolChoiceNotHonoredError` (and the two helpers) from `@workglow/deepseek/ai` so downstream code and tests can import them.

No behavior change to `DeepSeek_ToolCalling_Stream` itself, and no unrelated files touched. `@workglow/job-queue` was already listed as a peer dependency of the deepseek package.

## Tests added

- `packages/test/src/test/ai/AiJob_classifyProviderError.test.ts` — pins that `classifyProviderError` passes `DeepSeekToolChoiceNotHonoredError` through as a `RetryableJobError` (`toBe(err)` — same instance, not wrapped).
- `packages/test/src/test/ai-provider-api/DeepSeek_ToolCalling.test.ts` — pins `isForcingToolChoice` for undefined/auto/none vs required/named-function, `assertToolChoiceHonored` for the required-with-no-calls / required-with-calls / wrong-named-function cases (including that the diagnostic message contains `expected a call to "get_weather"` and `called: send_email`), and that the thrown error is an `instanceof RetryableJobError`.

## Verification

- `bun run build:types` — 41/41 packages successful (turbo).
- `bun test packages/test/src/test/ai/AiJob_classifyProviderError.test.ts` — 4/4 pass (5 expects).
- `bun test packages/test/src/test/ai-provider-api/DeepSeek_ToolCalling.test.ts` — 6/6 pass (11 expects).

---
_Generated by [Claude Code](https://claude.ai/code/session_018J4raxRKq12RLwudeGWvXx)_