### PR TITLE
fix(cli): release a disowned task's listeners instead of retaining it forever

### DIFF
--- a/examples/cli/src/test/taskGraphCliSubscriptions.test.ts
+++ b/examples/cli/src/test/taskGraphCliSubscriptions.test.ts
@@ -4,13 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ITask } from "@workglow/task-graph";
+import { Task, TaskGraph, type ITask } from "@workglow/task-graph";
 import { EventEmitter } from "@workglow/util";
 import { describe, expect, it } from "vitest";
 import {
   FULL_SLOT_TRACKING_MAX,
   MAX_RUNNING_ROWS,
   registerIterationListeners,
+  subscribeTaskGraphForCli,
+  type CliTaskLine,
   type IterationSlotRow,
 } from "../ui/taskGraphCliSubscriptions";
 
@@ -30,6 +32,104 @@ function makeSink() {
   };
   return { setter, get: () => state };
 }
+
+// Same idea for the task-row map, which `subscribeTaskGraphForCli` also seeds
+// with a plain value (not only updater functions).
+function makeInfoSink() {
+  let state = new Map<string, CliTaskLine>();
+  const setter = (
+    update:
+      Map<string, CliTaskLine> | ((prev: Map<string, CliTaskLine>) => Map<string, CliTaskLine>)
+  ) => {
+    state = typeof update === "function" ? update(state) : update;
+  };
+  return { setter, get: () => state };
+}
+
+const SCHEMA = { type: "object", properties: {} } as never;
+
+class DisownableTask extends Task<Record<string, never>, Record<string, never>> {
+  static override readonly type = "DisownableTask";
+  static override readonly category = "Test";
+  static override readonly cacheable = false;
+  static override inputSchema(): never {
+    return SCHEMA;
+  }
+  static override outputSchema(): never {
+    return SCHEMA;
+  }
+  override async execute() {
+    return {};
+  }
+}
+
+describe("subscribeTaskGraphForCli task lifecycle", () => {
+  it("disposes a removed task's listeners", () => {
+    const graph = new TaskGraph();
+    const task = new DisownableTask();
+    graph.addTask(task as never);
+
+    const infos = makeInfoSink();
+    const slots = makeSink();
+    const unsubscribe = subscribeTaskGraphForCli(
+      graph,
+      infos.setter as never,
+      undefined,
+      () => {},
+      slots.setter as never
+    );
+
+    const id = String(task.id);
+    expect(infos.get().has(id)).toBe(true);
+    expect(task.events.listenerCount("status")).toBe(1);
+    expect(task.events.listenerCount("iteration_start")).toBe(1);
+
+    task.events.emit("iteration_start", 0, 3);
+    expect(slots.get().get(id)).toHaveLength(3);
+
+    // What `context.disown` does to the graph.
+    graph.removeTask(task.id);
+
+    expect(infos.get().has(id)).toBe(false);
+    // Not just the row: the slot key must go too, or the Map grows unbounded.
+    expect(slots.get().has(id)).toBe(false);
+    // The listeners are the strong reference that survives `disown` — they must
+    // be off the task, not merely detached from the graph.
+    expect(task.events.listenerCount("status")).toBe(0);
+    expect(task.events.listenerCount("progress")).toBe(0);
+    expect(task.events.listenerCount("iteration_start")).toBe(0);
+    expect(task.events.listenerCount("iteration_complete")).toBe(0);
+    expect(task.events.listenerCount("iteration_progress")).toBe(0);
+
+    // Inert, not merely unreferenced: a late event writes nothing back.
+    task.events.emit("iteration_start", 1, 3);
+    task.events.emit("status", "COMPLETED");
+    expect(slots.get().has(id)).toBe(false);
+    expect(infos.get().has(id)).toBe(false);
+
+    unsubscribe();
+  });
+
+  it("re-wires a task owned again after being disowned", () => {
+    const graph = new TaskGraph();
+    const task = new DisownableTask();
+    graph.addTask(task as never);
+
+    const infos = makeInfoSink();
+    const unsubscribe = subscribeTaskGraphForCli(graph, infos.setter as never, undefined, () => {});
+
+    const id = String(task.id);
+    graph.removeTask(task.id);
+    expect(infos.get().has(id)).toBe(false);
+
+    graph.addTask(task as never);
+    expect(infos.get().has(id)).toBe(true);
+    expect(task.events.listenerCount("status")).toBe(1);
+
+    unsubscribe();
+    expect(task.events.listenerCount("status")).toBe(0);
+  });
+});
 
 describe("registerIterationListeners", () => {
   it("keeps full completed/running/pending slots for small loops", () => {

--- a/examples/cli/src/ui/taskGraphCliSubscriptions.ts
+++ b/examples/cli/src/ui/taskGraphCliSubscriptions.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ITask, TaskGraph, TaskIdType } from "@workglow/task-graph";
+import type { ITask, TaskGraph, TaskIdType, TaskStatus } from "@workglow/task-graph";
 import type { Dispatch, SetStateAction } from "react";
 
 export interface CliTaskLine {
@@ -76,14 +76,15 @@ export function sortIterationSlotsForDisplay(
   });
 }
 
+/** Returns a disposer — a task released with `context.disown` must not stay subscribed. */
 function registerTaskListeners(
   task: ITask,
   taskId: string,
   taskLabel: string,
   setTaskInfos: Dispatch<SetStateAction<Map<string, CliTaskLine>>>,
   appendCompletedLog?: (text: string) => void
-): void {
-  task.events.on("status", (status: string) => {
+): () => void {
+  const onStatus = (status: TaskStatus): void => {
     setTaskInfos((prev) => {
       const next = new Map(prev);
       const info = next.get(taskId);
@@ -95,9 +96,9 @@ function registerTaskListeners(
       }
       return next;
     });
-  });
+  };
 
-  task.events.on("progress", (progress: number | undefined, message?: string) => {
+  const onProgress = (progress: number | undefined, message?: string): void => {
     setTaskInfos((prev) => {
       const next = new Map(prev);
       const info = next.get(taskId);
@@ -106,7 +107,15 @@ function registerTaskListeners(
       }
       return next;
     });
-  });
+  };
+
+  task.events.on("status", onStatus);
+  task.events.on("progress", onProgress);
+
+  return () => {
+    task.events.off("status", onStatus);
+    task.events.off("progress", onProgress);
+  };
 }
 
 /**
@@ -282,13 +291,15 @@ export function subscribeTaskGraphForCli(
   }
   setTaskInfos(initial);
 
-  const wired = new Set<string>();
-  const iterationUnsubs: Array<() => void> = [];
+  // Keyed by task id so a removed task's listeners can actually be dropped —
+  // an append-only unsub array would keep a strong reference to every task the
+  // graph ever held (and its whole subtree), defeating `context.disown`.
+  // Doubles as the already-wired guard.
+  const taskUnsubs = new Map<string, () => void>();
 
   const wire = (task: ITask): void => {
     const taskId = String(task.id);
-    if (wired.has(taskId)) return;
-    wired.add(taskId);
+    if (taskUnsubs.has(taskId)) return;
     const taskType = (task as { type?: string }).type ?? "Unknown";
     const taskLabel = cliTaskLabel(task);
 
@@ -299,10 +310,15 @@ export function subscribeTaskGraphForCli(
       return next;
     });
 
-    registerTaskListeners(task, taskId, taskLabel, setTaskInfos, appendCompletedLog);
+    const unsubs: Array<() => void> = [
+      registerTaskListeners(task, taskId, taskLabel, setTaskInfos, appendCompletedLog),
+    ];
     if (setIterationSlots) {
-      iterationUnsubs.push(registerIterationListeners(task, taskId, setIterationSlots));
+      unsubs.push(registerIterationListeners(task, taskId, setIterationSlots));
     }
+    taskUnsubs.set(taskId, () => {
+      for (const u of unsubs) u();
+    });
   };
 
   for (const task of graph.getTasks()) {
@@ -315,18 +331,31 @@ export function subscribeTaskGraphForCli(
   };
 
   // A task released with `context.disown` is gone from the graph, so its row is
-  // stale — drop it, and un-wire the id so the same task owned again later
+  // stale — unsubscribe (dropping our last reference to it), drop the row and
+  // any iteration slots, and un-wire the id so the same task owned again later
   // (a reused node re-registered per batch) gets a fresh row rather than being
-  // silently skipped by the `wired` guard.
+  // silently skipped by the already-wired guard.
   const onTaskRemoved = (taskId: TaskIdType): void => {
     const id = String(taskId);
-    wired.delete(id);
+    const unsub = taskUnsubs.get(id);
+    if (unsub) {
+      unsub();
+      taskUnsubs.delete(id);
+    }
     setTaskInfos((prev) => {
       if (!prev.has(id)) return prev;
       const next = new Map(prev);
       next.delete(id);
       return next;
     });
+    if (setIterationSlots) {
+      setIterationSlots((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Map(prev);
+        next.delete(id);
+        return next;
+      });
+    }
   };
 
   const onGraphProgress = (progress: number | undefined): void => {
@@ -343,9 +372,10 @@ export function subscribeTaskGraphForCli(
   graph.on("start", onGraphStart);
 
   return () => {
-    for (const u of iterationUnsubs) {
+    for (const u of taskUnsubs.values()) {
       u();
     }
+    taskUnsubs.clear();
     graph.off("task_added", onTaskAdded);
     graph.off("task_removed", onTaskRemoved);
     graph.off("graph_progress", onGraphProgress);

--- a/packages/test/src/test/util/EventEmitter.test.ts
+++ b/packages/test/src/test/util/EventEmitter.test.ts
@@ -61,6 +61,41 @@ describe("EventEmitter", () => {
       expect(listener).toHaveBeenCalledWith("test", 42, true);
     });
 
+    it("should ignore a duplicate registration of the same listener reference", () => {
+      const listener = mock((value: string) => {});
+
+      emitter.on("test", listener);
+      emitter.on("test", listener);
+
+      expect(emitter.listenerCount("test")).toBe(1);
+
+      emitter.emit("test", "hello");
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // A single `off` therefore fully unsubscribes — no orphaned duplicate.
+      emitter.off("test", listener);
+      expect(emitter.listenerCount("test")).toBe(0);
+      emitter.emit("test", "again");
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should keep an `on` and a `once` of the same listener as separate subscriptions", () => {
+      const listener = mock((value: string) => {});
+
+      emitter.on("test", listener);
+      emitter.once("test", listener);
+
+      expect(emitter.listenerCount("test")).toBe(2);
+
+      emitter.emit("test", "hello");
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      // The `once` entry is consumed; the `on` entry survives.
+      expect(emitter.listenerCount("test")).toBe(1);
+      emitter.emit("test", "again");
+      expect(listener).toHaveBeenCalledTimes(3);
+    });
+
     it("should handle events with no arguments", () => {
       const listener = mock(() => {});
 

--- a/packages/util/src/events/EventEmitter.ts
+++ b/packages/util/src/events/EventEmitter.ts
@@ -99,7 +99,14 @@ export class EventEmitter<EventListenerTypes extends Record<string, (...args: an
   }
 
   /**
-   * Adds a listener function for the event
+   * Adds a listener function for the event.
+   *
+   * Registering the same function reference twice is a no-op: `off` removes a
+   * single entry, so a double-`on` would otherwise leave a subscription behind
+   * that no caller can unhook. This deliberately diverges from Node's
+   * `EventEmitter`, which does duplicate. A `once` registration of the same
+   * function stays a separate subscription.
+   *
    * @param event - The event name to listen for
    * @param listener - The listener function to add
    * @returns this, so that calls can be chained
@@ -110,6 +117,7 @@ export class EventEmitter<EventListenerTypes extends Record<string, (...args: an
   ): this {
     const listeners: EventListeners<EventListenerTypes, Event> =
       this.listeners[event] || (this.listeners[event] = []);
+    if (listeners.some((l) => l.listener === listener && !l.once)) return this;
     listeners.push({ listener });
     this.checkMaxListeners(event, listeners.length);
     return this;


### PR DESCRIPTION
## What retains what, and why `disown` alone was not enough

`subscribeTaskGraphForCli` (`examples/cli/src/ui/taskGraphCliSubscriptions.ts`) retained **every task the graph ever contained**, for the whole life of the subscription:

- `iterationUnsubs` was a plain append-only `Array<() => void>`. `wire()` pushed one closure per wired task and each closure captured `task` (it calls `task.events.off(...)`). Nothing ever removed an entry.
- `onTaskRemoved` deleted from `wired` and from `setTaskInfos`, but **never touched `iterationUnsubs`** — that array was the strong reference that survived `context.disown`.
- `onTaskRemoved` also never deleted the task's `iterationSlots` key → unbounded `Map` growth.
- `registerTaskListeners` returned `void`, so its `status` / `progress` listeners could **never** be removed at all — even the teardown could not drop them.

So `context.disown` did its half of the job (the node leaves the graph) and the CLI subscription silently undid it: the task, and transitively its whole subtree, stayed reachable. This is reached in practice through `examples/cli/src/ui/rows/useSubtaskRows.ts:61`, which calls `subscribeTaskGraphForCli(task.subGraph, …)` for every row.

## The fix

1. **`registerTaskListeners` returns a disposer.** The two inline handlers are hoisted to named consts (`onStatus`, `onProgress`); the returned closure `off`s both. `TaskStatus` added to the type-only import.
2. **`wired` + `iterationUnsubs` collapse into one `Map<string, () => void>` (`taskUnsubs`)**, keyed by task id. The Map doubles as the already-wired guard, and stores a single combined disposer (task listeners + iteration listeners when `setIterationSlots` is provided).
3. **`onTaskRemoved` disposes**: looks up the disposer, calls it, deletes the Map entry, deletes the id from `setTaskInfos` **and** from `setIterationSlots` (the latter was missing). A removed id can still be re-wired if the same node is owned again later — the behavior the old `wired.delete(id)` provided is preserved by the Map delete.
4. **The teardown disposes everything**: iterates `taskUnsubs.values()`, calls each, `clear()`s, then `off`s the four graph listeners as before.

## Downstream: the sec sweep this unblocks

`workglow-dev/sec`'s unbounded backfill sweeps own one `Workflow` per filing and now release it with `context.disown`. On a TTY run (the progress UI is subscribed) the retained array pinned every one of those workflows — and each one's whole subtree, ending at a multi-MB fetched SEC document — for the life of the sweep. With this change the disowned workflow is actually collectable.

## Falsification

Two new tests in `examples/cli/src/test/taskGraphCliSubscriptions.test.ts` (`subscribeTaskGraphForCli task lifecycle`):

- **"disposes a removed task's listeners"** — builds a real `TaskGraph` + `Task`, subscribes, asserts the row and `listenerCount === 1` for `status` / `iteration_start`, emits `iteration_start` and asserts the slots populate; then `graph.removeTask(task.id)` (what `disown` triggers) and asserts the row **and** the slots key are gone and `listenerCount` is `0` for `status`, `progress`, and all three iteration events; then re-emits and asserts nothing is written back — inert, not merely detached.
- **"re-wires a task owned again after being disowned"** — remove, re-add, assert the row is back and `listenerCount("status") === 1`. This pins the behavior that collapsing `wired` into `taskUnsubs` must not lose.

Both were run against the **unpatched** source (`git stash` of the one source file) and both fail there:

```
FAIL … > disposes a removed task's listeners
  expected true to be false            ← the iterationSlots key persists
FAIL … > re-wires a task owned again after being disowned
  expected 2 to be 1                   ← re-wiring stacks a second status listener
```

With the fix, all 5 tests in the file pass.

Verified:
- `bunx vitest run` in `examples/cli` — 5 passed in the touched file; 23 passed / 1 skipped for the whole package.
- `bun scripts/test.ts task vitest` — 1126 passed / 24 skipped.
- `bun scripts/test.ts util vitest` — 668 passed / 10 skipped.
- `bun run build:types`, plus a forced `tsgo --noEmit` in `examples/cli`, `packages/util`, and `packages/test` (turbo reported a types cache hit for `@workglow/cli`, so the direct run is the real signal).

## ⚠️ Second commit is separable: `EventEmitter.on` dedupe

`8223767` (`packages/util/src/events/EventEmitter.ts`) makes `on` skip the push when an identical **non-`once`** listener reference is already registered, with tests in `packages/test/src/test/util/EventEmitter.test.ts`.

**This does not fix the CLI bug above.** `registerTaskListeners` allocates fresh closures on every call, so nothing there is reference-equal — commits 1 and 2 are independent, and commit 1 is the load-bearing fix. The dedupe is a guard for *stable-reference* call sites (`Task.subGraph`'s `_taskAddedListener`, `WorkflowEventBridge`) that today rely on hand-written off-before-on discipline; because `off` removes a single entry, a double-`on` there leaves a subscription no caller can unhook.

It is a **deliberate divergence from Node's `EventEmitter`**, which does duplicate. An `on` plus a `once` of the same function deliberately remain two subscriptions. If reviewers would rather keep Node parity, drop `8223767` — the first commit stands alone.

## Follow-up (maintainer step, not done here)

A **`0.3.37` release** of `@workglow/cli` (and `@workglow/util` if the second commit lands) is needed before `workglow-dev/sec` can depend on this fix. No release was run and nothing was published from this branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VcERQoSbBT3B2b7QHSbXPt)_