### PR TITLE
fix(anthropic): stop sending sampling params to models that reject them

### DIFF
--- a/packages/test/src/test/ai-provider-api/AnthropicProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/AnthropicProvider.test.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ModelRecord } from "@workglow/ai";
-import { _testOnly } from "@workglow/anthropic/ai";
+import { ANTHROPIC_FALLBACK, _testOnly } from "@workglow/anthropic/ai";
 import { describe, expect, it } from "vitest";
 
 const { AnthropicQueuedProvider, ANTHROPIC_RUN_FN_SPECS, ANTHROPIC_RUN_FNS } = _testOnly;
@@ -61,6 +61,26 @@ describe("AnthropicQueuedProvider.inferCapabilities", () => {
     expect(caps).toContain("json-mode");
     expect(caps).toContain("vision-input");
     expect(caps).toContain("model.count-tokens");
+  });
+
+  it.each(["claude-opus-5", "claude-sonnet-5", "claude-haiku-5", "claude-fable-5"])(
+    "infers full capabilities for %s (Claude 5 family)",
+    (id) => {
+      const caps = provider.inferCapabilities(model(id));
+      expect(caps).toContain("text.generation");
+      expect(caps).toContain("tool-use");
+      expect(caps).toContain("json-mode");
+      expect(caps).toContain("vision-input");
+      expect(caps).toContain("model.count-tokens");
+    }
+  );
+
+  it("keeps claude-opus-4-7 / 4-8 on the Claude 4-series branch", () => {
+    for (const id of ["claude-opus-4-7", "claude-opus-4-8"]) {
+      const caps = provider.inferCapabilities(model(id));
+      expect(caps).toContain("text.generation");
+      expect(caps).toContain("vision-input");
+    }
   });
 
   it("infers full capabilities for claude-3-haiku family", () => {
@@ -148,6 +168,27 @@ describe("AnthropicQueuedProvider.inferCapabilities", () => {
       "tool-use",
       "vision-input",
     ]);
+  });
+});
+
+describe("ANTHROPIC_FALLBACK", () => {
+  const provider = new AnthropicQueuedProvider(ANTHROPIC_RUN_FNS);
+
+  // mapModelList emits `capabilities: []`, so a fallback model is only usable
+  // if inference recognizes its id. An unrecognized id yields meta-ops only.
+  it("every fallback model infers text.generation", () => {
+    expect(ANTHROPIC_FALLBACK.length).toBeGreaterThan(0);
+    for (const entry of ANTHROPIC_FALLBACK) {
+      expect(provider.inferCapabilities(model(entry.value)), entry.value).toContain(
+        "text.generation"
+      );
+    }
+  });
+
+  it("does not offer retired model ids", () => {
+    const values = ANTHROPIC_FALLBACK.map((entry) => entry.value);
+    expect(values).not.toContain("claude-3-5-sonnet-20241022");
+    expect(values).not.toContain("claude-3-5-haiku-20241022");
   });
 });
 

--- a/packages/test/src/test/ai-provider-api/Anthropic_SamplingParams.test.ts
+++ b/packages/test/src/test/ai-provider-api/Anthropic_SamplingParams.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { _testOnly } from "@workglow/anthropic/ai";
+import { getLogger } from "@workglow/util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { anthropicAcceptsSamplingParams, applyAnthropicSamplingParams } = _testOnly;
+
+function cfg(provider_config: Record<string, unknown>) {
+  return { provider: "ANTHROPIC", provider_config } as never;
+}
+
+function model(modelName: string) {
+  return cfg({ model_name: modelName });
+}
+
+describe("anthropicAcceptsSamplingParams — rejecting models", () => {
+  // Every id here returns HTTP 400 when temperature/top_p is sent.
+  const rejects = [
+    "claude-opus-5",
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-mythos-preview",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+  ];
+
+  it.each(rejects)("omits sampling params for %s", (id) => {
+    expect(anthropicAcceptsSamplingParams(model(id))).toBe(false);
+  });
+});
+
+describe("anthropicAcceptsSamplingParams — accepting models", () => {
+  const accepts = [
+    "claude-haiku-4-5",
+    "claude-haiku-4-5-20251001",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-opus-4-5",
+    "claude-opus-4-1",
+    // Regression: the trailing 8-digit segment is a release date, not minor 20250514.
+    "claude-sonnet-4-20250514",
+    "claude-opus-4-20250514",
+    // Regression: legacy `claude-<major>-<minor>-<family>` id shape.
+    "claude-3-5-sonnet-20241022",
+    "claude-3-5-haiku-20241022",
+    "claude-3-7-sonnet-20250219",
+    "claude-3-opus-20240229",
+    "claude-3-haiku-20240307",
+    "claude-2.1",
+  ];
+
+  it.each(accepts)("sends sampling params for %s", (id) => {
+    expect(anthropicAcceptsSamplingParams(model(id))).toBe(true);
+  });
+});
+
+describe("anthropicAcceptsSamplingParams — safe default and override", () => {
+  it("defaults to omitting for an unrecognized or future model id", () => {
+    // A brand-new id matches no known-accepting shape, so params are omitted
+    // and the request succeeds rather than failing with a 400.
+    expect(anthropicAcceptsSamplingParams(model("claude-opus-6"))).toBe(false);
+    expect(anthropicAcceptsSamplingParams(model("claude-quasar-9"))).toBe(false);
+    expect(anthropicAcceptsSamplingParams(model("gpt-4o"))).toBe(false);
+    expect(anthropicAcceptsSamplingParams(model(""))).toBe(false);
+    expect(anthropicAcceptsSamplingParams(cfg({}))).toBe(false);
+  });
+
+  it("honors an explicit sampling_params override in both directions", () => {
+    expect(
+      anthropicAcceptsSamplingParams(cfg({ model_name: "claude-opus-5", sampling_params: "send" }))
+    ).toBe(true);
+    expect(
+      anthropicAcceptsSamplingParams(
+        cfg({ model_name: "claude-haiku-4-5", sampling_params: "omit" })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("applyAnthropicSamplingParams", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("assigns both wire names on an accepting model", () => {
+    const params: Record<string, unknown> = {};
+    applyAnthropicSamplingParams(
+      params,
+      { temperature: 0.4, topP: 0.9 },
+      model("claude-haiku-4-5")
+    );
+    expect(params.temperature).toBe(0.4);
+    expect(params.top_p).toBe(0.9);
+  });
+
+  it("leaves the keys absent on a rejecting model", () => {
+    const params: Record<string, unknown> = {};
+    applyAnthropicSamplingParams(params, { temperature: 0.4, topP: 0.9 }, model("claude-opus-5"));
+    // Absent, not present-and-undefined — the SDK would serialize a null field.
+    expect("temperature" in params).toBe(false);
+    expect("top_p" in params).toBe(false);
+  });
+
+  it("does not warn when nothing was supplied", () => {
+    const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+    const params: Record<string, unknown> = {};
+    applyAnthropicSamplingParams(params, {}, model("claude-opus-5"));
+    expect(warn).not.toHaveBeenCalled();
+    expect(params).toEqual({});
+  });
+
+  it("warns exactly once naming every dropped parameter", () => {
+    const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+    applyAnthropicSamplingParams({}, { temperature: 0.4, topP: 0.9 }, model("claude-opus-5"));
+    expect(warn).toHaveBeenCalledTimes(1);
+    const meta = warn.mock.calls[0]?.[1] as { model: string; dropped: string[] };
+    expect(meta.model).toBe("claude-opus-5");
+    expect(meta.dropped).toEqual(["temperature", "top_p"]);
+  });
+});

--- a/providers/anthropic/CHANGELOG.md
+++ b/providers/anthropic/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- stop sending `temperature` / `top_p` to Claude models that reject them. Recent
+  models (`claude-opus-5`, `claude-fable-5`, `claude-sonnet-5`, `claude-opus-4-8`,
+  `claude-opus-4-7`, …) return HTTP 400 for sampling parameters, which maps to a
+  non-retryable `PermanentJobError` — so text generation and tool calling failed
+  outright on those models whenever a caller set either field. The parameters are
+  now forwarded only for model ids belonging to a generation known to accept them
+  (Claude 4.6 and older); anything else drops them with a single warning naming
+  what was dropped. `provider_config.sampling_params` (`"send"` / `"omit"`)
+  overrides the decision for a model whose id shape is misclassified.
+- infer the full capability set for the Claude 5 family (`claude-opus-5`,
+  `claude-sonnet-5`, `claude-haiku-5`) and the fable / mythos lines. Model search
+  emits an empty `capabilities` array, so without this those models resolved to
+  meta-ops only and could not run text generation at all.
+
+### Refactors
+
+- refresh the model-search fallback list: drop the retired
+  `claude-3-5-sonnet-20241022` / `claude-3-5-haiku-20241022` ids (both 404) and
+  offer the current Claude 5 and 4.x models, newest first.
+- raise the `provider_config.max_tokens` schema default from 1024 to 16384 to
+  match `ANTHROPIC_DEFAULT_MAX_TOKENS`. Existing records are unaffected; newly
+  created records will carry the higher ceiling.
+
 ## 0.3.34
 
 ### Refactors

--- a/providers/anthropic/src/ai/common/Anthropic_Capabilities.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Capabilities.ts
@@ -42,6 +42,22 @@ export function inferAnthropicCapabilities(model: CapabilityHints): readonly Cap
       ""
   );
 
+  // Claude 5 family (claude-sonnet-5*, claude-opus-5*, claude-haiku-5*) plus the
+  // fable / mythos lines — same full capability set as Claude 4.
+  if (/^claude-(?:(?:sonnet|opus|haiku)-5|fable-|mythos-)/i.test(id)) {
+    return [
+      "text.generation",
+      "text.rewriter",
+      "text.summary",
+      "tool-use",
+      "json-mode",
+      "vision-input",
+      "model.count-tokens",
+      "model.info",
+      "model.search",
+    ];
+  }
+
   // Claude 3.5 / 3.7 family (sonnet, haiku) — full capability set with vision.
   if (/^claude-3[.-][57]-/i.test(id)) {
     return [

--- a/providers/anthropic/src/ai/common/Anthropic_Client.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Client.ts
@@ -5,6 +5,7 @@
  */
 
 import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
+import { ANTHROPIC_DEFAULT_MAX_TOKENS } from "./Anthropic_Constants";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 
 /**
@@ -81,13 +82,6 @@ export function getModelName(model: AnthropicModelConfig | undefined): string {
   }
   return name;
 }
-
-/**
- * Anthropic requires `max_tokens`, and it bounds thinking and response text
- * together, so this fallback is always in play. 16k matches the vendor's
- * guidance for non-streaming requests; stream and pass `maxTokens` for more.
- */
-export const ANTHROPIC_DEFAULT_MAX_TOKENS = 16_384;
 
 /**
  * `input` is widened to `object` so every run-fn can hand its own task input

--- a/providers/anthropic/src/ai/common/Anthropic_Client.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Client.ts
@@ -89,9 +89,12 @@ export function getModelName(model: AnthropicModelConfig | undefined): string {
  */
 export const ANTHROPIC_DEFAULT_MAX_TOKENS = 16_384;
 
-export function getMaxTokens(
-  input: { maxTokens?: number },
-  model: AnthropicModelConfig | undefined
-): number {
-  return input.maxTokens ?? model?.provider_config?.max_tokens ?? ANTHROPIC_DEFAULT_MAX_TOKENS;
+/**
+ * `input` is widened to `object` so every run-fn can hand its own task input
+ * through, including the ones whose schema declares no `maxTokens` port. Those
+ * simply fall through to the configured default.
+ */
+export function getMaxTokens(input: object, model: AnthropicModelConfig | undefined): number {
+  const requested = (input as { maxTokens?: number }).maxTokens;
+  return requested ?? model?.provider_config?.max_tokens ?? ANTHROPIC_DEFAULT_MAX_TOKENS;
 }

--- a/providers/anthropic/src/ai/common/Anthropic_Constants.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Constants.ts
@@ -5,3 +5,13 @@
  */
 
 export const ANTHROPIC = "ANTHROPIC";
+
+/**
+ * Anthropic requires `max_tokens`, and it bounds thinking and response text
+ * together, so this fallback is always in play. 16k matches the vendor's
+ * guidance for non-streaming requests; stream and pass `maxTokens` for more.
+ *
+ * Lives here rather than beside {@link getMaxTokens} so the model schema can
+ * advertise it as its `default` without importing the client.
+ */
+export const ANTHROPIC_DEFAULT_MAX_TOKENS = 16_384;

--- a/providers/anthropic/src/ai/common/Anthropic_ModelSchema.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_ModelSchema.ts
@@ -6,7 +6,7 @@
 
 import { ModelConfigSchema, ModelRecordSchema } from "@workglow/ai/worker";
 import { DataPortSchemaObject, FromSchema } from "@workglow/util/worker";
-import { ANTHROPIC } from "./Anthropic_Constants";
+import { ANTHROPIC, ANTHROPIC_DEFAULT_MAX_TOKENS } from "./Anthropic_Constants";
 
 export const AnthropicModelSchema = {
   type: "object",
@@ -44,7 +44,7 @@ export const AnthropicModelSchema = {
         max_tokens: {
           type: "integer",
           description: "Default max tokens for responses. Anthropic requires this parameter.",
-          default: 16384,
+          default: ANTHROPIC_DEFAULT_MAX_TOKENS,
           minimum: 1,
         },
         sampling_params: {

--- a/providers/anthropic/src/ai/common/Anthropic_ModelSchema.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_ModelSchema.ts
@@ -22,7 +22,7 @@ export const AnthropicModelSchema = {
         model_name: {
           type: "string",
           description:
-            "The Anthropic model identifier (e.g., 'claude-sonnet-4-20250514', 'claude-3-5-haiku-20241022').",
+            "The Anthropic model identifier (e.g., 'claude-opus-5', 'claude-haiku-4-5').",
         },
         credential_key: {
           type: "string",
@@ -44,8 +44,15 @@ export const AnthropicModelSchema = {
         max_tokens: {
           type: "integer",
           description: "Default max tokens for responses. Anthropic requires this parameter.",
-          default: 1024,
+          default: 16384,
           minimum: 1,
+        },
+        sampling_params: {
+          type: "string",
+          enum: ["send", "omit"],
+          description:
+            "Override whether temperature/top_p are sent. Recent Claude models reject them with HTTP 400, so they are omitted unless the model id matches a generation known to accept them. Set explicitly only to correct that decision. Absent means 'decide from the model id'.",
+          "x-ui-hidden": true,
         },
       },
       required: ["model_name"],

--- a/providers/anthropic/src/ai/common/Anthropic_ModelSearch.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_ModelSearch.ts
@@ -20,15 +20,23 @@ interface AnthropicModelListItem {
   readonly description?: string;
 }
 
-const ANTHROPIC_FALLBACK: Array<{ label: string; value: string }> = [
-  { label: "claude-opus-4-7", value: "claude-opus-4-7" },
-  { label: "claude-sonnet-4-6", value: "claude-sonnet-4-6" },
-  { label: "claude-haiku-4-5-20251001", value: "claude-haiku-4-5-20251001" },
-  { label: "claude-opus-4-6", value: "claude-opus-4-6" },
-  { label: "claude-sonnet-4-5-20250929", value: "claude-sonnet-4-5-20250929" },
-  { label: "claude-3-5-sonnet-20241022", value: "claude-3-5-sonnet-20241022" },
-  { label: "claude-3-5-haiku-20241022", value: "claude-3-5-haiku-20241022" },
-];
+/**
+ * Offered when no credential is available to list models live. Newest first,
+ * and limited to ids that are generally available — a model restricted to an
+ * invite-only program would 404 for everyone else.
+ */
+export const ANTHROPIC_FALLBACK: ReadonlyArray<{ readonly label: string; readonly value: string }> =
+  [
+    { label: "claude-fable-5", value: "claude-fable-5" },
+    { label: "claude-opus-5", value: "claude-opus-5" },
+    { label: "claude-sonnet-5", value: "claude-sonnet-5" },
+    { label: "claude-opus-4-8", value: "claude-opus-4-8" },
+    { label: "claude-opus-4-7", value: "claude-opus-4-7" },
+    { label: "claude-haiku-4-5", value: "claude-haiku-4-5" },
+    { label: "claude-sonnet-4-6", value: "claude-sonnet-4-6" },
+    { label: "claude-opus-4-6", value: "claude-opus-4-6" },
+    { label: "claude-sonnet-4-5-20250929", value: "claude-sonnet-4-5-20250929" },
+  ];
 
 async function listAnthropicModels(credentialKey: string): Promise<AnthropicModelListItem[]> {
   const client = await getClient({
@@ -64,12 +72,9 @@ export const Anthropic_ModelSearch_Stream: AiProviderRunFn<
   ModelSearchTaskInput,
   ModelSearchTaskOutput
 > = async (input, _model, _signal, emit) => {
-  let models: AnthropicModelListItem[];
-  if (!input.credential_key) {
-    models = ANTHROPIC_FALLBACK;
-  } else {
-    models = await listAnthropicModels(input.credential_key);
-  }
-  models = filterLabeledModelsByQuery(models, input.query);
+  const available: ReadonlyArray<AnthropicModelListItem> = input.credential_key
+    ? await listAnthropicModels(input.credential_key)
+    : ANTHROPIC_FALLBACK;
+  const models = filterLabeledModelsByQuery(available, input.query);
   emit({ type: "finish", data: { results: mapModelList(models) } });
 };

--- a/providers/anthropic/src/ai/common/Anthropic_RequestParams.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_RequestParams.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from "@workglow/util/worker";
+import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
+
+/**
+ * Highest Claude generation that still accepts `temperature` / `top_p`.
+ * Newer generations reject them with HTTP 400, which maps to a
+ * non-retryable `PermanentJobError`.
+ */
+export const ANTHROPIC_LAST_SAMPLING_MAJOR = 4;
+/** Highest minor within {@link ANTHROPIC_LAST_SAMPLING_MAJOR} that accepts them. */
+export const ANTHROPIC_LAST_SAMPLING_MINOR = 6;
+
+/**
+ * A numeric id segment this long is a release date (`20250514`), not a minor
+ * version. Without this rule `claude-sonnet-4-20250514` parses as minor
+ * 20250514 and is wrongly treated as a post-cutoff generation.
+ */
+const DATE_SEGMENT = /^\d{6,}$/;
+const NUMERIC_SEGMENT = /^\d+$/;
+const CLAUDE_PREFIX = "claude-";
+/** Families that never accepted sampling parameters, whatever their version. */
+const REJECTED_FAMILY = /^claude-(?:fable|mythos)(?:$|[-.])/;
+
+interface ParsedAnthropicModelId {
+  /** Empty for the bare `claude-2.1` shape, which carries no family name. */
+  readonly family: string;
+  readonly major: number;
+  readonly minor: number | undefined;
+}
+
+/**
+ * Parses the three id shapes Anthropic has shipped:
+ * - modern `claude-<family>-<major>[-<minor>][-<date>]` (`claude-opus-4-8`)
+ * - legacy `claude-<major>[-<minor>]-<family>[-<date>]` (`claude-3-5-sonnet-20241022`)
+ * - bare `claude-[instant-]<major>[.<minor>]` (`claude-2.1`, `claude-instant-1.2`)
+ *
+ * Returns `undefined` for anything else, including non-Claude ids.
+ */
+function parseAnthropicModelId(id: string): ParsedAnthropicModelId | undefined {
+  const normalized = id.trim().toLowerCase();
+  if (!normalized.startsWith(CLAUDE_PREFIX)) return undefined;
+
+  let rest = normalized.slice(CLAUDE_PREFIX.length);
+  if (rest.length === 0) return undefined;
+
+  if (rest.startsWith("instant-")) rest = rest.slice("instant-".length);
+  const bare = /^(\d+)(?:\.(\d+))?$/.exec(rest);
+  if (bare) {
+    return {
+      family: "",
+      major: Number(bare[1]),
+      minor: bare[2] === undefined ? undefined : Number(bare[2]),
+    };
+  }
+
+  const segments = rest.split("-").filter((segment) => segment.length > 0);
+  if (segments.length < 2) return undefined;
+
+  const isVersionSegment = (segment: string | undefined): boolean =>
+    segment !== undefined && NUMERIC_SEGMENT.test(segment) && !DATE_SEGMENT.test(segment);
+
+  // Legacy shape leads with the version: claude-3-5-sonnet-20241022.
+  if (isVersionSegment(segments[0])) {
+    const major = Number(segments[0]);
+    let index = 1;
+    let minor: number | undefined;
+    if (isVersionSegment(segments[index])) {
+      minor = Number(segments[index]);
+      index += 1;
+    }
+    const family = segments[index];
+    if (family === undefined || NUMERIC_SEGMENT.test(family)) return undefined;
+    return { family, major, minor };
+  }
+
+  // Modern shape leads with the family: claude-opus-4-8.
+  if (!isVersionSegment(segments[1])) return undefined;
+  return {
+    family: segments[0]!,
+    major: Number(segments[1]),
+    minor: isVersionSegment(segments[2]) ? Number(segments[2]) : undefined,
+  };
+}
+
+interface AnthropicSamplingProviderConfig {
+  readonly model_name?: string;
+  readonly sampling_params?: "send" | "omit";
+}
+
+/**
+ * Whether the configured model accepts `temperature` / `top_p`.
+ *
+ * This is an allow-list of generations known to accept them, not a deny-list
+ * of the ones that reject them: an id that does not match a known-accepting
+ * shape is treated as rejecting. A wrong `false` changes sampling behavior; a
+ * wrong `true` is an unrecoverable 400, so an unrecognized id defaults to
+ * omitting. `provider_config.sampling_params` overrides the decision either way.
+ */
+export function anthropicAcceptsSamplingParams(model: AnthropicModelConfig | undefined): boolean {
+  const config = model?.provider_config as AnthropicSamplingProviderConfig | undefined;
+
+  const override = config?.sampling_params;
+  if (override === "send") return true;
+  if (override === "omit") return false;
+
+  const id = (config?.model_name ?? "").trim().toLowerCase();
+  if (REJECTED_FAMILY.test(id)) return false;
+
+  const parsed = parseAnthropicModelId(id);
+  if (parsed === undefined) return false;
+  if (parsed.major > ANTHROPIC_LAST_SAMPLING_MAJOR) return false;
+  // A missing minor means generation `.0` (e.g. `claude-sonnet-4-20250514`),
+  // which predates the cutoff — deliberately permissive.
+  if (
+    parsed.major === ANTHROPIC_LAST_SAMPLING_MAJOR &&
+    parsed.minor !== undefined &&
+    parsed.minor > ANTHROPIC_LAST_SAMPLING_MINOR
+  ) {
+    return false;
+  }
+  return true;
+}
+
+interface AnthropicSamplingInput {
+  readonly temperature?: number;
+  readonly topP?: number;
+}
+
+/**
+ * Copies the caller's sampling fields onto an Anthropic request body when the
+ * model accepts them. On a rejecting model the keys are left absent (rather
+ * than set to `undefined`) and a single warning names everything dropped, so
+ * the user's setting becoming a no-op is visible without failing the request.
+ */
+export function applyAnthropicSamplingParams(
+  params: Record<string, unknown>,
+  input: AnthropicSamplingInput,
+  model: AnthropicModelConfig | undefined
+): void {
+  const supplied: Array<readonly [wireName: string, value: number]> = [];
+  if (input.temperature !== undefined) supplied.push(["temperature", input.temperature]);
+  if (input.topP !== undefined) supplied.push(["top_p", input.topP]);
+  if (supplied.length === 0) return;
+
+  if (anthropicAcceptsSamplingParams(model)) {
+    for (const [wireName, value] of supplied) params[wireName] = value;
+    return;
+  }
+
+  getLogger().warn("Anthropic model rejects sampling parameters; dropping them.", {
+    model: model?.provider_config?.model_name ?? "",
+    dropped: supplied.map(([wireName]) => wireName),
+  });
+}

--- a/providers/anthropic/src/ai/common/Anthropic_TextGeneration.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_TextGeneration.ts
@@ -13,6 +13,7 @@ import { getLogger } from "@workglow/util/worker";
 import { getClient, getMaxTokens, getModelName } from "./Anthropic_Client";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 import { maybeEmitAnthropicRefusal } from "./Anthropic_Refusal";
+import { applyAnthropicSamplingParams } from "./Anthropic_RequestParams";
 import { buildAnthropicMessages } from "./Anthropic_ToolCalling";
 
 /**
@@ -64,9 +65,7 @@ export const Anthropic_TextGeneration_Stream: AiProviderRunFn<
       messages,
       max_tokens: getMaxTokens(input, model),
     };
-    if (input.temperature !== undefined) params.temperature = input.temperature;
-    if ((input as { topP?: number }).topP !== undefined)
-      params.top_p = (input as { topP?: number }).topP;
+    applyAnthropicSamplingParams(params, input, model);
 
     if (unified.systemPrompt) {
       params.system = sessionId

--- a/providers/anthropic/src/ai/common/Anthropic_TextRewriter.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_TextRewriter.ts
@@ -22,7 +22,7 @@ export const Anthropic_TextRewriter_Stream: AiProviderRunFn<
       model: modelName,
       system: input.prompt,
       messages: [{ role: "user", content: input.text }],
-      max_tokens: getMaxTokens({}, model),
+      max_tokens: getMaxTokens(input, model),
     },
     { signal }
   );

--- a/providers/anthropic/src/ai/common/Anthropic_TextSummary.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_TextSummary.ts
@@ -22,7 +22,7 @@ export const Anthropic_TextSummary_Stream: AiProviderRunFn<
       model: modelName,
       system: "Summarize the following text concisely.",
       messages: [{ role: "user", content: input.text }],
-      max_tokens: getMaxTokens({}, model),
+      max_tokens: getMaxTokens(input, model),
     },
     { signal }
   );

--- a/providers/anthropic/src/ai/common/Anthropic_ToolCalling.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_ToolCalling.ts
@@ -17,6 +17,7 @@ import { parsePartialJson } from "@workglow/util/worker";
 import { getClient, getMaxTokens, getModelName } from "./Anthropic_Client";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 import { maybeEmitAnthropicRefusal } from "./Anthropic_Refusal";
+import { applyAnthropicSamplingParams } from "./Anthropic_RequestParams";
 
 export function buildAnthropicMessages(
   messages: ReadonlyArray<ChatMessage> | undefined,
@@ -114,11 +115,7 @@ export const Anthropic_ToolCalling_Stream: AiProviderRunFn<
     max_tokens: getMaxTokens(input, model),
   };
 
-  // Only forward temperature when explicitly set — sending `undefined` would
-  // serialize a null/undefined field the Anthropic API may reject.
-  if (input.temperature !== undefined) {
-    params.temperature = input.temperature;
-  }
+  applyAnthropicSamplingParams(params, input, model);
 
   if (input.systemPrompt) {
     params.system = input.systemPrompt;

--- a/providers/anthropic/src/ai/index.ts
+++ b/providers/anthropic/src/ai/index.ts
@@ -16,6 +16,10 @@ import { AnthropicQueuedProvider } from "./AnthropicQueuedProvider";
 import { ANTHROPIC_RUN_FN_SPECS } from "./common/Anthropic_Capabilities";
 import { ANTHROPIC_RUN_FNS } from "./common/Anthropic_JobRunFns";
 import { maybeEmitAnthropicRefusal } from "./common/Anthropic_Refusal";
+import {
+  anthropicAcceptsSamplingParams,
+  applyAnthropicSamplingParams,
+} from "./common/Anthropic_RequestParams";
 
 /**
  * @internal Symbols exported only for use by `@workglow/test`. Not part of the stable public API.
@@ -25,4 +29,6 @@ export const _testOnly = {
   ANTHROPIC_RUN_FN_SPECS,
   ANTHROPIC_RUN_FNS,
   maybeEmitAnthropicRefusal,
+  anthropicAcceptsSamplingParams,
+  applyAnthropicSamplingParams,
 } as const;


### PR DESCRIPTION
## The defect

Recent Claude models **reject sampling parameters**. `claude-opus-5`, `claude-fable-5`, `claude-opus-4-8`, and `claude-opus-4-7` return HTTP 400 for `temperature` / `top_p` / `top_k`; `claude-sonnet-5` returns 400 for a non-default value. `claude-haiku-4-5` and older still accept them.

`Anthropic_TextGeneration.ts` and `Anthropic_ToolCalling.ts` forwarded them unconditionally. A 400 maps to `PermanentJobError` — **no retry**. So on any of those models, text generation and tool calling failed outright whenever a caller set either field. Downstream in builder, `temperature`/`topP` are user-editable node fields, and 3 of its 4 shipped Anthropic suggestions are affected.

## The gate: an allowlist of the past, not a denylist of the present

The predicate lives in the provider (`Anthropic_RequestParams.ts`) because this is a vendor request-shape constraint, not a task-layer capability — OpenAI's o-series has an incompatible rule, so `packages/ai` is the wrong home for it.

The load-bearing property is the direction of the default:

| Parsed id | Result |
|---|---|
| parses, generation ≤ 4.6 | `true` (send) |
| parses, generation ≥ 4.7 | `false` (omit) |
| family `fable` / `mythos` | `false` |
| unparseable / empty / non-Claude | `false` |

**A brand-new Claude id matches no known-accepting shape → params omitted → the request succeeds.** The failure modes are not symmetric: a wrong `false` merely changes sampling behavior, while a wrong `true` is an unrecoverable 400 that kills the job. So the default is `false`. Existing model ids never change, so the list does not rot as new models ship.

An escape hatch — `provider_config.sampling_params: "send" | "omit"` — overrides the decision in either direction when the shape heuristic is wrong for a given model. It has **no schema default**, so "absent" stays distinguishable from an explicit choice. (`provider_config` has `additionalProperties: false`, so without the schema entry the hatch silently could not be set at all.)

Two states rather than three: omitting a parameter and sending its default are behaviorally identical, so `claude-sonnet-5` collapses into "omit". A three-state design would need a per-model default-value table that rots, for zero behavioral gain.

### Parser

Handles the three id shapes Anthropic has shipped — modern (`claude-opus-4-8`), legacy (`claude-3-5-sonnet-20241022`), and bare (`claude-2.1`). The critical rule: **a numeric segment of 6+ digits is a date, not a minor version.** Without it, `claude-sonnet-4-20250514` parses as minor `20250514` and is wrongly rejected. Both `-20250514` ids are pinned as regression tests.

## Warn-and-drop

Failing fast would just trade one `PermanentJobError` for another and break working workflows the moment someone switches models. Silently dropping would make the user's setting a no-op with no feedback. So: exactly **one** `getLogger().warn` per request, listing every dropped parameter. No new `StreamEvent` variant, and `StreamPhase` is left alone — it is a progress label that `TaskRunner` converts into a progress event, not an error channel.

## The capability-inference coupling

`Anthropic_ModelSearch.mapModelList` emits `capabilities: []`, so fallback models depend **entirely** on `inferAnthropicCapabilities` — which had no Claude 5 branch. Adding `claude-opus-5` to the fallback list alone would have produced a model inferring only `["model.search", "model.info"]`: no `text.generation`, completely unusable.

So the inference branch lands **first** (matching `claude-(sonnet|opus|haiku)-5*`, `claude-fable-*`, `claude-mythos-*`, returning the same full set as the Claude 4 branch; `claude-opus-4-7`/`4-8` still match the existing `-4` branch), and only then the fallback list changes: the two retired ids (`claude-3-5-sonnet-20241022`, `claude-3-5-haiku-20241022` — both 404) come out and the current models go in, newest first. `claude-mythos-5` is deliberately **not** listed — it is Project-Glasswing-only and would 404 for everyone else, reintroducing exactly this class of defect. A guard test walks every `ANTHROPIC_FALLBACK` entry and asserts it infers `text.generation`.

## Also included

- `max_tokens` schema default 1024 → 16384, matching `ANTHROPIC_DEFAULT_MAX_TOKENS`. Existing records are untouched; newly created records carry the higher ceiling.
- `getMaxTokens({}, model)` → `getMaxTokens(input, model)` in `Anthropic_TextSummary` / `Anthropic_TextRewriter`. Behaviorally inert today (neither input schema has a `maxTokens` port) — it removes a latent trap where adding the port would silently not work. `getMaxTokens`'s parameter widened to `object` so those inputs typecheck.
- Retired example ids in the `model_name` description replaced with `claude-opus-5` / `claude-haiku-4-5`.

`Anthropic_StructuredGeneration.ts` is deliberately **not** touched: it declares `temperature` but has never forwarded it, so there is no 400 risk, and adding forwarding would be a feature change inside a defect fix that alters output for existing pre-4.7 users. Same for TextSummary/TextRewriter, whose inputs carry no sampling fields.

## Verification

- `bun scripts/test.ts provider-api vitest` — 513 passed, 60 skipped
- `bun scripts/test.ts ai vitest` — 247 passed
- `bunx tsc -p providers/anthropic/tsconfig.json --noEmit` — clean
- `bun run format` — clean
- `rg -n "params\.(temperature|top_p|top_k)\s*=" providers/anthropic/src` — no direct assignments remain; the only writes go through the gate module's computed-key assignment

## Out of scope — builder follow-up

On a rejecting model a user's `temperature` / `topP` node field now silently becomes a no-op, visible only in the log. Builder should surface that in the UI, and should **import this predicate rather than re-implement the rule** — a second copy of the id-shape logic would drift from this one.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPVsQokiWbnZfkE8HnyPVT


---
_Generated by [Claude Code](https://claude.ai/code/session_01QPVsQokiWbnZfkE8HnyPVT)_