### PR TITLE
feat(providers): fill the Usage seam per provider (#624 Phase 2)

### DIFF
--- a/packages/ai/src/provider-utils.ts
+++ b/packages/ai/src/provider-utils.ts
@@ -25,6 +25,7 @@ export * from "./provider-utils/CloudProviderClient";
 export * from "./provider-utils/OpenAIShapedChat";
 export * from "./provider-utils/OpenAIShapedResponses";
 export * from "./provider-utils/OpenAIShapedJsonSchema";
+export * from "./provider-utils/UsageMapping";
 export * from "./provider-utils/RefusalHelpers";
 export * from "./provider-utils/IBackendsTransport";
 export * from "./provider-utils/localUrl";

--- a/packages/ai/src/provider-utils/OpenAIShapedChat.ts
+++ b/packages/ai/src/provider-utils/OpenAIShapedChat.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { StreamEvent } from "@workglow/task-graph";
+import type { StreamEvent, Usage } from "@workglow/task-graph";
 import { parsePartialJson } from "@workglow/util/worker";
 import type { ToolCallingTaskOutput } from "../task/ToolCallingTask";
 import type { ToolCalls, ToolDefinition } from "../task/ToolCallingUtils";
 import { buildToolDescription, sanitizeToolArgs } from "../task/ToolCallingUtils";
+import { mapOpenAIChatUsage } from "./UsageMapping";
 
 /**
  * Shared helpers for providers that expose an OpenAI-compatible chat-completions
@@ -135,14 +136,28 @@ interface ToolCallAccumulatorEntry {
  * `{ text: "", toolCalls: [] }` so the final output satisfies
  * {@link ToolCallingTaskOutput} even when the model streams only
  * `tool_calls` (no `content` deltas).
+ *
+ * Returns the stream's token accounting when the request opted in with
+ * `stream_options: { include_usage: true }`, else `undefined`. That usage
+ * arrives on a final chunk with an **empty** `choices` array, so it is read
+ * before the choice-less chunk is skipped. The caller attaches it to its
+ * `finish` event as a sibling of `data`.
+ *
+ * `mapUsage` defaults to the standard OpenAI-shape mapping; a provider that
+ * reports counters beyond that common set (DeepSeek's cache hit/miss split,
+ * OpenRouter's `cost`) passes its own mapper instead.
  */
 export async function accumulateOpenAIChatStream(
   stream: AsyncIterable<any>,
-  emit: (event: StreamEvent<ToolCallingTaskOutput>) => void
-): Promise<void> {
+  emit: (event: StreamEvent<ToolCallingTaskOutput>) => void,
+  mapUsage: (raw: unknown) => Usage | undefined = mapOpenAIChatUsage
+): Promise<Usage | undefined> {
   const toolCallAccumulator = new Map<number, ToolCallAccumulatorEntry>();
+  let usage: Usage | undefined;
 
   for await (const chunk of stream) {
+    usage = mapUsage(chunk?.usage) ?? usage;
+
     const choice = chunk?.choices?.[0];
     if (!choice) continue;
 
@@ -188,4 +203,6 @@ export async function accumulateOpenAIChatStream(
       });
     }
   }
+
+  return usage;
 }

--- a/packages/ai/src/provider-utils/OpenAIShapedResponses.ts
+++ b/packages/ai/src/provider-utils/OpenAIShapedResponses.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { StreamEvent } from "@workglow/task-graph";
+import type { StreamEvent, Usage } from "@workglow/task-graph";
 import type { ToolCalls, ToolDefinition } from "../task/ToolCallingUtils";
 import { buildToolDescription, sanitizeToolArgs } from "../task/ToolCallingUtils";
 import { parseToolArgs } from "./OpenAIShapedChat";
+import { mapOpenAIResponsesUsage } from "./UsageMapping";
 
 /**
  * Shared helpers for the OpenAI **Responses** API (`client.responses.create`),
@@ -233,17 +234,23 @@ interface ResponsesToolCallEntry {
  * own `finish` event after this returns (per the streaming convention). Generic
  * over the output type so non-tool-calling run-fns (TextGeneration / Rewriter /
  * Summary) can pass their own `emit` under `strictFunctionTypes`.
+ *
+ * Returns the token accounting off the terminal `response.completed` event —
+ * the Responses API reports usage there unprompted — or `undefined` when the
+ * stream ended without one. The caller attaches it to its `finish` event as a
+ * sibling of `data`.
  */
 export async function accumulateOpenAIResponsesStream<Output = Record<string, any>>(
   stream: AsyncIterable<any>,
   emit: (event: StreamEvent<Output>) => void
-): Promise<void> {
+): Promise<Usage | undefined> {
   // Keyed by the output item's stable id (`item.id` on `output_item.{added,done}`,
   // `item_id` on `function_call_arguments.delta`). Falls back to `output_index`
   // only for gateways that omit both — keying purely on `output_index` collapses
   // concurrent function calls that share (or lack) the index onto one slot,
   // silently dropping every call but the last.
   const toolCalls = new Map<string, ResponsesToolCallEntry>();
+  let usage: Usage | undefined;
 
   const emitToolCall = (entry: ResponsesToolCallEntry): void => {
     const parsed = parseToolArgs(entry.arguments);
@@ -341,10 +348,22 @@ export async function accumulateOpenAIResponsesStream<Output = Record<string, an
         break;
       }
 
+      case "response.completed":
+      case "response.incomplete":
+      case "response.failed": {
+        // Terminal lifecycle events carry the authoritative token accounting.
+        // An incomplete/failed response still consumed tokens, so its usage is
+        // recorded too rather than being dropped as a non-success.
+        usage = mapOpenAIResponsesUsage(event.response?.usage) ?? usage;
+        break;
+      }
+
       default:
-        // Ignore lifecycle (created/in_progress/completed), reasoning summaries,
-        // and non-function tool events.
+        // Ignore the remaining lifecycle events (created/in_progress),
+        // reasoning summaries, and non-function tool events.
         break;
     }
   }
+
+  return usage;
 }

--- a/packages/ai/src/provider-utils/UsageMapping.ts
+++ b/packages/ai/src/provider-utils/UsageMapping.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Usage } from "@workglow/task-graph";
+
+/**
+ * Shared normalization from a provider's own token-accounting payload into the
+ * provider-agnostic {@link Usage} shape.
+ *
+ * The governing rule is that `undefined` means **the provider did not report
+ * this figure**, never "zero". A wire field that is absent, `null`, `NaN`, or
+ * not a number stays `undefined` so downstream cost math can tell "billed
+ * nothing" apart from "told us nothing"; only a real reported `0` becomes `0`.
+ *
+ * Usage is always read from the provider's own terminal frame — never derived
+ * by counting emitted output, which would drift from what the provider bills.
+ */
+
+/**
+ * Coerce one wire field to a usage counter. Anything that is not a finite
+ * number — absent, `null`, a string, `NaN` — is "not reported".
+ */
+export function toUsageCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Collapse a fully-unreported {@link Usage} to `undefined`. A provider that
+ * sent a usage object carrying nothing recognizable reported nothing, and
+ * should be indistinguishable from one that sent no usage object at all.
+ */
+export function usageOrUndefined(usage: Usage): Usage | undefined {
+  const reported =
+    usage.input !== undefined ||
+    usage.output !== undefined ||
+    usage.cached !== undefined ||
+    usage.cacheWrite !== undefined ||
+    usage.reasoning !== undefined ||
+    usage.total !== undefined ||
+    usage.extra !== undefined;
+  return reported ? usage : undefined;
+}
+
+/**
+ * Build the `extra` bag from provider-specific counters, dropping unreported
+ * ones. Returns `undefined` when nothing survives, so `extra` is absent rather
+ * than an empty object.
+ */
+export function usageExtra(
+  entries: Readonly<Record<string, number | string | undefined>>
+): Readonly<Record<string, number | string>> | undefined {
+  const extra: Record<string, number | string> = {};
+  for (const [key, value] of Object.entries(entries)) {
+    if (value !== undefined) extra[key] = value;
+  }
+  return Object.keys(extra).length > 0 ? extra : undefined;
+}
+
+/** Raw usage payload on an OpenAI-compatible chat-completions terminal chunk. */
+interface OpenAIChatUsagePayload {
+  readonly prompt_tokens?: unknown;
+  readonly completion_tokens?: unknown;
+  readonly total_tokens?: unknown;
+  readonly prompt_tokens_details?: { readonly cached_tokens?: unknown } | null;
+  readonly completion_tokens_details?: { readonly reasoning_tokens?: unknown } | null;
+}
+
+/**
+ * Map an OpenAI-compatible chat-completions `usage` object (xAI, DeepSeek,
+ * OpenRouter, llama.cpp server, Hugging Face Inference) into {@link Usage}.
+ *
+ * Chat completions only emit this object when the request asked for it with
+ * `stream_options: { include_usage: true }`, and it arrives on a final chunk
+ * whose `choices` array is **empty** — so a delta loop must read usage before
+ * it skips a choice-less chunk.
+ *
+ * Providers reporting counters beyond this common set layer their own on top
+ * (see {@link usageExtra}).
+ */
+export function mapOpenAIChatUsage(raw: unknown): Usage | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const payload = raw as OpenAIChatUsagePayload;
+  return usageOrUndefined({
+    input: toUsageCount(payload.prompt_tokens),
+    output: toUsageCount(payload.completion_tokens),
+    cached: toUsageCount(payload.prompt_tokens_details?.cached_tokens),
+    cacheWrite: undefined,
+    reasoning: toUsageCount(payload.completion_tokens_details?.reasoning_tokens),
+    total: toUsageCount(payload.total_tokens),
+    extra: undefined,
+  });
+}
+
+/** Raw usage payload on an OpenAI **Responses** `response.completed` event. */
+interface OpenAIResponsesUsagePayload {
+  readonly input_tokens?: unknown;
+  readonly output_tokens?: unknown;
+  readonly total_tokens?: unknown;
+  readonly input_tokens_details?: {
+    readonly cached_tokens?: unknown;
+    readonly cache_write_tokens?: unknown;
+  } | null;
+  readonly output_tokens_details?: { readonly reasoning_tokens?: unknown } | null;
+}
+
+/**
+ * Map an OpenAI **Responses** API `usage` object into {@link Usage}. The
+ * Responses shape names its fields differently from chat completions
+ * (`input_tokens` rather than `prompt_tokens`) and nests cache reads/writes
+ * under `input_tokens_details`.
+ */
+export function mapOpenAIResponsesUsage(raw: unknown): Usage | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const payload = raw as OpenAIResponsesUsagePayload;
+  return usageOrUndefined({
+    input: toUsageCount(payload.input_tokens),
+    output: toUsageCount(payload.output_tokens),
+    cached: toUsageCount(payload.input_tokens_details?.cached_tokens),
+    cacheWrite: toUsageCount(payload.input_tokens_details?.cache_write_tokens),
+    reasoning: toUsageCount(payload.output_tokens_details?.reasoning_tokens),
+    total: toUsageCount(payload.total_tokens),
+    extra: undefined,
+  });
+}
+
+/**
+ * Request fragment that turns on usage reporting for an OpenAI-compatible
+ * streaming chat completion. Spread into the request body by every provider on
+ * that shape — without it the stream carries no usage at all.
+ */
+export const OPENAI_STREAM_USAGE_OPTIONS = {
+  stream_options: { include_usage: true },
+} as const;

--- a/packages/test/src/contract/ai-provider/assertions/usageNormalization.ts
+++ b/packages/test/src/contract/ai-provider/assertions/usageNormalization.ts
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Usage } from "@workglow/ai";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Shared contract for every provider's usage normalization.
+ *
+ * Each provider reads token counts off a different terminal frame, but they all
+ * have to land in {@link Usage} under one rule: **`undefined` means the provider
+ * did not report this figure, and never means zero.** Collapsing "not reported"
+ * to `0` silently understates spend — a model that billed no cached tokens and
+ * a model that says nothing about caching are different facts.
+ *
+ * A provider registers its mapper here rather than re-litigating the rule in its
+ * own suite, so a new provider inherits the same guarantees.
+ */
+
+/** The full set of normalized counters, used to check untouched slots. */
+const USAGE_COUNTER_FIELDS = [
+  "input",
+  "output",
+  "cached",
+  "cacheWrite",
+  "reasoning",
+  "total",
+] as const;
+
+type UsageCounterField = (typeof USAGE_COUNTER_FIELDS)[number];
+
+export interface UsageNormalizationCase {
+  /** What this frame represents, e.g. "a cache-hit completion". */
+  readonly name: string;
+  /** The provider-shaped payload handed to the mapper. */
+  readonly frame: unknown;
+  /** The exact expected result — compared with `toEqual`, so extra keys fail. */
+  readonly expected: Usage | undefined;
+}
+
+export interface UsageNormalizationOpts {
+  /** Provider name, used in test titles. */
+  readonly provider: string;
+  /** The provider's own mapper from a raw frame to {@link Usage}. */
+  readonly mapUsage: (raw: unknown) => Usage | undefined;
+  /** Provider-specific frames and their expected mappings. */
+  readonly cases: readonly UsageNormalizationCase[];
+  /**
+   * A minimal real frame reporting only `sparseReports`. Every counter outside
+   * that set must come back `undefined` — this is the zero-vs-absent guard.
+   */
+  readonly sparseFrame: unknown;
+  /** Counters the sparse frame actually reports. */
+  readonly sparseReports: readonly UsageCounterField[];
+  /**
+   * A frame in which the provider genuinely reports `0` for `sparseReports`.
+   * Proves the mapper does not discard a real zero along with the absent ones.
+   */
+  readonly zeroFrame: unknown;
+}
+
+/** Assert a mapped {@link Usage} carries only numbers and `undefined`. */
+export function assertUsageShape(usage: Usage): void {
+  for (const field of USAGE_COUNTER_FIELDS) {
+    const value = usage[field];
+    if (value === undefined) continue;
+    expect(typeof value, `${field} must be a number when reported`).toBe("number");
+    expect(Number.isFinite(value as number), `${field} must be finite`).toBe(true);
+  }
+  if (usage.extra !== undefined) {
+    for (const [key, value] of Object.entries(usage.extra)) {
+      expect(["number", "string"], `extra.${key} must be a number or string`).toContain(
+        typeof value
+      );
+    }
+  }
+}
+
+export function usageNormalizationBlock(opts: UsageNormalizationOpts): void {
+  describe(`${opts.provider} usage normalization contract`, () => {
+    it("reports nothing when the provider sent no usage payload", () => {
+      for (const empty of [undefined, null, {}, "usage", 42]) {
+        expect(opts.mapUsage(empty), `mapped ${JSON.stringify(empty) ?? "undefined"}`).toBe(
+          undefined
+        );
+      }
+    });
+
+    it("leaves counters the provider did not report as undefined, never 0", () => {
+      const usage = opts.mapUsage(opts.sparseFrame);
+      expect(usage, "a frame with real counters must map to a Usage").toBeDefined();
+      const reported = new Set<UsageCounterField>(opts.sparseReports);
+      for (const field of USAGE_COUNTER_FIELDS) {
+        if (reported.has(field)) {
+          expect(usage![field], `${field} was reported and must survive`).toBeTypeOf("number");
+        } else {
+          // The whole point: an unreported counter is absent, not zero.
+          expect(usage![field], `${field} was not reported and must be undefined`).toBe(undefined);
+        }
+      }
+    });
+
+    it("preserves a genuinely reported zero rather than dropping it", () => {
+      const usage = opts.mapUsage(opts.zeroFrame);
+      expect(usage, "a frame reporting 0 still reported something").toBeDefined();
+      for (const field of opts.sparseReports) {
+        expect(usage![field], `${field} reported 0 and must stay 0`).toBe(0);
+      }
+    });
+
+    it("maps only numbers and undefined into the normalized shape", () => {
+      for (const testCase of opts.cases) {
+        const usage = opts.mapUsage(testCase.frame);
+        if (usage) assertUsageShape(usage);
+      }
+      const sparse = opts.mapUsage(opts.sparseFrame);
+      if (sparse) assertUsageShape(sparse);
+    });
+
+    for (const testCase of opts.cases) {
+      it(`maps ${testCase.name}`, () => {
+        expect(opts.mapUsage(testCase.frame)).toEqual(testCase.expected);
+      });
+    }
+  });
+}

--- a/packages/test/src/test/ai-provider-api/Anthropic_SamplingParams.test.ts
+++ b/packages/test/src/test/ai-provider-api/Anthropic_SamplingParams.test.ts
@@ -124,3 +124,93 @@ describe("applyAnthropicSamplingParams", () => {
     expect(meta.dropped).toEqual(["temperature", "top_p"]);
   });
 });
+
+/**
+ * Anthropic splits usage across two frames — `message_start` carries the prompt
+ * side, `message_delta` the running completion side — and both restate
+ * cumulative figures. The collector keeps the newest number per field; it never
+ * adds counts of its own.
+ */
+describe("createAnthropicUsageCollector", () => {
+  const { createAnthropicUsageCollector } = _testOnly;
+
+  it("combines the prompt side from message_start with the output from message_delta", () => {
+    const collector = createAnthropicUsageCollector();
+    collector.observe({
+      type: "message_start",
+      message: {
+        usage: {
+          input_tokens: 210,
+          output_tokens: 1,
+          cache_read_input_tokens: 180,
+          cache_creation_input_tokens: 24,
+        },
+      },
+    });
+    collector.observe({ type: "content_block_delta", delta: { type: "text_delta", text: "hi" } });
+    collector.observe({ type: "message_delta", usage: { output_tokens: 57 } });
+
+    expect(collector.result()).toEqual({
+      input: 210,
+      output: 57,
+      cached: 180,
+      cacheWrite: 24,
+      reasoning: undefined,
+      total: undefined,
+      extra: undefined,
+    });
+  });
+
+  it("takes the latest cumulative value rather than summing restatements", () => {
+    const collector = createAnthropicUsageCollector();
+    collector.observe({ type: "message_delta", usage: { output_tokens: 10 } });
+    collector.observe({ type: "message_delta", usage: { output_tokens: 25 } });
+    expect(collector.result()?.output).toBe(25);
+  });
+
+  it("treats a null prompt-side restatement as 'not restated', not as an erasure", () => {
+    const collector = createAnthropicUsageCollector();
+    collector.observe({
+      type: "message_start",
+      message: { usage: { input_tokens: 99, cache_read_input_tokens: 40 } },
+    });
+    collector.observe({
+      type: "message_delta",
+      usage: { output_tokens: 5, input_tokens: null, cache_read_input_tokens: null },
+    });
+
+    const usage = collector.result();
+    expect(usage?.input).toBe(99);
+    expect(usage?.cached).toBe(40);
+  });
+
+  it("reports thinking tokens as reasoning", () => {
+    const collector = createAnthropicUsageCollector();
+    collector.observe({
+      type: "message_delta",
+      usage: { output_tokens: 300, output_tokens_details: { thinking_tokens: 240 } },
+    });
+    expect(collector.result()?.reasoning).toBe(240);
+  });
+
+  it("returns undefined when the stream carried no usage frame at all", () => {
+    const collector = createAnthropicUsageCollector();
+    collector.observe({ type: "content_block_delta", delta: { type: "text_delta", text: "hi" } });
+    collector.observe({ type: "message_stop" });
+    expect(collector.result()).toBeUndefined();
+  });
+
+  it("leaves uncached requests' cache counters undefined, never 0", () => {
+    const collector = createAnthropicUsageCollector();
+    collector.observe({
+      type: "message_start",
+      message: { usage: { input_tokens: 12, output_tokens: 0 } },
+    });
+    collector.observe({ type: "message_delta", usage: { output_tokens: 4 } });
+
+    const usage = collector.result();
+    expect(usage?.cached).toBeUndefined();
+    expect(usage?.cacheWrite).toBeUndefined();
+    expect(usage?.total).toBeUndefined();
+  });
+});

--- a/packages/test/src/test/ai-provider-api/DeepSeek_ToolCalling.test.ts
+++ b/packages/test/src/test/ai-provider-api/DeepSeek_ToolCalling.test.ts
@@ -5,12 +5,13 @@
  */
 
 import {
+  _testOnly,
   assertToolChoiceHonored,
   DeepSeekToolChoiceNotHonoredError,
   isForcingToolChoice,
 } from "@workglow/deepseek/ai";
 import { RetryableJobError } from "@workglow/job-queue";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("isForcingToolChoice", () => {
   it("returns false for undefined, auto, and none", () => {
@@ -57,5 +58,105 @@ describe("assertToolChoiceHonored", () => {
       caught = err;
     }
     expect(caught).toBeInstanceOf(RetryableJobError);
+  });
+});
+
+/**
+ * DeepSeek is OpenAI-shaped but splits the prompt into cache hit/miss counters
+ * of its own. The hit count is the cache-read figure; the miss count is what
+ * makes its cache-miss-priced cost reconstructable, so it rides in `extra`.
+ */
+describe("DeepSeek usage from the terminal include_usage frame", () => {
+  const { DEEPSEEK_RUN_FNS } = _testOnly;
+
+  const textSummaryFn = (() => {
+    const reg = DEEPSEEK_RUN_FNS.find((r) => [...r.serves].sort().join(",") === "text.summary");
+    if (!reg) throw new Error("no DeepSeek run-fn registered for text.summary");
+    return reg.runFn;
+  })();
+
+  const model = {
+    model_id: "deepseek-x",
+    provider_config: { model_name: "deepseek-chat", api_key: "test-key" },
+  } as any;
+
+  function sseResponse(chunks: readonly unknown[]): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const c of chunks) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(c)}\n\n`));
+        }
+        controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  }
+
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  async function runSummary(chunks: readonly unknown[]) {
+    fetchSpy.mockResolvedValueOnce(sseResponse(chunks));
+    const events: any[] = [];
+    await textSummaryFn({ text: "input" } as any, model, new AbortController().signal, (e: any) =>
+      events.push(e)
+    );
+    return events.at(-1);
+  }
+
+  it("asks for usage and maps the cache hit/miss split", async () => {
+    const finish = await runSummary([
+      { choices: [{ delta: { content: "hi" } }] },
+      {
+        choices: [],
+        usage: {
+          prompt_tokens: 88,
+          completion_tokens: 21,
+          total_tokens: 109,
+          prompt_cache_hit_tokens: 64,
+          prompt_cache_miss_tokens: 24,
+        },
+      },
+    ]);
+
+    const body = JSON.parse(String((fetchSpy.mock.calls[0]![1] as RequestInit).body));
+    expect(body.stream_options).toEqual({ include_usage: true });
+
+    expect(finish.type).toBe("finish");
+    expect(finish.usage).toEqual({
+      input: 88,
+      output: 21,
+      cached: 64,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: 109,
+      extra: { promptCacheMissTokens: 24 },
+    });
+  });
+
+  it("leaves usage absent when the stream never reports it", async () => {
+    const finish = await runSummary([{ choices: [{ delta: { content: "hi" } }] }]);
+    expect(finish.usage).toBeUndefined();
+  });
+
+  it("omits extra entirely when no cache-miss count was reported", async () => {
+    const finish = await runSummary([
+      { choices: [{ delta: { content: "hi" } }] },
+      { choices: [], usage: { prompt_tokens: 4, completion_tokens: 1 } },
+    ]);
+    expect(finish.usage.extra).toBeUndefined();
+    expect(finish.usage.cached).toBeUndefined();
   });
 });

--- a/packages/test/src/test/ai-provider-api/LlamaCppServer_TextGenerationStream.test.ts
+++ b/packages/test/src/test/ai-provider-api/LlamaCppServer_TextGenerationStream.test.ts
@@ -91,4 +91,84 @@ describe("createLlamaCppServerTextGenerationStream", () => {
     const emit = (_e: any) => undefined;
     await expect(fn({ prompt: "x" } as any, model, controller.signal, emit)).rejects.toThrow();
   });
+
+  /**
+   * The usage frame carries an EMPTY `choices` array. The SSE parser used to
+   * admit a chunk only when it had a content delta, tool calls, or a finish
+   * reason — so a usage-only frame was dropped before any caller could see it.
+   */
+  describe("usage from the terminal include_usage frame", () => {
+    function usageLine(usage: Record<string, unknown>): string {
+      return `data: ${JSON.stringify({ choices: [], usage })}\n`;
+    }
+
+    it("requests usage and maps the usage-only frame onto finish", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          sseResponse([
+            dataLine("Hel"),
+            dataLine("lo"),
+            usageLine({ prompt_tokens: 26, completion_tokens: 5, total_tokens: 31 }),
+            "data: [DONE]\n",
+          ])
+        );
+      const fn = createLlamaCppServerTextGenerationStream({});
+
+      const events: any[] = [];
+      await fn({ prompt: "hi" } as any, model, undefined as any, (e: any) => events.push(e));
+
+      const body = JSON.parse(String((fetchSpy.mock.calls[0]![1] as RequestInit).body));
+      expect(body.stream_options).toEqual({ include_usage: true });
+
+      const finish = events.at(-1);
+      expect(finish.type).toBe("finish");
+      expect(finish.usage).toEqual({
+        input: 26,
+        output: 5,
+        cached: undefined,
+        cacheWrite: undefined,
+        reasoning: undefined,
+        total: 31,
+        extra: undefined,
+      });
+      // The usage frame must not be mistaken for content.
+      expect(events.filter((e) => e.type === "text-delta").map((e) => e.textDelta)).toEqual([
+        "Hel",
+        "lo",
+      ]);
+    });
+
+    it("leaves usage absent when the server reports none", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        sseResponse([dataLine("hi"), "data: [DONE]\n"])
+      );
+      const fn = createLlamaCppServerTextGenerationStream({});
+
+      const events: any[] = [];
+      await fn({ prompt: "hi" } as any, model, undefined as any, (e: any) => events.push(e));
+
+      expect(events.at(-1).usage).toBeUndefined();
+    });
+
+    it("reports counters llama.cpp omits as undefined, never 0", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        sseResponse([
+          dataLine("hi"),
+          usageLine({ prompt_tokens: 9, completion_tokens: 2 }),
+          "data: [DONE]\n",
+        ])
+      );
+      const fn = createLlamaCppServerTextGenerationStream({});
+
+      const events: any[] = [];
+      await fn({ prompt: "hi" } as any, model, undefined as any, (e: any) => events.push(e));
+
+      const { usage } = events.at(-1);
+      expect(usage.input).toBe(9);
+      expect(usage.cached).toBeUndefined();
+      expect(usage.reasoning).toBeUndefined();
+      expect(usage.total).toBeUndefined();
+    });
+  });
 });

--- a/packages/test/src/test/ai-provider-api/Ollama_TextGenerationStream.test.ts
+++ b/packages/test/src/test/ai-provider-api/Ollama_TextGenerationStream.test.ts
@@ -137,3 +137,73 @@ describe("createOllamaTextGenerationStream abort behavior", () => {
     expect(deltas.length).toBeGreaterThanOrEqual(2);
   });
 });
+
+/**
+ * Ollama reports token counts only on the terminal `done: true` chunk; the
+ * intermediate chunks carry none, and treating their absence as `0` would
+ * report a free request.
+ */
+describe("createOllamaTextGenerationStream usage", () => {
+  const model = {
+    model_id: "ollama:test",
+    provider_config: { model_name: "llama3.2" },
+  } as any;
+  const input = { prompt: "hi" } as any;
+
+  function streamOf(chunks: readonly Record<string, unknown>[]) {
+    return {
+      abort: vi.fn(),
+      async *[Symbol.asyncIterator]() {
+        for (const c of chunks) yield c;
+      },
+    };
+  }
+
+  async function finishEvent(chunks: readonly Record<string, unknown>[]) {
+    const getClient = vi.fn().mockResolvedValue({
+      chat: vi.fn().mockResolvedValue(streamOf(chunks)),
+    });
+    const events: any[] = [];
+    await createOllamaTextGenerationStream(getClient)(
+      input,
+      model,
+      new AbortController().signal,
+      (e: any) => events.push(e)
+    );
+    return events.at(-1);
+  }
+
+  it("maps the done chunk's prompt/eval counts onto finish", async () => {
+    const finish = await finishEvent([
+      { message: { content: "Hel" } },
+      { message: { content: "lo" } },
+      { message: { content: "" }, done: true, prompt_eval_count: 34, eval_count: 8 },
+    ]);
+
+    expect(finish.type).toBe("finish");
+    expect(finish.usage).toEqual({
+      input: 34,
+      output: 8,
+      // Ollama runs locally and reports no cache, reasoning or total counters.
+      cached: undefined,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: undefined,
+      extra: undefined,
+    });
+  });
+
+  it("leaves usage absent when the stream never reaches a done chunk", async () => {
+    const finish = await finishEvent([{ message: { content: "hi" } }]);
+    expect(finish.usage).toBeUndefined();
+  });
+
+  it("ignores counts on non-terminal chunks", async () => {
+    const finish = await finishEvent([
+      { message: { content: "hi" }, done: false, prompt_eval_count: 999, eval_count: 999 },
+      { message: { content: "" }, done: true, prompt_eval_count: 12, eval_count: 3 },
+    ]);
+    expect(finish.usage.input).toBe(12);
+    expect(finish.usage.output).toBe(3);
+  });
+});

--- a/packages/test/src/test/ai-provider-api/OpenRouter_StreamChunkSafety.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouter_StreamChunkSafety.test.ts
@@ -145,4 +145,78 @@ describe("OpenRouter streaming run-fns tolerate SDK chunks without choices/delta
       });
     }
   });
+
+  // Turning on `include_usage` is what appends the terminal `choices: []` frame
+  // these suites guard against, so the usage assertions belong right here.
+  describe("usage from the terminal include_usage frame", () => {
+    const requestBody = (): Record<string, unknown> =>
+      JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body));
+
+    it("asks for usage and carries OpenRouter's cost through extra", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        sseResponse([
+          { choices: [{ delta: { content: "hi" } }] },
+          {
+            choices: [],
+            usage: {
+              prompt_tokens: 44,
+              completion_tokens: 12,
+              total_tokens: 56,
+              cost: 0.00031,
+            },
+          },
+        ])
+      );
+
+      const events: any[] = [];
+      await textSummaryFn({ text: "input" } as any, model, new AbortController().signal, (e) =>
+        events.push(e)
+      );
+
+      expect(requestBody().stream_options).toEqual({ include_usage: true });
+      expect(events.at(-1).usage).toEqual({
+        input: 44,
+        output: 12,
+        cached: undefined,
+        cacheWrite: undefined,
+        reasoning: undefined,
+        total: 56,
+        extra: { cost: 0.00031 },
+      });
+    });
+
+    it("leaves usage absent when the stream never reports it", async () => {
+      fetchSpy.mockResolvedValueOnce(sseResponse([{ choices: [{ delta: { content: "hi" } }] }]));
+
+      const events: any[] = [];
+      await textSummaryFn({ text: "input" } as any, model, new AbortController().signal, (e) =>
+        events.push(e)
+      );
+
+      expect(events.at(-1).usage).toBeUndefined();
+    });
+
+    it("still assembles the object when a usage frame trails a structured stream", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        sseResponse([
+          { choices: [{ delta: { content: '{"a":' } }] },
+          { choices: [{ delta: { content: "1}" } }] },
+          { choices: [], usage: { prompt_tokens: 3, completion_tokens: 4 } },
+        ])
+      );
+
+      const events: any[] = [];
+      await structuredGenFn(
+        { prompt: "hi", outputSchema: strictObjectSchema } as any,
+        model,
+        new AbortController().signal,
+        (e) => events.push(e)
+      );
+
+      const finish = events.at(-1);
+      expect(finish.data.object).toEqual({ a: 1 });
+      expect(finish.usage.input).toBe(3);
+      expect(finish.usage.cached).toBeUndefined();
+    });
+  });
 });

--- a/packages/test/src/test/ai-provider-api/Xai_StreamChunkSafety.test.ts
+++ b/packages/test/src/test/ai-provider-api/Xai_StreamChunkSafety.test.ts
@@ -146,4 +146,79 @@ describe("xAI streaming run-fns tolerate SDK chunks without choices/delta", () =
       });
     }
   });
+
+  // Turning on `include_usage` is what appends the terminal `choices: []` frame
+  // these suites guard against, so the usage assertions belong right here.
+  describe("usage from the terminal include_usage frame", () => {
+    const requestBody = (): Record<string, unknown> =>
+      JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body));
+
+    it("asks for usage and maps the terminal frame onto finish", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        sseResponse([
+          { choices: [{ delta: { content: "hi" } }] },
+          {
+            choices: [],
+            usage: {
+              prompt_tokens: 31,
+              completion_tokens: 7,
+              total_tokens: 38,
+              prompt_tokens_details: { cached_tokens: 12 },
+              completion_tokens_details: { reasoning_tokens: 4 },
+            },
+          },
+        ])
+      );
+
+      const events: any[] = [];
+      await textSummaryFn({ text: "input" } as any, model, new AbortController().signal, (e) =>
+        events.push(e)
+      );
+
+      expect(requestBody().stream_options).toEqual({ include_usage: true });
+      const finish = events.at(-1);
+      expect(finish.type).toBe("finish");
+      expect(finish.usage).toEqual({
+        input: 31,
+        output: 7,
+        cached: 12,
+        cacheWrite: undefined,
+        reasoning: 4,
+        total: 38,
+        extra: undefined,
+      });
+    });
+
+    it("leaves usage absent when the stream never reports it", async () => {
+      fetchSpy.mockResolvedValueOnce(sseResponse([{ choices: [{ delta: { content: "hi" } }] }]));
+
+      const events: any[] = [];
+      await textSummaryFn({ text: "input" } as any, model, new AbortController().signal, (e) =>
+        events.push(e)
+      );
+
+      expect(events.at(-1).usage).toBeUndefined();
+    });
+
+    it("reports xAI's unreported cacheWrite as undefined, not 0", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        sseResponse([
+          { choices: [{ delta: { content: "hi" } }] },
+          { choices: [], usage: { prompt_tokens: 5, completion_tokens: 2 } },
+        ])
+      );
+
+      const events: any[] = [];
+      await textSummaryFn({ text: "input" } as any, model, new AbortController().signal, (e) =>
+        events.push(e)
+      );
+
+      const { usage } = events.at(-1);
+      expect(usage.input).toBe(5);
+      expect(usage.cached).toBeUndefined();
+      expect(usage.cacheWrite).toBeUndefined();
+      expect(usage.reasoning).toBeUndefined();
+      expect(usage.total).toBeUndefined();
+    });
+  });
 });

--- a/packages/test/src/test/ai-provider/OpenAIShapedResponses.test.ts
+++ b/packages/test/src/test/ai-provider/OpenAIShapedResponses.test.ts
@@ -448,3 +448,79 @@ describe("parseResponsesToolCalls", () => {
     expect(calls).toEqual([{ id: "call_0", name: "fn", input: {} }]);
   });
 });
+
+/**
+ * `response.completed` used to fall into the `default:` arm and be discarded,
+ * which threw away the only usage report the Responses API sends.
+ */
+describe("accumulateOpenAIResponsesStream usage", () => {
+  async function usageOf(list: readonly unknown[]) {
+    return accumulateOpenAIResponsesStream(events(list), () => {});
+  }
+
+  it("returns the token accounting from the terminal response.completed event", async () => {
+    const usage = await usageOf([
+      { type: "response.output_text.delta", delta: "hi" },
+      {
+        type: "response.completed",
+        response: {
+          usage: {
+            input_tokens: 120,
+            output_tokens: 34,
+            total_tokens: 154,
+            input_tokens_details: { cached_tokens: 64, cache_write_tokens: 16 },
+            output_tokens_details: { reasoning_tokens: 20 },
+          },
+        },
+      },
+    ]);
+    expect(usage).toEqual({
+      input: 120,
+      output: 34,
+      cached: 64,
+      cacheWrite: 16,
+      reasoning: 20,
+      total: 154,
+      extra: undefined,
+    });
+  });
+
+  it("returns undefined when the stream never reports usage", async () => {
+    expect(
+      await usageOf([
+        { type: "response.output_text.delta", delta: "hi" },
+        { type: "response.completed" },
+      ])
+    ).toBeUndefined();
+  });
+
+  it("leaves counters the response omitted as undefined, never 0", async () => {
+    const usage = await usageOf([
+      { type: "response.completed", response: { usage: { input_tokens: 7, output_tokens: 3 } } },
+    ]);
+    expect(usage).toEqual({
+      input: 7,
+      output: 3,
+      cached: undefined,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: undefined,
+      extra: undefined,
+    });
+  });
+
+  it("still records usage for an incomplete or failed response", async () => {
+    for (const type of ["response.incomplete", "response.failed"]) {
+      const usage = await usageOf([{ type, response: { usage: { input_tokens: 9 } } }]);
+      expect(usage?.input, `${type} consumed tokens and must report them`).toBe(9);
+    }
+  });
+
+  it("keeps a genuinely reported zero", async () => {
+    const usage = await usageOf([
+      { type: "response.completed", response: { usage: { input_tokens: 0, output_tokens: 0 } } },
+    ]);
+    expect(usage?.input).toBe(0);
+    expect(usage?.output).toBe(0);
+  });
+});

--- a/packages/test/src/test/ai-provider/ProviderUsageNormalization.test.ts
+++ b/packages/test/src/test/ai-provider/ProviderUsageNormalization.test.ts
@@ -1,0 +1,290 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mapOpenAIChatUsage, mapOpenAIResponsesUsage } from "@workglow/ai/provider-utils";
+import { _testOnly as anthropicTestOnly } from "@workglow/anthropic/ai";
+import { _testOnly as deepseekTestOnly } from "@workglow/deepseek/ai";
+import { _testOnly as geminiTestOnly } from "@workglow/google-gemini/ai";
+import { _testOnly as ollamaTestOnly } from "@workglow/ollama/ai";
+import { _testOnly as openrouterTestOnly } from "@workglow/openrouter/ai";
+import { describe, expect, it } from "vitest";
+
+import { usageNormalizationBlock } from "../../contract/ai-provider/assertions/usageNormalization";
+
+const { createAnthropicUsageCollector } = anthropicTestOnly;
+const { mapDeepSeekUsage } = deepseekTestOnly;
+const { mapGeminiUsage } = geminiTestOnly;
+const { mapOllamaUsage } = ollamaTestOnly;
+const { mapOpenRouterUsage } = openrouterTestOnly;
+
+/**
+ * Holds every provider's usage mapper to one normalization contract. The rule
+ * that matters is the zero-vs-absent one: a counter the provider never reported
+ * must come back `undefined`, because a `0` there would read as "billed nothing"
+ * and understate spend.
+ *
+ * Anthropic maps a two-frame event stream rather than one payload, so it is
+ * adapted to the same `(raw) => Usage | undefined` signature here.
+ */
+function mapAnthropicUsage(raw: unknown): ReturnType<typeof mapOpenAIChatUsage> {
+  const collector = createAnthropicUsageCollector();
+  collector.observe({ type: "message_delta", usage: raw });
+  return collector.result();
+}
+
+usageNormalizationBlock({
+  provider: "OpenAI (chat-completions shape)",
+  mapUsage: mapOpenAIChatUsage,
+  sparseFrame: { prompt_tokens: 40, completion_tokens: 11 },
+  sparseReports: ["input", "output"],
+  zeroFrame: { prompt_tokens: 0, completion_tokens: 0 },
+  cases: [
+    {
+      name: "a fully-detailed completion",
+      frame: {
+        prompt_tokens: 100,
+        completion_tokens: 25,
+        total_tokens: 125,
+        prompt_tokens_details: { cached_tokens: 60 },
+        completion_tokens_details: { reasoning_tokens: 10 },
+      },
+      expected: {
+        input: 100,
+        output: 25,
+        cached: 60,
+        cacheWrite: undefined,
+        reasoning: 10,
+        total: 125,
+        extra: undefined,
+      },
+    },
+    {
+      name: "null detail objects without inventing zeros",
+      frame: {
+        prompt_tokens: 5,
+        completion_tokens: 1,
+        prompt_tokens_details: null,
+        completion_tokens_details: null,
+      },
+      expected: {
+        input: 5,
+        output: 1,
+        cached: undefined,
+        cacheWrite: undefined,
+        reasoning: undefined,
+        total: undefined,
+        extra: undefined,
+      },
+    },
+  ],
+});
+
+usageNormalizationBlock({
+  provider: "OpenAI (Responses shape)",
+  mapUsage: mapOpenAIResponsesUsage,
+  sparseFrame: { input_tokens: 12, output_tokens: 4 },
+  sparseReports: ["input", "output"],
+  zeroFrame: { input_tokens: 0, output_tokens: 0 },
+  cases: [
+    {
+      name: "cache reads and writes from input_tokens_details",
+      frame: {
+        input_tokens: 200,
+        output_tokens: 50,
+        total_tokens: 250,
+        input_tokens_details: { cached_tokens: 128, cache_write_tokens: 32 },
+        output_tokens_details: { reasoning_tokens: 18 },
+      },
+      expected: {
+        input: 200,
+        output: 50,
+        cached: 128,
+        cacheWrite: 32,
+        reasoning: 18,
+        total: 250,
+        extra: undefined,
+      },
+    },
+  ],
+});
+
+usageNormalizationBlock({
+  provider: "Anthropic",
+  mapUsage: mapAnthropicUsage,
+  sparseFrame: { input_tokens: 30, output_tokens: 9 },
+  sparseReports: ["input", "output"],
+  zeroFrame: { input_tokens: 0, output_tokens: 0 },
+  cases: [
+    {
+      name: "cache reads as cached and cache creation as cacheWrite",
+      frame: {
+        input_tokens: 80,
+        output_tokens: 20,
+        cache_read_input_tokens: 64,
+        cache_creation_input_tokens: 16,
+      },
+      expected: {
+        input: 80,
+        output: 20,
+        cached: 64,
+        cacheWrite: 16,
+        reasoning: undefined,
+        // Anthropic states no total; synthesizing one would misreport
+        // cache-discounted input as if it were billed in full.
+        total: undefined,
+        extra: undefined,
+      },
+    },
+    {
+      name: "null cache fields as unreported rather than zero",
+      frame: {
+        input_tokens: 12,
+        output_tokens: 3,
+        cache_read_input_tokens: null,
+        cache_creation_input_tokens: null,
+      },
+      expected: {
+        input: 12,
+        output: 3,
+        cached: undefined,
+        cacheWrite: undefined,
+        reasoning: undefined,
+        total: undefined,
+        extra: undefined,
+      },
+    },
+  ],
+});
+
+usageNormalizationBlock({
+  provider: "Gemini",
+  mapUsage: mapGeminiUsage,
+  sparseFrame: { promptTokenCount: 22, candidatesTokenCount: 6 },
+  sparseReports: ["input", "output"],
+  zeroFrame: { promptTokenCount: 0, candidatesTokenCount: 0 },
+  cases: [
+    {
+      name: "cached content and thoughts token counts",
+      frame: {
+        promptTokenCount: 500,
+        candidatesTokenCount: 120,
+        cachedContentTokenCount: 400,
+        thoughtsTokenCount: 45,
+        totalTokenCount: 665,
+      },
+      expected: {
+        input: 500,
+        output: 120,
+        cached: 400,
+        cacheWrite: undefined,
+        reasoning: 45,
+        total: 665,
+        extra: undefined,
+      },
+    },
+  ],
+});
+
+usageNormalizationBlock({
+  provider: "Ollama",
+  mapUsage: mapOllamaUsage,
+  sparseFrame: { done: true, prompt_eval_count: 18, eval_count: 7 },
+  sparseReports: ["input", "output"],
+  zeroFrame: { done: true, prompt_eval_count: 0, eval_count: 0 },
+  cases: [
+    {
+      name: "the terminal done chunk's prompt/eval counts",
+      frame: { done: true, prompt_eval_count: 64, eval_count: 12, total_duration: 1234 },
+      expected: {
+        input: 64,
+        output: 12,
+        cached: undefined,
+        cacheWrite: undefined,
+        reasoning: undefined,
+        total: undefined,
+        extra: undefined,
+      },
+    },
+    {
+      name: "an intermediate (not done) chunk as no usage at all",
+      frame: { done: false, message: { content: "hi" } },
+      expected: undefined,
+    },
+  ],
+});
+
+usageNormalizationBlock({
+  provider: "DeepSeek",
+  mapUsage: mapDeepSeekUsage,
+  sparseFrame: { prompt_tokens: 15, completion_tokens: 5 },
+  sparseReports: ["input", "output"],
+  zeroFrame: { prompt_tokens: 0, completion_tokens: 0 },
+  cases: [
+    {
+      name: "the cache hit/miss split, hits as cached and misses in extra",
+      frame: {
+        prompt_tokens: 90,
+        completion_tokens: 30,
+        total_tokens: 120,
+        prompt_cache_hit_tokens: 70,
+        prompt_cache_miss_tokens: 20,
+      },
+      expected: {
+        input: 90,
+        output: 30,
+        cached: 70,
+        cacheWrite: undefined,
+        reasoning: undefined,
+        total: 120,
+        extra: { promptCacheMissTokens: 20 },
+      },
+    },
+  ],
+});
+
+usageNormalizationBlock({
+  provider: "OpenRouter",
+  mapUsage: mapOpenRouterUsage,
+  sparseFrame: { prompt_tokens: 8, completion_tokens: 2 },
+  sparseReports: ["input", "output"],
+  zeroFrame: { prompt_tokens: 0, completion_tokens: 0 },
+  cases: [
+    {
+      name: "credits charged into extra.cost",
+      frame: { prompt_tokens: 45, completion_tokens: 15, total_tokens: 60, cost: 0.00042 },
+      expected: {
+        input: 45,
+        output: 15,
+        cached: undefined,
+        cacheWrite: undefined,
+        reasoning: undefined,
+        total: 60,
+        extra: { cost: 0.00042 },
+      },
+    },
+  ],
+});
+
+describe("usage normalization rejects non-numeric wire values", () => {
+  // A gateway that stringifies its counters must not smuggle a string into a
+  // field the cost math will later add up.
+  it("drops string and NaN counters rather than coercing them", () => {
+    const usage = mapOpenAIChatUsage({
+      prompt_tokens: "120",
+      completion_tokens: Number.NaN,
+      total_tokens: 130,
+    });
+    expect(usage).toEqual({
+      input: undefined,
+      output: undefined,
+      cached: undefined,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: 130,
+      extra: undefined,
+    });
+  });
+});

--- a/providers/anthropic/src/ai/common/Anthropic_StructuredGeneration.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_StructuredGeneration.ts
@@ -13,6 +13,7 @@ import { parsePartialJson } from "@workglow/util/worker";
 import { getClient, getMaxTokens, getModelName } from "./Anthropic_Client";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 import { maybeEmitAnthropicRefusal } from "./Anthropic_Refusal";
+import { createAnthropicUsageCollector } from "./Anthropic_Usage";
 
 /**
  * Streaming run-fn for the `["text.generation", "json-mode"]` capability.
@@ -54,7 +55,9 @@ export const Anthropic_StructuredGeneration_Stream: AiProviderRunFn<
   );
 
   let accumulatedJson = "";
+  const usageCollector = createAnthropicUsageCollector();
   for await (const event of stream) {
+    usageCollector.observe(event);
     maybeEmitAnthropicRefusal(event, emit);
     if (event.type === "content_block_delta" && event.delta.type === "input_json_delta") {
       accumulatedJson += event.delta.partial_json;
@@ -74,5 +77,9 @@ export const Anthropic_StructuredGeneration_Stream: AiProviderRunFn<
   // Exception: structured generation MUST populate finish.data.object so the
   // StructuredGenerationTask consumer can read the parsed object without a
   // JSON streaming parser. See CLAUDE.md streaming-convention-exception note.
-  emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+  emit({
+    type: "finish",
+    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    usage: usageCollector.result(),
+  });
 };

--- a/providers/anthropic/src/ai/common/Anthropic_TextGeneration.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_TextGeneration.ts
@@ -20,6 +20,7 @@ import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 import { maybeEmitAnthropicRefusal } from "./Anthropic_Refusal";
 import { applyAnthropicSamplingParams } from "./Anthropic_RequestParams";
 import { buildAnthropicMessages } from "./Anthropic_ToolCalling";
+import { createAnthropicUsageCollector } from "./Anthropic_Usage";
 
 /**
  * Inputs that the unified `["text.generation"]` runFn handles. Both
@@ -102,7 +103,9 @@ export const Anthropic_TextGeneration_Stream: AiProviderRunFn<
       { signal }
     );
 
+    const usageCollector = createAnthropicUsageCollector();
     for await (const event of stream) {
+      usageCollector.observe(event);
       const e = event as {
         type: string;
         delta?: { type?: string; text?: string };
@@ -112,7 +115,11 @@ export const Anthropic_TextGeneration_Stream: AiProviderRunFn<
       }
       maybeEmitAnthropicRefusal(event, emit);
     }
-    emit({ type: "finish", data: {} as TextGenerationTaskOutput });
+    emit({
+      type: "finish",
+      data: {} as TextGenerationTaskOutput,
+      usage: usageCollector.result(),
+    });
   } finally {
     logger.timeEnd(timerLabel, { model: getModelName(model) });
   }

--- a/providers/anthropic/src/ai/common/Anthropic_TextRewriter.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_TextRewriter.ts
@@ -8,6 +8,7 @@ import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } f
 import { getClient, getMaxTokens, getModelName } from "./Anthropic_Client";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 import { maybeEmitAnthropicRefusal } from "./Anthropic_Refusal";
+import { createAnthropicUsageCollector } from "./Anthropic_Usage";
 
 export const Anthropic_TextRewriter_Stream: AiProviderRunFn<
   TextRewriterTaskInput,
@@ -27,11 +28,13 @@ export const Anthropic_TextRewriter_Stream: AiProviderRunFn<
     { signal }
   );
 
+  const usageCollector = createAnthropicUsageCollector();
   for await (const event of stream) {
+    usageCollector.observe(event);
     maybeEmitAnthropicRefusal(event, emit);
     if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
       emit({ type: "text-delta", port: "text", textDelta: event.delta.text });
     }
   }
-  emit({ type: "finish", data: {} as TextRewriterTaskOutput });
+  emit({ type: "finish", data: {} as TextRewriterTaskOutput, usage: usageCollector.result() });
 };

--- a/providers/anthropic/src/ai/common/Anthropic_TextSummary.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_TextSummary.ts
@@ -8,6 +8,7 @@ import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } fro
 import { getClient, getMaxTokens, getModelName } from "./Anthropic_Client";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 import { maybeEmitAnthropicRefusal } from "./Anthropic_Refusal";
+import { createAnthropicUsageCollector } from "./Anthropic_Usage";
 
 export const Anthropic_TextSummary_Stream: AiProviderRunFn<
   TextSummaryTaskInput,
@@ -27,11 +28,13 @@ export const Anthropic_TextSummary_Stream: AiProviderRunFn<
     { signal }
   );
 
+  const usageCollector = createAnthropicUsageCollector();
   for await (const event of stream) {
+    usageCollector.observe(event);
     maybeEmitAnthropicRefusal(event, emit);
     if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
       emit({ type: "text-delta", port: "text", textDelta: event.delta.text });
     }
   }
-  emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+  emit({ type: "finish", data: {} as TextSummaryTaskOutput, usage: usageCollector.result() });
 };

--- a/providers/anthropic/src/ai/common/Anthropic_ToolCalling.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_ToolCalling.ts
@@ -25,6 +25,7 @@ import { getClient, getMaxTokens, getModelName } from "./Anthropic_Client";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 import { maybeEmitAnthropicRefusal } from "./Anthropic_Refusal";
 import { applyAnthropicSamplingParams } from "./Anthropic_RequestParams";
+import { createAnthropicUsageCollector } from "./Anthropic_Usage";
 
 /**
  * Anthropic rejects empty text blocks and empty content arrays on non-final
@@ -201,7 +202,9 @@ export const Anthropic_ToolCalling_Stream: AiProviderRunFn<
   const validatedToolCallsInStreamOrder = (): ToolCall[] =>
     filterValidToolCalls(toolCallsInStreamOrder(), toolDefinitions);
 
+  const usageCollector = createAnthropicUsageCollector();
   for await (const event of stream) {
+    usageCollector.observe(event);
     maybeEmitAnthropicRefusal(event, emit);
     if (event.type === "content_block_start") {
       const block = event.content_block;
@@ -270,5 +273,9 @@ export const Anthropic_ToolCalling_Stream: AiProviderRunFn<
     }
   }
 
-  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput });
+  emit({
+    type: "finish",
+    data: { text: "", toolCalls: [] } as ToolCallingTaskOutput,
+    usage: usageCollector.result(),
+  });
 };

--- a/providers/anthropic/src/ai/common/Anthropic_Usage.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Usage.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Usage } from "@workglow/ai";
+import { toUsageCount, usageOrUndefined } from "@workglow/ai/provider-utils";
+
+/**
+ * Collects Anthropic's token accounting off a raw Messages event stream.
+ *
+ * Anthropic splits usage across two frames: `message_start` carries the prompt
+ * side (`input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`)
+ * while `message_delta` carries the running completion side. Both report
+ * **cumulative** figures, so each field is last-reported-wins rather than summed
+ * — the collector never adds counts of its own, it only keeps the newest number
+ * the SDK stated.
+ *
+ * `message_delta.usage` nulls the prompt-side fields on older API versions; a
+ * `null` is "not restated here", so it leaves the earlier value intact rather
+ * than erasing it. A field no frame ever reported stays `undefined`.
+ */
+export interface IAnthropicUsageCollector {
+  /** Feed one raw SDK stream event. Non-usage events are ignored. */
+  readonly observe: (event: unknown) => void;
+  /** The collected usage, or `undefined` when the stream reported none. */
+  readonly result: () => Usage | undefined;
+}
+
+interface AnthropicUsagePayload {
+  readonly input_tokens?: unknown;
+  readonly output_tokens?: unknown;
+  readonly cache_read_input_tokens?: unknown;
+  readonly cache_creation_input_tokens?: unknown;
+  readonly output_tokens_details?: { readonly thinking_tokens?: unknown } | null;
+}
+
+export function createAnthropicUsageCollector(): IAnthropicUsageCollector {
+  let input: number | undefined;
+  let output: number | undefined;
+  let cached: number | undefined;
+  let cacheWrite: number | undefined;
+  let reasoning: number | undefined;
+
+  const absorb = (raw: unknown): void => {
+    if (!raw || typeof raw !== "object") return;
+    const payload = raw as AnthropicUsagePayload;
+    input = toUsageCount(payload.input_tokens) ?? input;
+    output = toUsageCount(payload.output_tokens) ?? output;
+    cached = toUsageCount(payload.cache_read_input_tokens) ?? cached;
+    cacheWrite = toUsageCount(payload.cache_creation_input_tokens) ?? cacheWrite;
+    reasoning = toUsageCount(payload.output_tokens_details?.thinking_tokens) ?? reasoning;
+  };
+
+  return {
+    observe: (event: unknown): void => {
+      const e = event as { type?: string; usage?: unknown; message?: { usage?: unknown } };
+      if (e?.type === "message_start") absorb(e.message?.usage);
+      else if (e?.type === "message_delta") absorb(e.usage);
+    },
+    result: (): Usage | undefined =>
+      usageOrUndefined({
+        input,
+        output,
+        cached,
+        cacheWrite,
+        reasoning,
+        // Anthropic states no total of its own; synthesizing one from the parts
+        // would misreport cache-discounted input as if it were billed in full.
+        total: undefined,
+        extra: undefined,
+      }),
+  };
+}

--- a/providers/anthropic/src/ai/index.ts
+++ b/providers/anthropic/src/ai/index.ts
@@ -21,6 +21,7 @@ import {
   anthropicAcceptsSamplingParams,
   applyAnthropicSamplingParams,
 } from "./common/Anthropic_RequestParams";
+import { createAnthropicUsageCollector } from "./common/Anthropic_Usage";
 
 /**
  * @internal Symbols exported only for use by `@workglow/test`. Not part of the stable public API.
@@ -33,4 +34,5 @@ export const _testOnly = {
   anthropicAcceptsSamplingParams,
   applyAnthropicSamplingParams,
   setAnthropicClientForTests: clientTestOnly.setAnthropicClientForTests,
+  createAnthropicUsageCollector,
 } as const;

--- a/providers/chrome-ai/src/ai/common/WebBrowser_TextGeneration.ts
+++ b/providers/chrome-ai/src/ai/common/WebBrowser_TextGeneration.ts
@@ -47,6 +47,9 @@ export const WebBrowser_TextGeneration: AiProviderRunFn<
   try {
     const stream = session.promptStreaming(input.prompt, { signal });
     await snapshotStreamToTextDeltas<TextGenerationTaskOutput>(stream, "text", emit);
+    // No `usage`: the Chrome built-in AI API reports no token counts (it exposes
+    // only quota measures such as `inputUsage`, which are not billing counters).
+    // Absent is the honest answer — a zero here would read as "cost nothing".
     emit({ type: "finish", data: {} as TextGenerationTaskOutput });
   } finally {
     session.destroy();

--- a/providers/deepseek/src/ai/common/DeepSeek_StructuredGeneration.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_StructuredGeneration.ts
@@ -8,7 +8,9 @@ import type {
   AiProviderRunFn,
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
+  Usage,
 } from "@workglow/ai";
+import { OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { parsePartialJson } from "@workglow/util/worker";
 import {
   assertNotTruncatedByReasoning,
@@ -17,6 +19,7 @@ import {
   resolveMaxTokens,
 } from "./DeepSeek_Client";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+import { mapDeepSeekUsage } from "./DeepSeek_Usage";
 
 /**
  * Build the user message for DeepSeek's JSON mode.
@@ -67,6 +70,7 @@ export const DeepSeek_StructuredGeneration_Stream: AiProviderRunFn<
       max_tokens: resolveMaxTokens(model, input.maxTokens),
       temperature: input.temperature,
       stream: true,
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
@@ -74,7 +78,9 @@ export const DeepSeek_StructuredGeneration_Stream: AiProviderRunFn<
   let accumulatedJson = "";
   let refusal = "";
   let finishReason: string | null | undefined;
+  let usage: Usage | undefined;
   for await (const chunk of stream) {
+    usage = mapDeepSeekUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       accumulatedJson += delta;
@@ -99,5 +105,9 @@ export const DeepSeek_StructuredGeneration_Stream: AiProviderRunFn<
   } catch {
     finalObject = parsePartialJson(accumulatedJson) ?? {};
   }
-  emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+  emit({
+    type: "finish",
+    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    usage,
+  });
 };

--- a/providers/deepseek/src/ai/common/DeepSeek_TextGeneration.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_TextGeneration.ts
@@ -8,7 +8,9 @@ import type {
   AiProviderRunFn,
   TextGenerationTaskInput,
   TextGenerationTaskOutput,
+  Usage,
 } from "@workglow/ai";
+import { OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { toOpenAIMessages } from "@workglow/ai/worker";
 import { getLogger } from "@workglow/util/worker";
 import {
@@ -18,6 +20,7 @@ import {
   resolveMaxTokens,
 } from "./DeepSeek_Client";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+import { mapDeepSeekUsage } from "./DeepSeek_Usage";
 
 /**
  * Inputs that the unified `["text.generation"]` runFn handles. Both
@@ -86,18 +89,25 @@ export const DeepSeek_TextGeneration_Stream: AiProviderRunFn<
     const params = buildChatParams(input as UnifiedTextGenerationInput, model);
 
     const stream = await client.chat.completions.create(
-      { ...params, stream: true } as Parameters<typeof client.chat.completions.create>[0],
+      { ...params, stream: true, ...OPENAI_STREAM_USAGE_OPTIONS } as Parameters<
+        typeof client.chat.completions.create
+      >[0],
       { signal }
     );
 
     let emittedText = "";
     let finishReason: string | null | undefined;
+    let usage: Usage | undefined;
     for await (const chunk of stream as AsyncIterable<{
       choices?: Array<{
         delta?: { content?: string | null; refusal?: string | null };
         finish_reason?: string | null;
       }>;
+      usage?: unknown;
     }>) {
+      // The usage-bearing chunk arrives last with an empty `choices` array; the
+      // delta reads below already tolerate that, so nothing else needs guarding.
+      usage = mapDeepSeekUsage(chunk.usage) ?? usage;
       const delta = chunk.choices?.[0]?.delta?.content ?? "";
       if (delta) {
         emittedText += delta;
@@ -110,7 +120,7 @@ export const DeepSeek_TextGeneration_Stream: AiProviderRunFn<
       finishReason = chunk.choices?.[0]?.finish_reason ?? finishReason;
     }
     assertNotTruncatedByReasoning(finishReason, emittedText, input.maxTokens);
-    emit({ type: "finish", data: {} as TextGenerationTaskOutput });
+    emit({ type: "finish", data: {} as TextGenerationTaskOutput, usage });
   } finally {
     logger.timeEnd(timerLabel, { model: getModelName(model) });
   }

--- a/providers/deepseek/src/ai/common/DeepSeek_TextRewriter.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_TextRewriter.ts
@@ -4,9 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
+import type {
+  AiProviderRunFn,
+  TextRewriterTaskInput,
+  TextRewriterTaskOutput,
+  Usage,
+} from "@workglow/ai";
+import { OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { getClient, getModelName } from "./DeepSeek_Client";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+import { mapDeepSeekUsage } from "./DeepSeek_Usage";
 
 /**
  * Streaming run-fn for `["text.rewriter"]`. Emits `text-delta` events on the
@@ -28,11 +35,14 @@ export const DeepSeek_TextRewriter_Stream: AiProviderRunFn<
         { role: "user", content: input.text },
       ],
       stream: true,
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
 
+  let usage: Usage | undefined;
   for await (const chunk of stream) {
+    usage = mapDeepSeekUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
@@ -42,5 +52,5 @@ export const DeepSeek_TextRewriter_Stream: AiProviderRunFn<
       emit({ type: "refusal", refusal: refusalDelta });
     }
   }
-  emit({ type: "finish", data: {} as TextRewriterTaskOutput });
+  emit({ type: "finish", data: {} as TextRewriterTaskOutput, usage });
 };

--- a/providers/deepseek/src/ai/common/DeepSeek_TextSummary.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_TextSummary.ts
@@ -4,9 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
+import type {
+  AiProviderRunFn,
+  TextSummaryTaskInput,
+  TextSummaryTaskOutput,
+  Usage,
+} from "@workglow/ai";
+import { OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { getClient, getModelName } from "./DeepSeek_Client";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+import { mapDeepSeekUsage } from "./DeepSeek_Usage";
 
 /**
  * Streaming run-fn for `["text.summary"]`. Emits `text-delta` events on the
@@ -28,11 +35,14 @@ export const DeepSeek_TextSummary_Stream: AiProviderRunFn<
         { role: "user", content: input.text },
       ],
       stream: true,
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
 
+  let usage: Usage | undefined;
   for await (const chunk of stream) {
+    usage = mapDeepSeekUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
@@ -42,5 +52,5 @@ export const DeepSeek_TextSummary_Stream: AiProviderRunFn<
       emit({ type: "refusal", refusal: refusalDelta });
     }
   }
-  emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+  emit({ type: "finish", data: {} as TextSummaryTaskOutput, usage });
 };

--- a/providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts
@@ -10,11 +10,16 @@ import type {
   ToolCallingTaskOutput,
   ToolCalls,
 } from "@workglow/ai";
-import { accumulateOpenAIChatStream, buildOpenAITools } from "@workglow/ai/provider-utils";
+import {
+  accumulateOpenAIChatStream,
+  buildOpenAITools,
+  OPENAI_STREAM_USAGE_OPTIONS,
+} from "@workglow/ai/provider-utils";
 import { filterValidToolCalls, toOpenAIMessages } from "@workglow/ai/worker";
 import { RetryableJobError } from "@workglow/job-queue";
 import { getClient, getModelName, resolveMaxTokens } from "./DeepSeek_Client";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+import { mapDeepSeekUsage } from "./DeepSeek_Usage";
 
 /**
  * Thrown when the caller demanded a tool call that the model did not make.
@@ -132,6 +137,7 @@ export const DeepSeek_ToolCalling_Stream: AiProviderRunFn<
       stream: true,
       tools,
       tool_choice: toolChoice,
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
@@ -140,21 +146,25 @@ export const DeepSeek_ToolCalling_Stream: AiProviderRunFn<
   // latest name per id rather than counting events.
   const calledByCallId = new Map<string, string>();
 
-  await accumulateOpenAIChatStream(stream, (event) => {
-    if (event.type === "object-delta" && event.port === "toolCalls") {
-      const validated = filterValidToolCalls(event.objectDelta as ToolCalls, input.tools);
-      if (validated.length > 0) {
-        for (const call of validated) calledByCallId.set(call.id, call.name);
-        emit({ type: "object-delta", port: "toolCalls", objectDelta: validated });
+  const usage = await accumulateOpenAIChatStream(
+    stream,
+    (event) => {
+      if (event.type === "object-delta" && event.port === "toolCalls") {
+        const validated = filterValidToolCalls(event.objectDelta as ToolCalls, input.tools);
+        if (validated.length > 0) {
+          for (const call of validated) calledByCallId.set(call.id, call.name);
+          emit({ type: "object-delta", port: "toolCalls", objectDelta: validated });
+        }
+        return;
       }
-      return;
-    }
-    emit(event);
-  });
+      emit(event);
+    },
+    mapDeepSeekUsage
+  );
 
   if (isForcingToolChoice(input.toolChoice)) {
     assertToolChoiceHonored(input.toolChoice, [...calledByCallId.values()], modelName);
   }
 
-  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput });
+  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput, usage });
 };

--- a/providers/deepseek/src/ai/common/DeepSeek_Usage.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_Usage.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Usage } from "@workglow/ai";
+import { mapOpenAIChatUsage, toUsageCount, usageExtra } from "@workglow/ai/provider-utils";
+
+interface DeepSeekUsagePayload {
+  readonly prompt_cache_hit_tokens?: unknown;
+  readonly prompt_cache_miss_tokens?: unknown;
+}
+
+/**
+ * Map a DeepSeek chat-completions `usage` object into {@link Usage}.
+ *
+ * DeepSeek is OpenAI-shaped but splits the prompt across two counters of its
+ * own: `prompt_cache_hit_tokens` (billed at the cache-hit rate) and
+ * `prompt_cache_miss_tokens`. The hit count is the provider's cache-read figure,
+ * so it fills `cached` — including when the API omits the OpenAI-standard
+ * `prompt_tokens_details.cached_tokens`. The miss count has no normalized slot
+ * and is carried in `extra`, where it is what makes DeepSeek's cache-miss-priced
+ * cost reconstructable.
+ */
+export function mapDeepSeekUsage(raw: unknown): Usage | undefined {
+  const base = mapOpenAIChatUsage(raw);
+  if (!base) return undefined;
+
+  const payload = (raw ?? {}) as DeepSeekUsagePayload;
+  const cacheHit = toUsageCount(payload.prompt_cache_hit_tokens);
+  const cacheMiss = toUsageCount(payload.prompt_cache_miss_tokens);
+
+  return {
+    ...base,
+    cached: base.cached ?? cacheHit,
+    extra: usageExtra({ promptCacheMissTokens: cacheMiss }),
+  };
+}

--- a/providers/deepseek/src/ai/index.ts
+++ b/providers/deepseek/src/ai/index.ts
@@ -25,6 +25,7 @@ export * from "./registerDeepSeek";
 
 import { DEEPSEEK_RUN_FN_SPECS } from "./common/DeepSeek_Capabilities";
 import { DEEPSEEK_RUN_FNS } from "./common/DeepSeek_JobRunFns";
+import { mapDeepSeekUsage } from "./common/DeepSeek_Usage";
 import { DeepSeekQueuedProvider } from "./DeepSeekQueuedProvider";
 
 /**
@@ -34,4 +35,5 @@ export const _testOnly = {
   DeepSeekQueuedProvider,
   DEEPSEEK_RUN_FN_SPECS,
   DEEPSEEK_RUN_FNS,
+  mapDeepSeekUsage,
 } as const;

--- a/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
@@ -14,6 +14,7 @@ import { createGeminiClient, getModelName, resolveThinkingConfig } from "./Gemin
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { emitGeminiRefusal, geminiRefusalCategory } from "./Gemini_Refusal";
 import { sanitizeSchemaForGemini } from "./Gemini_Schema";
+import { mapGeminiUsage } from "./Gemini_Usage";
 
 /**
  * Default reasoning allowance (in tokens) for the model's internal "thinking"
@@ -72,7 +73,9 @@ export const Gemini_StructuredGeneration_Stream: AiProviderRunFn<
 
   let accumulatedJson = "";
   let refusalCategory: string | undefined;
+  let lastUsageMetadata: unknown;
   for await (const chunk of result) {
+    lastUsageMetadata = chunk.usageMetadata ?? lastUsageMetadata;
     // `chunk.text` concatenates the answer text (thought parts are excluded).
     const text = chunk.text;
     if (text) {
@@ -93,5 +96,9 @@ export const Gemini_StructuredGeneration_Stream: AiProviderRunFn<
     finalObject = parsePartialJson(accumulatedJson) ?? {};
   }
   // json-mode finish exception: populate finish.data.object with parsed result.
-  emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+  emit({
+    type: "finish",
+    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    usage: mapGeminiUsage(lastUsageMetadata),
+  });
 };

--- a/providers/google-gemini/src/ai/common/Gemini_TextGeneration.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_TextGeneration.ts
@@ -17,6 +17,7 @@ import { createGeminiClient, getModelName, resolveThinkingConfig } from "./Gemin
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { emitGeminiRefusal, geminiRefusalCategory } from "./Gemini_Refusal";
 import { buildGeminiContents } from "./Gemini_ToolCalling";
+import { mapGeminiUsage } from "./Gemini_Usage";
 
 interface GeminiGenerationConfig {
   maxOutputTokens?: number;
@@ -187,17 +188,23 @@ export const Gemini_TextGeneration_Stream: AiProviderRunFn<
     });
 
     let refusalCategory: string | undefined;
+    let lastUsageMetadata: unknown;
     for await (const chunk of result) {
       // `chunk.text` concatenates answer text and already skips thought parts.
       const text = chunk.text;
       if (text) {
         emit({ type: "text-delta", port: "text", textDelta: text });
       }
+      lastUsageMetadata = chunk.usageMetadata ?? lastUsageMetadata;
       refusalCategory = refusalCategory ?? geminiRefusalCategory(chunk);
     }
     emitGeminiRefusal(emit, refusalCategory);
 
-    emit({ type: "finish", data: {} as TextGenerationTaskOutput });
+    emit({
+      type: "finish",
+      data: {} as TextGenerationTaskOutput,
+      usage: mapGeminiUsage(lastUsageMetadata),
+    });
   } finally {
     logger.timeEnd(timerLabel, { model: getModelName(model) });
   }

--- a/providers/google-gemini/src/ai/common/Gemini_TextRewriter.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_TextRewriter.ts
@@ -8,6 +8,7 @@ import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } f
 import { createGeminiClient, getModelName } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { emitGeminiRefusal, geminiRefusalCategory } from "./Gemini_Refusal";
+import { mapGeminiUsage } from "./Gemini_Usage";
 
 export const Gemini_TextRewriter_Stream: AiProviderRunFn<
   TextRewriterTaskInput,
@@ -26,7 +27,9 @@ export const Gemini_TextRewriter_Stream: AiProviderRunFn<
   });
 
   let refusalCategory: string | undefined;
+  let lastUsageMetadata: unknown;
   for await (const chunk of result) {
+    lastUsageMetadata = chunk.usageMetadata ?? lastUsageMetadata;
     const text = chunk.text;
     if (text) {
       emit({ type: "text-delta", port: "text", textDelta: text });
@@ -34,5 +37,9 @@ export const Gemini_TextRewriter_Stream: AiProviderRunFn<
     refusalCategory = refusalCategory ?? geminiRefusalCategory(chunk);
   }
   emitGeminiRefusal(emit, refusalCategory);
-  emit({ type: "finish", data: {} as TextRewriterTaskOutput });
+  emit({
+    type: "finish",
+    data: {} as TextRewriterTaskOutput,
+    usage: mapGeminiUsage(lastUsageMetadata),
+  });
 };

--- a/providers/google-gemini/src/ai/common/Gemini_TextSummary.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_TextSummary.ts
@@ -8,6 +8,7 @@ import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } fro
 import { createGeminiClient, getModelName } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { emitGeminiRefusal, geminiRefusalCategory } from "./Gemini_Refusal";
+import { mapGeminiUsage } from "./Gemini_Usage";
 
 export const Gemini_TextSummary_Stream: AiProviderRunFn<
   TextSummaryTaskInput,
@@ -26,7 +27,9 @@ export const Gemini_TextSummary_Stream: AiProviderRunFn<
   });
 
   let refusalCategory: string | undefined;
+  let lastUsageMetadata: unknown;
   for await (const chunk of result) {
+    lastUsageMetadata = chunk.usageMetadata ?? lastUsageMetadata;
     const text = chunk.text;
     if (text) {
       emit({ type: "text-delta", port: "text", textDelta: text });
@@ -34,5 +37,9 @@ export const Gemini_TextSummary_Stream: AiProviderRunFn<
     refusalCategory = refusalCategory ?? geminiRefusalCategory(chunk);
   }
   emitGeminiRefusal(emit, refusalCategory);
-  emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+  emit({
+    type: "finish",
+    data: {} as TextSummaryTaskOutput,
+    usage: mapGeminiUsage(lastUsageMetadata),
+  });
 };

--- a/providers/google-gemini/src/ai/common/Gemini_ToolCalling.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ToolCalling.ts
@@ -23,6 +23,7 @@ import { evictIfStaleGeminiCachedContent, getGeminiCachedContent } from "./Gemin
 import { createGeminiClient, getModelName, resolveThinkingConfig } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { emitGeminiRefusal, geminiRefusalCategory } from "./Gemini_Refusal";
+import { mapGeminiUsage } from "./Gemini_Usage";
 
 export function buildGeminiContents(
   messages: ReadonlyArray<ChatMessage> | undefined,
@@ -227,8 +228,10 @@ export const Gemini_ToolCalling_Stream: AiProviderRunFn<
 
   let callIndex = 0;
   let refusalCategory: string | undefined;
+  let lastUsageMetadata: unknown;
 
   for await (const chunk of result) {
+    lastUsageMetadata = chunk.usageMetadata ?? lastUsageMetadata;
     refusalCategory = refusalCategory ?? geminiRefusalCategory(chunk);
     const parts = chunk.candidates?.[0]?.content?.parts ?? [];
     for (const part of parts) {
@@ -268,5 +271,9 @@ export const Gemini_ToolCalling_Stream: AiProviderRunFn<
   }
 
   emitGeminiRefusal(emit, refusalCategory);
-  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput });
+  emit({
+    type: "finish",
+    data: { text: "", toolCalls: [] } as ToolCallingTaskOutput,
+    usage: mapGeminiUsage(lastUsageMetadata),
+  });
 };

--- a/providers/google-gemini/src/ai/common/Gemini_Usage.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Usage.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Usage } from "@workglow/ai";
+import { toUsageCount, usageOrUndefined } from "@workglow/ai/provider-utils";
+
+interface GeminiUsageMetadata {
+  readonly promptTokenCount?: unknown;
+  readonly candidatesTokenCount?: unknown;
+  readonly cachedContentTokenCount?: unknown;
+  readonly thoughtsTokenCount?: unknown;
+  readonly totalTokenCount?: unknown;
+}
+
+/**
+ * Map a Gemini `usageMetadata` block into {@link Usage}.
+ *
+ * Gemini attaches `usageMetadata` to streamed chunks, restating **cumulative**
+ * counts as generation proceeds; callers keep the last non-null block and map it
+ * once, so nothing is summed locally. `promptTokenCount` already includes the
+ * cached-content tokens that `cachedContentTokenCount` breaks out, matching the
+ * `input`/`cached` relationship every other provider uses here.
+ */
+export function mapGeminiUsage(usageMetadata: unknown): Usage | undefined {
+  if (!usageMetadata || typeof usageMetadata !== "object") return undefined;
+  const metadata = usageMetadata as GeminiUsageMetadata;
+  return usageOrUndefined({
+    input: toUsageCount(metadata.promptTokenCount),
+    output: toUsageCount(metadata.candidatesTokenCount),
+    cached: toUsageCount(metadata.cachedContentTokenCount),
+    cacheWrite: undefined,
+    reasoning: toUsageCount(metadata.thoughtsTokenCount),
+    total: toUsageCount(metadata.totalTokenCount),
+    extra: undefined,
+  });
+}

--- a/providers/google-gemini/src/ai/index.ts
+++ b/providers/google-gemini/src/ai/index.ts
@@ -26,6 +26,7 @@ import {
 import { GEMINI_RUN_FNS } from "./common/Gemini_JobRunFns";
 import { emitGeminiRefusal, geminiRefusalCategory } from "./common/Gemini_Refusal";
 import { buildGeminiContents } from "./common/Gemini_ToolCalling";
+import { mapGeminiUsage } from "./common/Gemini_Usage";
 import { GoogleGeminiQueuedProvider } from "./GoogleGeminiQueuedProvider";
 
 /**
@@ -47,4 +48,5 @@ export const _testOnly = {
   cacheStoreTestOnly: _cacheStoreTestOnly,
   isGeminiCachedContentNotFoundError,
   generateGeminiStreamWithCacheFallback,
+  mapGeminiUsage,
 } as const;

--- a/providers/huggingface-inference/src/ai/common/HFI_ToolCalling.ts
+++ b/providers/huggingface-inference/src/ai/common/HFI_ToolCalling.ts
@@ -42,6 +42,9 @@ export const HFI_ToolCalling_Stream: AiProviderRunFn<
 
   const stream = client.chatCompletionStream(params, { signal });
 
-  await accumulateOpenAIChatStream(stream, emit);
-  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput });
+  // No `include_usage` opt-in here: the request is routed to a third-party
+  // inference provider whose support for it varies. Usage is forwarded when the
+  // upstream volunteers it on the terminal chunk, and stays absent otherwise.
+  const usage = await accumulateOpenAIChatStream(stream, emit);
+  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput, usage });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextGeneration.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextGeneration.ts
@@ -210,6 +210,9 @@ export const HFT_TextGeneration: AiProviderRunFn<
       snapshotHftSession(sessionContext.emitCheckpointId, past_key_values, modelPath, cacheKey);
     }
 
+    // No `usage`: transformers.js runs the model in-process and reports no
+    // token accounting of its own. Absent is the honest answer — counting our
+    // own emitted tokens would be a local estimate dressed up as a provider fact.
     emit({ type: "finish", data: {} as TextGenerationTaskOutput });
   });
 };

--- a/providers/llamacpp-server/src/ai/common/LlamaCppServer_Client.ts
+++ b/providers/llamacpp-server/src/ai/common/LlamaCppServer_Client.ts
@@ -110,6 +110,12 @@ export interface IChatCompletionDelta {
   }>;
   readonly done?: boolean;
   readonly finishReason?: string;
+  /**
+   * Raw OpenAI-shape `usage` payload, present only on the terminal chunk when
+   * the request set `stream_options: { include_usage: true }`. Left unmapped
+   * here so the parser stays a transport concern; callers normalize it.
+   */
+  readonly usage?: unknown;
 }
 
 /**
@@ -157,6 +163,7 @@ export async function* readChatCompletionDeltas(
             };
             finish_reason?: string;
           }>;
+          usage?: unknown;
         };
         try {
           chunk = JSON.parse(data) as typeof chunk;
@@ -167,8 +174,16 @@ export async function* readChatCompletionDeltas(
         const contentDelta = choice?.delta?.content;
         const toolCallDeltas = choice?.delta?.tool_calls;
         const finishReason = choice?.finish_reason;
-        if (contentDelta !== undefined || toolCallDeltas !== undefined || finishReason) {
-          yield { contentDelta, toolCallDeltas, finishReason };
+        // The usage-bearing chunk carries an empty `choices` array, so it must
+        // be admitted on its own merit or the token counts are silently dropped.
+        const usage = chunk.usage ?? undefined;
+        if (
+          contentDelta !== undefined ||
+          toolCallDeltas !== undefined ||
+          finishReason ||
+          usage !== undefined
+        ) {
+          yield { contentDelta, toolCallDeltas, finishReason, usage };
         }
       }
     }

--- a/providers/llamacpp-server/src/ai/common/LlamaCppServer_TextGeneration.ts
+++ b/providers/llamacpp-server/src/ai/common/LlamaCppServer_TextGeneration.ts
@@ -8,8 +8,13 @@ import type {
   AiProviderRunFn,
   TextGenerationTaskInput,
   TextGenerationTaskOutput,
+  Usage,
 } from "@workglow/ai";
-import { localOnlyFetch } from "@workglow/ai/provider-utils";
+import {
+  localOnlyFetch,
+  mapOpenAIChatUsage,
+  OPENAI_STREAM_USAGE_OPTIONS,
+} from "@workglow/ai/provider-utils";
 import {
   acquireBaseUrl,
   buildServerUrl,
@@ -74,6 +79,7 @@ export function createLlamaCppServerTextGenerationStream(
         ? { frequency_penalty: input.frequencyPenalty }
         : {}),
       ...(input.presencePenalty !== undefined ? { presence_penalty: input.presencePenalty } : {}),
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     });
 
     const { baseUrl, release } = await acquire(model, opts);
@@ -95,13 +101,15 @@ export function createLlamaCppServerTextGenerationStream(
           `LlamaCppServer: HTTP ${response.status} from /v1/chat/completions (text-generation) — ${text}`
         );
       }
+      let usage: Usage | undefined;
       for await (const delta of readChatCompletionDeltas(response, signal)) {
         if (delta.done) break;
+        usage = mapOpenAIChatUsage(delta.usage) ?? usage;
         if (delta.contentDelta) {
           emit({ type: "text-delta", port: "text", textDelta: delta.contentDelta });
         }
       }
-      emit({ type: "finish", data: {} as TextGenerationTaskOutput });
+      emit({ type: "finish", data: {} as TextGenerationTaskOutput, usage });
     } finally {
       await release();
     }

--- a/providers/llamacpp-server/src/ai/common/LlamaCppServer_TextRewriter.ts
+++ b/providers/llamacpp-server/src/ai/common/LlamaCppServer_TextRewriter.ts
@@ -4,8 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
-import { localOnlyFetch } from "@workglow/ai/provider-utils";
+import type {
+  AiProviderRunFn,
+  TextRewriterTaskInput,
+  TextRewriterTaskOutput,
+  Usage,
+} from "@workglow/ai";
+import {
+  localOnlyFetch,
+  mapOpenAIChatUsage,
+  OPENAI_STREAM_USAGE_OPTIONS,
+} from "@workglow/ai/provider-utils";
 import {
   acquireBaseUrl,
   buildServerUrl,
@@ -30,6 +39,7 @@ export function createLlamaCppServerTextRewriterStream(
         { role: "user", content: input.text },
       ],
       stream: true,
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     });
     const { baseUrl, release } = await acquire(model, opts);
     try {
@@ -49,13 +59,15 @@ export function createLlamaCppServerTextRewriterStream(
           `LlamaCppServer: HTTP ${response.status} from /v1/chat/completions (rewriter) — ${text}`
         );
       }
+      let usage: Usage | undefined;
       for await (const delta of readChatCompletionDeltas(response, signal)) {
         if (delta.done) break;
+        usage = mapOpenAIChatUsage(delta.usage) ?? usage;
         if (delta.contentDelta) {
           emit({ type: "text-delta", port: "text", textDelta: delta.contentDelta });
         }
       }
-      emit({ type: "finish", data: {} as TextRewriterTaskOutput });
+      emit({ type: "finish", data: {} as TextRewriterTaskOutput, usage });
     } finally {
       await release();
     }

--- a/providers/llamacpp-server/src/ai/common/LlamaCppServer_TextSummary.ts
+++ b/providers/llamacpp-server/src/ai/common/LlamaCppServer_TextSummary.ts
@@ -4,8 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
-import { localOnlyFetch } from "@workglow/ai/provider-utils";
+import type {
+  AiProviderRunFn,
+  TextSummaryTaskInput,
+  TextSummaryTaskOutput,
+  Usage,
+} from "@workglow/ai";
+import {
+  localOnlyFetch,
+  mapOpenAIChatUsage,
+  OPENAI_STREAM_USAGE_OPTIONS,
+} from "@workglow/ai/provider-utils";
 import {
   acquireBaseUrl,
   buildServerUrl,
@@ -30,6 +39,7 @@ export function createLlamaCppServerTextSummaryStream(
         { role: "user", content: input.text },
       ],
       stream: true,
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     });
     const { baseUrl, release } = await acquire(model, opts);
     try {
@@ -49,13 +59,15 @@ export function createLlamaCppServerTextSummaryStream(
           `LlamaCppServer: HTTP ${response.status} from /v1/chat/completions (summary) — ${text}`
         );
       }
+      let usage: Usage | undefined;
       for await (const delta of readChatCompletionDeltas(response, signal)) {
         if (delta.done) break;
+        usage = mapOpenAIChatUsage(delta.usage) ?? usage;
         if (delta.contentDelta) {
           emit({ type: "text-delta", port: "text", textDelta: delta.contentDelta });
         }
       }
-      emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+      emit({ type: "finish", data: {} as TextSummaryTaskOutput, usage });
     } finally {
       await release();
     }

--- a/providers/llamacpp-server/src/ai/common/LlamaCppServer_ToolCalling.ts
+++ b/providers/llamacpp-server/src/ai/common/LlamaCppServer_ToolCalling.ts
@@ -10,8 +10,13 @@ import type {
   ToolCallingTaskOutput,
   ToolCalls,
   ToolDefinition,
+  Usage,
 } from "@workglow/ai";
-import { localOnlyFetch } from "@workglow/ai/provider-utils";
+import {
+  localOnlyFetch,
+  mapOpenAIChatUsage,
+  OPENAI_STREAM_USAGE_OPTIONS,
+} from "@workglow/ai/provider-utils";
 import {
   buildToolDescription,
   filterValidToolCalls,
@@ -56,6 +61,7 @@ export function createLlamaCppServerToolCallingStream(
       stream: true,
       ...(input.temperature !== undefined ? { temperature: input.temperature } : {}),
       ...(input.maxTokens !== undefined ? { max_tokens: input.maxTokens } : {}),
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     });
     const { baseUrl, release } = await acquire(model, opts);
     try {
@@ -81,9 +87,11 @@ export function createLlamaCppServerToolCallingStream(
       const callMeta = new Map<number, { id?: string; name?: string }>();
       let nextSyntheticIndex = 0;
       let lastEmittedToolCalls: ToolCalls = [];
+      let usage: Usage | undefined;
 
       for await (const delta of readChatCompletionDeltas(response, signal)) {
         if (delta.done) break;
+        usage = mapOpenAIChatUsage(delta.usage) ?? usage;
         if (delta.contentDelta) {
           accumulatedText += delta.contentDelta;
           emit({ type: "text-delta", port: "text", textDelta: delta.contentDelta });
@@ -107,6 +115,7 @@ export function createLlamaCppServerToolCallingStream(
       emit({
         type: "finish",
         data: { text: accumulatedText, toolCalls: finalToolCalls } as ToolCallingTaskOutput,
+        usage,
       });
     } finally {
       await release();

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts
@@ -207,6 +207,9 @@ export const LlamaCpp_Chat_Stream: AiProviderRunFn<
       }
     }
     await promptPromise;
+    // No `usage`: node-llama-cpp runs the model locally and surfaces no token
+    // accounting on its prompt API. Absent is the honest answer — a zero would
+    // read as "billed nothing" rather than "reported nothing".
     emit({ type: "finish", data: {} as AiChatProviderOutput });
   });
 };

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
@@ -61,7 +61,20 @@ export interface LlamaCppSessionState {
   modelKey: string;
 }
 
-export const llamaCppSessions = new Map<string, LlamaCppSessionState>();
+// Shared across bundle copies via a Symbol.for key — same pattern as
+// PortCodecRegistry/globalContainer. `./ai` and `./ai-runtime` are built as
+// separate dist entry points; without this, inline (non-worker) usage would
+// have each entry point's copy of this module see its own Map, and a session
+// set through one entry point would look absent through the other.
+const GLOBAL_SESSIONS_KEY = Symbol.for("@workglow/node-llama-cpp/llamaCppSessions");
+const _sessionsGlobal = globalThis as Record<symbol, unknown>;
+if (!_sessionsGlobal[GLOBAL_SESSIONS_KEY]) {
+  _sessionsGlobal[GLOBAL_SESSIONS_KEY] = new Map<string, LlamaCppSessionState>();
+}
+export const llamaCppSessions = _sessionsGlobal[GLOBAL_SESSIONS_KEY] as Map<
+  string,
+  LlamaCppSessionState
+>;
 
 /**
  * Per-`sessionId` promise-chain mutex. The non-checkpoint shared-session paths

--- a/providers/ollama/src/ai/common/Ollama_StructuredGeneration.ts
+++ b/providers/ollama/src/ai/common/Ollama_StructuredGeneration.ts
@@ -8,10 +8,12 @@ import type {
   AiProviderRunFn,
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
+  Usage,
 } from "@workglow/ai";
 import { parsePartialJson } from "@workglow/util/worker";
 import type { OllamaModelConfig } from "./Ollama_ModelSchema";
 import { getOllamaModelName } from "./Ollama_ModelUtil";
+import { mapOllamaUsage } from "./Ollama_Usage";
 
 type GetClient = (model: OllamaModelConfig | undefined) => Promise<any>;
 
@@ -54,10 +56,12 @@ export function createOllamaStructuredGenerationStream(
     const onAbort = (): void => stream.abort();
     signal?.addEventListener("abort", onAbort, { once: true });
     let accumulatedJson = "";
+    let usage: Usage | undefined;
     try {
       if (signal?.aborted) stream.abort();
       signal?.throwIfAborted?.();
       for await (const chunk of stream) {
+        usage = mapOllamaUsage(chunk) ?? usage;
         const delta = chunk.message.content;
         if (delta) {
           accumulatedJson += delta;
@@ -77,6 +81,10 @@ export function createOllamaStructuredGenerationStream(
     } catch {
       finalObject = parsePartialJson(accumulatedJson) ?? {};
     }
-    emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+    emit({
+      type: "finish",
+      data: { object: finalObject } as StructuredGenerationTaskOutput,
+      usage,
+    });
   };
 }

--- a/providers/ollama/src/ai/common/Ollama_TextGeneration.ts
+++ b/providers/ollama/src/ai/common/Ollama_TextGeneration.ts
@@ -8,9 +8,11 @@ import type {
   AiProviderRunFn,
   TextGenerationTaskInput,
   TextGenerationTaskOutput,
+  Usage,
 } from "@workglow/ai";
 import type { OllamaModelConfig } from "./Ollama_ModelSchema";
 import { getOllamaModelName } from "./Ollama_ModelUtil";
+import { mapOllamaUsage } from "./Ollama_Usage";
 
 type GetClient = (model: OllamaModelConfig | undefined) => Promise<any>;
 
@@ -63,13 +65,15 @@ export function createOllamaTextGenerationStream(
     try {
       if (signal?.aborted) stream.abort();
       signal?.throwIfAborted?.();
+      let usage: Usage | undefined;
       for await (const chunk of stream) {
+        usage = mapOllamaUsage(chunk) ?? usage;
         const delta = chunk.message.content;
         if (delta) {
           emit({ type: "text-delta", port: "text", textDelta: delta });
         }
       }
-      emit({ type: "finish", data: {} as TextGenerationTaskOutput });
+      emit({ type: "finish", data: {} as TextGenerationTaskOutput, usage });
     } finally {
       signal?.removeEventListener("abort", onAbort);
     }

--- a/providers/ollama/src/ai/common/Ollama_TextRewriter.ts
+++ b/providers/ollama/src/ai/common/Ollama_TextRewriter.ts
@@ -4,9 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
+import type {
+  AiProviderRunFn,
+  TextRewriterTaskInput,
+  TextRewriterTaskOutput,
+  Usage,
+} from "@workglow/ai";
 import type { OllamaModelConfig } from "./Ollama_ModelSchema";
 import { getOllamaModelName } from "./Ollama_ModelUtil";
+import { mapOllamaUsage } from "./Ollama_Usage";
 
 type GetClient = (model: OllamaModelConfig | undefined) => Promise<any>;
 
@@ -29,13 +35,15 @@ export function createOllamaTextRewriterStream(
     const onAbort = (): void => stream.abort();
     signal?.addEventListener("abort", onAbort, { once: true });
     try {
+      let usage: Usage | undefined;
       for await (const chunk of stream) {
+        usage = mapOllamaUsage(chunk) ?? usage;
         const delta = chunk.message.content;
         if (delta) {
           emit({ type: "text-delta", port: "text", textDelta: delta });
         }
       }
-      emit({ type: "finish", data: {} as TextRewriterTaskOutput });
+      emit({ type: "finish", data: {} as TextRewriterTaskOutput, usage });
     } finally {
       signal?.removeEventListener("abort", onAbort);
     }

--- a/providers/ollama/src/ai/common/Ollama_TextSummary.ts
+++ b/providers/ollama/src/ai/common/Ollama_TextSummary.ts
@@ -4,9 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
+import type {
+  AiProviderRunFn,
+  TextSummaryTaskInput,
+  TextSummaryTaskOutput,
+  Usage,
+} from "@workglow/ai";
 import type { OllamaModelConfig } from "./Ollama_ModelSchema";
 import { getOllamaModelName } from "./Ollama_ModelUtil";
+import { mapOllamaUsage } from "./Ollama_Usage";
 
 type GetClient = (model: OllamaModelConfig | undefined) => Promise<any>;
 
@@ -29,13 +35,15 @@ export function createOllamaTextSummaryStream(
     const onAbort = (): void => stream.abort();
     signal?.addEventListener("abort", onAbort, { once: true });
     try {
+      let usage: Usage | undefined;
       for await (const chunk of stream) {
+        usage = mapOllamaUsage(chunk) ?? usage;
         const delta = chunk.message.content;
         if (delta) {
           emit({ type: "text-delta", port: "text", textDelta: delta });
         }
       }
-      emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+      emit({ type: "finish", data: {} as TextSummaryTaskOutput, usage });
     } finally {
       signal?.removeEventListener("abort", onAbort);
     }

--- a/providers/ollama/src/ai/common/Ollama_ToolCalling.ts
+++ b/providers/ollama/src/ai/common/Ollama_ToolCalling.ts
@@ -10,11 +10,13 @@ import type {
   ToolCallingTaskOutput,
   ToolCalls,
   ToolDefinition,
+  Usage,
 } from "@workglow/ai";
 import { buildToolDescription, filterValidToolCalls, sanitizeToolArgs } from "@workglow/ai/worker";
 import { parsePartialJson } from "@workglow/util/worker";
 import type { OllamaModelConfig } from "./Ollama_ModelSchema";
 import { getOllamaModelName } from "./Ollama_ModelUtil";
+import { mapOllamaUsage } from "./Ollama_Usage";
 
 type GetClient = (model: OllamaModelConfig | undefined) => Promise<any>;
 
@@ -60,9 +62,11 @@ export function createOllamaToolCallingStream(
     signal?.addEventListener("abort", onAbort, { once: true });
 
     let callIndex = 0;
+    let usage: Usage | undefined;
 
     try {
       for await (const chunk of stream) {
+        usage = mapOllamaUsage(chunk) ?? usage;
         const delta = chunk.message.content;
         if (delta) {
           emit({ type: "text-delta", port: "text", textDelta: delta });
@@ -106,6 +110,7 @@ export function createOllamaToolCallingStream(
       emit({
         type: "finish",
         data: { text: "", toolCalls: [] } as ToolCallingTaskOutput,
+        usage,
       });
     } finally {
       signal?.removeEventListener("abort", onAbort);

--- a/providers/ollama/src/ai/common/Ollama_Usage.ts
+++ b/providers/ollama/src/ai/common/Ollama_Usage.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Usage } from "@workglow/ai";
+import { toUsageCount, usageOrUndefined } from "@workglow/ai/provider-utils";
+
+interface OllamaDoneChunk {
+  readonly done?: unknown;
+  readonly prompt_eval_count?: unknown;
+  readonly eval_count?: unknown;
+}
+
+/**
+ * Map an Ollama terminal chunk's token counts into {@link Usage}.
+ *
+ * Ollama reports counts only on the final `done: true` chunk of a
+ * `chat`/`generate` stream: `prompt_eval_count` is the prompt side and
+ * `eval_count` the generated side. Intermediate chunks omit them, so this
+ * returns `undefined` for anything but the terminal chunk rather than
+ * mistaking an absent count for zero.
+ *
+ * Ollama runs locally and reports no cache, reasoning, or total counters, so
+ * those slots stay unreported.
+ */
+export function mapOllamaUsage(chunk: unknown): Usage | undefined {
+  if (!chunk || typeof chunk !== "object") return undefined;
+  const done = chunk as OllamaDoneChunk;
+  if (done.done !== true) return undefined;
+  return usageOrUndefined({
+    input: toUsageCount(done.prompt_eval_count),
+    output: toUsageCount(done.eval_count),
+    cached: undefined,
+    cacheWrite: undefined,
+    reasoning: undefined,
+    total: undefined,
+    extra: undefined,
+  });
+}

--- a/providers/ollama/src/ai/index.ts
+++ b/providers/ollama/src/ai/index.ts
@@ -12,6 +12,7 @@ export * from "./registerOllama";
 
 import { OLLAMA_RUN_FN_SPECS } from "./common/Ollama_Capabilities";
 import { OLLAMA_RUN_FNS } from "./common/Ollama_JobRunFns";
+import { mapOllamaUsage } from "./common/Ollama_Usage";
 import { OllamaQueuedProvider } from "./OllamaQueuedProvider";
 
 /**
@@ -21,4 +22,5 @@ export const _testOnly = {
   OllamaQueuedProvider,
   OLLAMA_RUN_FN_SPECS,
   OLLAMA_RUN_FNS,
+  mapOllamaUsage,
 } as const;

--- a/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
+++ b/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
@@ -8,8 +8,13 @@ import type {
   AiProviderRunFn,
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
+  Usage,
 } from "@workglow/ai";
-import { firstNonStrictReason, isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
+import {
+  firstNonStrictReason,
+  isStrictCompatibleSchema,
+  mapOpenAIResponsesUsage,
+} from "@workglow/ai/provider-utils";
 import { parsePartialJson } from "@workglow/util/worker";
 import { finalizeResponsesRequest, getClient, getModelName } from "./OpenAI_Client";
 import type { OpenAiModelConfig } from "./OpenAI_ModelSchema";
@@ -64,8 +69,19 @@ export const OpenAI_StructuredGeneration_Stream: AiProviderRunFn<
 
   let accumulatedJson = "";
   let refusal = "";
-  for await (const event of stream as AsyncIterable<{ type?: string; delta?: string }>) {
-    if (event.type === "response.output_text.delta") {
+  let usage: Usage | undefined;
+  for await (const event of stream as AsyncIterable<{
+    type?: string;
+    delta?: string;
+    response?: { usage?: unknown };
+  }>) {
+    if (
+      event.type === "response.completed" ||
+      event.type === "response.incomplete" ||
+      event.type === "response.failed"
+    ) {
+      usage = mapOpenAIResponsesUsage(event.response?.usage) ?? usage;
+    } else if (event.type === "response.output_text.delta") {
       const delta = event.delta ?? "";
       if (delta) {
         accumulatedJson += delta;
@@ -91,5 +107,9 @@ export const OpenAI_StructuredGeneration_Stream: AiProviderRunFn<
   } catch {
     finalObject = parsePartialJson(accumulatedJson) ?? {};
   }
-  emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+  emit({
+    type: "finish",
+    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    usage,
+  });
 };

--- a/providers/openai/src/ai/common/OpenAI_TextEmbedding.ts
+++ b/providers/openai/src/ai/common/OpenAI_TextEmbedding.ts
@@ -9,6 +9,7 @@ import type {
   TextEmbeddingTaskInput,
   TextEmbeddingTaskOutput,
 } from "@workglow/ai";
+import { toUsageCount, usageOrUndefined } from "@workglow/ai/provider-utils";
 import { getLogger } from "@workglow/util/worker";
 import { getClient, getModelName } from "./OpenAI_Client";
 import type { OpenAiModelConfig } from "./OpenAI_ModelSchema";
@@ -46,7 +47,21 @@ export const OpenAI_TextEmbedding_Stream: AiProviderRunFn<
         } as unknown as TextEmbeddingTaskOutput)
       : ({ vector: new Float32Array(response.data[0].embedding) } as TextEmbeddingTaskOutput);
 
-    emit({ type: "finish", data: result });
+    // Embeddings bill only the prompt side; the endpoint reports no completion,
+    // cache or reasoning counters, so those stay unreported rather than zeroed.
+    const rawUsage = (response as { usage?: { prompt_tokens?: unknown; total_tokens?: unknown } })
+      .usage;
+    const usage = usageOrUndefined({
+      input: toUsageCount(rawUsage?.prompt_tokens),
+      output: undefined,
+      cached: undefined,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: toUsageCount(rawUsage?.total_tokens),
+      extra: undefined,
+    });
+
+    emit({ type: "finish", data: result, usage });
   } finally {
     logger.timeEnd(timerLabel, { model: getModelName(model) });
   }

--- a/providers/openai/src/ai/common/OpenAI_TextGeneration.ts
+++ b/providers/openai/src/ai/common/OpenAI_TextGeneration.ts
@@ -126,8 +126,8 @@ export const OpenAI_TextGeneration_Stream: AiProviderRunFn<
       { signal }
     );
 
-    await accumulateOpenAIResponsesStream(stream as AsyncIterable<unknown>, emit);
-    emit({ type: "finish", data: {} as TextGenerationTaskOutput });
+    const usage = await accumulateOpenAIResponsesStream(stream as AsyncIterable<unknown>, emit);
+    emit({ type: "finish", data: {} as TextGenerationTaskOutput, usage });
   } finally {
     logger.timeEnd(timerLabel, { model: getModelName(model) });
   }

--- a/providers/openai/src/ai/common/OpenAI_TextRewriter.ts
+++ b/providers/openai/src/ai/common/OpenAI_TextRewriter.ts
@@ -33,6 +33,6 @@ export const OpenAI_TextRewriter_Stream: AiProviderRunFn<
     { signal }
   );
 
-  await accumulateOpenAIResponsesStream(stream as AsyncIterable<unknown>, emit);
-  emit({ type: "finish", data: {} as TextRewriterTaskOutput });
+  const usage = await accumulateOpenAIResponsesStream(stream as AsyncIterable<unknown>, emit);
+  emit({ type: "finish", data: {} as TextRewriterTaskOutput, usage });
 };

--- a/providers/openai/src/ai/common/OpenAI_TextSummary.ts
+++ b/providers/openai/src/ai/common/OpenAI_TextSummary.ts
@@ -32,6 +32,6 @@ export const OpenAI_TextSummary_Stream: AiProviderRunFn<
     { signal }
   );
 
-  await accumulateOpenAIResponsesStream(stream as AsyncIterable<unknown>, emit);
-  emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+  const usage = await accumulateOpenAIResponsesStream(stream as AsyncIterable<unknown>, emit);
+  emit({ type: "finish", data: {} as TextSummaryTaskOutput, usage });
 };

--- a/providers/openai/src/ai/common/OpenAI_ToolCalling.ts
+++ b/providers/openai/src/ai/common/OpenAI_ToolCalling.ts
@@ -77,7 +77,7 @@ export const OpenAI_ToolCalling_Stream: AiProviderRunFn<
     { signal }
   );
 
-  await accumulateOpenAIResponsesStream<ToolCallingTaskOutput>(
+  const usage = await accumulateOpenAIResponsesStream<ToolCallingTaskOutput>(
     stream as AsyncIterable<unknown>,
     (event) => {
       if (event.type === "object-delta" && event.port === "toolCalls") {
@@ -90,5 +90,5 @@ export const OpenAI_ToolCalling_Stream: AiProviderRunFn<
       emit(event);
     }
   );
-  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput });
+  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput, usage });
 };

--- a/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
@@ -8,12 +8,14 @@ import type {
   AiProviderRunFn,
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
+  Usage,
 } from "@workglow/ai";
-import { isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
+import { isStrictCompatibleSchema, OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { parsePartialJson } from "@workglow/util/worker";
 import { getClient, getModelName } from "./OpenRouter_Client";
 import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
 import { buildOpenRouterExtras } from "./OpenRouter_RequestParams";
+import { mapOpenRouterUsage } from "./OpenRouter_Usage";
 
 /**
  * Streaming run-fn for `["text.generation", "json-mode"]`. Emits `object-delta`
@@ -52,13 +54,16 @@ export const OpenRouter_StructuredGeneration_Stream: AiProviderRunFn<
       temperature: input.temperature,
       stream: true,
       ...buildOpenRouterExtras(model),
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
 
   let accumulatedJson = "";
   let refusal = "";
+  let usage: Usage | undefined;
   for await (const chunk of stream) {
+    usage = mapOpenRouterUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       accumulatedJson += delta;
@@ -80,5 +85,9 @@ export const OpenRouter_StructuredGeneration_Stream: AiProviderRunFn<
   } catch {
     finalObject = parsePartialJson(accumulatedJson) ?? {};
   }
-  emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+  emit({
+    type: "finish",
+    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    usage,
+  });
 };

--- a/providers/openrouter/src/ai/common/OpenRouter_TextGeneration.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_TextGeneration.ts
@@ -8,11 +8,14 @@ import type {
   AiProviderRunFn,
   TextGenerationTaskInput,
   TextGenerationTaskOutput,
+  Usage,
 } from "@workglow/ai";
+import { OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { getLogger } from "@workglow/util/worker";
 import { getClient, getModelName } from "./OpenRouter_Client";
 import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
 import { buildChatParams, buildOpenRouterExtras } from "./OpenRouter_RequestParams";
+import { mapOpenRouterUsage } from "./OpenRouter_Usage";
 
 /**
  * Streaming run-fn for `["text.generation"]`. Serves both TextGenerationTask
@@ -32,13 +35,20 @@ export const OpenRouter_TextGeneration_Stream: AiProviderRunFn<
     const params = { ...buildChatParams(input, model), ...buildOpenRouterExtras(model) };
 
     const stream = await client.chat.completions.create(
-      { ...params, stream: true } as Parameters<typeof client.chat.completions.create>[0],
+      { ...params, stream: true, ...OPENAI_STREAM_USAGE_OPTIONS } as Parameters<
+        typeof client.chat.completions.create
+      >[0],
       { signal }
     );
 
+    let usage: Usage | undefined;
     for await (const chunk of stream as AsyncIterable<{
       choices?: Array<{ delta?: { content?: string | null; refusal?: string | null } }>;
+      usage?: unknown;
     }>) {
+      // The usage-bearing chunk arrives last with an empty `choices` array; the
+      // delta reads below already tolerate that, so nothing else needs guarding.
+      usage = mapOpenRouterUsage(chunk.usage) ?? usage;
       const delta = chunk.choices?.[0]?.delta?.content ?? "";
       if (delta) {
         emit({ type: "text-delta", port: "text", textDelta: delta });
@@ -48,7 +58,7 @@ export const OpenRouter_TextGeneration_Stream: AiProviderRunFn<
         emit({ type: "refusal", refusal: refusalDelta });
       }
     }
-    emit({ type: "finish", data: {} as TextGenerationTaskOutput });
+    emit({ type: "finish", data: {} as TextGenerationTaskOutput, usage });
   } finally {
     logger.timeEnd(timerLabel, { model: getModelName(model) });
   }

--- a/providers/openrouter/src/ai/common/OpenRouter_TextRewriter.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_TextRewriter.ts
@@ -4,10 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
+import type {
+  AiProviderRunFn,
+  TextRewriterTaskInput,
+  TextRewriterTaskOutput,
+  Usage,
+} from "@workglow/ai";
+import { OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { getClient, getModelName } from "./OpenRouter_Client";
 import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
 import { buildOpenRouterExtras } from "./OpenRouter_RequestParams";
+import { mapOpenRouterUsage } from "./OpenRouter_Usage";
 
 /** Streaming run-fn for `["text.rewriter"]`. */
 export const OpenRouter_TextRewriter_Stream: AiProviderRunFn<
@@ -27,11 +34,14 @@ export const OpenRouter_TextRewriter_Stream: AiProviderRunFn<
       ],
       stream: true,
       ...buildOpenRouterExtras(model),
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
 
+  let usage: Usage | undefined;
   for await (const chunk of stream) {
+    usage = mapOpenRouterUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
@@ -41,5 +51,5 @@ export const OpenRouter_TextRewriter_Stream: AiProviderRunFn<
       emit({ type: "refusal", refusal: refusalDelta });
     }
   }
-  emit({ type: "finish", data: {} as TextRewriterTaskOutput });
+  emit({ type: "finish", data: {} as TextRewriterTaskOutput, usage });
 };

--- a/providers/openrouter/src/ai/common/OpenRouter_TextSummary.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_TextSummary.ts
@@ -4,10 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
+import type {
+  AiProviderRunFn,
+  TextSummaryTaskInput,
+  TextSummaryTaskOutput,
+  Usage,
+} from "@workglow/ai";
+import { OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { getClient, getModelName } from "./OpenRouter_Client";
 import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
 import { buildOpenRouterExtras } from "./OpenRouter_RequestParams";
+import { mapOpenRouterUsage } from "./OpenRouter_Usage";
 
 /** Streaming run-fn for `["text.summary"]`. */
 export const OpenRouter_TextSummary_Stream: AiProviderRunFn<
@@ -27,11 +34,14 @@ export const OpenRouter_TextSummary_Stream: AiProviderRunFn<
       ],
       stream: true,
       ...buildOpenRouterExtras(model),
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
 
+  let usage: Usage | undefined;
   for await (const chunk of stream) {
+    usage = mapOpenRouterUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
@@ -41,5 +51,5 @@ export const OpenRouter_TextSummary_Stream: AiProviderRunFn<
       emit({ type: "refusal", refusal: refusalDelta });
     }
   }
-  emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+  emit({ type: "finish", data: {} as TextSummaryTaskOutput, usage });
 };

--- a/providers/openrouter/src/ai/common/OpenRouter_ToolCalling.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_ToolCalling.ts
@@ -14,11 +14,13 @@ import {
   accumulateOpenAIChatStream,
   buildOpenAITools,
   mapOpenAIToolChoice,
+  OPENAI_STREAM_USAGE_OPTIONS,
 } from "@workglow/ai/provider-utils";
 import { filterValidToolCalls, toOpenAIMessages } from "@workglow/ai/worker";
 import { getClient, getModelName } from "./OpenRouter_Client";
 import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
 import { buildOpenRouterExtras } from "./OpenRouter_RequestParams";
+import { mapOpenRouterUsage } from "./OpenRouter_Usage";
 
 /**
  * Streaming run-fn for `["text.generation", "tool-use"]`. Forwards deltas via
@@ -47,19 +49,24 @@ export const OpenRouter_ToolCalling_Stream: AiProviderRunFn<
       tools,
       tool_choice: toolChoice,
       ...buildOpenRouterExtras(model),
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
 
-  await accumulateOpenAIChatStream(stream, (event) => {
-    if (event.type === "object-delta" && event.port === "toolCalls") {
-      const validated = filterValidToolCalls(event.objectDelta as ToolCalls, input.tools);
-      if (validated.length > 0) {
-        emit({ type: "object-delta", port: "toolCalls", objectDelta: validated });
+  const usage = await accumulateOpenAIChatStream(
+    stream,
+    (event) => {
+      if (event.type === "object-delta" && event.port === "toolCalls") {
+        const validated = filterValidToolCalls(event.objectDelta as ToolCalls, input.tools);
+        if (validated.length > 0) {
+          emit({ type: "object-delta", port: "toolCalls", objectDelta: validated });
+        }
+        return;
       }
-      return;
-    }
-    emit(event);
-  });
-  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput });
+      emit(event);
+    },
+    mapOpenRouterUsage
+  );
+  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput, usage });
 };

--- a/providers/openrouter/src/ai/common/OpenRouter_Usage.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_Usage.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Usage } from "@workglow/ai";
+import { mapOpenAIChatUsage, toUsageCount, usageExtra } from "@workglow/ai/provider-utils";
+
+interface OpenRouterUsagePayload {
+  readonly cost?: unknown;
+}
+
+/**
+ * Map an OpenRouter chat-completions `usage` object into {@link Usage}.
+ *
+ * OpenRouter is OpenAI-shaped and additionally reports `cost` — the credits
+ * actually charged for the request. That is a price, not a token count, so it
+ * has no normalized slot and rides in `extra`. It is worth carrying because
+ * OpenRouter routes to whichever upstream model is cheapest/available, which
+ * makes per-token pricing something the caller cannot reconstruct locally.
+ */
+export function mapOpenRouterUsage(raw: unknown): Usage | undefined {
+  const base = mapOpenAIChatUsage(raw);
+  const cost = toUsageCount((raw as OpenRouterUsagePayload | undefined)?.cost);
+  const extra = usageExtra({ cost });
+  if (!base) return extra ? { ...emptyUsage, extra } : undefined;
+  return { ...base, extra };
+}
+
+const emptyUsage: Usage = {
+  input: undefined,
+  output: undefined,
+  cached: undefined,
+  cacheWrite: undefined,
+  reasoning: undefined,
+  total: undefined,
+  extra: undefined,
+};

--- a/providers/openrouter/src/ai/index.ts
+++ b/providers/openrouter/src/ai/index.ts
@@ -17,6 +17,7 @@ import { OPENROUTER_RUN_FN_SPECS } from "./common/OpenRouter_Capabilities";
 import { OPENROUTER_RUN_FNS } from "./common/OpenRouter_JobRunFns";
 import { mapOpenRouterModels } from "./common/OpenRouter_ModelSearch";
 import { buildChatParams, buildOpenRouterExtras } from "./common/OpenRouter_RequestParams";
+import { mapOpenRouterUsage } from "./common/OpenRouter_Usage";
 import { OpenRouterQueuedProvider } from "./OpenRouterQueuedProvider";
 
 /**
@@ -30,4 +31,5 @@ export const _testOnly = {
   buildChatParams,
   buildOpenRouterExtras,
   mapOpenRouterModels,
+  mapOpenRouterUsage,
 } as const;

--- a/providers/xai/src/ai/common/Xai_StructuredGeneration.ts
+++ b/providers/xai/src/ai/common/Xai_StructuredGeneration.ts
@@ -8,8 +8,13 @@ import type {
   AiProviderRunFn,
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
+  Usage,
 } from "@workglow/ai";
-import { isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
+import {
+  isStrictCompatibleSchema,
+  mapOpenAIChatUsage,
+  OPENAI_STREAM_USAGE_OPTIONS,
+} from "@workglow/ai/provider-utils";
 import { parsePartialJson } from "@workglow/util/worker";
 import { getClient, getModelName } from "./Xai_Client";
 import type { XaiModelConfig } from "./Xai_ModelSchema";
@@ -45,13 +50,16 @@ export const Xai_StructuredGeneration_Stream: AiProviderRunFn<
       max_completion_tokens: input.maxTokens,
       temperature: input.temperature,
       stream: true,
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
 
   let accumulatedJson = "";
   let refusal = "";
+  let usage: Usage | undefined;
   for await (const chunk of stream) {
+    usage = mapOpenAIChatUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       accumulatedJson += delta;
@@ -73,5 +81,9 @@ export const Xai_StructuredGeneration_Stream: AiProviderRunFn<
   } catch {
     finalObject = parsePartialJson(accumulatedJson) ?? {};
   }
-  emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+  emit({
+    type: "finish",
+    data: { object: finalObject } as StructuredGenerationTaskOutput,
+    usage,
+  });
 };

--- a/providers/xai/src/ai/common/Xai_TextGeneration.ts
+++ b/providers/xai/src/ai/common/Xai_TextGeneration.ts
@@ -8,7 +8,9 @@ import type {
   AiProviderRunFn,
   TextGenerationTaskInput,
   TextGenerationTaskOutput,
+  Usage,
 } from "@workglow/ai";
+import { mapOpenAIChatUsage, OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { toOpenAIMessages } from "@workglow/ai/worker";
 import { getLogger } from "@workglow/util/worker";
 import { getClient, getModelName } from "./Xai_Client";
@@ -80,13 +82,20 @@ export const Xai_TextGeneration_Stream: AiProviderRunFn<
     const params = buildChatParams(input as UnifiedTextGenerationInput, model);
 
     const stream = await client.chat.completions.create(
-      { ...params, stream: true } as Parameters<typeof client.chat.completions.create>[0],
+      { ...params, stream: true, ...OPENAI_STREAM_USAGE_OPTIONS } as Parameters<
+        typeof client.chat.completions.create
+      >[0],
       { signal }
     );
 
+    let usage: Usage | undefined;
     for await (const chunk of stream as AsyncIterable<{
       choices?: Array<{ delta?: { content?: string | null; refusal?: string | null } }>;
+      usage?: unknown;
     }>) {
+      // The usage-bearing chunk arrives last with an empty `choices` array; the
+      // delta reads below already tolerate that, so nothing else needs guarding.
+      usage = mapOpenAIChatUsage(chunk.usage) ?? usage;
       const delta = chunk.choices?.[0]?.delta?.content ?? "";
       if (delta) {
         emit({ type: "text-delta", port: "text", textDelta: delta });
@@ -96,7 +105,7 @@ export const Xai_TextGeneration_Stream: AiProviderRunFn<
         emit({ type: "refusal", refusal: refusalDelta });
       }
     }
-    emit({ type: "finish", data: {} as TextGenerationTaskOutput });
+    emit({ type: "finish", data: {} as TextGenerationTaskOutput, usage });
   } finally {
     logger.timeEnd(timerLabel, { model: getModelName(model) });
   }

--- a/providers/xai/src/ai/common/Xai_TextRewriter.ts
+++ b/providers/xai/src/ai/common/Xai_TextRewriter.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
+import type {
+  AiProviderRunFn,
+  TextRewriterTaskInput,
+  TextRewriterTaskOutput,
+  Usage,
+} from "@workglow/ai";
+import { mapOpenAIChatUsage, OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { getClient, getModelName } from "./Xai_Client";
 import type { XaiModelConfig } from "./Xai_ModelSchema";
 
@@ -28,11 +34,14 @@ export const Xai_TextRewriter_Stream: AiProviderRunFn<
         { role: "user", content: input.text },
       ],
       stream: true,
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
 
+  let usage: Usage | undefined;
   for await (const chunk of stream) {
+    usage = mapOpenAIChatUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
@@ -42,5 +51,5 @@ export const Xai_TextRewriter_Stream: AiProviderRunFn<
       emit({ type: "refusal", refusal: refusalDelta });
     }
   }
-  emit({ type: "finish", data: {} as TextRewriterTaskOutput });
+  emit({ type: "finish", data: {} as TextRewriterTaskOutput, usage });
 };

--- a/providers/xai/src/ai/common/Xai_TextSummary.ts
+++ b/providers/xai/src/ai/common/Xai_TextSummary.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
+import type {
+  AiProviderRunFn,
+  TextSummaryTaskInput,
+  TextSummaryTaskOutput,
+  Usage,
+} from "@workglow/ai";
+import { mapOpenAIChatUsage, OPENAI_STREAM_USAGE_OPTIONS } from "@workglow/ai/provider-utils";
 import { getClient, getModelName } from "./Xai_Client";
 import type { XaiModelConfig } from "./Xai_ModelSchema";
 
@@ -28,11 +34,14 @@ export const Xai_TextSummary_Stream: AiProviderRunFn<
         { role: "user", content: input.text },
       ],
       stream: true,
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
 
+  let usage: Usage | undefined;
   for await (const chunk of stream) {
+    usage = mapOpenAIChatUsage(chunk.usage) ?? usage;
     const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
@@ -42,5 +51,5 @@ export const Xai_TextSummary_Stream: AiProviderRunFn<
       emit({ type: "refusal", refusal: refusalDelta });
     }
   }
-  emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+  emit({ type: "finish", data: {} as TextSummaryTaskOutput, usage });
 };

--- a/providers/xai/src/ai/common/Xai_ToolCalling.ts
+++ b/providers/xai/src/ai/common/Xai_ToolCalling.ts
@@ -14,6 +14,7 @@ import {
   accumulateOpenAIChatStream,
   buildOpenAITools,
   mapOpenAIToolChoice,
+  OPENAI_STREAM_USAGE_OPTIONS,
 } from "@workglow/ai/provider-utils";
 import { filterValidToolCalls, toOpenAIMessages } from "@workglow/ai/worker";
 import { getClient, getModelName } from "./Xai_Client";
@@ -50,11 +51,12 @@ export const Xai_ToolCalling_Stream: AiProviderRunFn<
       stream: true,
       tools,
       tool_choice: toolChoice,
+      ...OPENAI_STREAM_USAGE_OPTIONS,
     },
     { signal }
   );
 
-  await accumulateOpenAIChatStream(stream, (event) => {
+  const usage = await accumulateOpenAIChatStream(stream, (event) => {
     if (event.type === "object-delta" && event.port === "toolCalls") {
       const validated = filterValidToolCalls(event.objectDelta as ToolCalls, input.tools);
       if (validated.length > 0) {
@@ -64,5 +66,5 @@ export const Xai_ToolCalling_Stream: AiProviderRunFn<
     }
     emit(event);
   });
-  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput });
+  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput, usage });
 };


### PR DESCRIPTION
Closes #624

## Stacked PR — merge after #641

This branches from **`ai-provider-cache-checkpoints`** (PR #641), not `main`, and targets that branch. **It must merge after #641.**

Phase 1 (#680, already on `main`) added the generic seam — `Usage`, `USAGE_OUTPUT_KEY`, `mergeUsage`, and `usage` as an optional **sibling of `data`** on `StreamFinish` — with every provider emitting `usage: undefined`. This PR is the per-provider fill-in: each run-fn maps its own terminal frame into `Usage` and attaches it to the `finish` event it already emits. The consumer side (`StreamEventAccumulator.applyUsage` / `StreamProcessor`) is untouched.

`usage` is always attached as a sibling of `data`, never inside it — folding token counts into `data` would break the `{}`-for-delta-streams, full-Output-for-one-shot, and `data.object`-for-json-mode conventions all at once.

## The `undefined` vs `0` rule

**`undefined` means "the provider did not report this figure". It never means zero.**

A model that billed 0 cached tokens and a model that says nothing about caching are different facts, and collapsing them to `0` silently understates spend — the reader of a cost report cannot tell "this request used no cache" from "we have no idea whether it did". So an absent, `null`, `NaN`, or non-numeric wire field maps to `undefined`, while a genuinely reported `0` survives as `0`. Providers with no usage at all leave it absent entirely.

Usage is also always read from the provider's **own terminal frame** — never derived by counting our own emitted output, which would drift from what the provider actually bills.

## Per-provider mapping

| Provider | Source frame | input | output | cached | cacheWrite | reasoning | total | extra |
|---|---|---|---|---|---|---|---|---|
| **anthropic** | `message_start` + `message_delta` | `input_tokens` | `output_tokens` | `cache_read_input_tokens` | `cache_creation_input_tokens` | `output_tokens_details.thinking_tokens` | — | — |
| **openai** (Responses) | `response.completed` | `input_tokens` | `output_tokens` | `input_tokens_details.cached_tokens` | `input_tokens_details.cache_write_tokens` | `output_tokens_details.reasoning_tokens` | `total_tokens` | — |
| **openai** (embeddings) | non-streaming result | `usage.prompt_tokens` | — | — | — | — | `usage.total_tokens` | — |
| **google-gemini** | last non-null `chunk.usageMetadata` | `promptTokenCount` | `candidatesTokenCount` | `cachedContentTokenCount` | — | `thoughtsTokenCount` | `totalTokenCount` | — |
| **ollama** | `done: true` chunk | `prompt_eval_count` | `eval_count` | — | — | — | — | — |
| **xai** | `include_usage` frame | `prompt_tokens` | `completion_tokens` | `prompt_tokens_details.cached_tokens` | — | `completion_tokens_details.reasoning_tokens` | `total_tokens` | — |
| **deepseek** | `include_usage` frame | `prompt_tokens` | `completion_tokens` | `prompt_cache_hit_tokens` | — | `completion_tokens_details.reasoning_tokens` | `total_tokens` | `promptCacheMissTokens` |
| **openrouter** | `include_usage` frame | `prompt_tokens` | `completion_tokens` | `prompt_tokens_details.cached_tokens` | — | `completion_tokens_details.reasoning_tokens` | `total_tokens` | `cost` |
| **llamacpp-server** | `include_usage` frame | `prompt_tokens` | `completion_tokens` | `prompt_tokens_details.cached_tokens` | — | `completion_tokens_details.reasoning_tokens` | `total_tokens` | — |
| **huggingface-inference** | terminal chunk, if volunteered | `prompt_tokens` | `completion_tokens` | `prompt_tokens_details.cached_tokens` | — | `completion_tokens_details.reasoning_tokens` | `total_tokens` | — |

### Providers that report nothing — `usage` stays absent

| Provider | Why |
|---|---|
| **node-llama-cpp** | Runs the model locally; its prompt API surfaces no token accounting. |
| **huggingface-transformers** | transformers.js runs in-process and reports no counts. |
| **chrome-ai** | The Chrome built-in AI API exposes only quota measures (`inputUsage`), not billing counters. |
| **tf-mediapipe** | Vision pipelines; no token concept. |

These are left absent with a short comment recording why, so the next reader does not "fix" it by emitting zeros or by counting our own emitted tokens.

### Notes on specific decisions

- **Anthropic reports no `total`.** Synthesizing one from the parts would misreport cache-discounted input as if it had been billed in full, and `Usage.total` is documented as never synthesized. Both frames restate **cumulative** figures, so the collector keeps the newest value per field rather than summing; a `null` on `message_delta` means "not restated here" and leaves the earlier value intact rather than erasing it.
- **DeepSeek's `prompt_cache_miss_tokens`** has no normalized slot but is what makes its cache-miss-priced cost reconstructable, so it rides in `extra`.
- **OpenRouter's `cost`** is a price, not a token count. It is worth carrying because OpenRouter routes to whichever upstream is cheapest, which the caller cannot reconstruct locally.
- **Ollama field names were verified** against the installed SDK's `ChatResponse` / `GenerateResponse` types rather than taken on trust.

## Shared plumbing

`packages/ai/src/provider-utils/UsageMapping.ts` normalizes the two OpenAI wire shapes and exposes the primitives provider packages compose their quirks from (`toUsageCount`, `usageOrUndefined`, `usageExtra`, `OPENAI_STREAM_USAGE_OPTIONS`).

Both shared accumulators now **return** the usage they read instead of discarding it:

- `accumulateOpenAIResponsesStream` handles `response.completed` (plus the `incomplete` / `failed` terminals, which still consumed tokens) rather than dropping them into the `default:` arm. One change covers OpenAI TextGeneration, ToolCalling, Rewriter and Summary.
- `accumulateOpenAIChatStream` reads `chunk.usage` **before** skipping a choice-less chunk, and takes an optional mapper so DeepSeek/OpenRouter can supply their own.

### `include_usage` safety

xAI, DeepSeek, OpenRouter and llama.cpp-server needed `stream_options: { include_usage: true }` added to the request. That opt-in appends a final chunk whose **`choices` array is empty** — exactly the shape the `*_StreamChunkSafety` suites exist to guard. Every delta read already optional-chains `chunk.choices?.[0]`, and usage is read before the choice-less chunk is skipped. Those suites were extended rather than duplicated.

llama.cpp-server parses SSE itself, so `IChatCompletionDelta` gained a `usage` field and the parser now admits a usage-only frame on its own merit — it previously required a content delta, tool calls, or a finish reason, which silently dropped the usage chunk.

## Tests

A shared contract assertion at `packages/test/src/contract/ai-provider/assertions/usageNormalization.ts` (sibling of `sessionReuse.ts`) holds every provider's mapper to the same rules: no payload maps to `undefined`, unreported counters come back `undefined` rather than `0`, a genuinely reported `0` survives, and only numbers and `undefined` reach the normalized shape. `ProviderUsageNormalization.test.ts` runs all seven mappers through it, so the zero-vs-absent rule is enforced in one place instead of being restated per provider.

Per-provider suites were extended in place: `Xai_StreamChunkSafety`, `OpenRouter_StreamChunkSafety`, `LlamaCppServer_TextGenerationStream`, `Ollama_TextGenerationStream`, `DeepSeek_ToolCalling`, `Anthropic_SamplingParams`, and `OpenAIShapedResponses`.

## Verification

All commands run against the committed branch state.

```
$ bun run build
 Tasks:    84 successful, 84 total
Cached:    84 cached, 84 total

$ bun run build:types
 Tasks:    41 successful, 41 total
Cached:    41 cached, 41 total

$ bun scripts/test.ts ai provider provider-nodellama vitest unit
 Test Files  1 failed | 63 passed (64)
      Tests  1 failed | 669 passed | 1 skipped (671)

$ bun scripts/test.ts provider-api vitest unit
 Test Files  38 passed (38)
      Tests  431 passed (431)
```

`provider-api` went from 413 to 431 tests; the `ai`/`provider` sweep gained the shared-contract and Responses-usage suites.

### Inherited failure — not from this PR

The single failure is `packages/test/src/test/ai-provider/OpenAIGeminiCheckpointParams.test.ts` → "evicts and retries inline once on a NOT_FOUND".

It **already fails on the base branch**: commit `5d9088f3 fix(gemini): tighten reactive CachedContent NOT_FOUND matcher` (the rebased `3206e7de`) tightened the CachedContent NOT_FOUND matcher without updating that older test. `5d9088f3` is the second commit of `ai-provider-cache-checkpoints`, and this PR's diff touches neither `Gemini_CachedContentFallback.ts` nor that test file — the stack trace runs entirely through `generateGeminiStreamWithCacheFallback`, which is untouched here. It is reported on #641 and awaiting the owner's decision; it is deliberately not fixed in this PR.

Only the `unit` test kind was run. Integration suites were not run locally, since the preloader unlocks real API keys and `test-vitest-ai-provider-api` makes real billable `gpt-image-2` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwyJuFrJnibKvrrk8Fa4Fn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwyJuFrJnibKvrrk8Fa4Fn)_