### PR TITLE
feat(ai): add a uniform usage telemetry channel (Phase 1: the generic seam)

### DIFF
--- a/packages/ai/src/capability/StreamEventAccumulator.ts
+++ b/packages/ai/src/capability/StreamEventAccumulator.ts
@@ -4,8 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { StreamEvent, TaskOutput } from "@workglow/task-graph";
-import { REFUSAL_CATEGORY_OUTPUT_KEY, REFUSAL_OUTPUT_KEY } from "@workglow/task-graph";
+import type { StreamEvent, TaskOutput, Usage } from "@workglow/task-graph";
+import {
+  mergeUsage,
+  REFUSAL_CATEGORY_OUTPUT_KEY,
+  REFUSAL_OUTPUT_KEY,
+  USAGE_OUTPUT_KEY,
+} from "@workglow/task-graph";
 
 const isNonEmptyObject = (v: unknown): v is Record<string, unknown> =>
   v !== null && typeof v === "object" && !Array.isArray(v) && Object.keys(v).length > 0;
@@ -55,6 +60,7 @@ export class StreamEventAccumulator<T extends TaskOutput = TaskOutput> {
   private finishData: T | undefined;
   private refusalText = "";
   private refusalCategory: string | undefined;
+  private usage: Usage | undefined;
   /**
    * The `type` of the most recent observed event. Surfaced in the
    * no-finish materialise error so operators can see what the stream
@@ -125,6 +131,9 @@ export class StreamEventAccumulator<T extends TaskOutput = TaskOutput> {
   observeFinish(event: Extract<StreamEvent<T>, { type: "finish" }>): void {
     this.finished = true;
     this.finishData = event.data;
+    // Merged rather than replaced: a consumer driving several finishes through
+    // one accumulator (a tool-calling loop) is billed for every turn.
+    this.usage = mergeUsage(this.usage, event.usage);
     this.lastEventType = "finish";
   }
 
@@ -141,19 +150,19 @@ export class StreamEventAccumulator<T extends TaskOutput = TaskOutput> {
     }
     // One-shot: finish carries the complete payload.
     if (!this.hasTextDeltas && !this.hasObjectDeltas && !this.hasSnapshots) {
-      if (isNonEmptyObject(this.finishData)) return this.applyRefusal(this.finishData);
-      return this.applyRefusal(this.finishData as unknown as T);
+      if (isNonEmptyObject(this.finishData)) return this.finalize(this.finishData);
+      return this.finalize(this.finishData as unknown as T);
     }
 
     // Snapshot (replace) mode — last snapshot wins, finish merged on top.
     if (this.hasSnapshots && !this.hasTextDeltas && !this.hasObjectDeltas) {
       if (isNonEmptyObject(this.finishData)) {
-        return this.applyRefusal({
+        return this.finalize({
           ...(this.snapshotAccumulator as object),
           ...(this.finishData as object),
         } as T);
       }
-      return this.applyRefusal(this.snapshotAccumulator as T);
+      return this.finalize(this.snapshotAccumulator as T);
     }
 
     // Delta mode — text and/or object deltas. Accumulated deltas take precedence
@@ -174,7 +183,30 @@ export class StreamEventAccumulator<T extends TaskOutput = TaskOutput> {
     for (const [port, obj] of this.objectAccumulator) {
       result[port] = obj;
     }
-    return this.applyRefusal(result as unknown as T);
+    return this.finalize(result as unknown as T);
+  }
+
+  /**
+   * Applies every reserved output field to a materialised value. Usage is
+   * folded last so a refused turn still reports the tokens it was billed for —
+   * {@link applyRefusal} returns early when nothing was refused.
+   */
+  private finalize(output: T): T {
+    return this.applyUsage(this.applyRefusal(output));
+  }
+
+  /**
+   * Folds accumulated token counts into the reserved `usage` output field.
+   * No-op when no provider reported usage, so the key is absent rather than
+   * present-and-empty.
+   */
+  private applyUsage(output: T): T {
+    if (!this.usage) return output;
+    const base = (output !== null && typeof output === "object" ? output : {}) as Record<
+      string,
+      unknown
+    >;
+    return { ...base, [USAGE_OUTPUT_KEY]: this.usage } as unknown as T;
   }
 
   /**

--- a/packages/ai/src/capability/StreamEvents.ts
+++ b/packages/ai/src/capability/StreamEvents.ts
@@ -18,4 +18,12 @@ export type {
   StreamPhase,
   StreamSnapshot,
   StreamTextDelta,
+  Usage,
 } from "@workglow/task-graph";
+
+/**
+ * Usage helpers are re-exported as values so a provider package can normalize
+ * its own token counts (`import type { Usage } from "@workglow/ai"`) without
+ * depending on `@workglow/task-graph` directly.
+ */
+export { USAGE_OUTPUT_KEY, mergeUsage } from "@workglow/task-graph";

--- a/packages/ai/src/capability/UsageTelemetry.ts
+++ b/packages/ai/src/capability/UsageTelemetry.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TaskOutput, Usage } from "@workglow/task-graph";
+import { USAGE_OUTPUT_KEY } from "@workglow/task-graph";
+import type { SpanAttributes } from "@workglow/util";
+import { getLogger, getTelemetryProvider } from "@workglow/util";
+
+/**
+ * Reads the reserved `usage` field off a materialised task output. Returns
+ * `undefined` when the field is absent — no provider on this run reported
+ * token counts.
+ */
+export function readUsage(output: TaskOutput | undefined): Usage | undefined {
+  if (!output || typeof output !== "object") return undefined;
+  const usage = (output as Record<string, unknown>)[USAGE_OUTPUT_KEY];
+  if (!usage || typeof usage !== "object") return undefined;
+  return usage as Usage;
+}
+
+/**
+ * Flattens {@link Usage} into OpenTelemetry gen-ai semantic-convention span
+ * attributes. Unreported counters are omitted rather than zeroed, so a
+ * consumer can tell "billed nothing" from "told us nothing".
+ */
+function usageAttributes(usage: Usage, modelId: string | undefined): SpanAttributes {
+  const attributes: SpanAttributes = {};
+  if (modelId !== undefined) attributes["gen_ai.request.model"] = modelId;
+  if (usage.input !== undefined) attributes["gen_ai.usage.input_tokens"] = usage.input;
+  if (usage.output !== undefined) attributes["gen_ai.usage.output_tokens"] = usage.output;
+  if (usage.cached !== undefined) attributes["gen_ai.usage.cached_input_tokens"] = usage.cached;
+  if (usage.cacheWrite !== undefined) {
+    attributes["gen_ai.usage.cache_write_input_tokens"] = usage.cacheWrite;
+  }
+  if (usage.reasoning !== undefined) {
+    attributes["gen_ai.usage.reasoning_tokens"] = usage.reasoning;
+  }
+  if (usage.total !== undefined) attributes["gen_ai.usage.total_tokens"] = usage.total;
+  if (usage.extra) {
+    for (const [key, value] of Object.entries(usage.extra)) {
+      attributes[`gen_ai.usage.extra.${key}`] = value;
+    }
+  }
+  return attributes;
+}
+
+/**
+ * Records one run's token accounting on a telemetry span and a debug log line.
+ *
+ * Called once from the AI task layer, never from a provider run-fn: providers
+ * normalize their own numbers into {@link Usage} and stay free of any telemetry
+ * dependency (they also execute inside workers, where the main thread's
+ * telemetry provider does not exist).
+ *
+ * No-ops when the run reported no usage. The span is skipped when no telemetry
+ * provider is collecting, so the attribute flattening is never paid for.
+ */
+export function recordUsageTelemetry(
+  output: TaskOutput | undefined,
+  taskType: string,
+  modelId: string | undefined
+): void {
+  const usage = readUsage(output);
+  if (!usage) return;
+
+  const telemetry = getTelemetryProvider();
+  if (telemetry.isEnabled) {
+    const span = telemetry.startSpan("workglow.ai.usage", {
+      attributes: { "workglow.task.type": taskType, ...usageAttributes(usage, modelId) },
+    });
+    span.end();
+  }
+
+  getLogger().debug(`AI usage for ${taskType}`, { model: modelId, usage });
+}

--- a/packages/ai/src/capability/index.ts
+++ b/packages/ai/src/capability/index.ts
@@ -13,3 +13,4 @@ export * from "./collectStream";
 export * from "./emitQueue";
 export * from "./StreamEventAccumulator";
 export * from "./StreamEvents";
+export * from "./UsageTelemetry";

--- a/packages/ai/src/task/AiChatWithKbTask.ts
+++ b/packages/ai/src/task/AiChatWithKbTask.ts
@@ -6,8 +6,8 @@
 
 import type { ChunkSearchResult, KnowledgeBase } from "@workglow/knowledge-base";
 import { getKnowledgeBase, slugifyHeading } from "@workglow/knowledge-base";
-import type { CachePolicy, IExecuteContext, StreamEvent } from "@workglow/task-graph";
-import { TaskConfigSchema } from "@workglow/task-graph";
+import type { CachePolicy, IExecuteContext, StreamEvent, Usage } from "@workglow/task-graph";
+import { mergeUsage, TaskConfigSchema } from "@workglow/task-graph";
 import type { IHumanRequest } from "@workglow/util";
 import { DEFAULT_LIMITS, resolveHumanConnector } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
@@ -433,6 +433,12 @@ export class AiChatWithKbTask extends StreamingAiTask<
     // shift naturally replaces the carry-forward set on the next match.
     let lastNonEmptyRefs: readonly ChatChunkReference[] = [];
 
+    // Token accounting for the whole conversation. Each turn is its own provider
+    // request, and only the outer finish reaches the caller, so the per-turn
+    // counts have to be summed here or the run under-reports its cost by every
+    // turn but the last.
+    let conversationUsage: Usage | undefined;
+
     for (let turn = 0; turn < maxIterations; turn++) {
       const lastUserText = extractLastUserText(history);
 
@@ -632,7 +638,9 @@ export class AiChatWithKbTask extends StreamingAiTask<
                 // Invariant: inner turn run-fns must be text.generation only;
                 // finish.data from inner turns is intentionally discarded. If
                 // json-mode capability is ever added to inner dispatch, this
-                // swallow must be revisited.
+                // swallow must be revisited. The `usage` sibling is NOT
+                // discarded — it is summed onto the outer finish below.
+                conversationUsage = mergeUsage(conversationUsage, event.usage);
               } else {
                 queue.push(event as StreamEvent<AiChatWithKbTaskOutput>);
               }
@@ -698,6 +706,7 @@ export class AiChatWithKbTask extends StreamingAiTask<
     yield {
       type: "finish",
       data: { iterations: completedTurns } as Partial<AiChatWithKbTaskOutput>,
+      ...(conversationUsage ? { usage: conversationUsage } : {}),
     } as StreamEvent<AiChatWithKbTaskOutput>;
   }
 }

--- a/packages/ai/src/task/StructuredGenerationTask.ts
+++ b/packages/ai/src/task/StructuredGenerationTask.ts
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, IRunConfig, StreamEvent, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, TaskConfigurationError, TaskError, Workflow } from "@workglow/task-graph";
+import type {
+  IExecuteContext,
+  IRunConfig,
+  StreamEvent,
+  TaskConfig,
+  Usage,
+} from "@workglow/task-graph";
+import {
+  CreateWorkflow,
+  mergeUsage,
+  TaskConfigurationError,
+  TaskError,
+  USAGE_OUTPUT_KEY,
+  Workflow,
+} from "@workglow/task-graph";
 import { DEFAULT_LIMITS } from "@workglow/util";
 import type { DataPortSchema, SchemaNode } from "@workglow/util/schema";
 import { compileSchema } from "@workglow/util/schema";
@@ -190,6 +203,9 @@ export class StructuredGenerationTask extends StreamingAiTask<
     const maxAttempts = maxRetries + 1;
     const attempts: StructuredOutputValidationAttempt[] = [];
     let currentInput = input;
+    // A rejected attempt is still a billed request. Summing across attempts is
+    // what keeps a schema-flaky model from looking as cheap as a clean one.
+    let attemptsUsage: Usage | undefined;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       let lastObject: Record<string, unknown> | undefined;
@@ -212,8 +228,12 @@ export class StructuredGenerationTask extends StreamingAiTask<
           }
           yield event;
         } else if (event.type === "finish") {
+          attemptsUsage = mergeUsage(attemptsUsage, event.usage);
           if (refused) {
-            yield event as StreamEvent<StructuredGenerationTaskOutput>;
+            yield {
+              ...event,
+              ...(attemptsUsage ? { usage: attemptsUsage } : {}),
+            } as StreamEvent<StructuredGenerationTaskOutput>;
             return;
           }
           // Prefer the finish payload's object (some providers populate it);
@@ -225,6 +245,7 @@ export class StructuredGenerationTask extends StreamingAiTask<
             yield {
               type: "finish",
               data: { object: finalObject } as StructuredGenerationTaskOutput,
+              ...(attemptsUsage ? { usage: attemptsUsage } : {}),
             } as StreamEvent<StructuredGenerationTaskOutput>;
             return;
           }
@@ -270,10 +291,17 @@ export class StructuredGenerationTask extends StreamingAiTask<
     context: IExecuteContext
   ): Promise<StructuredGenerationTaskOutput | undefined> {
     let result: StructuredGenerationTaskOutput | undefined;
+    let usage: Usage | undefined;
     for await (const event of this.executeStream(input, context)) {
       if (event.type === "finish") {
         result = (event as { type: "finish"; data: StructuredGenerationTaskOutput }).data;
+        usage = mergeUsage(usage, event.usage);
       }
+    }
+    // Fold the finish's `usage` sibling onto the returned output so this
+    // direct-drain path reports the same tokens the streaming path does.
+    if (result && usage) {
+      return { ...result, [USAGE_OUTPUT_KEY]: usage } as StructuredGenerationTaskOutput;
     }
     return result;
   }

--- a/packages/ai/src/task/base/AiTask.ts
+++ b/packages/ai/src/task/base/AiTask.ts
@@ -29,6 +29,7 @@ import { accumulatingEmit } from "../../capability/accumulatingEmit";
 import type { AiEmit } from "../../capability/AiEmit";
 import { noopEmit } from "../../capability/AiEmit";
 import type { Capability } from "../../capability/Capabilities";
+import { recordUsageTelemetry } from "../../capability/UsageTelemetry";
 import { AiJob, AiJobInput } from "../../job/AiJob";
 import { MODEL_REPOSITORY } from "../../model/ModelRegistry";
 import type { ModelRepository } from "../../model/ModelRepository";
@@ -249,6 +250,8 @@ export class AiTask<
       // expectations are stable.
       throw providerError;
     }
+
+    recordUsageTelemetry(output, this.type, model.model_id);
 
     // Register a disposer so the caller can release the in-memory model when
     // done. The disposer is wired via the "model.dispose" capability —

--- a/packages/ai/src/task/base/StreamingAiTask.ts
+++ b/packages/ai/src/task/base/StreamingAiTask.ts
@@ -138,34 +138,43 @@ export class StreamingAiTask<
     // record it once the stream drains — a run that streamed its answer costs
     // the same tokens as one that did not.
     let usage: Usage | undefined;
-    for await (const event of iterable) {
-      if (
-        !firstDataSeen &&
-        (event.type === "text-delta" || event.type === "object-delta" || event.type === "snapshot")
-      ) {
-        firstDataSeen = true;
-        yield {
-          type: "phase",
-          message: streamingLabel,
-          progress: undefined,
-        } as StreamEvent<Output>;
-      }
+    // `finally`, not a trailing statement: a consumer that stops early closes
+    // this generator at its `yield` instead of running past the loop. The
+    // retry loop in `StructuredGenerationTask` does exactly that — it returns
+    // (or breaks) the moment it sees `finish` — so a trailing call would never
+    // record the tokens of the task that bills the most of them.
+    try {
+      for await (const event of iterable) {
+        if (
+          !firstDataSeen &&
+          (event.type === "text-delta" ||
+            event.type === "object-delta" ||
+            event.type === "snapshot")
+        ) {
+          firstDataSeen = true;
+          yield {
+            type: "phase",
+            message: streamingLabel,
+            progress: undefined,
+          } as StreamEvent<Output>;
+        }
 
-      if (event.type === "finish") {
-        usage = mergeUsage(usage, event.usage);
-      }
+        if (event.type === "finish") {
+          usage = mergeUsage(usage, event.usage);
+        }
 
-      if (event.type === "text-delta") {
-        yield { ...event, port: event.port ?? defaultPort } as StreamEvent<Output>;
-      } else if (event.type === "object-delta") {
-        yield { ...event, port: event.port ?? defaultPort } as StreamEvent<Output>;
-      } else {
-        yield event as StreamEvent<Output>;
+        if (event.type === "text-delta") {
+          yield { ...event, port: event.port ?? defaultPort } as StreamEvent<Output>;
+        } else if (event.type === "object-delta") {
+          yield { ...event, port: event.port ?? defaultPort } as StreamEvent<Output>;
+        } else {
+          yield event as StreamEvent<Output>;
+        }
       }
-    }
-
-    if (usage) {
-      recordUsageTelemetry({ [USAGE_OUTPUT_KEY]: usage }, this.type, model.model_id);
+    } finally {
+      if (usage) {
+        recordUsageTelemetry({ [USAGE_OUTPUT_KEY]: usage }, this.type, model.model_id);
+      }
     }
   }
 }

--- a/packages/ai/src/task/base/StreamingAiTask.ts
+++ b/packages/ai/src/task/base/StreamingAiTask.ts
@@ -4,9 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, StreamEvent, TaskConfig, TaskOutput } from "@workglow/task-graph";
-import { getStreamingPorts, TaskConfigurationError } from "@workglow/task-graph";
+import type {
+  IExecuteContext,
+  StreamEvent,
+  TaskConfig,
+  TaskOutput,
+  Usage,
+} from "@workglow/task-graph";
+import {
+  getStreamingPorts,
+  mergeUsage,
+  TaskConfigurationError,
+  USAGE_OUTPUT_KEY,
+} from "@workglow/task-graph";
 
+import { recordUsageTelemetry } from "../../capability/UsageTelemetry";
 import type { ModelConfig } from "../../model/ModelSchema";
 import { getAiProviderRegistry } from "../../provider/AiProviderRegistry";
 import type { AiTaskInput } from "./AiTask";
@@ -121,6 +133,11 @@ export class StreamingAiTask<
     );
 
     let firstDataSeen = false;
+    // Streaming tasks never reach `AiTask.execute`, so the telemetry call sited
+    // there would never fire for them. Sum the provider's finish usage here and
+    // record it once the stream drains — a run that streamed its answer costs
+    // the same tokens as one that did not.
+    let usage: Usage | undefined;
     for await (const event of iterable) {
       if (
         !firstDataSeen &&
@@ -134,6 +151,10 @@ export class StreamingAiTask<
         } as StreamEvent<Output>;
       }
 
+      if (event.type === "finish") {
+        usage = mergeUsage(usage, event.usage);
+      }
+
       if (event.type === "text-delta") {
         yield { ...event, port: event.port ?? defaultPort } as StreamEvent<Output>;
       } else if (event.type === "object-delta") {
@@ -141,6 +162,10 @@ export class StreamingAiTask<
       } else {
         yield event as StreamEvent<Output>;
       }
+    }
+
+    if (usage) {
+      recordUsageTelemetry({ [USAGE_OUTPUT_KEY]: usage }, this.type, model.model_id);
     }
   }
 }

--- a/packages/task-graph/src/task/CacheCoordinator.ts
+++ b/packages/task-graph/src/task/CacheCoordinator.ts
@@ -11,7 +11,7 @@ import { RunPrivateCacheRepo } from "../cache/RunPrivateCacheRepo";
 import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ITask } from "./ITask";
 import type { StreamEvent } from "./StreamTypes";
-import { REFUSAL_OUTPUT_KEY } from "./StreamTypes";
+import { REFUSAL_OUTPUT_KEY, USAGE_OUTPUT_KEY } from "./StreamTypes";
 import { Task } from "./Task";
 import type { TaskRunContext } from "./TaskRunContext";
 import type { TaskInput, TaskOutput } from "./TaskTypes";
@@ -155,9 +155,13 @@ export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput
     ) {
       return;
     }
+    // Token counts are a fact about ONE execution, not about the value. Serving
+    // this entry later costs zero tokens, so replaying the original counts would
+    // invent spend that never happened. Unlike a refusal (which blocks the save
+    // entirely), the value itself is still worth memoizing — strip the field.
     const outputSchema = (this.task.constructor as typeof Task).outputSchema();
     const wireOutputs = await CacheCoordinator.serializeOutputPorts(
-      output as Record<string, unknown>,
+      CacheCoordinator.withoutUsage(output as Record<string, unknown>),
       outputSchema as unknown as SchemaProperties
     );
     await outputCache.saveOutput(
@@ -216,6 +220,15 @@ export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput
   // Private static helpers (lifted from current module-private functions in
   // TaskRunner.ts)
   // ========================================================================
+
+  private static withoutUsage(output: Record<string, unknown>): Record<string, unknown> {
+    if (output === null || typeof output !== "object" || !(USAGE_OUTPUT_KEY in output)) {
+      return output;
+    }
+    const stripped = { ...output };
+    delete stripped[USAGE_OUTPUT_KEY];
+    return stripped;
+  }
 
   private static async serializeOutputPorts(
     output: Record<string, unknown>,

--- a/packages/task-graph/src/task/StreamProcessor.ts
+++ b/packages/task-graph/src/task/StreamProcessor.ts
@@ -7,12 +7,14 @@
 import type { ResourceScope, ServiceRegistry } from "@workglow/util";
 import type { Taskish } from "../task-graph/Conversions";
 import type { ITask } from "./ITask";
-import type { StreamEvent, StreamMode } from "./StreamTypes";
+import type { StreamEvent, StreamMode, Usage } from "./StreamTypes";
 import {
   getOutputStreamMode,
   getStreamingPorts,
+  mergeUsage,
   REFUSAL_CATEGORY_OUTPUT_KEY,
   REFUSAL_OUTPUT_KEY,
+  USAGE_OUTPUT_KEY,
 } from "./StreamTypes";
 import { TaskAbortedError, TaskError } from "./TaskError";
 import type { TaskRunContext } from "./TaskRunContext";
@@ -80,6 +82,7 @@ export class StreamProcessor<Input extends TaskInput, Output extends TaskOutput>
     let finalOutput: Output | undefined;
     let refusalText = "";
     let refusalCategory: string | undefined;
+    let usage: Usage | undefined;
 
     this.task.emit("stream_start");
 
@@ -168,6 +171,12 @@ export class StreamProcessor<Input extends TaskInput, Output extends TaskOutput>
           break;
         }
         case "finish": {
+          usage = mergeUsage(usage, event.usage);
+          // Re-attached to every finish this processor constructs below, so a
+          // downstream StreamPump consumer sees the same token counts the
+          // provider reported. Spread conditionally: an unreported usage must
+          // leave no key at all rather than an explicit `usage: undefined`.
+          const usageOnEvent = event.usage ? { usage: event.usage } : {};
           if (accumulated || accumulatedObjects) {
             // Emit an enriched finish event: merge accumulated deltas into
             // the finish payload so downstream dataflows get complete port data
@@ -193,12 +202,17 @@ export class StreamProcessor<Input extends TaskInput, Output extends TaskOutput>
                 this.task.emit("stream_chunk", {
                   type: "finish",
                   data: lastSnapshot,
+                  ...usageOnEvent,
                 } as StreamEvent);
                 break;
               }
             }
             finalOutput = merged as unknown as Output;
-            this.task.emit("stream_chunk", { type: "finish", data: merged } as StreamEvent);
+            this.task.emit("stream_chunk", {
+              type: "finish",
+              data: merged,
+              ...usageOnEvent,
+            } as StreamEvent);
           } else {
             // No accumulation. For replace-mode streams the provider's finish
             // event carries `data: {}` by convention — the snapshots already
@@ -214,6 +228,7 @@ export class StreamProcessor<Input extends TaskInput, Output extends TaskOutput>
                 this.task.emit("stream_chunk", {
                   type: "finish",
                   data: lastSnapshot,
+                  ...usageOnEvent,
                 } as StreamEvent);
                 break;
               }
@@ -262,6 +277,16 @@ export class StreamProcessor<Input extends TaskInput, Output extends TaskOutput>
         ...(this.task.runOutputData as Record<string, unknown> | undefined),
         [REFUSAL_OUTPUT_KEY]: refusalText,
         ...(refusalCategory ? { [REFUSAL_CATEGORY_OUTPUT_KEY]: refusalCategory } : {}),
+      } as unknown as Output;
+    }
+
+    // Same treatment for token accounting: a reserved output field, kept off
+    // dataflow edges, applied after any refusal so a refused turn still reports
+    // what it was billed. Absent when no provider reported usage.
+    if (usage) {
+      this.task.runOutputData = {
+        ...(this.task.runOutputData as Record<string, unknown> | undefined),
+        [USAGE_OUTPUT_KEY]: usage,
       } as unknown as Output;
     }
 

--- a/packages/task-graph/src/task/StreamTypes.ts
+++ b/packages/task-graph/src/task/StreamTypes.ts
@@ -54,15 +54,53 @@ export type StreamSnapshot<Output = Record<string, any>> = {
 };
 
 /**
+ * Provider-agnostic token accounting for one model request.
+ *
+ * Every field is `number | undefined`, and `undefined` means **the provider did
+ * not report this figure** — it is NOT the same as `0`. Cost math depends on the
+ * distinction: a model that bills 0 cached tokens and a model that never tells
+ * you about caching are different facts, and collapsing them to `0` silently
+ * understates spend.
+ *
+ * - `input` / `output` — prompt and completion tokens.
+ * - `cached` — input tokens served from a provider-side prompt cache (read).
+ * - `cacheWrite` — input tokens written into that cache.
+ * - `reasoning` — output tokens spent on hidden reasoning, when reported separately.
+ * - `total` — the provider's own total, when it reports one. Never synthesized.
+ * - `extra` — provider-specific counters that have no normalized slot.
+ */
+export interface Usage {
+  readonly input: number | undefined;
+  readonly output: number | undefined;
+  readonly cached: number | undefined;
+  readonly cacheWrite: number | undefined;
+  readonly reasoning: number | undefined;
+  readonly total: number | undefined;
+  readonly extra: Readonly<Record<string, number | string>> | undefined;
+}
+
+/**
+ * Reserved output-port name that {@link Usage} is surfaced on. Not a declared
+ * task port — kept out of dataflow like {@link REFUSAL_OUTPUT_KEY} and `__cv`.
+ */
+export const USAGE_OUTPUT_KEY = "usage";
+
+/**
  * Signals that the stream has finished. In append mode, the runner
  * accumulates text-delta chunks into the append port (determined by
  * the output schema's `x-stream: "append"` annotation); `data` may
  * carry additional fields (merged into the final output).
  * In replace mode, `data` contains the final output.
+ *
+ * `usage` is a SIBLING of `data`, never a member of it: `data` is governed by
+ * the streaming conventions (`{}` for delta streams, the full payload for
+ * one-shot run-fns, the parsed object for json-mode), and folding token counts
+ * into it would corrupt all three.
  */
 export type StreamFinish<Output = Record<string, any>> = {
   type: "finish";
   data: Output;
+  usage?: Usage;
 };
 
 /**
@@ -93,6 +131,53 @@ export type StreamRefusal = {
  */
 export const REFUSAL_OUTPUT_KEY = "refusal";
 export const REFUSAL_CATEGORY_OUTPUT_KEY = "refusalCategory";
+
+/**
+ * Adds two optional counters while preserving "not reported". Two unreported
+ * counters stay unreported; one reported counter survives a missing partner
+ * unchanged (rather than being diluted by an implicit zero).
+ */
+function addUsageField(a: number | undefined, b: number | undefined): number | undefined {
+  if (a === undefined && b === undefined) return undefined;
+  return (a ?? 0) + (b ?? 0);
+}
+
+function mergeUsageExtra(
+  a: Readonly<Record<string, number | string>> | undefined,
+  b: Readonly<Record<string, number | string>> | undefined
+): Readonly<Record<string, number | string>> | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  const merged: Record<string, number | string> = { ...a };
+  for (const [key, value] of Object.entries(b)) {
+    const existing = merged[key];
+    // Only counters compose. A string is a label (model id, service tier, cache
+    // key), so the later turn's value replaces the earlier one.
+    merged[key] =
+      typeof existing === "number" && typeof value === "number" ? existing + value : value;
+  }
+  return merged;
+}
+
+/**
+ * Combines the token accounting of two requests — a tool-calling loop's turns,
+ * or a structured-generation task's validation retries — into one {@link Usage}.
+ * Field-wise addition that preserves `undefined` (see {@link Usage}), so a
+ * provider that reports nothing never fabricates zeros for the caller's cost math.
+ */
+export function mergeUsage(a: Usage | undefined, b: Usage | undefined): Usage | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return {
+    input: addUsageField(a.input, b.input),
+    output: addUsageField(a.output, b.output),
+    cached: addUsageField(a.cached, b.cached),
+    cacheWrite: addUsageField(a.cacheWrite, b.cacheWrite),
+    reasoning: addUsageField(a.reasoning, b.reasoning),
+    total: addUsageField(a.total, b.total),
+    extra: mergeUsageExtra(a.extra, b.extra),
+  };
+}
 
 /**
  * Phase / status event yielded by a streaming source to signal a named

--- a/packages/test/src/test/ai/AiChatWithKbTask.test.ts
+++ b/packages/test/src/test/ai/AiChatWithKbTask.test.ts
@@ -15,7 +15,7 @@ import type {
 import { AiChatWithKbTask, AiProvider, getAiProviderRegistry, registerAiTasks } from "@workglow/ai";
 import type { ChunkSearchResult, KnowledgeBase } from "@workglow/knowledge-base";
 import { getGlobalKnowledgeBases } from "@workglow/knowledge-base";
-import type { IExecuteContext, StreamEvent } from "@workglow/task-graph";
+import type { IExecuteContext, StreamEvent, Usage } from "@workglow/task-graph";
 import { TaskRegistry } from "@workglow/task-graph";
 import type { IHumanConnector, IHumanRequest, IHumanResponse } from "@workglow/util";
 import { Container, HUMAN_CONNECTOR, ResourceScope, ServiceRegistry } from "@workglow/util";
@@ -1072,6 +1072,172 @@ describe("AiChatWithKbTask — responseFormat", () => {
       expect(captured).toMatch(/\[1\] \[Help\] \(Doc 1\) A/);
       // No `<url>` brackets in text mode.
       expect(captured).not.toContain("</help/d1>");
+    } finally {
+      unregister();
+      fake.unregister();
+    }
+  });
+});
+
+describe("AiChatWithKbTask — usage aggregation across turns", () => {
+  function mkUsage(partial: Partial<Usage>): Usage {
+    return {
+      input: undefined,
+      output: undefined,
+      cached: undefined,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: undefined,
+      extra: undefined,
+      ...partial,
+    };
+  }
+
+  function mkKb(id: string) {
+    return makeFakeKb({
+      id,
+      label: "Help",
+      results: [
+        {
+          chunk_id: "c1",
+          doc_id: "d1",
+          score: 0.9,
+          metadata: { doc_title: "Doc 1", text: "chunk" },
+        } as any,
+      ],
+    });
+  }
+
+  it("sums every turn's usage onto the outer finish, alongside iterations", async () => {
+    const fake = mkKb("kb-usage");
+
+    // Each turn is its own provider request reporting its own token counts.
+    const perTurnUsage = [
+      mkUsage({ input: 100, output: 10, cached: 80, extra: { audioTokens: 4, tier: "standard" } }),
+      mkUsage({ input: 150, output: 20, cached: 120, extra: { audioTokens: 6, tier: "priority" } }),
+    ];
+    let turn = 0;
+    const stream: AiProviderRunFn<any, any, ModelConfig> = async (
+      _taskInput,
+      _model,
+      _signal,
+      emit
+    ) => {
+      const usage = perTurnUsage[Math.min(turn, perTurnUsage.length - 1)];
+      turn++;
+      emit({ type: "text-delta", port: "text", textDelta: "answer" });
+      emit({ type: "finish", data: {} as any, usage } as any);
+    };
+    const unregister = registerFakeChatKbProvider(stream);
+
+    try {
+      const connector = new FakeConnector([
+        { action: "accept", content: { content: "follow up" }, done: false, requestId: "" },
+        { action: "decline", content: undefined, done: true, requestId: "" },
+      ]);
+      const input = {
+        model: mkModel(),
+        prompt: "q",
+        knowledgeBaseIds: ["kb-usage"],
+        maxIterations: 5,
+      };
+      const task = new AiChatWithKbTask({ defaults: input } as any);
+      const { events } = await accumulateKbChatStream(
+        task.executeStream(input as any, mkContext(connector))
+      );
+
+      // Exactly two provider turns ran, so exactly two usages compose.
+      expect(turn).toBe(2);
+      const finishes = events.filter((e) => e.type === "finish");
+      // Inner-turn finishes stay swallowed; only the outer one reaches the consumer.
+      expect(finishes).toHaveLength(1);
+      const outer = finishes[0] as { data: { iterations: number }; usage?: Usage };
+      expect(outer.data.iterations).toBe(2);
+      // Counters sum across turns; the string label takes the later turn's value.
+      expect(outer.usage).toEqual(
+        mkUsage({
+          input: 250,
+          output: 30,
+          cached: 200,
+          extra: { audioTokens: 10, tier: "priority" },
+        })
+      );
+    } finally {
+      unregister();
+      fake.unregister();
+    }
+  });
+
+  it("does not double-count: one turn reports exactly that turn's usage", async () => {
+    const fake = mkKb("kb-usage-1");
+    const stream: AiProviderRunFn<any, any, ModelConfig> = async (
+      _taskInput,
+      _model,
+      _signal,
+      emit
+    ) => {
+      emit({ type: "text-delta", port: "text", textDelta: "answer" });
+      emit({
+        type: "finish",
+        data: {} as any,
+        usage: mkUsage({ input: 100, output: 10 }),
+      } as any);
+    };
+    const unregister = registerFakeChatKbProvider(stream);
+
+    try {
+      const connector = new FakeConnector([
+        { action: "decline", content: undefined, done: true, requestId: "" },
+      ]);
+      const input = {
+        model: mkModel(),
+        prompt: "q",
+        knowledgeBaseIds: ["kb-usage-1"],
+        maxIterations: 5,
+      };
+      const task = new AiChatWithKbTask({ defaults: input } as any);
+      const { events } = await accumulateKbChatStream(
+        task.executeStream(input as any, mkContext(connector))
+      );
+
+      const outer = events.find((e) => e.type === "finish") as { usage?: Usage };
+      expect(outer.usage).toEqual(mkUsage({ input: 100, output: 10 }));
+    } finally {
+      unregister();
+      fake.unregister();
+    }
+  });
+
+  it("omits usage entirely when no turn reported any", async () => {
+    const fake = mkKb("kb-usage-none");
+    const stream: AiProviderRunFn<any, any, ModelConfig> = async (
+      _taskInput,
+      _model,
+      _signal,
+      emit
+    ) => {
+      emit({ type: "text-delta", port: "text", textDelta: "answer" });
+      emit({ type: "finish", data: {} as any });
+    };
+    const unregister = registerFakeChatKbProvider(stream);
+
+    try {
+      const connector = new FakeConnector([
+        { action: "decline", content: undefined, done: true, requestId: "" },
+      ]);
+      const input = {
+        model: mkModel(),
+        prompt: "q",
+        knowledgeBaseIds: ["kb-usage-none"],
+        maxIterations: 5,
+      };
+      const task = new AiChatWithKbTask({ defaults: input } as any);
+      const { events } = await accumulateKbChatStream(
+        task.executeStream(input as any, mkContext(connector))
+      );
+
+      const outer = events.find((e) => e.type === "finish")!;
+      expect("usage" in outer).toBe(false);
     } finally {
       unregister();
       fake.unregister();

--- a/packages/test/src/test/ai/StreamEventAccumulator.test.ts
+++ b/packages/test/src/test/ai/StreamEventAccumulator.test.ts
@@ -5,8 +5,23 @@
  */
 
 import { StreamEventAccumulator } from "@workglow/ai";
-import type { StreamEvent } from "@workglow/task-graph";
+import type { StreamEvent, Usage } from "@workglow/task-graph";
+import { mergeUsage } from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
+
+/** Builds a {@link Usage} with every unstated counter explicitly unreported. */
+function usage(partial: Partial<Usage>): Usage {
+  return {
+    input: undefined,
+    output: undefined,
+    cached: undefined,
+    cacheWrite: undefined,
+    reasoning: undefined,
+    total: undefined,
+    extra: undefined,
+    ...partial,
+  };
+}
 
 interface Out {
   text?: string;
@@ -160,6 +175,91 @@ describe("StreamEventAccumulator", () => {
     expect(acc.materialize()).toEqual({ text: "hi" });
   });
 
+  it("surfaces finish usage on the reserved usage field (one-shot finish)", () => {
+    const acc = new StreamEventAccumulator<Out>();
+    acc.observeFinish({
+      type: "finish",
+      data: { count: 1 },
+      usage: usage({ input: 10, output: 4 }),
+    });
+    const result = acc.materialize();
+    expect(result.count).toBe(1);
+    expect(result.usage).toEqual(usage({ input: 10, output: 4 }));
+  });
+
+  it("keeps one-shot finish data as the payload when usage rides alongside", () => {
+    // The one-shot convention says finish.data IS the Output. A usage sibling
+    // must not displace or reshape it.
+    const acc = new StreamEventAccumulator<Out>();
+    acc.observeFinish({
+      type: "finish",
+      data: { count: 42, items: [1, 2] },
+      usage: usage({ input: 7 }),
+    });
+    const result = acc.materialize();
+    expect(result.count).toBe(42);
+    expect(result.items).toEqual([1, 2]);
+    expect(result.usage).toEqual(usage({ input: 7 }));
+  });
+
+  it("keeps accumulated deltas winning when usage rides on the finish", () => {
+    const acc = new StreamEventAccumulator<Out>();
+    acc.observe({ type: "text-delta", port: "text", textDelta: "Hel" } as StreamEvent<Out>);
+    acc.observe({ type: "text-delta", port: "text", textDelta: "lo" } as StreamEvent<Out>);
+    acc.observeFinish({ type: "finish", data: { text: "" }, usage: usage({ output: 2 }) });
+    const result = acc.materialize();
+    expect(result.text).toBe("Hello");
+    expect(result.usage).toEqual(usage({ output: 2 }));
+  });
+
+  it("surfaces usage in snapshot (replace) mode", () => {
+    const acc = new StreamEventAccumulator<Out>();
+    acc.observe({ type: "snapshot", data: { count: 5 } } as StreamEvent<Out>);
+    acc.observeFinish({ type: "finish", data: {}, usage: usage({ input: 3, output: 1 }) });
+    const result = acc.materialize();
+    expect(result.count).toBe(5);
+    expect(result.usage).toEqual(usage({ input: 3, output: 1 }));
+  });
+
+  it("does not add a usage field when no usage was reported", () => {
+    const acc = new StreamEventAccumulator<Out>();
+    acc.observe({ type: "text-delta", port: "text", textDelta: "hi" } as StreamEvent<Out>);
+    acc.observeFinish({ type: "finish", data: {} });
+    const result = acc.materialize();
+    expect(result).toEqual({ text: "hi" });
+    expect("usage" in result).toBe(false);
+  });
+
+  it("reports usage and refusal together — a refused turn is still billed", () => {
+    const acc = new StreamEventAccumulator<Out>();
+    acc.observe({
+      type: "refusal",
+      refusal: "declined",
+      category: "output-refusal",
+    } as StreamEvent<Out>);
+    acc.observeFinish({ type: "finish", data: {}, usage: usage({ input: 12, output: 3 }) });
+    expect(acc.materialize()).toEqual({
+      refusal: "declined",
+      refusalCategory: "output-refusal",
+      usage: usage({ input: 12, output: 3 }),
+    });
+  });
+
+  it("sums usage across several observed finishes (multi-turn)", () => {
+    const acc = new StreamEventAccumulator<Out>();
+    acc.observe({
+      type: "finish",
+      data: {},
+      usage: usage({ input: 10, output: 2 }),
+    } as StreamEvent<Out>);
+    acc.observe({
+      type: "finish",
+      data: {},
+      usage: usage({ input: 5, output: 3 }),
+    } as StreamEvent<Out>);
+    expect(acc.materialize().usage).toEqual(usage({ input: 15, output: 5 }));
+  });
+
   it("includes lastEventType=(none) when materialize is called with no events at all", () => {
     const acc = new StreamEventAccumulator<Out>();
     let caught: unknown;
@@ -171,5 +271,77 @@ describe("StreamEventAccumulator", () => {
     const err = caught as { code?: string; lastEventType?: string };
     expect(err.code).toBe("ACCUMULATOR_NO_FINISH");
     expect(err.lastEventType).toBe("(none)");
+  });
+});
+
+describe("mergeUsage", () => {
+  it("returns undefined when neither side reported usage", () => {
+    expect(mergeUsage(undefined, undefined)).toBeUndefined();
+  });
+
+  it("returns the reported side verbatim when the other is absent", () => {
+    const a = usage({ input: 5 });
+    expect(mergeUsage(a, undefined)).toBe(a);
+    expect(mergeUsage(undefined, a)).toBe(a);
+  });
+
+  it("preserves undefined field-wise: undefined + undefined stays undefined", () => {
+    // The distinction that makes cost math honest — a counter neither provider
+    // reported must NOT become 0.
+    const merged = mergeUsage(usage({ input: 1 }), usage({ input: 2 }));
+    expect(merged?.input).toBe(3);
+    expect(merged?.cached).toBeUndefined();
+    expect(merged?.cacheWrite).toBeUndefined();
+    expect(merged?.reasoning).toBeUndefined();
+    expect(merged?.total).toBeUndefined();
+  });
+
+  it("preserves a one-sided value: undefined + 5 === 5 (never diluted to 0)", () => {
+    const merged = mergeUsage(usage({ input: 1 }), usage({ input: 2, cached: 5 }));
+    expect(merged?.cached).toBe(5);
+    const flipped = mergeUsage(usage({ cached: 5 }), usage({ input: 2 }));
+    expect(flipped?.cached).toBe(5);
+  });
+
+  it("adds every normalized counter", () => {
+    const merged = mergeUsage(
+      usage({ input: 1, output: 2, cached: 3, cacheWrite: 4, reasoning: 5, total: 6 }),
+      usage({ input: 10, output: 20, cached: 30, cacheWrite: 40, reasoning: 50, total: 60 })
+    );
+    expect(merged).toEqual(
+      usage({ input: 11, output: 22, cached: 33, cacheWrite: 44, reasoning: 55, total: 66 })
+    );
+  });
+
+  it("merges extra: numeric keys are summed, string keys are last-wins", () => {
+    const merged = mergeUsage(
+      usage({ extra: { audioTokens: 4, tier: "standard", onlyA: 1 } }),
+      usage({ extra: { audioTokens: 6, tier: "priority", onlyB: "x" } })
+    );
+    expect(merged?.extra).toEqual({
+      audioTokens: 10,
+      tier: "priority",
+      onlyA: 1,
+      onlyB: "x",
+    });
+  });
+
+  it("carries extra through when only one side has it", () => {
+    expect(mergeUsage(usage({ extra: { a: 1 } }), usage({ input: 2 }))?.extra).toEqual({ a: 1 });
+    expect(mergeUsage(usage({ input: 2 }), usage({ extra: { a: 1 } }))?.extra).toEqual({ a: 1 });
+  });
+
+  it("takes the later value when a key changes between number and string", () => {
+    const merged = mergeUsage(usage({ extra: { k: 3 } }), usage({ extra: { k: "n/a" } }));
+    expect(merged?.extra).toEqual({ k: "n/a" });
+  });
+
+  it("does not mutate either input", () => {
+    const a = usage({ input: 1, extra: { k: 1 } });
+    const b = usage({ input: 2, extra: { k: 2 } });
+    mergeUsage(a, b);
+    expect(a.input).toBe(1);
+    expect(a.extra).toEqual({ k: 1 });
+    expect(b.extra).toEqual({ k: 2 });
   });
 });

--- a/packages/test/src/test/ai/StructuredGenerationTask.test.ts
+++ b/packages/test/src/test/ai/StructuredGenerationTask.test.ts
@@ -17,7 +17,7 @@ import {
   StructuredGenerationTask,
   StructuredOutputValidationError,
 } from "@workglow/ai";
-import type { IExecuteContext } from "@workglow/task-graph";
+import type { IExecuteContext, Usage } from "@workglow/task-graph";
 import { TaskConfigurationError, TaskRegistry } from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
 
@@ -349,5 +349,149 @@ describe("StructuredGenerationTask — schema compile errors", () => {
     expect((caught as TaskConfigurationError).message.toLowerCase()).toContain(
       "invalid outputschema"
     );
+  });
+});
+
+// ============================================================================
+// Usage aggregation across validation retries
+// ============================================================================
+
+describe("StructuredGenerationTask — usage aggregation", () => {
+  function mkUsage(partial: Partial<Usage>): Usage {
+    return {
+      input: undefined,
+      output: undefined,
+      cached: undefined,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: undefined,
+      extra: undefined,
+      ...partial,
+    };
+  }
+
+  /**
+   * Like {@link registerFakeStructuredProvider}, but each scripted attempt also
+   * carries its own token counts on the finish event.
+   */
+  function registerUsageProvider(
+    attempts: ReadonlyArray<{ payload: Record<string, unknown>; usage: Usage | undefined }>
+  ): { unregister: () => void } {
+    let index = 0;
+    const stream: AiProviderRunFn<any, any, ModelConfig> = async (
+      _input,
+      _model,
+      _signal,
+      emit
+    ) => {
+      const attempt = attempts[Math.min(index, attempts.length - 1)];
+      index++;
+      emit({ type: "object-delta", port: "object", objectDelta: attempt.payload });
+      emit({
+        type: "finish",
+        data: { object: attempt.payload } as any,
+        ...(attempt.usage ? { usage: attempt.usage } : {}),
+      } as any);
+    };
+    const registry = getAiProviderRegistry();
+    registry.registerProvider(new FakeStructuredProvider([{ serves: JSON_MODE, runFn: stream }]));
+    registry.registerRunFn("fake-structured", { serves: JSON_MODE, runFn: stream });
+    return { unregister: () => registry.unregisterProvider("fake-structured") };
+  }
+
+  it("sums usage across a failed attempt and the retry that succeeds", async () => {
+    // A rejected attempt is still billed — the run costs both requests.
+    const { unregister } = registerUsageProvider([
+      { payload: { name: "Alice", age: "thirty" }, usage: mkUsage({ input: 50, output: 8 }) },
+      { payload: { name: "Alice", age: 30 }, usage: mkUsage({ input: 90, output: 12 }) },
+    ]);
+    try {
+      const input = {
+        model: mkModel(),
+        prompt: "Give me a person",
+        outputSchema: PERSON_SCHEMA,
+        maxRetries: 2,
+      };
+      const task = new StructuredGenerationTask({ defaults: input } as any);
+      const events = await drain(task.executeStream(input as any, mkContext()));
+
+      const finishes = events.filter((e) => e.type === "finish") as Array<{
+        data: { object: Record<string, unknown> };
+        usage?: Usage;
+      }>;
+      // Only the successful attempt yields a finish to the consumer.
+      expect(finishes).toHaveLength(1);
+      expect(finishes[0].data.object).toEqual({ name: "Alice", age: 30 });
+      expect(finishes[0].usage).toEqual(mkUsage({ input: 140, output: 20 }));
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does not double-count a single successful attempt", async () => {
+    const { unregister } = registerUsageProvider([
+      { payload: { name: "Alice", age: 30 }, usage: mkUsage({ input: 90, output: 12 }) },
+    ]);
+    try {
+      const input = {
+        model: mkModel(),
+        prompt: "Give me a person",
+        outputSchema: PERSON_SCHEMA,
+        maxRetries: 2,
+      };
+      const task = new StructuredGenerationTask({ defaults: input } as any);
+      const events = await drain(task.executeStream(input as any, mkContext()));
+      const finish = events.find((e) => e.type === "finish") as { usage?: Usage };
+      expect(finish.usage).toEqual(mkUsage({ input: 90, output: 12 }));
+    } finally {
+      unregister();
+    }
+  });
+
+  it("folds retry-summed usage onto the execute() output next to the object", async () => {
+    // The output schema declares `additionalProperties: false` and requires
+    // `object`; `usage` is a reserved field, so it rides along without tripping
+    // validation and without displacing the structured payload.
+    const { unregister } = registerUsageProvider([
+      { payload: { name: "Alice", age: "thirty" }, usage: mkUsage({ input: 50, output: 8 }) },
+      { payload: { name: "Alice", age: 30 }, usage: mkUsage({ input: 90, output: 12 }) },
+    ]);
+    try {
+      const input = {
+        model: mkModel(),
+        prompt: "Give me a person",
+        outputSchema: PERSON_SCHEMA,
+        maxRetries: 2,
+      };
+      const task = new StructuredGenerationTask({ defaults: input } as any);
+      const result = (await task.execute(input as any, mkContext())) as {
+        object: Record<string, unknown>;
+        usage?: Usage;
+      };
+      expect(result.object).toEqual({ name: "Alice", age: 30 });
+      expect(result.usage).toEqual(mkUsage({ input: 140, output: 20 }));
+    } finally {
+      unregister();
+    }
+  });
+
+  it("leaves no usage key when the provider reported none", async () => {
+    const { unregister } = registerUsageProvider([
+      { payload: { name: "Alice", age: 30 }, usage: undefined },
+    ]);
+    try {
+      const input = {
+        model: mkModel(),
+        prompt: "Give me a person",
+        outputSchema: PERSON_SCHEMA,
+        maxRetries: 0,
+      };
+      const task = new StructuredGenerationTask({ defaults: input } as any);
+      const result = await task.execute(input as any, mkContext());
+      expect(result).toEqual({ object: { name: "Alice", age: 30 } });
+      expect("usage" in (result as object)).toBe(false);
+    } finally {
+      unregister();
+    }
   });
 });

--- a/packages/test/src/test/ai/StructuredGenerationTask.test.ts
+++ b/packages/test/src/test/ai/StructuredGenerationTask.test.ts
@@ -19,6 +19,8 @@ import {
 } from "@workglow/ai";
 import type { IExecuteContext, Usage } from "@workglow/task-graph";
 import { TaskConfigurationError, TaskRegistry } from "@workglow/task-graph";
+import type { ILogger } from "@workglow/util";
+import { getLogger, setLogger } from "@workglow/util";
 import { describe, expect, it } from "vitest";
 
 // ============================================================================
@@ -398,6 +400,39 @@ describe("StructuredGenerationTask — usage aggregation", () => {
     registry.registerRunFn("fake-structured", { serves: JSON_MODE, runFn: stream });
     return { unregister: () => registry.unregisterProvider("fake-structured") };
   }
+
+  it("records usage telemetry even though the retry loop closes the stream early", async () => {
+    // `StructuredGenerationTask` returns the moment it sees a valid `finish`,
+    // which closes the base class's generator at its `yield`. A telemetry call
+    // sited after that loop would never run, so the task that bills the most
+    // tokens would be the one reporting none.
+    const { unregister } = registerUsageProvider([
+      { payload: { name: "Alice", age: 30 }, usage: mkUsage({ input: 90, output: 12 }) },
+    ]);
+    const recorded: Array<Record<string, unknown> | undefined> = [];
+    const previous = getLogger();
+    setLogger({
+      ...previous,
+      debug: (message: string, meta?: Record<string, unknown>) => {
+        if (message.startsWith("AI usage for")) recorded.push(meta);
+      },
+    } as ILogger);
+    try {
+      const input = {
+        model: mkModel(),
+        prompt: "Give me a person",
+        outputSchema: PERSON_SCHEMA,
+        maxRetries: 0,
+      };
+      const task = new StructuredGenerationTask({ defaults: input } as any);
+      await task.execute(input as any, mkContext());
+      expect(recorded).toHaveLength(1);
+      expect(recorded[0]?.usage).toEqual(mkUsage({ input: 90, output: 12 }));
+    } finally {
+      setLogger(previous);
+      unregister();
+    }
+  });
 
   it("sums usage across a failed attempt and the retry that succeeds", async () => {
     // A rejected attempt is still billed — the run costs both requests.

--- a/packages/test/src/test/ai/WorkerRunFn_roundtrip.test.ts
+++ b/packages/test/src/test/ai/WorkerRunFn_roundtrip.test.ts
@@ -91,6 +91,47 @@ describe("WorkerServerBase.handleRunCall protocol", () => {
     expect(receivedSessionId).toBe("sess-42");
   });
 
+  it("forwards a finish event's `usage` sibling across the worker boundary", async () => {
+    // The usage channel needs no protocol change: the whole event object is
+    // forwarded, so a sibling field survives structured clone untouched.
+    const server = new WorkerServerBase();
+    const usage = {
+      input: 120,
+      output: 45,
+      cached: 100,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: 165,
+      extra: { tier: "standard" },
+    };
+    server.registerRunFunction("usage.fn", async (_input, _model, _signal, emit) => {
+      emit({ type: "finish", data: {}, usage } as any);
+    });
+
+    await (server as any).handleRunCall("req-usage", "usage.fn", [
+      "input",
+      undefined,
+      undefined,
+      undefined,
+    ]);
+
+    const chunks = captured.filter((m) => m.type === "stream_chunk");
+    expect(chunks).toHaveLength(1);
+    // Round-trip through structured clone the way postMessage would.
+    const roundTripped = structuredClone(chunks[0].data);
+    expect(roundTripped.type).toBe("finish");
+    expect(roundTripped.data).toEqual({});
+    expect(roundTripped.usage).toEqual({
+      input: 120,
+      output: 45,
+      cached: 100,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: 165,
+      extra: { tier: "standard" },
+    });
+  });
+
   it("sends 'error' and no 'complete' when the run-fn throws", async () => {
     const server = new WorkerServerBase();
     server.registerRunFunction("fail.fn", async () => {

--- a/packages/test/src/test/ai/collectStream.test.ts
+++ b/packages/test/src/test/ai/collectStream.test.ts
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type Capability, collectStream, type StreamEvent } from "@workglow/ai";
+import { type Capability, collectStream, type StreamEvent, type Usage } from "@workglow/ai";
 import { describe, expect, expectTypeOf, it } from "vitest";
+
+function usage(partial: Partial<Usage>): Usage {
+  return {
+    input: undefined,
+    output: undefined,
+    cached: undefined,
+    cacheWrite: undefined,
+    reasoning: undefined,
+    total: undefined,
+    extra: undefined,
+    ...partial,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -186,6 +199,60 @@ describe("collectStream", () => {
     );
     const result = await collectStream(stream);
     expect(result).toMatchObject({ result: { a: 1 }, meta: "done" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Usage channel
+  // -------------------------------------------------------------------------
+
+  it("usage: finish usage surfaces as result.usage alongside accumulated deltas", async () => {
+    type Output = { text: string };
+    const stream = makeStream<Output>(
+      { type: "text-delta", port: "text", textDelta: "Hello" },
+      { type: "finish", data: {} as Output, usage: usage({ input: 12, output: 3 }) }
+    );
+    const result = (await collectStream(stream)) as Output & { usage?: Usage };
+    expect(result.text).toBe("Hello");
+    expect(result.usage).toEqual(usage({ input: 12, output: 3 }));
+  });
+
+  it("usage: a stream with no usage leaves no usage key at all", async () => {
+    type Output = { text: string };
+    const stream = makeStream<Output>(
+      { type: "text-delta", port: "text", textDelta: "Hello" },
+      { type: "finish", data: {} as Output }
+    );
+    const result = await collectStream(stream);
+    expect(result).toEqual({ text: "Hello" });
+    expect("usage" in (result as object)).toBe(false);
+  });
+
+  it("usage: one-shot finish keeps data as the payload (embedding-shaped run-fn)", async () => {
+    type Output = { embedding: number[] };
+    const stream = makeStream<Output>({
+      type: "finish",
+      data: { embedding: [0.1, 0.2] },
+      usage: usage({ input: 8, total: 8 }),
+    });
+    const result = (await collectStream(stream)) as Output & { usage?: Usage };
+    expect(result.embedding).toEqual([0.1, 0.2]);
+    expect(result.usage).toEqual(usage({ input: 8, total: 8 }));
+  });
+
+  it("usage: json-mode finish keeps data.object intact next to usage", async () => {
+    type Output = { object: Record<string, unknown> };
+    const stream = makeStream<Output>(
+      { type: "object-delta", port: "object", objectDelta: { name: "A" } },
+      {
+        type: "finish",
+        data: { object: { name: "Alice", age: 30 } },
+        usage: usage({ input: 40, output: 12 }),
+      }
+    );
+    const result = (await collectStream(stream)) as Output & { usage?: Usage };
+    // Deltas win on the `object` port; the usage sibling is untouched by that.
+    expect(result.object).toEqual({ name: "A" });
+    expect(result.usage).toEqual(usage({ input: 40, output: 12 }));
   });
 
   // -------------------------------------------------------------------------

--- a/packages/test/src/test/task-graph/StreamingAccumulation.test.ts
+++ b/packages/test/src/test/task-graph/StreamingAccumulation.test.ts
@@ -24,7 +24,7 @@
  *  - Cache: auto-enables accumulation
  */
 
-import type { CachePolicy, StreamEvent } from "@workglow/task-graph";
+import type { CachePolicy, StreamEvent, Usage } from "@workglow/task-graph";
 import {
   Dataflow,
   IExecuteContext,
@@ -229,6 +229,90 @@ class CacheableAppendTask extends Task<SimpleInput, SimpleOutput> {
 
   override async execute(_input: SimpleInput): Promise<SimpleOutput | undefined> {
     return { text: "cached value" };
+  }
+}
+
+function mkUsage(partial: Partial<Usage>): Usage {
+  return {
+    input: undefined,
+    output: undefined,
+    cached: undefined,
+    cacheWrite: undefined,
+    reasoning: undefined,
+    total: undefined,
+    extra: undefined,
+    ...partial,
+  };
+}
+
+const TASK_USAGE = mkUsage({ input: 25, output: 7, cached: 20, total: 32 });
+
+/**
+ * Append-mode task whose finish carries a `usage` sibling, mirroring a provider
+ * that reports token counts.
+ */
+class UsageAppendTask extends Task<SimpleInput, SimpleOutput> {
+  public static override type = "AccumTest_UsageAppendTask";
+  public static override cachePolicy: CachePolicy = { kind: "none" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { prompt: { type: "string", default: "test" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+      required: ["text"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  async *executeStream(
+    _input: SimpleInput,
+    _context: IExecuteContext
+  ): AsyncIterable<StreamEvent<SimpleOutput>> {
+    yield { type: "text-delta", port: "text", textDelta: "hello" };
+    yield { type: "text-delta", port: "text", textDelta: " world" };
+    yield { type: "finish", data: {} as SimpleOutput, usage: TASK_USAGE };
+  }
+}
+
+/**
+ * Cacheable variant used to prove a cache hit does not replay token counts.
+ */
+class UsageCacheableTask extends Task<SimpleInput, SimpleOutput> {
+  public static override type = "AccumTest_UsageCacheableTask";
+  public static override cacheable = true;
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { prompt: { type: "string" } },
+      required: ["prompt"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+      required: ["text"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  async *executeStream(
+    _input: SimpleInput,
+    _context: IExecuteContext
+  ): AsyncIterable<StreamEvent<SimpleOutput>> {
+    yield { type: "text-delta", port: "text", textDelta: "billed" };
+    yield { type: "finish", data: {} as SimpleOutput, usage: TASK_USAGE };
   }
 }
 
@@ -486,6 +570,112 @@ describe("Source-task streaming accumulation", () => {
       expect(resultB).toBeDefined();
       expect(resultA!.data.text).toBe("sink:hello world");
       expect(resultB!.data.text).toBe("sink:hello world");
+    });
+  });
+
+  describe("Usage channel", () => {
+    it("folds finish usage onto the run output's reserved usage field", async () => {
+      const task = new UsageAppendTask({ defaults: { prompt: "test" } });
+      const result = (await task.run({ prompt: "test" })) as SimpleOutput & { usage?: Usage };
+
+      expect(result.text).toBe("hello world");
+      expect(result.usage).toEqual(TASK_USAGE);
+    });
+
+    it("re-emits usage on the enriched finish event downstream consumers see", async () => {
+      const task = new UsageAppendTask({ defaults: { prompt: "test" } });
+      const emitted: StreamEvent[] = [];
+      task.on("stream_chunk", (e) => emitted.push(e));
+
+      await task.run({ prompt: "test" });
+
+      const finishEvent = emitted.find((e) => e.type === "finish") as
+        (StreamFinish<{ text: string }> & { usage?: Usage }) | undefined;
+      expect(finishEvent).toBeDefined();
+      // The finish is enriched with accumulated text AND still carries usage.
+      expect(finishEvent!.data.text).toBe("hello world");
+      expect(finishEvent!.usage).toEqual(TASK_USAGE);
+    });
+
+    it("parity: run() and the streaming path report identical usage", async () => {
+      const task = new UsageAppendTask({ defaults: { prompt: "test" } });
+      let streamEndOutput: (SimpleOutput & { usage?: Usage }) | undefined;
+      task.on("stream_end", (out) => {
+        streamEndOutput = out as SimpleOutput & { usage?: Usage };
+      });
+
+      const runResult = (await task.run({ prompt: "test" })) as SimpleOutput & { usage?: Usage };
+
+      expect(streamEndOutput?.usage).toEqual(runResult.usage);
+      expect(runResult.usage).toEqual(TASK_USAGE);
+    });
+
+    it("leaves no usage key when the stream reported none", async () => {
+      const task = new AppendTask({ defaults: { prompt: "test" } });
+      const result = await task.run({ prompt: "test" });
+
+      expect(result).toEqual({ text: "hello world" });
+      expect("usage" in result).toBe(false);
+
+      const finishFromEvents: StreamEvent[] = [];
+      const task2 = new AppendTask({ defaults: { prompt: "test" } });
+      task2.on("stream_chunk", (e) => finishFromEvents.push(e));
+      await task2.run({ prompt: "test" });
+      const finishEvent = finishFromEvents.find((e) => e.type === "finish")!;
+      expect("usage" in finishEvent).toBe(false);
+    });
+
+    it("does not leak usage onto a downstream task's input", async () => {
+      // Usage is a reserved field, not a port: it must not ride a dataflow edge.
+      const { graph, runner } = makeGraph();
+      const source = new UsageAppendTask({ id: "source", defaults: { prompt: "test" } });
+      const sink = new SinkTask({ id: "sink" });
+
+      graph.addTasks([source, sink]);
+      graph.addDataflow(new Dataflow("source", "text", "sink", "text"));
+
+      const results = await runner.runGraph({ prompt: "test" });
+
+      const sinkResult = results.find((r) => r.id === "sink");
+      expect(sinkResult!.data.text).toBe("sink:hello world");
+      expect("usage" in sinkResult!.data).toBe(false);
+    });
+  });
+
+  describe("Usage is not resurrected from the output cache", () => {
+    let usageCache: InMemoryTaskOutputRepository;
+
+    beforeEach(async () => {
+      usageCache = new InMemoryTaskOutputRepository();
+      await usageCache.setupDatabase();
+    });
+
+    it("strips usage on save so a cache hit reports no phantom tokens", async () => {
+      const task1 = new UsageCacheableTask(
+        { defaults: { prompt: "hello" } },
+        { outputCache: usageCache }
+      );
+      const first = (await task1.run({ prompt: "hello" })) as SimpleOutput & { usage?: Usage };
+      // The executed run IS billed.
+      expect(first.usage).toEqual(TASK_USAGE);
+
+      // The stored entry carries the value but not the token counts.
+      const cached = await usageCache.getOutput("AccumTest_UsageCacheableTask", {
+        prompt: "hello",
+        __cv: "1",
+      });
+      expect(cached).toBeDefined();
+      expect(cached!.text).toBe("billed");
+      expect("usage" in cached!).toBe(false);
+
+      // The cache hit cost zero tokens, so it must report none.
+      const task2 = new UsageCacheableTask(
+        { defaults: { prompt: "hello" } },
+        { outputCache: usageCache }
+      );
+      const second = (await task2.run({ prompt: "hello" })) as SimpleOutput & { usage?: Usage };
+      expect(second.text).toBe("billed");
+      expect(second.usage).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Refs #624 — **Phase 1 of 2** (the generic seam only; no provider run-fn is touched).

Providers surface no token usage today, so nothing downstream can compute cost. This lands the provider-agnostic channel end to end and leaves the per-provider fill-in to Phase 2. Every provider currently emits **`usage: undefined`** (none sets the new field), so this is **purely additive with no behavior change**: absent usage leaves no key on any output, and all existing streaming/caching semantics are untouched.

## The four design decisions

### 1. Shape — a normalized `Usage`, where `undefined ≠ 0`

`Usage` (in `packages/task-graph/src/task/StreamTypes.ts`) carries `input`, `output`, `cached`, `cacheWrite`, `reasoning`, `total`, plus an `extra` bag for provider-specific counters with no normalized slot.

Every counter is `number | undefined`, and **`undefined` means "the provider did not report this", never "zero"**. This is the load-bearing detail for cost math: a model that billed 0 cached tokens and a model that never tells you about caching are different facts, and collapsing them to `0` silently understates spend. `mergeUsage` preserves the distinction field-wise (`undefined + undefined === undefined`, `undefined + 5 === 5`).

It lives in `task-graph` beside the other canonical stream types (`StreamFinish` is defined there, not in `packages/ai`), and is re-exported from `@workglow/ai` so a provider package can `import type { Usage } from "@workglow/ai"` without depending on `task-graph` directly.

### 2. Transport — a sibling field on `finish`

`StreamFinish` gains an optional `usage`, as a **sibling of `data`, never inside it**.

- **Why not inside `data`?** `data` is governed by the streaming conventions: `{}` for delta streams, the *entire* Output for one-shot run-fns, and `finish.data.object` for json-mode. Folding token counts into `data` would corrupt all three at once.
- **Why not a new `usage` stream-event arm?** Every `switch (event.type)` over `StreamEvent` in the codebase and in downstream consumers would need a new case, and a stray usage event arriving mid-stream would have ambiguous ordering against `finish`. A sibling on the event that already means "this request is over" has exactly the right lifetime.
- **Why not the run result?** `AiProviderRunFn` returns `Promise<void>` by explicit contract — there is no return value to put metadata on.
- The worker boundary (`WorkerManager.callWorkerRunFunction`) forwards the whole event object, so a sibling field survives structured clone with **no protocol change**. Covered by a test.

### 3. Surfacing — a reserved output key, mirroring `refusal`

There is already a proven precedent for a non-port output field: **refusal**. `USAGE_OUTPUT_KEY` follows it exactly —

| | `refusal` | `usage` |
|---|---|---|
| Folded by `StreamEventAccumulator` | `applyRefusal()` | `applyUsage()`, chained into all three `materialize()` exits |
| Folded by `StreamProcessor` | yes, before `stream_end` | yes, next to the refusal fold |
| Declared on any `outputSchema()` | no (reserved by design) | no (reserved by design) |
| Kept off dataflow edges | yes | yes |
| Output cache | **blocks** the save | **strips** the field, saves the value |

The cache difference is deliberate. A refusal must not be memoized because it would replay as "the answer". Usage is different: the *value* is still worth caching, but token counts are a fact about **one execution** — serving that entry later costs zero tokens, so replaying the original counts would invent spend that never happened. So `CacheCoordinator.save` strips `USAGE_OUTPUT_KEY` rather than bailing. **This lands in the same commit as the accumulator/processor change**, so there is no window in which cache hits report phantom tokens.

Telemetry is recorded in **one place** — `AiTask.execute()`, via a new `packages/ai/src/capability/UsageTelemetry.ts` — so provider packages never touch telemetry directly (they also run inside workers, which have a separate registry and no main-thread telemetry provider). It records OTel gen-ai semantic-convention attributes (`gen_ai.usage.input_tokens`, `…output_tokens`, `…cached_input_tokens`, `…cache_write_input_tokens`, `…reasoning_tokens`, `…total_tokens`) and one `getLogger().debug(...)`. Guarded on `isEnabled` following the `traced.ts` pattern, so attribute flattening is never paid for when nothing is collecting. **`ITelemetryProvider` is unchanged** — `SpanAttributes` already accepts flat numbers.

### 4. Multi-turn — aggregated consumer-side, keeping providers stateless

The no-accumulation rule means a provider must never buffer. So summing happens at the two places that already own multi-request control flow, both of which drop the sibling today:

- **`AiChatWithKbTask`** deliberately swallows inner-turn `finish` events (the agent loop). It now merges each turn's usage into an accumulator and attaches the total to the outer finish, which already carries `{ iterations }`.
- **`StructuredGenerationTask`** synthesizes a fresh finish across validation-retry attempts. It now sums across attempts — **a rejected attempt is still a billed request**, and without this a schema-flaky model would look exactly as cheap as a clean one.

`mergeUsage` sums numeric `extra` keys and takes last-wins on string keys (a string is a label — service tier, cache key — not a counter).

### On output schemas

`usage` is **not** added to any task's `outputSchema()` — reserved keys are undeclared by design, exactly like refusal. Checked the `additionalProperties: false` exposure explicitly: task output is never validated against `outputSchema` at runtime (only *input* and *config* are), and `Task.addInput` copies only keys the target declares as ports, so `usage` cannot reach a strict downstream input over a normal edge. Both are pinned by tests — one runs `StructuredGenerationTask` (whose output schema is `additionalProperties: false, required: ["object"]`) with usage attached, and one asserts usage does not leak onto a downstream task's input.

## Phase 2 is deliberately deferred

Per-provider fill-in **must land after #641** (`ai-provider-cache-checkpoints`, 84 files) merges — that PR edits ~15 of the provider run-fns Phase 2 would touch. **Phase 1 changes no provider file at all** (all 16 files here are in `packages/ai`, `packages/task-graph`, `packages/test`).

Checked against #641's actual file list rather than assuming: it shares exactly **2 of my 16 files**, and in both the change is a single line inside `getJobInput` (`sessionId: x` → `session: { sessionId: x }`) —

| shared file | #641 hunk | this PR's hunks |
|---|---|---|
| `packages/ai/src/task/base/AiTask.ts` | `getJobInput`, ~L314 | import; one call after the provider-error throw, ~L252 |
| `packages/ai/src/task/AiChatWithKbTask.ts` | `getJobInput`, ~L368 | imports; turn loop ~L434; emit factory ~L631; final yield ~L698 |

So the overlap is file-level only, with **no overlapping hunks** — these auto-merge. The deferral is about the ~15 provider run-fns Phase 2 needs, which this PR leaves untouched.

Because the seam is generic, the follow-up is mechanical: each run-fn maps its own finish payload into `Usage` and attaches it to the `finish` it already emits. Checklist:

**Usage already flows past the loop and is discarded — no request change needed**

- [ ] `@workglow/anthropic` — `usage.input_tokens` / `output_tokens` / `cache_read_input_tokens` → `cached` / `cache_creation_input_tokens` → `cacheWrite`
- [ ] `@workglow/openai` (Responses) — `usage.input_tokens` / `output_tokens` / `input_tokens_details.cached_tokens` / `cache_write_tokens` / `output_tokens_details.reasoning_tokens`
- [ ] `@workglow/google-gemini` — `usageMetadata.promptTokenCount` / `candidatesTokenCount` / `cachedContentTokenCount`
- [ ] `@workglow/ollama` — the final chunk's prompt/eval counts (exact field names to confirm against the SDK response at implementation time)

**Needs `stream_options: { include_usage: true }` on the request**

- [ ] `@workglow/xai`
- [ ] `@workglow/deepseek`
- [ ] `@workglow/openrouter`
- [ ] `@workglow/llamacpp-server`

**No usage available — leave unreported (`undefined`, not `0`)**

- [ ] `@workglow/node-llama-cpp`
- [ ] `@workglow/huggingface-transformers`
- [ ] `@workglow/chrome-ai`
- [ ] `@workglow/tf-mediapipe`

## Tests

Driven entirely from synthetic streams (no provider emits usage yet), extending the existing suites rather than adding parallel ones — `collectStream.test.ts`, `StreamEventAccumulator.test.ts`, `StreamingAccumulation.test.ts`, `WorkerRunFn_roundtrip.test.ts`, `AiChatWithKbTask.test.ts`, `StructuredGenerationTask.test.ts`.

Covered: usage on finish surfaces as `result.usage`; absent usage leaves **no key at all**; one-shot finish + usage keeps `data` as the payload; delta-mode finish + usage keeps deltas winning; json-mode keeps `data.object` intact; usage and refusal coexist (a refused turn still reports its billed tokens); `mergeUsage` unit tests (undefined preservation both directions, extras merged with numeric summed / string last-wins, no input mutation); **parity invariant** — `run()` and the streaming path produce identical usage; usage is **not** resurrected from the output cache (and the stored entry has no `usage` key); usage survives the worker boundary through `structuredClone`; a 2-turn agent loop and a 2-attempt structured-generation retry each aggregate correctly, with single-turn/single-attempt cases asserting no double-counting.

## Verification

All commands run on this branch at `5fff2be`.

```
$ bun run build
 Tasks:    84 successful, 84 total
  Time:    45.283s

$ bun run build:types --force
 Tasks:    41 successful, 41 total
Cached:    0 cached, 41 total
  Time:    56.46s

$ bun scripts/test.ts ai vitest
Running all tests in sections [ai] — 38 file(s)
 Test Files  38 passed (38)
      Tests  275 passed (275)

$ bun scripts/test.ts task graph vitest
Running all tests in sections [task+graph] — 148 file(s)
 Test Files  148 passed (148)
      Tests  1885 passed | 24 skipped (1909)
```

`bun run format` then reordered imports in two files, so both affected sections were re-run afterwards to confirm the formatted tree is still green:

```
$ bun scripts/test.ts ai graph vitest
Running all tests in sections [ai+graph] — 114 file(s)
 Test Files  114 passed (114)
      Tests  1028 passed (1028)
   Duration  322.53s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwyJuFrJnibKvrrk8Fa4Fn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwyJuFrJnibKvrrk8Fa4Fn)_