### PR TITLE
fix(tasks): keep resolved credentials out of queued job payloads, add credential schemes

### DIFF
--- a/docs/technical/15-credential-management.md
+++ b/docs/technical/15-credential-management.md
@@ -75,9 +75,13 @@ The full resolution sequence during task execution:
    config.credential_key === "sk-ant-..."  // Already the real API key
 ```
 
-If the credential store does not contain the requested key, the resolver returns the
-original string unchanged, allowing `getClient()` to fall through to the `api_key`
-or environment variable checks.
+If the credential store does not contain the requested key, the resolver returns
+`undefined` — **never the reference string**. Echoing the id back would thread the
+credential's *name* through as its *value*, so a missing key would end up sent as a
+real secret (for example straight into an `Authorization: Bearer <key-name>` header),
+leaking the key name to the remote host and masking the misconfiguration. Consumers
+treat `undefined` as "no credential" and fall through to the `api_key` or environment
+variable checks, or raise their own missing-key error.
 
 ---
 
@@ -249,6 +253,64 @@ extends it with provider-specific fields:
 The `credential_key` field is marked with `"x-ui-hidden": true` in provider schemas,
 keeping it out of end-user form UIs while still participating in the automatic
 resolution system.
+
+---
+
+## Credentials in FetchUrlTask
+
+`FetchUrlTask` consumes credentials through the same `format: "credential"` path: its
+`credential_key` input is resolved to the real secret before `execute()` runs. Two
+sibling ports — plain, non-secret configuration — decide where that secret goes:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `credential_key` | `string` (`format: "credential"`) | -- | Key to look up in the credential store. |
+| `credential_scheme` | `"bearer" \| "basic" \| "header" \| "none"` | `"bearer"` | How the resolved secret is placed on the request. |
+| `credential_header` | `string` | `"Authorization"` | Header name used when `credential_scheme` is `"header"`. |
+
+- **`bearer`** -- `Authorization: Bearer <secret>`. The default, so existing graphs
+  are unaffected.
+- **`basic`** -- `Authorization: Basic <secret>`. The secret is used **verbatim** and
+  must already be the base64 encoding of `user:pass`; the task performs no splitting
+  or encoding of its own.
+- **`header`** -- the raw secret becomes the value of `credential_header`, for
+  API-key style services (e.g. `X-Api-Key`).
+- **`none`** -- the credential is resolved but never placed on the request.
+
+`credential_header` must be 1-64 characters of letters, digits, or hyphens; anything
+else raises a `TaskConfigurationError`. The narrow allow-list rejects the CR/LF, colon
+and whitespace characters that would otherwise let a configured header name inject
+additional headers into the outbound request. Validation runs even for schemes that
+ignore the field, so a malformed name is reported rather than silently discarded.
+
+The placement logic is the exported pure function `applyCredentialToHeaders()`
+(`packages/tasks/src/task/FetchUrlCredentials.ts`), so it can be exercised directly.
+
+### Credentials and the queued path
+
+`FetchUrlTask` can dispatch through a job queue (`config.queue`) to get per-domain
+rate limiting. **A credential cannot be combined with that path.** Queue payloads are
+persisted durably (SQLite / Postgres / SQS), so a resolved secret written into the
+queued job input would be written to storage. Setting both raises a
+`TaskConfigurationError`:
+
+```ts
+// Throws: credential_key cannot be combined with config.queue
+new FetchUrlTask({ queue: "fetch:api.example.com" })
+  .run({ url: "https://api.example.com/data", credential_key: "my-api-key" });
+```
+
+The refusal is deliberate and explicit rather than a silent downgrade to the inline
+path, which would quietly drop the rate limiting the caller asked for. To use both,
+have the queue worker supply the credential itself instead of threading it through
+the job payload.
+
+The invariant holds regardless of scheme: `credential_key`, `credential_scheme`, and
+`credential_header` are all stripped from the job input, so the resolved secret only
+ever exists as an in-process request header. Note that a resolved credential
+**overwrites** a same-named header the caller supplied in `headers` -- the credential
+store is authoritative, and letting a hard-coded header shadow it would silently
+defeat the configured credential.
 
 ---
 

--- a/packages/tasks/src/common.ts
+++ b/packages/tasks/src/common.ts
@@ -21,6 +21,7 @@ export * from "./task/ArrayTask";
 export * from "./task/DateFormatTask";
 export * from "./task/DebugLogTask";
 export * from "./task/DelayTask";
+export * from "./task/FetchUrlCredentials";
 export * from "./task/FetchUrlJobError";
 export * from "./task/FetchUrlTask";
 export * from "./task/HumanApprovalTask";

--- a/packages/tasks/src/task/FetchUrlCredentials.ts
+++ b/packages/tasks/src/task/FetchUrlCredentials.ts
@@ -75,6 +75,12 @@ export function credentialHeaderName(
  * credential store is the authoritative source, and letting a hard-coded header
  * shadow it would silently defeat the configured credential.
  *
+ * The override is case-INSENSITIVE, because HTTP header names are. A plain
+ * `{ ...headers, Authorization: value }` leaves a caller's `authorization` key
+ * in place as a distinct object property, and the `Headers` constructor then
+ * folds the two into one comma-joined field — sending the caller's stale token
+ * alongside the real one and breaking the request.
+ *
  * @throws {TaskConfigurationError} when `headerName` is not a bare header token.
  */
 export function applyCredentialToHeaders(
@@ -98,5 +104,12 @@ export function applyCredentialToHeaders(
         ? `Basic ${credential}`
         : credential;
 
-  return { ...headers, [name]: value };
+  const lowerName = name.toLowerCase();
+  const result: Record<string, string> = {};
+  for (const [key, existing] of Object.entries(headers ?? {})) {
+    if (key.toLowerCase() === lowerName) continue;
+    result[key] = existing;
+  }
+  result[name] = value;
+  return result;
 }

--- a/packages/tasks/src/task/FetchUrlCredentials.ts
+++ b/packages/tasks/src/task/FetchUrlCredentials.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TaskConfigurationError } from "@workglow/task-graph";
+
+/**
+ * How a resolved credential is placed onto the outbound request.
+ *
+ * - `bearer` — `Authorization: Bearer <secret>` (default; OAuth 2.0 style)
+ * - `basic`  — `Authorization: Basic <secret>`; the secret is used verbatim and
+ *   must already be the base64 of `user:pass`. Nothing is encoded here, so a
+ *   caller keeps full control over how the pair is assembled.
+ * - `header` — the raw secret as the value of {@link credentialHeaderName}
+ *   (API-key style, e.g. `X-Api-Key`)
+ * - `none`   — the credential is resolved but never placed on the request
+ */
+export const CredentialSchemes = {
+  BEARER: "bearer",
+  BASIC: "basic",
+  HEADER: "header",
+  NONE: "none",
+} as const;
+
+export type CredentialScheme = (typeof CredentialSchemes)[keyof typeof CredentialSchemes];
+
+export const DEFAULT_CREDENTIAL_SCHEME: CredentialScheme = CredentialSchemes.BEARER;
+export const DEFAULT_CREDENTIAL_HEADER = "Authorization";
+
+/**
+ * Header names are restricted to RFC 7230 token characters that survive every
+ * transport unambiguously. The narrow allow-list is deliberate: it rejects the
+ * CR/LF, colon, and whitespace that would otherwise let a configured header
+ * name inject additional headers into the request.
+ */
+const CREDENTIAL_HEADER_NAME_PATTERN = /^[A-Z0-9-]{1,64}$/i;
+
+export interface ApplyCredentialOptions {
+  readonly headers: Readonly<Record<string, string>> | undefined;
+  readonly credential: string | undefined;
+  readonly scheme: CredentialScheme | undefined;
+  readonly headerName: string | undefined;
+}
+
+/**
+ * Returns the header name a scheme writes to, after validating any caller-supplied
+ * name. Validation runs even for schemes that ignore `headerName` so a malformed
+ * value is reported rather than silently discarded.
+ *
+ * @throws {TaskConfigurationError} when `headerName` is not a bare header token.
+ */
+export function credentialHeaderName(
+  scheme: CredentialScheme,
+  headerName: string | undefined
+): string {
+  if (headerName !== undefined && !CREDENTIAL_HEADER_NAME_PATTERN.test(headerName)) {
+    throw new TaskConfigurationError(
+      `FetchUrlTask: invalid credential_header ${JSON.stringify(headerName)}. ` +
+        "Header names must be 1-64 characters of letters, digits, or hyphens."
+    );
+  }
+  if (scheme === CredentialSchemes.HEADER) {
+    return headerName ?? DEFAULT_CREDENTIAL_HEADER;
+  }
+  return DEFAULT_CREDENTIAL_HEADER;
+}
+
+/**
+ * Places a resolved credential onto a copy of `headers` according to `scheme`.
+ *
+ * Pure: it never reads a credential store and never mutates its arguments. A
+ * resolved credential wins over a same-named header the caller supplied — the
+ * credential store is the authoritative source, and letting a hard-coded header
+ * shadow it would silently defeat the configured credential.
+ *
+ * @throws {TaskConfigurationError} when `headerName` is not a bare header token.
+ */
+export function applyCredentialToHeaders(
+  options: ApplyCredentialOptions
+): Record<string, string> | undefined {
+  const { headers, credential, headerName } = options;
+  const scheme = options.scheme ?? DEFAULT_CREDENTIAL_SCHEME;
+
+  // Validated unconditionally: a bad header name is a configuration error even
+  // when the active scheme would not have used it.
+  const name = credentialHeaderName(scheme, headerName);
+
+  if (!credential || scheme === CredentialSchemes.NONE) {
+    return headers ? { ...headers } : headers;
+  }
+
+  const value =
+    scheme === CredentialSchemes.BEARER
+      ? `Bearer ${credential}`
+      : scheme === CredentialSchemes.BASIC
+        ? `Basic ${credential}`
+        : credential;
+
+  return { ...headers, [name]: value };
+}

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -27,6 +27,7 @@ import {
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { safeFetch } from "../util/SafeFetch";
 import { classifyUrl, urlResourcePattern } from "../util/UrlClassifier";
+import { applyCredentialToHeaders } from "./FetchUrlCredentials";
 import {
   createFetchUrlAbortedError,
   createFetchUrlHttpError,
@@ -81,7 +82,23 @@ const inputSchema = {
       format: "credential",
       title: "Credential Key",
       description:
-        "Key to look up in the credential store. The resolved value is sent as a Bearer token in the Authorization header.",
+        "Key to look up in the credential store. The resolved secret is placed on the request according to credential_scheme. Incompatible with the queued path, which would persist the secret.",
+      "x-ui-hidden": true,
+    },
+    credential_scheme: {
+      enum: ["bearer", "basic", "header", "none"],
+      title: "Credential Scheme",
+      description:
+        "How the resolved credential is sent. 'bearer' and 'basic' use the Authorization header ('basic' expects an already base64-encoded user:pass); 'header' uses credential_header; 'none' resolves but sends nothing.",
+      default: "bearer",
+      "x-ui-hidden": true,
+    },
+    credential_header: {
+      type: "string",
+      title: "Credential Header",
+      description:
+        "Header name used when credential_scheme is 'header'. Must be a bare header token (letters, digits, hyphens).",
+      default: "Authorization",
       "x-ui-hidden": true,
     },
   },
@@ -480,25 +497,49 @@ export class FetchUrlTask<
   /**
    * Executes the fetch task, either directly or via a job queue depending on
    * the `queue` config/input. Credential resolution is handled by the input
-   * resolver system — credential_key arrives already resolved.
+   * resolver system — credential_key arrives already resolved to the secret.
+   *
+   * Invariant: a resolved secret never leaves this method. Job queues persist
+   * their payloads durably (SQLite/Postgres/SQS), so the secret is only ever
+   * placed on the in-process request headers of the inline path, and the
+   * queued path refuses to run at all when a credential is present.
    */
   override async execute(
     input: FetchUrlTaskInput,
     executeContext: IExecuteContext
   ): Promise<Output> {
-    // Apply credential as Authorization header and strip it from the payload
-    // so the secret is not persisted to queue storage.
     const credential = input.credential_key;
-    let jobInput: FetchUrlTaskInput = input;
-    if (credential) {
-      const { credential_key: _omit, ...rest } = input;
-      jobInput = {
-        ...rest,
-        headers: { ...input.headers, Authorization: `Bearer ${credential}` },
-      };
+    const queuePref = this.config.queue ?? false;
+
+    // Refuse rather than silently downgrading to the inline path: a downgrade
+    // would quietly drop the queue's rate limiting, which is the reason the
+    // caller asked for a queue in the first place.
+    if (credential && queuePref !== false) {
+      throw new TaskConfigurationError(
+        "FetchUrlTask: credential_key cannot be combined with the queued path (config.queue), " +
+          "because queued job payloads are persisted to durable storage. Remove config.queue to " +
+          "run inline, or have the queue worker supply the credential itself."
+      );
     }
 
-    const queuePref = this.config.queue ?? false;
+    // Strip the credential ports unconditionally — after input resolution
+    // credential_key holds the secret itself, not the reference id, so it must
+    // never survive as a data port. The scheme decides where (or whether) the
+    // secret is placed; the job only ever sees the resulting headers.
+    const {
+      credential_key: _omitCredential,
+      credential_scheme: _omitScheme,
+      credential_header: _omitHeader,
+      ...rest
+    } = input;
+    const headers = applyCredentialToHeaders({
+      headers: input.headers,
+      credential,
+      scheme: input.credential_scheme,
+      headerName: input.credential_header,
+    });
+    const jobInput: FetchUrlTaskInput = headers ? { ...rest, headers } : rest;
+
     let cleanup: () => void = () => {};
 
     try {

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -11,6 +11,7 @@ import {
   InMemoryRateLimiterStorage,
   JobQueueClient,
   JobQueueServer,
+  JobStatus,
   PermanentJobError,
   RateLimiter,
   RetryableJobError,
@@ -20,9 +21,11 @@ import {
   getTaskQueueRegistry,
   JobTaskFailedError,
   setTaskQueueRegistry,
+  TaskConfigurationError,
 } from "@workglow/task-graph";
 import type { FetchUrlTaskInput, FetchUrlTaskOutput } from "@workglow/tasks";
 import {
+  applyCredentialToHeaders,
   createFetchUrlJobError,
   fetchUrl,
   FetchUrlErrorCode,
@@ -32,7 +35,15 @@ import {
   registerSafeFetch,
   type SafeFetchFn,
 } from "@workglow/tasks";
-import { setLogger, sleep } from "@workglow/util";
+import {
+  Container,
+  InMemoryCredentialStore,
+  registerCredentialDefaults,
+  ServiceRegistry,
+  setGlobalCredentialStore,
+  setLogger,
+  sleep,
+} from "@workglow/util";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
 
@@ -783,6 +794,343 @@ describe("FetchUrlTask", () => {
       expect(isFetchUrlJobError(jobErr)).toBe(true);
       expect((jobErr as { code?: string }).code).toBe(FetchUrlErrorCode.NETWORK_ERROR);
       expect(jobErr).toBeInstanceOf(RetryableJobError);
+    });
+  });
+
+  describe("credentials", () => {
+    const SECRET = "sk-super-secret-value-1234567890";
+    const CREDENTIAL_KEY = "my-api-credential";
+
+    /**
+     * Builds a registry scoped to its own container so the credential store
+     * never leaks into the global registry shared by the other suites.
+     */
+    const createCredentialRegistry = async (
+      entries: Readonly<Record<string, string>> = { [CREDENTIAL_KEY]: SECRET }
+    ): Promise<ServiceRegistry> => {
+      const registry = new ServiceRegistry(new Container());
+      registerCredentialDefaults(registry);
+      const store = new InMemoryCredentialStore();
+      for (const [key, value] of Object.entries(entries)) {
+        await store.put(key, value);
+      }
+      setGlobalCredentialStore(store, registry);
+      return registry;
+    };
+
+    const lastRequestHeaders = (): Record<string, string> => {
+      const call = mockFetch.mock.calls.at(-1);
+      const options = call?.[1] as { headers?: Record<string, string> } | undefined;
+      return options?.headers ?? {};
+    };
+
+    test("resolves credential_key into an Authorization: Bearer header", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(createMockResponse({ ok: true })));
+
+      const registry = await createCredentialRegistry();
+      const task = new FetchUrlTask();
+      await task.run(
+        { url: "https://api.example.com/data", credential_key: CREDENTIAL_KEY },
+        { registry }
+      );
+
+      expect(lastRequestHeaders().Authorization).toBe(`Bearer ${SECRET}`);
+    });
+
+    test("keeps the secret out of the request body and off the job input", async () => {
+      let seenInput: FetchUrlTaskInput | undefined;
+      const originalExecute = FetchUrlJob.prototype.execute;
+      const spy = vi.spyOn(FetchUrlJob.prototype, "execute").mockImplementation(async function (
+        this: FetchUrlJob,
+        input: any,
+        context: any
+      ) {
+        seenInput = input;
+        return originalExecute.call(this, input, context) as any;
+      });
+
+      try {
+        mockFetch.mockImplementation(() => Promise.resolve(createMockResponse({ ok: true })));
+
+        const registry = await createCredentialRegistry();
+        const task = new FetchUrlTask();
+        await task.run(
+          {
+            url: "https://api.example.com/data",
+            method: "POST",
+            body: "payload-without-secrets",
+            credential_key: CREDENTIAL_KEY,
+          },
+          { registry }
+        );
+
+        // The resolved secret must never survive as a data port: it is a header,
+        // not an input field the job (or a queue) can persist.
+        expect(seenInput).toBeDefined();
+        expect(seenInput).not.toHaveProperty("credential_key");
+        expect(seenInput?.body).toBe("payload-without-secrets");
+
+        const call = mockFetch.mock.calls.at(-1);
+        const options = call?.[1] as { body?: string } | undefined;
+        expect(options?.body).toBe("payload-without-secrets");
+        expect(options?.body ?? "").not.toContain(SECRET);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // Regression: a resolved secret must never reach durable queue storage.
+    // The queued path persists the job input (SQLite/Postgres/SQS), so the
+    // credential is refused up front instead of being written to disk.
+    // -----------------------------------------------------------------------
+    test("refuses the queued path when a credential is present, and persists no secret", async () => {
+      const queueName = "credential-leak-queue";
+      const storage = new InMemoryQueueStorage<FetchUrlTaskInput, FetchUrlTaskOutput>(queueName);
+      await storage.migrate();
+      const { messageQueue, jobStore } = wrapQueueStorage(storage);
+      const server = new JobQueueServer<FetchUrlTaskInput, FetchUrlTaskOutput>(FetchUrlJob, {
+        messageQueue,
+        jobStore,
+        queueName,
+        pollIntervalMs: 1,
+      });
+      const client = new JobQueueClient<FetchUrlTaskInput, FetchUrlTaskOutput>({
+        messageQueue,
+        jobStore,
+        queueName,
+      });
+      client.attach(server);
+      getTaskQueueRegistry().registerQueue({ server, client, storage });
+
+      mockFetch.mockImplementation(() => Promise.resolve(createMockResponse({ ok: true })));
+
+      try {
+        const registry = await createCredentialRegistry();
+        const task = new FetchUrlTask({ queue: queueName });
+        const error = await task
+          .run(
+            { url: "https://api.example.com/data", credential_key: CREDENTIAL_KEY },
+            { registry }
+          )
+          .catch((e: unknown) => e);
+
+        // The leak assertion comes first: it is the defect under regression.
+        const persisted = JSON.stringify(storage.jobQueue);
+        expect(persisted).not.toContain(SECRET);
+        expect(await storage.size(JobStatus.PENDING)).toBe(0);
+
+        // ...and the refusal must be explicit, never a silent downgrade to the
+        // inline path (which would quietly drop queue-level rate limiting).
+        const configError = (error as { cause?: unknown })?.cause ?? error;
+        expect(String((configError as Error)?.message ?? "")).toContain("credential");
+        expect(String((configError as Error)?.message ?? "")).not.toContain(SECRET);
+      } finally {
+        await server.stop();
+        await storage.deleteAll();
+      }
+    });
+
+    test("credential_scheme 'header' places the secret in the named header only", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(createMockResponse({ ok: true })));
+
+      const registry = await createCredentialRegistry();
+      const task = new FetchUrlTask();
+      await task.run(
+        {
+          url: "https://api.example.com/data",
+          credential_key: CREDENTIAL_KEY,
+          credential_scheme: "header",
+          credential_header: "X-Api-Key",
+        },
+        { registry }
+      );
+
+      const headers = lastRequestHeaders();
+      expect(headers["X-Api-Key"]).toBe(SECRET);
+      expect(headers.Authorization).toBeUndefined();
+    });
+
+    test("credential_scheme 'basic' sends the secret as a Basic credential", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(createMockResponse({ ok: true })));
+
+      const registry = await createCredentialRegistry();
+      const task = new FetchUrlTask();
+      await task.run(
+        {
+          url: "https://api.example.com/data",
+          credential_key: CREDENTIAL_KEY,
+          credential_scheme: "basic",
+        },
+        { registry }
+      );
+
+      expect(lastRequestHeaders().Authorization).toBe(`Basic ${SECRET}`);
+    });
+
+    test("credential_scheme 'none' resolves the credential but sends no header", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(createMockResponse({ ok: true })));
+
+      const registry = await createCredentialRegistry();
+      const task = new FetchUrlTask();
+      await task.run(
+        {
+          url: "https://api.example.com/data",
+          credential_key: CREDENTIAL_KEY,
+          credential_scheme: "none",
+        },
+        { registry }
+      );
+
+      const headers = lastRequestHeaders();
+      expect(headers.Authorization).toBeUndefined();
+      expect(JSON.stringify(headers)).not.toContain(SECRET);
+    });
+
+    test("rejects a credential_header carrying CRLF (header injection)", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(createMockResponse({ ok: true })));
+
+      const registry = await createCredentialRegistry();
+      const task = new FetchUrlTask();
+      const error = await task
+        .run(
+          {
+            url: "https://api.example.com/data",
+            credential_key: CREDENTIAL_KEY,
+            credential_scheme: "header",
+            credential_header: "X-Api-Key\r\nX-Injected: evil",
+          },
+          { registry }
+        )
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(Error);
+      const configError = (error as { cause?: unknown })?.cause ?? error;
+      expect(String((configError as Error)?.message ?? "")).toContain("credential_header");
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    test("a missing credential key sends no Authorization and never echoes the key name", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(createMockResponse({ ok: true })));
+
+      // Registry has a store, but not this key.
+      const registry = await createCredentialRegistry({ "some-other-key": SECRET });
+      const task = new FetchUrlTask();
+      await task.run(
+        { url: "https://api.example.com/data", credential_key: "absent-key-name" },
+        { registry }
+      );
+
+      const headers = lastRequestHeaders();
+      expect(headers.Authorization).toBeUndefined();
+      // Guards the CredentialStoreRegistry invariant: a miss resolves to
+      // undefined, never to the reference id, so the key *name* is never
+      // threaded through as if it were the secret.
+      expect(JSON.stringify(headers)).not.toContain("absent-key-name");
+    });
+
+    test("a resolved credential overrides a user-supplied Authorization header", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(createMockResponse({ ok: true })));
+
+      const registry = await createCredentialRegistry();
+      const task = new FetchUrlTask();
+      await task.run(
+        {
+          url: "https://api.example.com/data",
+          headers: { Authorization: "Bearer hard-coded-token", "X-Trace": "keep-me" },
+          credential_key: CREDENTIAL_KEY,
+        },
+        { registry }
+      );
+
+      const headers = lastRequestHeaders();
+      expect(headers.Authorization).toBe(`Bearer ${SECRET}`);
+      expect(headers["X-Trace"]).toBe("keep-me");
+    });
+  });
+
+  describe("applyCredentialToHeaders", () => {
+    test("defaults to bearer and leaves other headers intact", () => {
+      expect(
+        applyCredentialToHeaders({
+          headers: { "X-Trace": "abc" },
+          credential: "s3cret",
+          scheme: undefined,
+          headerName: undefined,
+        })
+      ).toEqual({ "X-Trace": "abc", Authorization: "Bearer s3cret" });
+    });
+
+    test("passes a basic credential through verbatim", () => {
+      expect(
+        applyCredentialToHeaders({
+          headers: undefined,
+          credential: "dXNlcjpwYXNz",
+          scheme: "basic",
+          headerName: undefined,
+        })
+      ).toEqual({ Authorization: "Basic dXNlcjpwYXNz" });
+    });
+
+    test("places the credential in a custom header", () => {
+      expect(
+        applyCredentialToHeaders({
+          headers: undefined,
+          credential: "s3cret",
+          scheme: "header",
+          headerName: "X-Api-Key",
+        })
+      ).toEqual({ "X-Api-Key": "s3cret" });
+    });
+
+    test("'none' applies nothing", () => {
+      expect(
+        applyCredentialToHeaders({
+          headers: { "X-Trace": "abc" },
+          credential: "s3cret",
+          scheme: "none",
+          headerName: undefined,
+        })
+      ).toEqual({ "X-Trace": "abc" });
+    });
+
+    test("an absent credential is a no-op", () => {
+      expect(
+        applyCredentialToHeaders({
+          headers: { "X-Trace": "abc" },
+          credential: undefined,
+          scheme: "bearer",
+          headerName: undefined,
+        })
+      ).toEqual({ "X-Trace": "abc" });
+    });
+
+    test.each([
+      ["X-Api-Key\r\nX-Injected: evil"],
+      ["X-Api Key"],
+      ["X-Api:Key"],
+      [""],
+      ["a".repeat(65)],
+    ])("rejects invalid header name %j", (headerName) => {
+      expect(() =>
+        applyCredentialToHeaders({
+          headers: undefined,
+          credential: "s3cret",
+          scheme: "header",
+          headerName,
+        })
+      ).toThrow(TaskConfigurationError);
+    });
+
+    test("validates the header name even when the scheme ignores it", () => {
+      expect(() =>
+        applyCredentialToHeaders({
+          headers: undefined,
+          credential: "s3cret",
+          scheme: "bearer",
+          headerName: "bad\r\nname",
+        })
+      ).toThrow(TaskConfigurationError);
     });
   });
 

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -1122,6 +1122,29 @@ describe("FetchUrlTask", () => {
       ).toThrow(TaskConfigurationError);
     });
 
+    test("replaces a differently-cased header the caller supplied", () => {
+      // HTTP header names are case-insensitive, and `new Headers({...})` folds
+      // duplicate spellings into one comma-joined field — so leaving the
+      // caller's key in place would send the stale token alongside the real one.
+      expect(
+        applyCredentialToHeaders({
+          headers: { authorization: "Bearer stale", "X-Trace": "abc" },
+          credential: "s3cret",
+          scheme: "bearer",
+          headerName: undefined,
+        })
+      ).toEqual({ "X-Trace": "abc", Authorization: "Bearer s3cret" });
+
+      expect(
+        applyCredentialToHeaders({
+          headers: { "x-api-key": "stale" },
+          credential: "s3cret",
+          scheme: "header",
+          headerName: "X-Api-Key",
+        })
+      ).toEqual({ "X-Api-Key": "s3cret" });
+    });
+
     test("validates the header name even when the scheme ignores it", () => {
       expect(() =>
         applyCredentialToHeaders({


### PR DESCRIPTION
Fixes the two remaining defects in `FetchUrlTask`'s credential handling. The broader credential subsystem (`ICredentialStore`, the stores, `CREDENTIAL_STORE`, the `format: "credential"` resolver path, AI credential resolution) was already shipped and is unchanged here — see the now-closed #238.

## Security defect (#673)

`FetchUrlTask` resolved `credential_key` into the real secret and wrote it as an `Authorization` header onto **the same object** that was then handed to the queue:

```ts
jobInput = { ...rest, headers: { ...input.headers, Authorization: `Bearer ${credential}` } };
// ...
const handle = await registeredQueue.client.send(jobInput as Input, { ... });
```

A source comment claimed the credential was stripped "so the secret is not persisted to queue storage". It stripped the `credential_key` field but not the header it had just written. Queue bodies are persisted durably (SQLite / Postgres / SQS), so the bearer token was written to storage.

**Scope: the opt-in queued path only** (`config.queue` truthy). The default inline path (`queue ?? false`) never reached the queue and was not affected.

### Behavior chosen

The queued path now **refuses to run** when a credential is present, raising a `TaskConfigurationError`:

```
FetchUrlTask: credential_key cannot be combined with the queued path (config.queue),
because queued job payloads are persisted to durable storage. Remove config.queue to
run inline, or have the queue worker supply the credential itself.
```

Explicit refusal rather than a silent downgrade to the inline path — a downgrade would quietly drop the per-domain rate limiting that is the whole reason a caller asks for a queue. Resolving the credential inside `FetchUrlJob.execute()` was rejected as the alternative: run-fns execute in workers with a separate `globalServiceRegistry`, so touching a credential store there violates the worker-isolation rule in CLAUDE.md.

All three credential ports are now stripped from the job input unconditionally, so a resolved secret only ever exists as an in-process request header. The misleading comment is replaced with the real invariant.

## Credential schemes (#674)

`Authorization: Bearer` was hard-coded, so non-OAuth APIs could not use credential references. Added two plain non-secret config ports (only `credential_key` carries `format: "credential"`):

| Field | Type | Default |
|-------|------|---------|
| `credential_scheme` | `bearer \| basic \| header \| none` | `bearer` |
| `credential_header` | `string` | `Authorization` |

`bearer` remains the default, so **this is not a breaking change**. `basic` sends the secret verbatim as a pre-encoded `user:pass` base64 blob — no splitting or encoding is invented here. `header` places the raw secret in `credential_header` for API-key style services.

`credential_header` is validated as a bare header token (1–64 chars of letters, digits, hyphens); anything else raises a `TaskConfigurationError`. This rejects the CR/LF, colon and whitespace that would otherwise permit header injection. Validation runs even for schemes that ignore the field, so a malformed name is reported rather than silently discarded.

Placement logic is extracted into the exported pure function `applyCredentialToHeaders()` (`packages/tasks/src/task/FetchUrlCredentials.ts`) so it is unit-testable directly.

**Precedence decision:** a resolved credential **overwrites** a same-named header supplied in `headers`. The credential store is authoritative, and letting a hard-coded header shadow it would silently defeat the configured credential. This matches the previous behavior and is now asserted and documented.

## Docs (#673)

`docs/technical/15-credential-management.md` claimed that on a store miss "the resolver returns the original string unchanged". The code deliberately returns `undefined` — echoing the id would thread the credential's *name* through as its *value*, sending the key name to the remote host in an `Authorization` header and masking the misconfiguration. The doc now matches the code, and gains a section covering the new fields and the queue interaction.

## Tests

`packages/test/src/test/task/FetchTask.test.ts` had zero credential coverage. Added 12 tests using `InMemoryCredentialStore` on a `ServiceRegistry` scoped to its own `Container`, plus direct unit tests of the pure function.

## Verification

The G1 regression test was written first and confirmed failing on unmodified `main`. The failure shows the secret verbatim inside the persisted queue row:

```
FAIL  FetchUrlTask > credentials > refuses the queued path when a credential is present, and persists no secret
AssertionError: expected '[{"queue":"credential-leak-queue","in…' not to contain 'sk-super-secret-value-1234567890'

Received: "[{"queue":"credential-leak-queue","input":{"method":"GET",
"headers":{"Authorization":"Bearer sk-super-secret-value-1234567890"},
"response_type":null,"url":"https://api.example.com/data"},...,"status":"COMPLETED",...}]"

 ❯ packages/test/src/test/task/FetchTask.test.ts:915:31
```

After the fix:

```
$ npx vitest run packages/test/src/test/task/FetchTask.test.ts
 Test Files  1 passed (1)
      Tests  56 passed (56)

$ bun run build
 Tasks:    84 successful, 84 total

$ bun scripts/test.ts task vitest
 Test Files  72 passed (72)
      Tests  1152 passed | 24 skipped (1176)

$ bun run build:types
 Tasks:    41 successful, 41 total

$ npx vitest run packages/test/src/test/util/CredentialStore.test.ts packages/test/src/test/task/FetchUrlSsrf.test.ts
 Test Files  2 passed (2)
      Tests  89 passed (89)
```

## Not in scope

AWS Secrets Manager / HashiCorp Vault / GCP Secret Manager adapters are tracked separately in #675 and are not attempted here — three heavyweight SDKs with three auth models, untestable in CI, and no consumer in this repo currently needs them.

Closes #673
Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwyJuFrJnibKvrrk8Fa4Fn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwyJuFrJnibKvrrk8Fa4Fn)_