### PR TITLE
Add disown() and setTitle() for task lifecycle management

### DIFF
--- a/examples/cli/src/ui/cliTaskUi.ts
+++ b/examples/cli/src/ui/cliTaskUi.ts
@@ -7,6 +7,7 @@
 import type { TaskGraph } from "@workglow/task-graph";
 import type { Dispatch, SetStateAction } from "react";
 import type { CliTaskLine } from "./taskGraphCliSubscriptions";
+import { cliTaskLabel } from "./taskGraphCliSubscriptions";
 
 /** Single-character status column: done → active (spinner in UI) → waiting → error. */
 export function cliTaskStatusGlyph(status: string): string {
@@ -118,9 +119,14 @@ export function startGraphTaskPoll(
         if (!info) continue;
         const st = task.status;
         const prog = task.progress;
-        if (info.status !== st || info.progress !== prog) {
+        // Label is re-read, not just carried over: a task instance reused for a
+        // sequence of jobs is relabelled per job (`setTitle`), and the row is
+        // wired once at `task_added`, so without this the row would keep naming
+        // the first job for the life of the run.
+        const label = cliTaskLabel(task);
+        if (info.status !== st || info.progress !== prog || info.label !== label) {
           if (!next) next = new Map(prev);
-          next.set(taskId, { ...info, status: st, progress: prog });
+          next.set(taskId, { ...info, status: st, progress: prog, label });
         }
       }
       return next ?? prev;

--- a/examples/cli/src/ui/taskGraphCliSubscriptions.ts
+++ b/examples/cli/src/ui/taskGraphCliSubscriptions.ts
@@ -314,6 +314,21 @@ export function subscribeTaskGraphForCli(
     if (t) wire(t);
   };
 
+  // A task released with `context.disown` is gone from the graph, so its row is
+  // stale — drop it, and un-wire the id so the same task owned again later
+  // (a reused node re-registered per batch) gets a fresh row rather than being
+  // silently skipped by the `wired` guard.
+  const onTaskRemoved = (taskId: TaskIdType): void => {
+    const id = String(taskId);
+    wired.delete(id);
+    setTaskInfos((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+  };
+
   const onGraphProgress = (progress: number | undefined): void => {
     setOverallProgress(progress);
   };
@@ -323,6 +338,7 @@ export function subscribeTaskGraphForCli(
   };
 
   graph.on("task_added", onTaskAdded);
+  graph.on("task_removed", onTaskRemoved);
   graph.on("graph_progress", onGraphProgress);
   graph.on("start", onGraphStart);
 
@@ -331,6 +347,7 @@ export function subscribeTaskGraphForCli(
       u();
     }
     graph.off("task_added", onTaskAdded);
+    graph.off("task_removed", onTaskRemoved);
     graph.off("graph_progress", onGraphProgress);
     graph.off("start", onGraphStart);
   };

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -56,6 +56,25 @@ export interface IExecuteContext {
    * already an `ITask` keeps its own config; name those at construction.
    */
   own: <T extends ITask | ITaskGraph | IWorkflow>(i: T, config?: TaskConfig) => T;
+  /**
+   * Release a task previously registered with {@link IExecuteContext.own}, so
+   * the running task stops holding it once its work is done.
+   *
+   * `own` is add-only and the subgraph is cleared only between graph runs, so a
+   * task that owns one child per item in a loop retains every child — and
+   * everything each child's own subgraph accumulated — for the whole of its
+   * `execute()`. Where that retention is unbounded (a per-filing wrapper in a
+   * backfill sweep, a per-section AI call holding its prompt), disown the child
+   * once it settles.
+   *
+   * Pass the value `own` returned — for a graph or workflow that is the original,
+   * not the wrapper task the subgraph actually holds, and only `disown` can map
+   * between them. Releasing something this context never owned is a no-op.
+   *
+   * Progress UIs drop the row when the task leaves the subgraph, so keep owning
+   * children whose completed rows are the point (a short, fixed pipeline).
+   */
+  disown: <T extends ITask | ITaskGraph | IWorkflow>(i: T) => void;
   registry: ServiceRegistry;
   /**
    * Input streams for pass-through streaming tasks. Keyed by input port name.
@@ -252,6 +271,12 @@ export interface ITaskIO<Input extends TaskInput> {
   get type(): string; // gets local access for static type property
   get category(): string; // gets local access for static category property
   get title(): string; // gets local access for static title property
+  /**
+   * Relabels this instance. Needed when one task instance is reused for a
+   * sequence of distinct jobs (so a progress UI names the current one) — the
+   * usual case is set-once via `config.title` at construction.
+   */
+  setTitle(title: string): void;
   get description(): string; // gets local access for static description property
 
   setDefaults(defaults: Partial<Input>): void;

--- a/packages/task-graph/src/task/StreamProcessor.ts
+++ b/packages/task-graph/src/task/StreamProcessor.ts
@@ -36,6 +36,7 @@ export interface StreamProcessorDeps {
     ...args: any[]
   ) => Promise<void>;
   readonly own: <T extends Taskish<any, any>>(i: T, config?: TaskConfig) => T;
+  readonly disown: <T extends Taskish<any, any>>(i: T) => void;
 }
 
 /**
@@ -86,6 +87,7 @@ export class StreamProcessor<Input extends TaskInput, Output extends TaskOutput>
       signal: ctx.abortController.signal,
       updateProgress: deps.onProgress,
       own: deps.own,
+      disown: deps.disown,
       registry: deps.registry,
       resourceScope: deps.resourceScope,
       inputStreams: deps.inputStreams,

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -284,6 +284,15 @@ export class Task<
     return this.config?.title ?? (this.constructor as typeof Task).title;
   }
 
+  /**
+   * Relabels this instance. Needed when one task instance is reused for a
+   * sequence of distinct jobs (so a progress UI names the current one) — the
+   * usual case is set-once via `config.title` at construction.
+   */
+  public setTitle(title: string): void {
+    this.config.title = title;
+  }
+
   public get description(): string {
     return this.config?.description ?? (this.constructor as typeof Task).description;
   }

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -136,6 +136,7 @@ export class TaskRunner<
   constructor(task: ITask<Input, Output, Config>) {
     this.task = task;
     this.own = this.own.bind(this);
+    this.disown = this.disown.bind(this);
     this.handleProgress = this.handleProgress.bind(this);
     this.cacheCoordinator = new CacheCoordinator(task);
     this.streamProcessor = new StreamProcessor(task);
@@ -263,6 +264,7 @@ export class TaskRunner<
                 inputStreams: this.inputStreams,
                 onProgress: this.handleProgress.bind(this),
                 own: this.own,
+                disown: this.disown,
               })
             : await this.executeTask(inputs, ctx);
 
@@ -519,9 +521,21 @@ export class TaskRunner<
   // Protected methods
   // ========================================================================
 
+  /**
+   * What {@link own} actually added to the subgraph, keyed by the value the
+   * caller handed in. A graph or workflow is adapted into a wrapper task and
+   * `own` hands the caller back their original, so the wrapper's id — the only
+   * thing {@link disown} can remove — is otherwise unrecoverable. Weak so an
+   * owned task that is never disowned still dies with the subgraph.
+   */
+  private readonly ownedWrappers = new WeakMap<object, ITask>();
+
   protected own<T extends Taskish<any, any>>(i: T, config: TaskConfig = {}): T {
     const task = ensureTask(i, { ...config, isOwned: true });
     this.task.subGraph.addTask(task);
+    if (i !== null && typeof i === "object") {
+      this.ownedWrappers.set(i, task);
+    }
     // Propagate parent registry and abort signal to owned ITask instances so
     // that calling task.run() on the returned value inherits this execution context.
     if (hasRunConfig(i)) {
@@ -550,11 +564,35 @@ export class TaskRunner<
     return i;
   }
 
+  /**
+   * Releases a value previously registered by {@link own}. `own` is add-only and
+   * the subgraph is cleared only between graph runs, so a task owning one child
+   * per loop iteration retains them all — with whatever each child's own
+   * subgraph accumulated — until its `execute()` returns.
+   *
+   * Takes the value `own` returned (for a graph or workflow that is the original,
+   * not the wrapper task actually in the subgraph) and resolves it through
+   * {@link ownedWrappers}. A value this runner never owned is a no-op, so
+   * disowning after an `own` that was an identity no-op against a stub context
+   * is harmless.
+   */
+  protected disown<T extends Taskish<any, any>>(i: T): void {
+    if (i === null || typeof i !== "object") return;
+    const wrapper = this.ownedWrappers.get(i);
+    if (wrapper === undefined || !this.task.hasChildren()) return;
+    this.ownedWrappers.delete(i);
+    this.task.subGraph.removeTask(wrapper.id);
+    if ((this.task.constructor as typeof Task).hasDynamicEntitlements) {
+      this.task.emit("entitlementChange", this.task.entitlements());
+    }
+  }
+
   protected async executeTask(input: Input, ctx: TaskRunContext): Promise<Output | undefined> {
     const result = await this.task.execute(input, {
       signal: ctx.abortController.signal,
       updateProgress: this.handleProgress.bind(this),
       own: this.own,
+      disown: this.disown,
       registry: this.registry,
       resourceScope: this.resourceScope,
       runId: this.runId,

--- a/packages/task-graph/src/task/WhileTaskRunner.ts
+++ b/packages/task-graph/src/task/WhileTaskRunner.ts
@@ -36,6 +36,7 @@ export class WhileTaskRunner<
       signal: ctx.abortController.signal,
       updateProgress: this.handleProgress.bind(this),
       own: this.own,
+      disown: this.disown,
       registry: this.registry,
     });
 

--- a/packages/test/src/test/ai/StructuredGenerationTask.test.ts
+++ b/packages/test/src/test/ai/StructuredGenerationTask.test.ts
@@ -33,6 +33,7 @@ function mkContext(): IExecuteContext {
     signal: controller.signal,
     updateProgress: async () => {},
     own: <T>(i: T) => i,
+    disown: () => {},
     registry: {
       has: () => false,
       get: () => {

--- a/packages/test/src/test/ai/streaming-abort.test.ts
+++ b/packages/test/src/test/ai/streaming-abort.test.ts
@@ -54,6 +54,7 @@ function makeContext(parentSignal?: AbortSignal): IExecuteContext {
     signal: parentSignal ?? new AbortController().signal,
     updateProgress: async () => {},
     own: ((t: unknown) => t) as IExecuteContext["own"],
+    disown: () => {},
     registry: undefined as unknown as IExecuteContext["registry"],
   };
 }

--- a/packages/test/src/test/task-graph/taskrunner-internals.test.ts
+++ b/packages/test/src/test/task-graph/taskrunner-internals.test.ts
@@ -134,6 +134,7 @@ describe("StreamProcessor", () => {
       inputStreams: undefined,
       onProgress: async () => {},
       own: (i) => i,
+      disown: () => {},
     });
 
     expect(finishData).toEqual({ text: "Hello, world!" });
@@ -151,6 +152,7 @@ describe("StreamProcessor", () => {
       inputStreams: undefined,
       onProgress: async () => {},
       own: (i) => i,
+      disown: () => {},
     });
 
     expect(result).toEqual({ result: "final" });

--- a/packages/test/src/test/task/ImageFilterTask.test.ts
+++ b/packages/test/src/test/task/ImageFilterTask.test.ts
@@ -39,6 +39,7 @@ function makeContext(): IExecuteContext {
     signal: new AbortController().signal,
     updateProgress: async () => {},
     own: <T>(t: T) => t,
+    disown: () => {},
     registry: undefined as unknown as IExecuteContext["registry"],
     resourceScope: undefined,
   };

--- a/packages/test/src/test/task/OwnTask.test.ts
+++ b/packages/test/src/test/task/OwnTask.test.ts
@@ -6,6 +6,15 @@ import { setLogger } from "@workglow/util";
 import { getTestingLogger } from "../../binding/TestingLogger";
 import { TaskCreatorTask } from "./TestTasks";
 
+class SimpleTask extends Task {
+  public static override readonly type = "SimpleOwnedTask";
+  public static override readonly title = "Simple";
+
+  override async execute(): Promise<TaskOutput> {
+    return {};
+  }
+}
+
 describe("Task own functionality", () => {
   let logger = getTestingLogger();
   setLogger(logger);
@@ -83,6 +92,95 @@ describe("Task own functionality", () => {
         "Own[Graph]",
         "Own[Workflow]",
       ]);
+    });
+  });
+
+  // `own` is add-only and the subgraph is cleared only between graph runs, so a
+  // task owning one child per loop iteration retains them all — and everything
+  // each child owned in turn — for the whole of its execute(). `disown` is how a
+  // sweep over an unbounded worklist stays flat.
+  describe("disown(taskish)", () => {
+    class LoopingTask extends Task {
+      public static override readonly type = "LoopingTask";
+      public static override readonly title = "Looping";
+
+      public peakSubgraphSize = 0;
+
+      override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+        for (let i = 0; i < 5; i++) {
+          const wf = context.own(new Workflow(), { title: `Item ${i}` });
+          wf.pipe(new SimpleTask());
+          await wf.run();
+          this.peakSubgraphSize = Math.max(this.peakSubgraphSize, this.subGraph.getTasks().length);
+          context.disown(wf);
+        }
+        return {};
+      }
+    }
+
+    it("keeps a per-iteration owner flat instead of growing with the worklist", async () => {
+      const task = new LoopingTask();
+      await task.run();
+
+      // One live child at a time across five iterations, none retained after.
+      expect(task.peakSubgraphSize).toBe(1);
+      expect(task.subGraph.getTasks()).toHaveLength(0);
+    });
+
+    it("resolves a workflow to the wrapper task the subgraph actually holds", async () => {
+      class DisownWorkflowTask extends Task {
+        public static override readonly type = "DisownWorkflowTask";
+        public static override readonly title = "Disown workflow";
+
+        override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+          const kept = context.own(new Workflow(), { title: "Kept" });
+          const dropped = context.own(new Workflow(), { title: "Dropped" });
+          // `own` hands back the Workflow, never the Own[Workflow] wrapper that
+          // was added — so disown has to map between them.
+          context.disown(dropped);
+          expect(this.subGraph.getTasks().map((t) => t.title)).toEqual(["Kept"]);
+          expect(kept).toBeDefined();
+          return {};
+        }
+      }
+
+      const task = new DisownWorkflowTask();
+      await task.run();
+      expect(task.subGraph.getTasks().map((t) => t.title)).toEqual(["Kept"]);
+    });
+
+    it("is a no-op for a value this context never owned", async () => {
+      class StrayDisownTask extends Task {
+        public static override readonly type = "StrayDisownTask";
+        public static override readonly title = "Stray disown";
+
+        override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+          context.own(new Workflow(), { title: "Kept" });
+          // Never owned here — disowning it must not throw or evict anything.
+          context.disown(new Workflow());
+          context.disown(new SimpleTask());
+          return {};
+        }
+      }
+
+      const task = new StrayDisownTask();
+      await task.run();
+      expect(task.subGraph.getTasks().map((t) => t.title)).toEqual(["Kept"]);
+    });
+  });
+
+  // A task instance reused for a sequence of jobs needs to be relabelled per job,
+  // otherwise a progress UI keeps naming the first one.
+  describe("setTitle", () => {
+    it("overrides the static title and is re-readable", () => {
+      const task = new SimpleTask();
+      expect(task.title).toBe("Simple");
+
+      task.setTitle("Extract management");
+      expect(task.title).toBe("Extract management");
+
+      task.setTitle("Extract beneficial ownership");
+      expect(task.title).toBe("Extract beneficial ownership");
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds two new capabilities to task execution: `disown()` for releasing owned child tasks from a parent's subgraph, and `setTitle()` for relabeling task instances that are reused across multiple jobs.

## Key Changes

- **`disown()` method** — New `IExecuteContext.disown()` allows tasks to release previously owned children, keeping the subgraph flat when iterating over unbounded worklists. Uses a `WeakMap` to track wrapper tasks created by `own()`, enabling proper cleanup without memory leaks.

- **`setTitle()` method** — New `Task.setTitle()` allows relabeling task instances at runtime. Essential for reused task instances that process multiple jobs sequentially, so progress UIs display the current job name rather than the first one.

- **Task removal event** — Added `task_removed` event to `TaskGraph` (emitted by `disown()`) so the CLI UI can drop stale rows and unwire task IDs for re-registration.

- **CLI UI updates** — Updated `taskGraphCliSubscriptions.ts` to listen for `task_removed` events and clean up task info. Updated `cliTaskUi.ts` to re-read task labels on each poll, reflecting dynamic title changes.

- **Context propagation** — Added `disown` to all `IExecuteContext` implementations: `TaskRunner`, `WhileTaskRunner`, `StreamProcessor`, and test mocks.

## Implementation Details

- `disown()` is a no-op for values never owned by the context, making it safe to call defensively
- `own()` returns the original value (not the wrapper task), so `disown()` must map through `ownedWrappers` to find the actual task to remove
- `WeakMap` ensures owned tasks that are never disowned still die with the subgraph between graph runs
- `setTitle()` updates `config.title`, which is re-read by `task.title` getter on each access
- Tests added for all three scenarios: looping with disown, workflow resolution, and stray disown calls

https://claude.ai/code/session_01XgMNjWhP23c83zZGeZua4U