### PR TITLE
perf(util): add an incremental partial-JSON stream parser

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -239,8 +239,25 @@ Shared cloud-provider helpers (base classes, registration, model search, OpenAI-
 **Streaming convention exception (structured generation):** Run-fns serving
 `["text.generation", "json-mode"]` MUST populate `finish.data.object` with the
 parsed final object. The `StructuredGenerationTask` consumer reads the parsed
-object from finish.data and re-validates it against the output schema; this
-avoids requiring a JSON streaming parser in the consumer layer.
+object from finish.data and re-validates it against the output schema: it needs
+one definitive final object to validate and to drive its retry loop, which a
+sequence of partial deltas cannot supply.
+
+Do **not** accumulate the JSON text to produce it. Feed the deltas to
+`createPartialJsonStream()` (`@workglow/util/worker`, or `/schema` off-worker):
+`push(chunk)` is O(chunk) and returns the partial object to emit as an
+`object-delta`, and `finish()` returns the value for `finish.data.object`.
+Re-parsing a growing buffer on every delta is O(n²) and blocks the worker
+thread. Use the `skipPreamble` option for providers that emit prose, a
+`<think>` block, or a code fence ahead of the JSON.
+
+`push()` returns the parser's **live** root, which later pushes mutate — that
+aliasing is what keeps it linear. It is safe for the `object-delta` path
+(`StreamEventAccumulator` / `StreamProcessor` use replace semantics for
+non-array object-deltas, and events are structured-cloned across the worker
+hop), but a consumer that retains an earlier delta in-process will see it
+change; call `snapshot()` for a detached copy. One-shot repair of an
+already-accumulated buffer stays on `parsePartialJson`.
 
 **Capability collision:** When two task types share the same `requires` set
 (e.g. `AiChatTask` and `TextGenerationTask` both require `["text.generation"]`),

--- a/packages/test/src/test/util/PartialJsonStream.test.ts
+++ b/packages/test/src/test/util/PartialJsonStream.test.ts
@@ -147,6 +147,19 @@ describe("createPartialJsonStream", () => {
       expect(pushAll([""])).toEqual({});
       expect(pushAll(["   "])).toEqual({});
     });
+
+    it("does not let a stray close at the root end the document", () => {
+      // Popping the empty stack would mark the stream `complete` with an
+      // undefined root, so everything after the stray brace is discarded.
+      const stream = createPartialJsonStream();
+      stream.push('}{"a":1}');
+      expect(stream.complete).toBe(false);
+      expect(stream.finish()).toEqual({});
+
+      const bracket = createPartialJsonStream();
+      bracket.push("]");
+      expect(bracket.complete).toBe(false);
+    });
   });
 
   describe("preamble skipping", () => {

--- a/packages/test/src/test/util/PartialJsonStream.test.ts
+++ b/packages/test/src/test/util/PartialJsonStream.test.ts
@@ -79,6 +79,11 @@ describe("createPartialJsonStream", () => {
       expect(pushAll(['{"k":"a\\', '\\b"}'])).toEqual({ k: "a\\b" });
     });
 
+    it("keeps an invalid unicode escape verbatim, digits included", () => {
+      expect(pushAll(['{"k":"\\u00zz"}'])).toEqual({ k: "\\u00zz" });
+      expect(pushAll(['{"k":"\\u00', 'zz"}'])).toEqual({ k: "\\u00zz" });
+    });
+
     it("reassembles a surrogate pair split across chunks", () => {
       expect(pushAll(['{"k":"\\ud83d', '\\ude00"}'])).toEqual({ k: "😀" });
     });
@@ -172,6 +177,17 @@ describe("createPartialJsonStream", () => {
 
     it("discards a markdown code fence", () => {
       expect(pushAll(['```json\n{"a":1}\n```'], true)).toEqual({ a: 1 });
+    });
+
+    it("does not mistake a bracketed aside in the prose for the payload", () => {
+      // A citation marker parses as a complete array; locking onto it would
+      // close the root and throw away the real object behind it.
+      expect(pushAll(['See [1] for details. {"ok":true}'], true)).toEqual({ ok: true });
+      // An array that stays open until non-JSON prose is worse: its non-empty
+      // root would make the failure unrecoverable.
+      expect(pushAll(['Based on [2024 figures], here it is: {"ok":true}'], true)).toEqual({
+        ok: true,
+      });
     });
 
     it("emits nothing for text containing no JSON", () => {

--- a/packages/test/src/test/util/PartialJsonStream.test.ts
+++ b/packages/test/src/test/util/PartialJsonStream.test.ts
@@ -1,0 +1,309 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createPartialJsonStream, parsePartialJson } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+
+/** Documents covering nesting, arrays, escapes, unicode, numbers and literals. */
+const DOCS: readonly string[] = [
+  '{"name":"Alice","age":30}',
+  "{}",
+  '{"a":{"b":{"c":[1,2,3]}}}',
+  '{"s":"he said \\"hi\\"\\n\\t","u":"\\u0041\\u00e9"}',
+  '{"nums":[0,-1,1.5,2e3,-4.25e-2,1e+5]}',
+  '{"t":true,"f":false,"n":null}',
+  '{"empty":{},"earr":[],"nested":[[],{},[{}]]}',
+  '{"deep":{"a":[{"b":[{"c":"d"}]}]}}',
+  '{"emoji":"\\ud83d\\ude00 ok","esc":"a\\\\b\\/c"}',
+  '{"mixed":[1,"two",true,null,{"k":[]},[3]]}',
+  '{"pretty": {\n  "x": 1,\n  "y": [ 2, 3 ]\n}}',
+];
+
+function pushAll(chunks: readonly string[], skipPreamble = false): Record<string, unknown> {
+  const stream = createPartialJsonStream(skipPreamble ? { skipPreamble: true } : {});
+  for (const chunk of chunks) stream.push(chunk);
+  return stream.finish();
+}
+
+describe("createPartialJsonStream", () => {
+  describe("chunk boundaries", () => {
+    it("reassembles every document across every single-character split point", () => {
+      for (const doc of DOCS) {
+        const expected = JSON.parse(doc);
+        for (let split = 0; split <= doc.length; split++) {
+          const got = pushAll([doc.slice(0, split), doc.slice(split)]);
+          expect(got, `doc ${doc} split at ${split}`).toEqual(expected);
+        }
+      }
+    });
+
+    it("reassembles every document fed one character at a time", () => {
+      for (const doc of DOCS) {
+        expect(pushAll([...doc]), doc).toEqual(JSON.parse(doc));
+      }
+    });
+
+    it("reports `complete` only once the root value closes", () => {
+      const stream = createPartialJsonStream();
+      stream.push('{"a":1');
+      expect(stream.complete).toBe(false);
+      stream.push("}");
+      expect(stream.complete).toBe(true);
+    });
+
+    it("ignores trailing content after the root value closes", () => {
+      expect(pushAll(['{"a":1}', "trailing noise {"])).toEqual({ a: 1 });
+    });
+  });
+
+  describe("split escapes", () => {
+    it("handles an escaped quote split across chunks", () => {
+      expect(pushAll(['{"k":"a\\', '"b"}'])).toEqual({ k: 'a"b' });
+    });
+
+    it("handles a unicode escape split across chunks", () => {
+      expect(pushAll(['{"k":"\\u00', '41"}'])).toEqual({ k: "A" });
+    });
+
+    it("handles a unicode escape split at every internal boundary", () => {
+      const doc = '{"k":"\\u0041\\u00e9"}';
+      for (let split = 0; split <= doc.length; split++) {
+        expect(pushAll([doc.slice(0, split), doc.slice(split)])).toEqual({ k: "Aé" });
+      }
+    });
+
+    it("handles a backslash escape at a chunk edge", () => {
+      expect(pushAll(['{"k":"a\\', '\\b"}'])).toEqual({ k: "a\\b" });
+    });
+
+    it("reassembles a surrogate pair split across chunks", () => {
+      expect(pushAll(['{"k":"\\ud83d', '\\ude00"}'])).toEqual({ k: "😀" });
+    });
+  });
+
+  describe("split scalars", () => {
+    it("reassembles a number split across three chunks", () => {
+      expect(pushAll(['{"n":1.', "5e", "-3}"])).toEqual({ n: 1.5e-3 });
+    });
+
+    it("reassembles `true` split across chunks", () => {
+      expect(pushAll(['{"b":tr', "ue}"])).toEqual({ b: true });
+    });
+
+    it("reassembles `null` split across chunks", () => {
+      expect(pushAll(['{"z":nul', "l}"])).toEqual({ z: null });
+    });
+
+    it("reassembles a negative exponent number terminated by end of stream", () => {
+      expect(pushAll(['{"n":-4.25e', "-2"])).toEqual({ n: -0.0425 });
+    });
+  });
+
+  describe("truncated streams", () => {
+    it("closes open containers on finish", () => {
+      expect(pushAll(['{"a":1,"b":{"c":[1,2'])).toEqual({ a: 1, b: { c: [1, 2] } });
+    });
+
+    it("keeps a partially received string value", () => {
+      expect(pushAll(['{"name":"Ali'])).toEqual({ name: "Ali" });
+    });
+
+    it("drops a trailing incomplete literal, matching parsePartialJson", () => {
+      expect(pushAll(['{"a": tru'])).toEqual({});
+      expect(pushAll(['{"flag": fal'])).toEqual({});
+      expect(pushAll(['{"x": nul'])).toEqual({});
+    });
+
+    it("drops a trailing incomplete number but keeps a complete one", () => {
+      expect(pushAll(['{"n": 1.'])).toEqual({});
+      expect(pushAll(['{"n": 30'])).toEqual({ n: 30 });
+    });
+
+    it("drops a trailing partial key", () => {
+      expect(pushAll(['{"a":1,"bc'])).toEqual({ a: 1 });
+    });
+
+    it("tolerates a trailing comma", () => {
+      expect(pushAll(['{"name":"Alice",'])).toEqual({ name: "Alice" });
+    });
+
+    it("is idempotent", () => {
+      const stream = createPartialJsonStream();
+      stream.push('{"a":[1,2');
+      const first = stream.finish();
+      expect(stream.finish()).toEqual(first);
+      expect(stream.finish()).toEqual({ a: [1, 2] });
+    });
+
+    it("returns an empty object when nothing was ever parsed", () => {
+      expect(pushAll([""])).toEqual({});
+      expect(pushAll(["   "])).toEqual({});
+    });
+  });
+
+  describe("preamble skipping", () => {
+    it("discards prose before the JSON object", () => {
+      expect(pushAll(['Here you go: {"a":1}'], true)).toEqual({ a: 1 });
+    });
+
+    it("discards prose split across chunks and trailing commentary", () => {
+      expect(pushAll(["Sure! Here ", 'you go: {"a":1}', " Hope that helps."], true)).toEqual({
+        a: 1,
+      });
+    });
+
+    it("discards a <think> block prefix", () => {
+      expect(pushAll(["<think>Let me reason first.</think>", '{"ok":true}'], true)).toEqual({
+        ok: true,
+      });
+    });
+
+    it("recovers when a <think> block itself contains braces", () => {
+      // Prose braces open a candidate that immediately fails to parse. Because it
+      // never yielded any data it is discarded and scanning resumes, so the real
+      // payload is still found.
+      expect(pushAll(['<think>I should use {braces}</think>{"ok":true}'], true)).toEqual({
+        ok: true,
+      });
+    });
+
+    it("discards a markdown code fence", () => {
+      expect(pushAll(['```json\n{"a":1}\n```'], true)).toEqual({ a: 1 });
+    });
+
+    it("emits nothing for text containing no JSON", () => {
+      const stream = createPartialJsonStream({ skipPreamble: true });
+      expect(stream.push("no json here")).toBeUndefined();
+      expect(stream.finish()).toEqual({});
+    });
+
+    it("does not skip preamble unless asked", () => {
+      const stream = createPartialJsonStream();
+      expect(stream.push('Here you go: {"a":1}')).toBeUndefined();
+    });
+  });
+
+  describe("live root and snapshot", () => {
+    it("returns undefined until a top-level object opens", () => {
+      const stream = createPartialJsonStream();
+      expect(stream.push("  ")).toBeUndefined();
+      expect(stream.push("{")).toEqual({});
+    });
+
+    it("returns undefined for a top-level array, matching parsePartialJson", () => {
+      const stream = createPartialJsonStream();
+      expect(stream.push("[1,2,3]")).toBeUndefined();
+      expect(parsePartialJson("[1,2,3]")).toBeUndefined();
+      // finish() still yields the parsed document, as JSON.parse would.
+      expect(stream.finish()).toEqual([1, 2, 3]);
+    });
+
+    it("returns the live root, which later pushes mutate", () => {
+      const stream = createPartialJsonStream();
+      const first = stream.push('{"a":1');
+      stream.push(',"b":2}');
+      // Documented aliasing: the retained delta is the same object, now grown.
+      expect(first).toEqual({ a: 1, b: 2 });
+    });
+
+    it("snapshot() detaches a copy that later pushes do not mutate", () => {
+      const stream = createPartialJsonStream();
+      stream.push('{"a":1');
+      const snap = stream.snapshot();
+      stream.push(',"b":2}');
+      expect(snap).toEqual({ a: 1 });
+      expect(stream.finish()).toEqual({ a: 1, b: 2 });
+    });
+
+    it("snapshot() returns undefined when there is no object root yet", () => {
+      expect(createPartialJsonStream().snapshot()).toBeUndefined();
+    });
+
+    it("creates __proto__ as an own property without polluting Object.prototype", () => {
+      const result = pushAll(['{"__proto__":{"polluted":1},"x":2}']);
+      expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(true);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(result.x).toBe(2);
+    });
+  });
+
+  describe("equivalence with parsePartialJson", () => {
+    // Prefixes ending in whitespace are excluded: parsePartialJson trims its
+    // input, so `{"s":"he ` loses the space inside the in-flight string value
+    // while the stream preserves it. That divergence is asserted on its own below.
+    it("agrees at every prefix where parsePartialJson produces a result", () => {
+      for (const doc of DOCS) {
+        for (let n = 1; n <= doc.length; n++) {
+          const prefix = doc.slice(0, n);
+          if (/\s$/.test(prefix)) continue;
+          const oneShot = parsePartialJson(prefix);
+          if (oneShot === undefined) continue;
+          const stream = createPartialJsonStream();
+          stream.push(prefix);
+          expect(stream.snapshot(), `prefix ${JSON.stringify(prefix)}`).toEqual(oneShot);
+        }
+      }
+    });
+
+    it("never loses a result that parsePartialJson would have produced", () => {
+      for (const doc of DOCS) {
+        for (let n = 1; n <= doc.length; n++) {
+          const prefix = doc.slice(0, n);
+          if (/\s$/.test(prefix)) continue;
+          if (parsePartialJson(prefix) === undefined) continue;
+          const stream = createPartialJsonStream();
+          expect(stream.push(prefix), `prefix ${JSON.stringify(prefix)}`).toBeDefined();
+        }
+      }
+    });
+
+    it("diverges by keeping the object built so far while a key is in flight", () => {
+      // parsePartialJson discards the whole object; the stream keeps what it has.
+      expect(parsePartialJson('{"name":"Alice","ag')).toBeUndefined();
+      const stream = createPartialJsonStream();
+      expect(stream.push('{"name":"Alice","ag')).toEqual({ name: "Alice" });
+    });
+
+    it("diverges by preserving trailing whitespace inside an in-flight string", () => {
+      expect(parsePartialJson('{"s":"he ')).toEqual({ s: "he" });
+      const stream = createPartialJsonStream();
+      expect(stream.push('{"s":"he ')).toEqual({ s: "he " });
+    });
+  });
+
+  describe("performance", () => {
+    it("parses 100 KB in 40-character chunks in linear time", () => {
+      const items: unknown[] = [];
+      let size = 0;
+      while (size < 110_000) {
+        const item = {
+          id: items.length,
+          name: `entity number ${items.length}`,
+          tags: ["alpha", "beta"],
+          score: items.length * 1.5,
+          ok: items.length % 2 === 0,
+        };
+        size += JSON.stringify(item).length + 1;
+        items.push(item);
+      }
+      const doc = JSON.stringify({ items });
+      expect(doc.length).toBeGreaterThan(100_000);
+
+      const started = performance.now();
+      const stream = createPartialJsonStream();
+      for (let i = 0; i < doc.length; i += 40) {
+        stream.push(doc.slice(i, i + 40));
+      }
+      const result = stream.finish();
+      const elapsed = performance.now() - started;
+
+      expect(result).toEqual(JSON.parse(doc));
+      // Re-parsing the growing buffer on every chunk takes multiple seconds here.
+      // The bound is deliberately loose so only an algorithmic regression trips it.
+      expect(elapsed).toBeLessThan(250);
+    });
+  });
+});

--- a/packages/util/src/json-schema/PartialJsonStream.ts
+++ b/packages/util/src/json-schema/PartialJsonStream.ts
@@ -1,0 +1,650 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Parser modes. The tokenizer is a flat state machine so a chunk can end in the
+ * middle of any token and resume on the next `push()` without re-reading input.
+ */
+const Mode = {
+  /** Discarding preamble text until the first `{` or `[`. */
+  Seek: 0,
+  /** Expecting the start of a value. */
+  Value: 1,
+  /** Expecting an object key or the closing `}`. */
+  Key: 2,
+  /** Expecting the `:` between key and value. */
+  Colon: 3,
+  /** Expecting `,` or a closing delimiter after a completed value. */
+  Comma: 4,
+  /** Inside a string literal. */
+  String: 5,
+  /** Inside a number token. */
+  Number: 6,
+  /** Inside a `true` / `false` / `null` token. */
+  Literal: 7,
+  /** The root value closed; further input is ignored. */
+  Done: 8,
+  /** Malformed input; further input is ignored and the partial root is kept. */
+  Invalid: 9,
+} as const;
+type Mode = (typeof Mode)[keyof typeof Mode];
+
+const CHAR_TAB = 9;
+const CHAR_LF = 10;
+const CHAR_CR = 13;
+const CHAR_SPACE = 32;
+const CHAR_QUOTE = 34;
+const CHAR_BACKSLASH = 92;
+
+/** Strict JSON number grammar — rejects `1.`, `1e`, `-`, `+1`, `01`. */
+const COMPLETE_NUMBER = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:e[+-]?\d+)?$/i;
+
+const LITERALS: Record<string, boolean | null> = {
+  true: true,
+  false: false,
+  null: null,
+};
+
+function isWhitespace(code: number): boolean {
+  return code === CHAR_SPACE || code === CHAR_LF || code === CHAR_TAB || code === CHAR_CR;
+}
+
+function isNumberChar(code: number): boolean {
+  // 0-9, '-', '+', '.', 'e', 'E'
+  return (
+    (code >= 48 && code <= 57) ||
+    code === 45 ||
+    code === 43 ||
+    code === 46 ||
+    code === 101 ||
+    code === 69
+  );
+}
+
+function hexValue(code: number): number {
+  if (code >= 48 && code <= 57) return code - 48;
+  if (code >= 97 && code <= 102) return code - 87;
+  if (code >= 65 && code <= 70) return code - 55;
+  return -1;
+}
+
+function isLiteralPrefix(text: string): boolean {
+  return "true".startsWith(text) || "false".startsWith(text) || "null".startsWith(text);
+}
+
+/**
+ * Assigns an own property, matching `JSON.parse` for the `__proto__` key.
+ *
+ * A plain `target["__proto__"] = value` mutates the prototype instead of
+ * creating an own property, so untrusted model output could otherwise reach
+ * `Object.prototype`.
+ */
+function assignKey(target: Record<string, unknown>, key: string, value: unknown): void {
+  if (key === "__proto__") {
+    Object.defineProperty(target, key, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    return;
+  }
+  target[key] = value;
+}
+
+interface Frame {
+  readonly isArray: boolean;
+  readonly value: Record<string, unknown> | unknown[];
+  /** Key awaiting a value, for object frames. */
+  key: string;
+}
+
+/**
+ * Where the value currently being tokenized will be written. Held so an
+ * in-flight string or number can be revised in place as more of it arrives,
+ * instead of being appended twice.
+ */
+type PendingSlot =
+  | { readonly kind: "object"; readonly target: Record<string, unknown>; readonly key: string }
+  | { readonly kind: "array"; readonly target: unknown[]; readonly index: number }
+  | { readonly kind: "root" };
+
+export interface PartialJsonStreamOptions {
+  /**
+   * Discard any text before the first `{` or `[`. Use for providers that emit
+   * prose, a `<think>` block, or a Markdown fence ahead of the JSON. Once the
+   * root value closes, trailing text is ignored either way.
+   */
+  readonly skipPreamble?: boolean;
+}
+
+/**
+ * An incremental JSON parser that consumes a document in chunks.
+ *
+ * Each {@link push} costs O(chunk.length) — consumed input is never re-scanned —
+ * so feeding a document in N chunks costs O(document length) overall rather than
+ * the O(n²) of re-parsing a growing buffer on every delta.
+ *
+ * ## Aliasing
+ *
+ * {@link push} returns the **live** root object, which the parser keeps mutating
+ * as more input arrives. That aliasing is what keeps the cost linear: deep-cloning
+ * per delta would restore the quadratic behavior. It is safe for a consumer that
+ * reads each delta before the next `push()`, and safe across a worker boundary
+ * (events are structured-cloned on the way out), but a consumer that retains an
+ * earlier delta will observe it change. Use {@link snapshot} for a detached copy.
+ */
+export interface PartialJsonStream {
+  /**
+   * Consumes a chunk and returns the live root object, or `undefined` while the
+   * root is not (yet) a plain object — no container has opened, or the document
+   * has an array or scalar at its root. Mirrors {@link parsePartialJson}'s
+   * object-only contract, so a caller can emit the result as an object delta
+   * without first checking for an array.
+   */
+  push(chunk: string): Record<string, unknown> | undefined;
+  /**
+   * Closes any open strings and containers and returns the parsed document.
+   * A trailing incomplete token (`1.`, `tru`, a partial key) is dropped, matching
+   * {@link parsePartialJson}'s repair. Idempotent; input after it is ignored.
+   */
+  finish(): Record<string, unknown>;
+  /** A detached deep copy of the current live root; O(size of the value). */
+  snapshot(): Record<string, unknown> | undefined;
+  /** Whether the root value closed on its own (as opposed to being truncated). */
+  readonly complete: boolean;
+}
+
+class PartialJsonStreamImpl implements PartialJsonStream {
+  private mode: Mode;
+  private readonly skipPreamble: boolean;
+  private readonly stack: Frame[] = [];
+  private root: unknown = undefined;
+  private pending: PendingSlot | undefined = undefined;
+  /** Buffer for the token in flight — bounded by that token, not the document. */
+  private buf = "";
+  private stringIsKey = false;
+  private escaped = false;
+  private unicodeRemaining = 0;
+  private unicodeValue = 0;
+  private closed = false;
+  private finished = false;
+
+  constructor(skipPreamble: boolean) {
+    this.skipPreamble = skipPreamble;
+    this.mode = skipPreamble ? Mode.Seek : Mode.Value;
+  }
+
+  get complete(): boolean {
+    return this.closed;
+  }
+
+  push(chunk: string): Record<string, unknown> | undefined {
+    if (!this.finished && chunk.length > 0) {
+      this.consume(chunk);
+    }
+    return this.liveRoot();
+  }
+
+  finish(): Record<string, unknown> {
+    if (!this.finished) {
+      this.finished = true;
+      this.flushPendingToken();
+      this.stack.length = 0;
+    }
+    const root = this.root;
+    return root === undefined ? {} : (root as Record<string, unknown>);
+  }
+
+  snapshot(): Record<string, unknown> | undefined {
+    const live = this.liveRoot();
+    if (live === undefined) return undefined;
+    // The tree is JSON by construction, so a round-trip is a faithful clone.
+    return JSON.parse(JSON.stringify(live)) as Record<string, unknown>;
+  }
+
+  /**
+   * Writes the in-flight token into its slot so a caller reading between chunks
+   * sees a partially-received string or an already-valid number. Repeatable: the
+   * slot is overwritten, never appended to.
+   */
+  private materializePending(): void {
+    if (this.pending === undefined) return;
+    if (this.mode === Mode.String) {
+      if (!this.stringIsKey) this.writeSlot(this.buf);
+      return;
+    }
+    if (this.mode === Mode.Number) {
+      if (COMPLETE_NUMBER.test(this.buf)) this.writeSlot(Number(this.buf));
+      else this.clearSlot();
+    }
+  }
+
+  /** Commits a trailing token at end of stream, dropping anything incomplete. */
+  private flushPendingToken(): void {
+    if (this.mode === Mode.String) {
+      if (this.stringIsKey) this.clearSlot();
+      else this.commit(this.buf);
+      return;
+    }
+    if (this.mode === Mode.Number) {
+      if (COMPLETE_NUMBER.test(this.buf)) this.commit(Number(this.buf));
+      else this.clearSlot();
+      return;
+    }
+    if (this.mode === Mode.Literal) this.clearSlot();
+  }
+
+  /**
+   * Handles a character that cannot occur in the current state.
+   *
+   * Normally the rest of the stream is abandoned and whatever was parsed so far
+   * is kept. When skipping preamble the text is untrusted prose, so a candidate
+   * that never yielded any data — prose braces such as `{braces}` inside a
+   * `<think>` block — is discarded and scanning resumes for the real payload. A
+   * candidate that did produce data is kept rather than gambling on a better one.
+   */
+  private fail(index: number): number {
+    if (this.skipPreamble && !this.closed && this.rootIsEmpty()) {
+      this.stack.length = 0;
+      this.pending = undefined;
+      this.buf = "";
+      this.escaped = false;
+      this.unicodeRemaining = 0;
+      this.root = undefined;
+      this.mode = Mode.Seek;
+      return index;
+    }
+    this.mode = Mode.Invalid;
+    return index;
+  }
+
+  private rootIsEmpty(): boolean {
+    const root = this.root;
+    if (root === undefined) return true;
+    if (Array.isArray(root)) return root.length === 0;
+    if (root !== null && typeof root === "object") {
+      return Object.keys(root).length === 0;
+    }
+    return false;
+  }
+
+  private liveRoot(): Record<string, unknown> | undefined {
+    this.materializePending();
+    const root = this.root;
+    if (root === null || typeof root !== "object" || Array.isArray(root)) return undefined;
+    return root as Record<string, unknown>;
+  }
+
+  private writeSlot(value: unknown): void {
+    const slot = this.pending;
+    if (slot === undefined) return;
+    if (slot.kind === "object") assignKey(slot.target, slot.key, value);
+    else if (slot.kind === "array") slot.target[slot.index] = value;
+    else this.root = value;
+  }
+
+  private clearSlot(): void {
+    const slot = this.pending;
+    if (slot === undefined) return;
+    if (slot.kind === "object") delete slot.target[slot.key];
+    else if (slot.kind === "array") slot.target.length = slot.index;
+    else this.root = undefined;
+  }
+
+  /**
+   * Reserves the destination of a value that is about to be tokenized. Array
+   * slots record the index rather than pushing a placeholder, so an incomplete
+   * token leaves no hole behind.
+   */
+  private beginValue(): void {
+    const top = this.stack[this.stack.length - 1];
+    if (top === undefined) {
+      this.pending = { kind: "root" };
+    } else if (top.isArray) {
+      const target = top.value as unknown[];
+      this.pending = { kind: "array", target, index: target.length };
+    } else {
+      this.pending = { kind: "object", target: top.value as Record<string, unknown>, key: top.key };
+    }
+  }
+
+  private commit(value: unknown): void {
+    this.writeSlot(value);
+    this.pending = undefined;
+    this.buf = "";
+    this.afterValue();
+  }
+
+  private afterValue(): void {
+    if (this.stack.length === 0) {
+      this.mode = Mode.Done;
+      this.closed = true;
+      return;
+    }
+    this.mode = Mode.Comma;
+  }
+
+  private openContainer(isArray: boolean): void {
+    this.beginValue();
+    const value: Record<string, unknown> | unknown[] = isArray ? [] : {};
+    this.writeSlot(value);
+    this.pending = undefined;
+    this.stack.push({ isArray, value, key: "" });
+    this.mode = isArray ? Mode.Value : Mode.Key;
+  }
+
+  private closeContainer(): void {
+    this.stack.pop();
+    this.buf = "";
+    this.pending = undefined;
+    this.afterValue();
+  }
+
+  private consume(chunk: string): void {
+    const len = chunk.length;
+    let i = 0;
+    while (i < len) {
+      switch (this.mode) {
+        case Mode.Seek:
+          i = this.consumeSeek(chunk, i, len);
+          break;
+        case Mode.String:
+          i = this.consumeString(chunk, i, len);
+          break;
+        case Mode.Number:
+          i = this.consumeNumber(chunk, i, len);
+          break;
+        case Mode.Literal:
+          i = this.consumeLiteral(chunk, i, len);
+          break;
+        case Mode.Value:
+          i = this.consumeValueStart(chunk, i, len);
+          break;
+        case Mode.Key:
+          i = this.consumeKeyStart(chunk, i, len);
+          break;
+        case Mode.Colon:
+          i = this.consumeColon(chunk, i, len);
+          break;
+        case Mode.Comma:
+          i = this.consumeComma(chunk, i, len);
+          break;
+        default:
+          // Done or Invalid: the rest of the stream is ignored.
+          return;
+      }
+    }
+  }
+
+  private consumeSeek(chunk: string, start: number, len: number): number {
+    for (let i = start; i < len; i++) {
+      const ch = chunk[i]!;
+      if (ch === "{" || ch === "[") {
+        this.mode = Mode.Value;
+        return i;
+      }
+    }
+    return len;
+  }
+
+  private consumeValueStart(chunk: string, start: number, len: number): number {
+    let i = start;
+    while (i < len) {
+      const code = chunk.charCodeAt(i);
+      if (isWhitespace(code)) {
+        i++;
+        continue;
+      }
+      const ch = chunk[i]!;
+      i++;
+      if (ch === "{") {
+        this.openContainer(false);
+        return i;
+      }
+      if (ch === "[") {
+        this.openContainer(true);
+        return i;
+      }
+      if (ch === '"') {
+        this.beginValue();
+        this.buf = "";
+        this.stringIsKey = false;
+        this.mode = Mode.String;
+        return i;
+      }
+      if (ch === "}" || ch === "]") {
+        // Lenient close: an empty container, or a trailing comma before the
+        // close, which a truncated model response often produces.
+        this.closeContainer();
+        return i;
+      }
+      if (code === 45 || (code >= 48 && code <= 57)) {
+        this.beginValue();
+        this.buf = ch;
+        this.mode = Mode.Number;
+        return i;
+      }
+      if (ch === "t" || ch === "f" || ch === "n") {
+        this.beginValue();
+        this.buf = ch;
+        this.mode = Mode.Literal;
+        return i;
+      }
+      return this.fail(i);
+    }
+    return i;
+  }
+
+  private consumeKeyStart(chunk: string, start: number, len: number): number {
+    let i = start;
+    while (i < len) {
+      const code = chunk.charCodeAt(i);
+      if (isWhitespace(code)) {
+        i++;
+        continue;
+      }
+      const ch = chunk[i]!;
+      i++;
+      if (ch === '"') {
+        this.buf = "";
+        this.stringIsKey = true;
+        this.mode = Mode.String;
+        return i;
+      }
+      if (ch === "}") {
+        this.closeContainer();
+        return i;
+      }
+      if (ch === ",") continue;
+      return this.fail(i);
+    }
+    return i;
+  }
+
+  private consumeColon(chunk: string, start: number, len: number): number {
+    let i = start;
+    while (i < len) {
+      const code = chunk.charCodeAt(i);
+      if (isWhitespace(code)) {
+        i++;
+        continue;
+      }
+      const ch = chunk[i]!;
+      i++;
+      if (ch === ":") {
+        this.mode = Mode.Value;
+        return i;
+      }
+      return this.fail(i);
+    }
+    return i;
+  }
+
+  private consumeComma(chunk: string, start: number, len: number): number {
+    let i = start;
+    while (i < len) {
+      const code = chunk.charCodeAt(i);
+      if (isWhitespace(code)) {
+        i++;
+        continue;
+      }
+      const ch = chunk[i]!;
+      i++;
+      if (ch === ",") {
+        const top = this.stack[this.stack.length - 1];
+        this.mode = top !== undefined && !top.isArray ? Mode.Key : Mode.Value;
+        return i;
+      }
+      if (ch === "}" || ch === "]") {
+        this.closeContainer();
+        return i;
+      }
+      return this.fail(i);
+    }
+    return i;
+  }
+
+  private consumeString(chunk: string, start: number, len: number): number {
+    let i = start;
+    while (i < len) {
+      if (this.unicodeRemaining > 0) {
+        const digit = hexValue(chunk.charCodeAt(i));
+        if (digit < 0) {
+          // Not a valid \uXXXX escape; keep the text as written.
+          this.buf += "\\u";
+          this.unicodeRemaining = 0;
+          this.unicodeValue = 0;
+          continue;
+        }
+        this.unicodeValue = this.unicodeValue * 16 + digit;
+        this.unicodeRemaining--;
+        i++;
+        if (this.unicodeRemaining === 0) {
+          this.buf += String.fromCharCode(this.unicodeValue);
+          this.unicodeValue = 0;
+        }
+        continue;
+      }
+
+      if (this.escaped) {
+        const ch = chunk[i]!;
+        this.escaped = false;
+        i++;
+        switch (ch) {
+          case "b":
+            this.buf += "\b";
+            break;
+          case "f":
+            this.buf += "\f";
+            break;
+          case "n":
+            this.buf += "\n";
+            break;
+          case "r":
+            this.buf += "\r";
+            break;
+          case "t":
+            this.buf += "\t";
+            break;
+          case "u":
+            this.unicodeRemaining = 4;
+            this.unicodeValue = 0;
+            break;
+          default:
+            this.buf += ch;
+            break;
+        }
+        continue;
+      }
+
+      // Bulk-copy the run up to the next quote or backslash.
+      let j = i;
+      while (j < len) {
+        const code = chunk.charCodeAt(j);
+        if (code === CHAR_QUOTE || code === CHAR_BACKSLASH) break;
+        j++;
+      }
+      if (j > i) {
+        this.buf += chunk.slice(i, j);
+        i = j;
+      }
+      if (i >= len) return len;
+      const code = chunk.charCodeAt(i);
+      i++;
+      if (code === CHAR_BACKSLASH) {
+        this.escaped = true;
+        continue;
+      }
+      this.endString();
+      return i;
+    }
+    return i;
+  }
+
+  private endString(): void {
+    if (this.stringIsKey) {
+      const top = this.stack[this.stack.length - 1];
+      if (top !== undefined) top.key = this.buf;
+      this.buf = "";
+      this.mode = Mode.Colon;
+      return;
+    }
+    this.commit(this.buf);
+  }
+
+  private consumeNumber(chunk: string, start: number, len: number): number {
+    let i = start;
+    while (i < len && isNumberChar(chunk.charCodeAt(i))) i++;
+    if (i > start) this.buf += chunk.slice(start, i);
+    if (i >= len) return len;
+    if (!COMPLETE_NUMBER.test(this.buf)) {
+      this.clearSlot();
+      return this.fail(i);
+    }
+    // The terminator belongs to the enclosing container; re-dispatch it.
+    this.commit(Number(this.buf));
+    return i;
+  }
+
+  private consumeLiteral(chunk: string, start: number, len: number): number {
+    let i = start;
+    while (i < len) {
+      const code = chunk.charCodeAt(i);
+      if (code < 97 || code > 122) break;
+      this.buf += chunk[i]!;
+      i++;
+      if (this.buf in LITERALS) {
+        this.commit(LITERALS[this.buf]);
+        return i;
+      }
+      if (!isLiteralPrefix(this.buf)) {
+        this.clearSlot();
+        return this.fail(i);
+      }
+    }
+    if (i < len) {
+      // A non-letter terminated a literal that never completed.
+      this.clearSlot();
+      return this.fail(i);
+    }
+    return i;
+  }
+}
+
+/**
+ * Creates an incremental partial-JSON parser.
+ *
+ * Feed it provider deltas as they arrive and emit the value `push` returns; call
+ * `finish()` once for the final document. See {@link PartialJsonStream} for the
+ * live-root aliasing contract.
+ *
+ * For a one-shot repair of an already-accumulated buffer, use
+ * {@link parsePartialJson} instead.
+ */
+export function createPartialJsonStream(options: PartialJsonStreamOptions = {}): PartialJsonStream {
+  return new PartialJsonStreamImpl(options.skipPreamble === true);
+}

--- a/packages/util/src/json-schema/PartialJsonStream.ts
+++ b/packages/util/src/json-schema/PartialJsonStream.ts
@@ -9,7 +9,7 @@
  * middle of any token and resume on the next `push()` without re-reading input.
  */
 const Mode = {
-  /** Discarding preamble text until the first `{` or `[`. */
+  /** Discarding preamble text until the first `{`. */
   Seek: 0,
   /** Expecting the start of a value. */
   Value: 1,
@@ -114,9 +114,14 @@ type PendingSlot =
 
 export interface PartialJsonStreamOptions {
   /**
-   * Discard any text before the first `{` or `[`. Use for providers that emit
-   * prose, a `<think>` block, or a Markdown fence ahead of the JSON. Once the
-   * root value closes, trailing text is ignored either way.
+   * Discard any text before the first `{`. Use for providers that emit prose,
+   * a `<think>` block, or a Markdown fence ahead of the JSON. Once the root
+   * value closes, trailing text is ignored either way.
+   *
+   * A `[` never starts the payload in this mode: prose is full of bracketed
+   * asides that parse as valid arrays, and the object-only contract makes an
+   * array root useless anyway. A document that really is array-rooted must be
+   * fed without `skipPreamble`.
    */
   readonly skipPreamble?: boolean;
 }
@@ -170,6 +175,8 @@ class PartialJsonStreamImpl implements PartialJsonStream {
   private escaped = false;
   private unicodeRemaining = 0;
   private unicodeValue = 0;
+  /** Raw hex digits of the `\uXXXX` escape in flight, kept so an invalid one replays verbatim. */
+  private unicodeText = "";
   private closed = false;
   private finished = false;
 
@@ -254,6 +261,8 @@ class PartialJsonStreamImpl implements PartialJsonStream {
       this.buf = "";
       this.escaped = false;
       this.unicodeRemaining = 0;
+      this.unicodeValue = 0;
+      this.unicodeText = "";
       this.root = undefined;
       this.mode = Mode.Seek;
       return index;
@@ -380,10 +389,18 @@ class PartialJsonStreamImpl implements PartialJsonStream {
     }
   }
 
+  /**
+   * Scans past preamble to the start of the payload. Only `{` opens a
+   * candidate: the parser's contract is object-only, and prose is full of
+   * bracketed asides (`[1]`, `[2024 figures]`) that parse as a perfectly
+   * valid array. A complete one would close the root and make the parser
+   * ignore the real payload behind it; an incomplete one leaves a non-empty
+   * root, which {@link fail} then refuses to discard. Neither is recoverable,
+   * so a bracket never starts a candidate here.
+   */
   private consumeSeek(chunk: string, start: number, len: number): number {
     for (let i = start; i < len; i++) {
-      const ch = chunk[i]!;
-      if (ch === "{" || ch === "[") {
+      if (chunk[i] === "{") {
         this.mode = Mode.Value;
         return i;
       }
@@ -514,18 +531,23 @@ class PartialJsonStreamImpl implements PartialJsonStream {
       if (this.unicodeRemaining > 0) {
         const digit = hexValue(chunk.charCodeAt(i));
         if (digit < 0) {
-          // Not a valid \uXXXX escape; keep the text as written.
-          this.buf += "\\u";
+          // Not a valid \uXXXX escape; keep the text exactly as written,
+          // including any hex digits already consumed (`\u00zz` must not
+          // come back as `\uzz`). The offending character is re-dispatched.
+          this.buf += `\\u${this.unicodeText}`;
           this.unicodeRemaining = 0;
           this.unicodeValue = 0;
+          this.unicodeText = "";
           continue;
         }
         this.unicodeValue = this.unicodeValue * 16 + digit;
+        this.unicodeText += chunk[i]!;
         this.unicodeRemaining--;
         i++;
         if (this.unicodeRemaining === 0) {
           this.buf += String.fromCharCode(this.unicodeValue);
           this.unicodeValue = 0;
+          this.unicodeText = "";
         }
         continue;
       }

--- a/packages/util/src/json-schema/PartialJsonStream.ts
+++ b/packages/util/src/json-schema/PartialJsonStream.ts
@@ -435,7 +435,12 @@ class PartialJsonStreamImpl implements PartialJsonStream {
       }
       if (ch === "}" || ch === "]") {
         // Lenient close: an empty container, or a trailing comma before the
-        // close, which a truncated model response often produces.
+        // close, which a truncated model response often produces. With no open
+        // container there is nothing to close — a stray `}` at the root is
+        // malformed input, and treating it as a close would pop the empty
+        // stack, mark the document `complete` with an undefined root, and make
+        // the parser ignore the real payload behind it.
+        if (this.stack.length === 0) return this.fail(i);
         this.closeContainer();
         return i;
       }

--- a/packages/util/src/schema-entry.ts
+++ b/packages/util/src/schema-entry.ts
@@ -11,6 +11,7 @@ export * from "./json-schema/FromSchema";
 export * from "./json-schema/JsonSchema";
 export * from "./json-schema/SchemaUtils";
 export * from "./json-schema/SchemaValidation";
+export * from "./json-schema/PartialJsonStream";
 export * from "./json-schema/parsePartialJson";
 export * from "./vector/Tensor";
 export * from "./vector/TypedArray";

--- a/packages/util/src/worker-entry.ts
+++ b/packages/util/src/worker-entry.ts
@@ -28,6 +28,7 @@ export * from "./worker/WorkerServerBase";
 export * from "./worker/WorkerManager";
 export * from "./worker/scrubStack";
 
+export * from "./json-schema/PartialJsonStream";
 export * from "./json-schema/parsePartialJson";
 
 export type { DataPortSchemaObject } from "./json-schema/DataPortSchema";

--- a/providers/anthropic/src/ai/common/Anthropic_StructuredGeneration.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_StructuredGeneration.ts
@@ -9,7 +9,7 @@ import type {
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream } from "@workglow/util/worker";
 import { getClient, getMaxTokens, getModelName } from "./Anthropic_Client";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 import { maybeEmitAnthropicRefusal } from "./Anthropic_Refusal";
@@ -20,12 +20,12 @@ import { createAnthropicUsageCollector } from "./Anthropic_Usage";
  *
  * Anthropic implements structured generation via tool-use under the hood:
  * a synthetic `structured_output` tool forces the model to emit JSON conforming
- * to the output schema. We accumulate the `input_json_delta` stream events and
- * yield `object-delta` for consumers that want incremental updates. The final
- * `finish` event carries the parsed object in `finish.data.object` per the
- * documented streaming-convention exception for structured generation (CLAUDE.md
- * lines 201-205): the `StructuredGenerationTask` consumer reads the parsed
- * object from `finish.data` directly instead of accumulating deltas.
+ * to the output schema. The `input_json_delta` stream events are fed to an
+ * incremental parser and yielded as `object-delta` for consumers that want
+ * progressive updates. The final `finish` event carries the parsed object in
+ * `finish.data.object` per the streaming-convention exception for structured
+ * generation: it is the definitive object `StructuredGenerationTask` validates
+ * against the schema and retries on.
  */
 export const Anthropic_StructuredGeneration_Stream: AiProviderRunFn<
   StructuredGenerationTaskInput,
@@ -54,32 +54,22 @@ export const Anthropic_StructuredGeneration_Stream: AiProviderRunFn<
     { signal }
   );
 
-  let accumulatedJson = "";
+  const json = createPartialJsonStream();
   const usageCollector = createAnthropicUsageCollector();
   for await (const event of stream) {
     usageCollector.observe(event);
     maybeEmitAnthropicRefusal(event, emit);
     if (event.type === "content_block_delta" && event.delta.type === "input_json_delta") {
-      accumulatedJson += event.delta.partial_json;
-      const partial = parsePartialJson(accumulatedJson);
+      const partial = json.push(event.delta.partial_json);
       if (partial !== undefined) {
         emit({ type: "object-delta", port: "object", objectDelta: partial });
       }
     }
   }
 
-  let finalObject: Record<string, unknown>;
-  try {
-    finalObject = JSON.parse(accumulatedJson);
-  } catch {
-    finalObject = parsePartialJson(accumulatedJson) ?? {};
-  }
-  // Exception: structured generation MUST populate finish.data.object so the
-  // StructuredGenerationTask consumer can read the parsed object without a
-  // JSON streaming parser. See CLAUDE.md streaming-convention-exception note.
   emit({
     type: "finish",
-    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    data: { object: json.finish() } as StructuredGenerationTaskOutput,
     usage: usageCollector.result(),
   });
 };

--- a/providers/chrome-ai/src/ai/common/WebBrowser_StructuredGeneration.ts
+++ b/providers/chrome-ai/src/ai/common/WebBrowser_StructuredGeneration.ts
@@ -12,7 +12,7 @@ import type {
 import { PermanentJobError } from "@workglow/job-queue";
 import type { JsonSchema } from "@workglow/util/schema";
 import { compileSchema } from "@workglow/util/schema";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream } from "@workglow/util/worker";
 
 import {
   createDownloadMonitor,
@@ -85,7 +85,7 @@ export const WebBrowser_StructuredGeneration: AiProviderRunFn<
       omitResponseConstraintInput: true,
     });
 
-    let accumulatedJson = "";
+    let json = createPartialJsonStream();
     let previousSnapshot = "";
     const reader = stream.getReader();
     try {
@@ -93,15 +93,16 @@ export const WebBrowser_StructuredGeneration: AiProviderRunFn<
         const { done, value } = await reader.read();
         if (done) break;
         // Chrome's streaming surface emits progressive full-text snapshots,
-        // not deltas. Diff against the previous snapshot so the accumulated
-        // JSON grows monotonically; on the (rare) replacement case, reset.
+        // not deltas. Feed the parser only the newly-appended tail; on the
+        // (rare) replacement case, restart it on the replacement text.
+        let partial: Record<string, unknown> | undefined;
         if (value.startsWith(previousSnapshot)) {
-          accumulatedJson += value.slice(previousSnapshot.length);
+          partial = json.push(value.slice(previousSnapshot.length));
         } else {
-          accumulatedJson = value;
+          json = createPartialJsonStream();
+          partial = json.push(value);
         }
         previousSnapshot = value;
-        const partial = parsePartialJson(accumulatedJson);
         if (partial !== undefined) {
           emit({ type: "object-delta", port: "object", objectDelta: partial });
         }
@@ -110,15 +111,9 @@ export const WebBrowser_StructuredGeneration: AiProviderRunFn<
       reader.releaseLock();
     }
 
-    let finalObject: Record<string, unknown>;
-    try {
-      finalObject = JSON.parse(accumulatedJson) as Record<string, unknown>;
-    } catch {
-      finalObject = (parsePartialJson(accumulatedJson) ?? {}) as Record<string, unknown>;
-    }
     emit({
       type: "finish",
-      data: { object: finalObject } as StructuredGenerationTaskOutput,
+      data: { object: json.finish() } as StructuredGenerationTaskOutput,
     });
   } finally {
     try {

--- a/providers/deepseek/src/ai/common/DeepSeek_StructuredGeneration.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_StructuredGeneration.ts
@@ -11,7 +11,7 @@ import type {
   Usage,
 } from "@workglow/ai";
 import { OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream } from "@workglow/util/worker";
 import {
   assertNotTruncatedByReasoning,
   getClient,
@@ -75,16 +75,20 @@ export const DeepSeek_StructuredGeneration_Stream: AiProviderRunFn<
     { signal }
   );
 
-  let accumulatedJson = "";
+  const json = createPartialJsonStream();
   let refusal = "";
   let finishReason: string | null | undefined;
   let usage: Usage | undefined;
+  // The reasoning-exhaustion guard below only distinguishes "no content at all"
+  // from "some content", so retaining one delta answers it without re-growing a
+  // copy of the whole document.
+  let anyContent = "";
   for await (const chunk of stream) {
     usage = mapDeepSeekUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
-      accumulatedJson += delta;
-      const partial = parsePartialJson(accumulatedJson);
+      if (anyContent === "") anyContent = delta;
+      const partial = json.push(delta);
       if (partial !== undefined) {
         emit({ type: "object-delta", port: "object", objectDelta: partial });
       }
@@ -97,17 +101,11 @@ export const DeepSeek_StructuredGeneration_Stream: AiProviderRunFn<
     emit({ type: "refusal", refusal });
   }
 
-  assertNotTruncatedByReasoning(finishReason, accumulatedJson, input.maxTokens);
+  assertNotTruncatedByReasoning(finishReason, anyContent, input.maxTokens);
 
-  let finalObject: Record<string, unknown>;
-  try {
-    finalObject = JSON.parse(accumulatedJson);
-  } catch {
-    finalObject = parsePartialJson(accumulatedJson) ?? {};
-  }
   emit({
     type: "finish",
-    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    data: { object: json.finish() } as StructuredGenerationTaskOutput,
     usage,
   });
 };

--- a/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
@@ -9,7 +9,7 @@ import type {
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream } from "@workglow/util/worker";
 import { createGeminiClient, getModelName, resolveThinkingConfig } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { emitGeminiRefusal, geminiRefusalCategory } from "./Gemini_Refusal";
@@ -31,8 +31,8 @@ const DEFAULT_STRUCTURED_THINKING_BUDGET = 2048;
  * Streaming run-fn for `["text.generation", "json-mode"]`. Gemini uses
  * `responseSchema` + `responseMimeType: "application/json"` to produce
  * structured output. Per the streaming convention exception for json-mode,
- * the `finish` event MUST include the parsed `object` so that
- * `StructuredGenerationTask` can read it without a JSON streaming parser.
+ * the `finish` event MUST include the parsed `object` — it is the definitive
+ * result `StructuredGenerationTask` validates against the schema.
  *
  * With `responseMimeType: "application/json"` the response payload is JSON only —
  * reasoning stays internal and never appears in the emitted parts — so the
@@ -71,7 +71,7 @@ export const Gemini_StructuredGeneration_Stream: AiProviderRunFn<
     },
   });
 
-  let accumulatedJson = "";
+  const json = createPartialJsonStream();
   let refusalCategory: string | undefined;
   let lastUsageMetadata: unknown;
   for await (const chunk of result) {
@@ -79,8 +79,7 @@ export const Gemini_StructuredGeneration_Stream: AiProviderRunFn<
     // `chunk.text` concatenates the answer text (thought parts are excluded).
     const text = chunk.text;
     if (text) {
-      accumulatedJson += text;
-      const partial = parsePartialJson(accumulatedJson);
+      const partial = json.push(text);
       if (partial !== undefined) {
         emit({ type: "object-delta", port: "object", objectDelta: partial });
       }
@@ -89,16 +88,10 @@ export const Gemini_StructuredGeneration_Stream: AiProviderRunFn<
   }
   emitGeminiRefusal(emit, refusalCategory);
 
-  let finalObject: Record<string, unknown>;
-  try {
-    finalObject = JSON.parse(accumulatedJson);
-  } catch {
-    finalObject = parsePartialJson(accumulatedJson) ?? {};
-  }
   // json-mode finish exception: populate finish.data.object with parsed result.
   emit({
     type: "finish",
-    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    data: { object: json.finish() } as StructuredGenerationTaskOutput,
     usage: mapGeminiUsage(lastUsageMetadata),
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_StructuredGeneration.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_StructuredGeneration.ts
@@ -10,7 +10,7 @@ import type {
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream } from "@workglow/util/worker";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
 import {
   getPipeline,
@@ -27,41 +27,6 @@ function buildStructuredGenerationPrompt(input: StructuredGenerationTaskInput): 
     `You MUST respond with ONLY a valid JSON object conforming to this JSON schema:\n${schemaStr}\n\n` +
     `Output ONLY the JSON object, no other text.`
   );
-}
-
-/**
- * Strip thinking blocks (`<think>...</think>`) and HFT special tokens
- * (`<|im_end|>`, `<|end_of_turn|>`, etc.) that thinking models prepend
- * to their actual output.
- */
-function stripThinkingAndSpecialTokens(text: string): string {
-  return text
-    .replace(/<think>[\s\S]*?<\/think>/g, "")
-    .replace(/<\|[a-z_]+\|>/g, "")
-    .trim();
-}
-
-function extractJsonFromText(text: string): Record<string, unknown> {
-  // Strip thinking blocks and special tokens first so they don't
-  // interfere with JSON extraction (greedy regex would match braces
-  // inside thinking content).
-  const cleaned = stripThinkingAndSpecialTokens(text);
-
-  // Try parsing the cleaned text directly
-  try {
-    return JSON.parse(cleaned);
-  } catch {
-    // Try to extract JSON object from the text
-    const match = cleaned.match(/\{[\s\S]*\}/);
-    if (match) {
-      try {
-        return JSON.parse(match[0]);
-      } catch {
-        return (parsePartialJson(match[0]) as Record<string, unknown>) ?? {};
-      }
-    }
-    return {};
-  }
 }
 
 export const HFT_StructuredGeneration: AiProviderRunFn<
@@ -81,20 +46,17 @@ export const HFT_StructuredGeneration: AiProviderRunFn<
       add_generation_prompt: true,
     }) as string;
 
-    let fullText = "";
-    // Incrementally maintain cleaned text to avoid O(n²) full-string regex on every token.
-    // Use a simple state machine to skip <think>...</think> blocks and strip special
-    // tokens only from the delta received, not from the entire accumulated string.
-    let cleanedText = "";
+    // A state machine skips <think>...</think> blocks and strips special tokens
+    // from each delta, so no full-string regex ever runs over the accumulated
+    // output. What survives is fed straight into the incremental JSON parser,
+    // which discards any remaining preamble ahead of the first '{'.
     let inThinkBlock = false;
-    let jsonStart = -1; // index into cleanedText where the first '{' was found
+    const json = createPartialJsonStream({ skipPreamble: true });
 
     const streamer = createStreamingTextStreamer(
       generateText.tokenizer,
       (delta) => {
-        fullText += delta;
-
-        // Process the delta through the state machine to update cleanedText
+        let cleanedDelta = "";
         let remaining = delta;
         while (remaining.length > 0) {
           if (inThinkBlock) {
@@ -108,26 +70,20 @@ export const HFT_StructuredGeneration: AiProviderRunFn<
           } else {
             const openIdx = remaining.indexOf("<think>");
             if (openIdx !== -1) {
-              cleanedText += remaining.slice(0, openIdx).replace(/<\|[a-z_]+\|>/g, "");
+              cleanedDelta += remaining.slice(0, openIdx).replace(/<\|[a-z_]+\|>/g, "");
               inThinkBlock = true;
               remaining = remaining.slice(openIdx + "<think>".length);
             } else {
-              cleanedText += remaining.replace(/<\|[a-z_]+\|>/g, "");
+              cleanedDelta += remaining.replace(/<\|[a-z_]+\|>/g, "");
               remaining = "";
             }
           }
         }
 
-        // Locate the start of the JSON object once and reuse that index
-        if (jsonStart === -1) {
-          jsonStart = cleanedText.indexOf("{");
-        }
-        if (jsonStart !== -1) {
-          const partial = parsePartialJson(cleanedText.slice(jsonStart));
-          if (partial !== undefined) {
-            emit({ type: "object-delta", port: "object", objectDelta: partial });
-            return;
-          }
+        const partial = json.push(cleanedDelta);
+        if (partial !== undefined) {
+          emit({ type: "object-delta", port: "object", objectDelta: partial });
+          return;
         }
         emit({ type: "text-delta", port: "text", textDelta: delta });
       },
@@ -146,7 +102,6 @@ export const HFT_StructuredGeneration: AiProviderRunFn<
       stopping_criteria: [stopping_criteria],
     });
 
-    const object = extractJsonFromText(fullText);
-    emit({ type: "finish", data: { object } as StructuredGenerationTaskOutput });
+    emit({ type: "finish", data: { object: json.finish() } as StructuredGenerationTaskOutput });
   });
 };

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_StructuredGeneration.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_StructuredGeneration.ts
@@ -9,7 +9,7 @@ import type {
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream } from "@workglow/util/worker";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
   createDisposableTextContext,
@@ -63,7 +63,7 @@ export const LlamaCpp_StructuredGeneration_Stream: AiProviderRunFn<
             resolveWait = null;
           };
 
-          let accumulatedText = "";
+          const json = createPartialJsonStream();
           const promptPromise = session
             .prompt(input.prompt as string, {
               signal,
@@ -90,14 +90,9 @@ export const LlamaCpp_StructuredGeneration_Stream: AiProviderRunFn<
             while (true) {
               while (queue.length > 0) {
                 const chunk = queue.shift()!;
-                accumulatedText += chunk;
-                const partial = parsePartialJson(accumulatedText);
+                const partial = json.push(chunk);
                 if (partial !== undefined) {
-                  emit({
-                    type: "object-delta",
-                    port: "object",
-                    objectDelta: partial as Record<string, unknown>,
-                  });
+                  emit({ type: "object-delta", port: "object", objectDelta: partial });
                 }
               }
               if (isComplete) break;
@@ -107,14 +102,9 @@ export const LlamaCpp_StructuredGeneration_Stream: AiProviderRunFn<
             }
             while (queue.length > 0) {
               const chunk = queue.shift()!;
-              accumulatedText += chunk;
-              const partial = parsePartialJson(accumulatedText);
+              const partial = json.push(chunk);
               if (partial !== undefined) {
-                emit({
-                  type: "object-delta",
-                  port: "object",
-                  objectDelta: partial as Record<string, unknown>,
-                });
+                emit({ type: "object-delta", port: "object", objectDelta: partial });
               }
             }
           } finally {
@@ -129,14 +119,10 @@ export const LlamaCpp_StructuredGeneration_Stream: AiProviderRunFn<
             throw completionError;
           }
 
-          let finalObject: Record<string, unknown>;
-          try {
-            finalObject = JSON.parse(accumulatedText);
-          } catch {
-            finalObject = (parsePartialJson(accumulatedText) as Record<string, unknown>) ?? {};
-          }
-
-          emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+          emit({
+            type: "finish",
+            data: { object: json.finish() } as StructuredGenerationTaskOutput,
+          });
         },
         { signal }
       );

--- a/providers/ollama/src/ai/common/Ollama_StructuredGeneration.ts
+++ b/providers/ollama/src/ai/common/Ollama_StructuredGeneration.ts
@@ -10,7 +10,7 @@ import type {
   StructuredGenerationTaskOutput,
   Usage,
 } from "@workglow/ai";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream } from "@workglow/util/worker";
 import type { OllamaModelConfig } from "./Ollama_ModelSchema";
 import { getOllamaModelName } from "./Ollama_ModelUtil";
 import { mapOllamaUsage } from "./Ollama_Usage";
@@ -24,9 +24,9 @@ type GetClient = (model: OllamaModelConfig | undefined) => Promise<any>;
  * parsed partial JSON on the `object` port.
  *
  * Per the structured-generation streaming-convention exception, the final
- * `finish` event MUST carry the parsed object in `finish.data.object` so the
- * {@link StructuredGenerationTask} consumer can read it without running a JSON
- * streaming parser.
+ * `finish` event MUST carry the parsed object in `finish.data.object`: it is the
+ * definitive result the {@link StructuredGenerationTask} consumer validates
+ * against the output schema.
  */
 export function createOllamaStructuredGenerationStream(
   getClient: GetClient
@@ -55,7 +55,7 @@ export function createOllamaStructuredGenerationStream(
 
     const onAbort = (): void => stream.abort();
     signal?.addEventListener("abort", onAbort, { once: true });
-    let accumulatedJson = "";
+    const json = createPartialJsonStream();
     let usage: Usage | undefined;
     try {
       if (signal?.aborted) stream.abort();
@@ -64,8 +64,7 @@ export function createOllamaStructuredGenerationStream(
         usage = mapOllamaUsage(chunk) ?? usage;
         const delta = chunk.message.content;
         if (delta) {
-          accumulatedJson += delta;
-          const partial = parsePartialJson(accumulatedJson);
+          const partial = json.push(delta);
           if (partial !== undefined) {
             emit({ type: "object-delta", port: "object", objectDelta: partial });
           }
@@ -75,15 +74,9 @@ export function createOllamaStructuredGenerationStream(
       signal?.removeEventListener("abort", onAbort);
     }
 
-    let finalObject: Record<string, unknown>;
-    try {
-      finalObject = JSON.parse(accumulatedJson);
-    } catch {
-      finalObject = parsePartialJson(accumulatedJson) ?? {};
-    }
     emit({
       type: "finish",
-      data: { object: finalObject } as StructuredGenerationTaskOutput,
+      data: { object: json.finish() } as StructuredGenerationTaskOutput,
       usage,
     });
   };

--- a/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
+++ b/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
@@ -15,7 +15,7 @@ import {
   isStrictCompatibleSchema,
   mapOpenAIResponsesUsage,
 } from "@workglow/ai/provider-utils";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream } from "@workglow/util/worker";
 import { finalizeResponsesRequest, getClient, getModelName } from "./OpenAI_Client";
 import type { OpenAiModelConfig } from "./OpenAI_ModelSchema";
 import { warnStrictDowngradedOnce } from "./OpenAI_ResponsesWarnings";
@@ -67,7 +67,7 @@ export const OpenAI_StructuredGeneration_Stream: AiProviderRunFn<
     { signal }
   );
 
-  let accumulatedJson = "";
+  const json = createPartialJsonStream();
   let refusal = "";
   let usage: Usage | undefined;
   for await (const event of stream as AsyncIterable<{
@@ -84,8 +84,7 @@ export const OpenAI_StructuredGeneration_Stream: AiProviderRunFn<
     } else if (event.type === "response.output_text.delta") {
       const delta = event.delta ?? "";
       if (delta) {
-        accumulatedJson += delta;
-        const partial = parsePartialJson(accumulatedJson);
+        const partial = json.push(delta);
         if (partial !== undefined) {
           emit({ type: "object-delta", port: "object", objectDelta: partial });
         }
@@ -101,15 +100,9 @@ export const OpenAI_StructuredGeneration_Stream: AiProviderRunFn<
     emit({ type: "refusal", refusal });
   }
 
-  let finalObject: Record<string, unknown>;
-  try {
-    finalObject = JSON.parse(accumulatedJson);
-  } catch {
-    finalObject = parsePartialJson(accumulatedJson) ?? {};
-  }
   emit({
     type: "finish",
-    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    data: { object: json.finish() } as StructuredGenerationTaskOutput,
     usage,
   });
 };

--- a/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
@@ -11,7 +11,7 @@ import type {
   Usage,
 } from "@workglow/ai";
 import { isStrictCompatibleSchema, OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream } from "@workglow/util/worker";
 import { getClient, getModelName } from "./OpenRouter_Client";
 import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
 import { buildOpenRouterExtras } from "./OpenRouter_RequestParams";
@@ -59,15 +59,14 @@ export const OpenRouter_StructuredGeneration_Stream: AiProviderRunFn<
     { signal }
   );
 
-  let accumulatedJson = "";
+  const json = createPartialJsonStream();
   let refusal = "";
   let usage: Usage | undefined;
   for await (const chunk of stream) {
     usage = mapOpenRouterUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
-      accumulatedJson += delta;
-      const partial = parsePartialJson(accumulatedJson);
+      const partial = json.push(delta);
       if (partial !== undefined) {
         emit({ type: "object-delta", port: "object", objectDelta: partial });
       }
@@ -79,15 +78,9 @@ export const OpenRouter_StructuredGeneration_Stream: AiProviderRunFn<
     emit({ type: "refusal", refusal });
   }
 
-  let finalObject: Record<string, unknown>;
-  try {
-    finalObject = JSON.parse(accumulatedJson);
-  } catch {
-    finalObject = parsePartialJson(accumulatedJson) ?? {};
-  }
   emit({
     type: "finish",
-    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    data: { object: json.finish() } as StructuredGenerationTaskOutput,
     usage,
   });
 };

--- a/providers/tf-mediapipe/src/ai/common/TFMP_StructuredGeneration.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_StructuredGeneration.ts
@@ -9,7 +9,7 @@ import type {
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream, parsePartialJson } from "@workglow/util/worker";
 import { buildGenaiPrompt, resolveTfmpChatTemplate } from "./TFMP_ChatTemplate";
 import { generateGenaiResponse, getGenaiLlm, withGenaiLock } from "./TFMP_GenaiRuntime";
 import type { TFMPModelConfig } from "./TFMP_ModelSchema";
@@ -76,31 +76,21 @@ export const TFMP_StructuredGeneration: AiProviderRunFn<
     template
   );
 
-  let fullText = "";
-  let jsonStart = -1;
+  // The parser discards any prose or code fence ahead of the first '{', so the
+  // pieces stream straight in with no accumulated copy to re-scan.
+  const json = createPartialJsonStream({ skipPreamble: true });
 
   await withGenaiLock(model!.provider_config.model_path, async () => {
     const llm = await getGenaiLlm(model!, emit, signal);
     await generateGenaiResponse(llm, prompt, signal, (piece) => {
-      fullText += piece;
-      if (jsonStart === -1) {
-        jsonStart = fullText.indexOf("{");
-      }
-      if (jsonStart !== -1) {
-        const partial = parsePartialJson(fullText.slice(jsonStart));
-        if (partial !== undefined) {
-          emit({
-            type: "object-delta",
-            port: "object",
-            objectDelta: partial as Record<string, unknown>,
-          });
-          return;
-        }
+      const partial = json.push(piece);
+      if (partial !== undefined) {
+        emit({ type: "object-delta", port: "object", objectDelta: partial });
+        return;
       }
       emit({ type: "text-delta", port: "text", textDelta: piece });
     });
   });
 
-  const object = extractJsonFromText(fullText);
-  emit({ type: "finish", data: { object } as StructuredGenerationTaskOutput });
+  emit({ type: "finish", data: { object: json.finish() } as StructuredGenerationTaskOutput });
 };

--- a/providers/xai/src/ai/common/Xai_StructuredGeneration.ts
+++ b/providers/xai/src/ai/common/Xai_StructuredGeneration.ts
@@ -15,7 +15,7 @@ import {
   mapOpenAIChatUsage,
   OPENAI_STREAM_USAGE_OPTIONS,
 } from "@workglow/ai/provider-utils";
-import { parsePartialJson } from "@workglow/util/worker";
+import { createPartialJsonStream } from "@workglow/util/worker";
 import { getClient, getModelName } from "./Xai_Client";
 import type { XaiModelConfig } from "./Xai_ModelSchema";
 
@@ -55,15 +55,14 @@ export const Xai_StructuredGeneration_Stream: AiProviderRunFn<
     { signal }
   );
 
-  let accumulatedJson = "";
+  const json = createPartialJsonStream();
   let refusal = "";
   let usage: Usage | undefined;
   for await (const chunk of stream) {
     usage = mapOpenAIChatUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
-      accumulatedJson += delta;
-      const partial = parsePartialJson(accumulatedJson);
+      const partial = json.push(delta);
       if (partial !== undefined) {
         emit({ type: "object-delta", port: "object", objectDelta: partial });
       }
@@ -75,15 +74,9 @@ export const Xai_StructuredGeneration_Stream: AiProviderRunFn<
     emit({ type: "refusal", refusal });
   }
 
-  let finalObject: Record<string, unknown>;
-  try {
-    finalObject = JSON.parse(accumulatedJson);
-  } catch {
-    finalObject = parsePartialJson(accumulatedJson) ?? {};
-  }
   emit({
     type: "finish",
-    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    data: { object: json.finish() } as StructuredGenerationTaskOutput,
     usage,
   });
 };


### PR DESCRIPTION
Closes #507

## The literal ask was already done; the stated goal was not

A partial-JSON parser already exists — `packages/util/src/json-schema/parsePartialJson.ts`, tested and in use. So "add a json streaming parser" reads as satisfied.

But the issue's stated **goal** is "so we don't have to accumulate structured output", and that never happened. `parsePartialJson` is a *repair-and-reparse of a truncated buffer*, not a streaming parser: every call runs `JSON.parse` on the whole buffer, then re-scans the whole buffer character-by-character to repair it, then `JSON.parse`s again. There is no cursor, no container stack, no `push()`/`finish()`.

Accumulation was therefore never eliminated — it was **relocated into every provider run-fn**. All eleven `*_StructuredGeneration.ts` files held a growing `accumulatedJson` string and called `parsePartialJson(accumulatedJson)` once per delta. That is O(n²), and run-fns execute inside workers, so it fully blocks a worker thread.

Measured on the built bundle (`packages/util/dist`), accumulate-and-reparse vs. the new parser:

| payload | chunk size | chunks | before | after | speedup |
| --- | --- | --- | --- | --- | --- |
| 24 KB | 8 chars | 3129 | 3999 ms | 12.3 ms | 326x |
| 98 KB | 40 chars | 2502 | 9512 ms | 9.8 ms | 971x |

4.1x the bytes costs ~2.4x the time before (super-linear); after, it is flat.

## What this adds

`createPartialJsonStream(options?)` in `packages/util/src/json-schema/PartialJsonStream.ts` — a resumable tokenizer holding a container stack of live JS objects/arrays, the pending key, a scalar buffer bounded by the *current token* (not the document), and string-escape / `\uXXXX` state. `push(chunk)` is O(chunk.length) and never re-scans consumed input.

- `push(chunk)` → the live root once a top-level object has opened, else `undefined`
- `finish()` → closes open containers/strings; idempotent
- `snapshot()` → detached deep copy
- `complete` → whether the root closed on its own
- `skipPreamble` option → discards text before the first `{`/`[`, for providers that emit prose or a `<think>` block first

`parsePartialJson` is **exported and unchanged** — it remains correct and in use for one-shot repair call sites.

## ⚠️ Behavioral tradeoff reviewers must consent to: live-root aliasing

`push()` returns the parser's **live** root object, which subsequent pushes keep mutating. This is the one intentional behavior change, and it is what makes the parser O(n) — deep-cloning on every delta would reinstate the O(n²) this PR exists to remove.

Why it is safe on the paths we actually use:
- `StreamEventAccumulator.observe` and `StreamProcessor` use **replace** semantics for non-array object-deltas, so repeatedly storing the same growing object converges to the correct final value.
- Events are structured-cloned crossing the worker boundary, so out-of-process consumers get independent copies anyway.

Where it bites: an **in-process** consumer that retains an earlier delta will see that object change under it. The aliasing is documented in the interface JSDoc, `snapshot()` is the escape hatch for anyone needing a frozen copy, and there is a test asserting each behavior explicitly.

Guard preserved: `push()` returns `undefined` for a top-level **array** root (matching `parsePartialJson`), so no run-fn can emit an array as an `objectDelta` — that would hit the accumulators' append-by-`id` branch and re-append the whole growing array each delta.

## Why the parser stays in `@workglow/util`, not `@workglow/ai`

The issue says "to the ai package", but that placement would be wrong here. `util` is the foundation package, and the consumers are provider run-fns that already import worker-safe helpers from `@workglow/util/worker` — `@workglow/ai` sits *above* them in the dependency graph. Moving it would break that import path and buy nothing. It is exported from both `schema-entry.ts` and `worker-entry.ts`, exactly like `parsePartialJson`.

## Migrated call sites

All 11 `*_StructuredGeneration.ts` run-fns: anthropic, openai, google-gemini, ollama, xai, deepseek, openrouter, chrome-ai, node-llama-cpp, huggingface-transformers, tf-mediapipe. Each collapses `accumulatedJson` + per-delta `parsePartialJson` + the trailing `try { JSON.parse } catch { parsePartialJson }` into one stream instance ending in `emit({ type: "finish", data: { object: json.finish() } })`.

Notes:
- **HFT / TFMP** additionally did `parsePartialJson(fullText.slice(jsonStart))` per delta; both now use `skipPreamble` and drop the `jsonStart` bookkeeping and the per-delta `.slice()`. Their existing behavior of emitting `text-delta` while no JSON has appeared yet is preserved (detected via `push()` returning `undefined`). HFT's now-dead `extractJsonFromText`/`stripThinkingAndSpecialTokens` helpers are removed; TFMP's `extractJsonFromText` is exported and tested, so it stays.
- **chrome-ai** emits progressive full-text snapshots rather than deltas; it keeps its snapshot diff and feeds only the newly-appended tail, restarting the parser on the rare replacement case.
- **deepseek**'s `assertNotTruncatedByReasoning` only distinguishes "no content" from "some content", so it now gets one retained delta instead of a full second copy of the document. The helper's public signature is untouched.
- The CLAUDE.md rule that json-mode run-fns MUST populate `finish.data.object` **stays in force** — `json.finish()` satisfies it, and it remains the validation anchor for `StructuredGenerationTask`'s retry loop. The stale rationale ("avoids requiring a JSON streaming parser in the consumer layer") is replaced with the real reason plus the aliasing note.

Two incidental correctness wins over `parsePartialJson`, both asserted as tests: a mid-key prefix keeps the object built so far instead of discarding the whole object, and trailing whitespace inside an in-flight string value is preserved instead of being trimmed away. `__proto__` is written as an own property via `defineProperty`, matching `JSON.parse` and avoiding prototype pollution from untrusted model output.

## Deliberately NOT in scope

The `*_ToolCalling.ts` call sites (anthropic, ollama, llamacpp-server, and the `provider-utils` shared helper) still use `parsePartialJson`. Open PR #641 edits those files, so migrating them here would conflict. Follow-up:

- `providers/anthropic/src/ai/common/Anthropic_ToolCalling.ts`
- `providers/ollama/src/ai/common/Ollama_ToolCalling.ts`
- `providers/llamacpp-server/src/ai/common/LlamaCppServer_ToolCalling.ts`
- `packages/ai/src/provider-utils/OpenAIShapedChat.ts`

## Verification

All run on this branch; every command's real result:

| command | result |
| --- | --- |
| `bun run build` | 84/84 tasks successful |
| `bun run build:types` | 41/41 tasks successful |
| `bun scripts/test.ts util vitest` | 47 files passed, **711 passed** / 10 skipped |
| `bun scripts/test.ts ai vitest` | 38 files passed, **247 passed** |
| `bun scripts/test.ts provider-api unit vitest` | 38 files passed, **410 passed** |
| `bun scripts/test.ts provider unit vitest` | 16 passed / 1 skipped, **226 passed** / 5 skipped |
| `npx eslint` on changed files | clean |

`packages/test/src/test/util/PartialJsonStream.test.ts` adds 39 tests:

1. **Chunk-boundary exhaustive** — 11 documents (nested objects, arrays, escapes, unicode, numbers, `null`/`true`/`false`, empty containers, pretty-printed whitespace) split at **every** 1-character boundary, plus fed one character at a time; `finish()` deep-equals `JSON.parse(doc)` in every case.
2. **Equivalence with `parsePartialJson` at every prefix** — where it produces a result the stream matches it, and the stream never loses a result it would have produced. Prefixes ending in whitespace are excluded because `parsePartialJson` trims its input; both intentional divergences are asserted explicitly as their own tests.
3. **Split escapes** — `"a\` + `"b"`, `\u00` + `41`, `\\` at a chunk edge, a surrogate pair, and a `\uXXXX` document split at every internal boundary.
4. **Split scalars** — `1.` + `5e` + `-3`, `tr` + `ue`, `nul` + `l`, and an exponent terminated by end of stream.
5. **Truncated streams** — `finish()` closes open containers and drops trailing incomplete tokens, matching the current repair behavior (`{"a": tru` → `{}`, `{"n": 30` → `{n:30}`); idempotency asserted.
6. **Preamble skipping** — `Here you go: {"a":1}`, a `<think>…</think>` prefix, a markdown fence, trailing commentary, and recovery when a `<think>` block itself contains braces.
7. **Perf regression guard** — 100 KB in 40-char chunks must finish under 250 ms (measured ~10 ms; the old path takes multiple seconds), so only a genuine algorithmic regression trips it.

`packages/test/src/test/ai-provider-api/Ollama_StructuredGenerationStream.test.ts` — which specifically asserts the no-closing-brace recovery path — passes unchanged, as does `parsePartialJson.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwyJuFrJnibKvrrk8Fa4Fn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwyJuFrJnibKvrrk8Fa4Fn)_