### PR TITLE
fix(util,ai): restrict TurboQuant to signed targets; harden input validation

### DIFF
--- a/packages/ai/src/task/VectorQuantizeTask.ts
+++ b/packages/ai/src/task/VectorQuantizeTask.ts
@@ -52,7 +52,8 @@ const inputSchema = {
     normalize: {
       type: "boolean",
       title: "Normalize",
-      description: "Normalize vector before quantization",
+      description:
+        "Normalize vector before quantization. Ignored for method 'turbo', which always L2-normalizes internally.",
       default: true,
     },
     method: {
@@ -60,7 +61,7 @@ const inputSchema = {
       enum: Object.values(QuantizationMethod),
       title: "Method",
       description:
-        "Quantization method: 'linear' for simple min-max scaling, 'turbo' for TurboQuant (randomized rotation + optimal scalar quantization, better distortion than linear at the same bit width). Turbo requires an integer targetType (int8, uint8, int16, uint16).",
+        "Quantization method: 'linear' for simple min-max scaling, 'turbo' for TurboQuant (randomized rotation + optimal scalar quantization, better distortion than linear at the same bit width). Turbo requires a signed integer targetType (int8 or int16). Turbo rotates in nextPowerOf2(d) dimensions but keeps only the first d coordinates, so for a non-power-of-2 dimensionality it is a random projection and cosine similarity is preserved only approximately (measured int8 RMSE: d=1024 -> 0.001, d=1536 -> 0.013, d=768 -> 0.019); zero-pad to a power of 2 when fidelity matters.",
       default: QuantizationMethod.LINEAR,
     },
     turboSeed: {
@@ -107,8 +108,21 @@ const outputSchema = {
       title: "Target Type",
       description: "Target quantization type",
     },
+    method: {
+      type: "string",
+      enum: Object.values(QuantizationMethod),
+      title: "Method",
+      description:
+        "Quantization method that produced the output vector. Recorded so downstream consumers can tell a turbo-rotated vector from a linearly quantized one — the two are not comparable.",
+    },
+    turboSeed: {
+      type: "integer",
+      title: "TurboQuant Seed",
+      description:
+        "Seed of the random rotation applied when method is 'turbo' (absent otherwise). Vectors quantized with different seeds, or mixed with vectors quantized using method 'linear', are NOT comparable: cosine similarity between them is meaningless and no error is raised.",
+    },
   },
-  required: ["vector", "originalType", "targetType"],
+  required: ["vector", "originalType", "targetType", "method"],
   additionalProperties: false,
 } as const satisfies DataPortSchema;
 
@@ -116,13 +130,17 @@ export type VectorQuantizeTaskInput = {
   normalize?: boolean | undefined;
   vector: TypedArray | TypedArray[];
   targetType: "float16" | "float32" | "float64" | "int8" | "uint8" | "int16" | "uint16";
-  method?: QuantizationMethod | undefined;
-  turboSeed?: number | undefined;
+  readonly method?: QuantizationMethod | undefined;
+  readonly turboSeed?: number | undefined;
 };
 export type VectorQuantizeTaskOutput = {
   vector: TypedArray | TypedArray[];
   targetType: "float16" | "float32" | "float64" | "int8" | "uint8" | "int16" | "uint16";
   originalType: "float16" | "float32" | "float64" | "int8" | "uint8" | "int16" | "uint16";
+  /** Method that produced `vector`. A turbo vector is not comparable with a linear one. */
+  readonly method: QuantizationMethod;
+  /** Rotation seed, present only for `method: "turbo"`. Different seeds are not comparable. */
+  readonly turboSeed: number | undefined;
 };
 export type VectorQuantizeTaskConfig = TaskConfig<VectorQuantizeTaskInput>;
 
@@ -171,6 +189,14 @@ export class VectorQuantizeTask extends Task<
     let quantized: TypedArray[];
 
     if (method === QuantizationMethod.TURBO) {
+      // TurboQuant is restricted to signed integer targets: an unsigned target
+      // encodes a DC offset that breaks cosine similarity (translation is not a
+      // cosine invariant), and float targets have no quantization to do.
+      if (targetType !== TensorType.INT8 && targetType !== TensorType.INT16) {
+        throw new Error(
+          `VectorQuantizeTask: method "turbo" supports signed integer target types only (int8, int16), got "${targetType}"`
+        );
+      }
       quantized = vectors.map((v) => turboQuantizeToTypedArray(v, targetType, turboSeed));
     } else {
       quantized = vectors.map((v) => this.vectorQuantize(v, targetType, normalize));
@@ -180,6 +206,8 @@ export class VectorQuantizeTask extends Task<
       vector: isArray ? quantized : quantized[0],
       originalType,
       targetType,
+      method,
+      turboSeed: method === QuantizationMethod.TURBO ? turboSeed : undefined,
     };
   }
 

--- a/packages/test/src/test/rag/VectorQuantizeTask.test.ts
+++ b/packages/test/src/test/rag/VectorQuantizeTask.test.ts
@@ -299,5 +299,32 @@ describe("VectorQuantizeTask", () => {
       out.forEach((v) => expect(v).toBeInstanceOf(Int8Array));
       expect(result.targetType).toBe(TensorType.INT8);
     });
+
+    test("should reject unsigned targetType for turbo", async () => {
+      const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
+
+      for (const targetType of [TensorType.UINT8, TensorType.UINT16] as const) {
+        await expect(
+          vectorQuantize({ vector, targetType, method: "turbo", turboSeed: 42 })
+        ).rejects.toThrow();
+      }
+    });
+
+    test("should report method and turboSeed on the output", async () => {
+      const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
+
+      const turbo = await vectorQuantize({
+        vector,
+        targetType: TensorType.INT8,
+        method: "turbo",
+        turboSeed: 99,
+      });
+      expect(turbo.method).toBe("turbo");
+      expect(turbo.turboSeed).toBe(99);
+
+      const linear = await vectorQuantize({ vector, targetType: TensorType.INT8 });
+      expect(linear.method).toBe("linear");
+      expect(linear.turboSeed).toBeUndefined();
+    });
   });
 });

--- a/packages/test/src/test/util/TurboQuantize.test.ts
+++ b/packages/test/src/test/util/TurboQuantize.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,6 +20,21 @@ import {
 } from "@workglow/util/schema";
 import { describe, expect, test } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
+
+/**
+ * Deterministic PRNG (mulberry32) so the fidelity tests below never depend on
+ * `Math.random` — a flaky bound here would be indistinguishable from a real
+ * regression.
+ */
+function makeRandom(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
 
 describe("TurboQuantize", () => {
   let logger = getTestingLogger();
@@ -78,6 +93,47 @@ describe("TurboQuantize", () => {
       const vector = new Float32Array([0, 0, 0, 0]);
       const result = turboQuantize(vector, { bits: 4, seed: 42 });
       expect(result.norm).toBe(0);
+    });
+
+    test("should reject NaN and Infinity inputs", () => {
+      expect(() =>
+        turboQuantize(new Float32Array([1, 2, NaN, 4, 5, 6, 7, 8]), { bits: 4, seed: 42 })
+      ).toThrow("NaN or Infinity");
+      expect(() =>
+        turboQuantize(new Float32Array([1, 2, Infinity, 4, 5, 6, 7, 8]), { bits: 4, seed: 42 })
+      ).toThrow("NaN or Infinity");
+      expect(() =>
+        turboQuantize(new Float32Array([1, 2, -Infinity, 4, 5, 6, 7, 8]), { bits: 4, seed: 42 })
+      ).toThrow("NaN or Infinity");
+      expect(() =>
+        turboQuantizeToTypedArray(new Float32Array([1, 2, NaN, 4, 5, 6, 7, 8]), TensorType.INT8, 42)
+      ).toThrow("NaN or Infinity");
+      expect(() =>
+        turboQuantizeToTypedArray(
+          new Float32Array([1, 2, Infinity, 4, 5, 6, 7, 8]),
+          TensorType.INT8,
+          42
+        )
+      ).toThrow("NaN or Infinity");
+    });
+
+    test("should match hardcoded golden bytes (cross-process determinism)", () => {
+      // Literal expectations, not a second in-process call: only a checked-in
+      // byte sequence can catch a non-deterministic (e.g. Math.random) regression
+      // introduced elsewhere in the rotation path.
+      const codes = Array.from(
+        turboQuantize(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]), { bits: 4, seed: 42 }).codes
+      );
+      expect(codes).toEqual([117, 165, 180, 133]);
+
+      const v64 = new Float32Array(64);
+      for (let i = 0; i < 64; i++) v64[i] = Math.sin(i * 0.7) * ((i % 5) + 1);
+      const first16 = Array.from(
+        turboQuantizeToTypedArray(v64, TensorType.INT8, 42).slice(0, 16) as Int8Array
+      );
+      expect(first16).toEqual([
+        21, -29, -20, -39, -22, -22, 45, 10, -44, -17, -41, -93, 10, 35, -14, -17,
+      ]);
     });
 
     test("should support different TypedArray inputs", () => {
@@ -159,6 +215,20 @@ describe("TurboQuantize", () => {
       for (let i = 0; i < reconstructed.length; i++) {
         expect(Math.abs(reconstructed[i])).toBe(0);
       }
+    });
+
+    test("should reject a paddedDimensions that is not nextPowerOf2(dimensions)", () => {
+      // TurboQuantizeResult is a plain serializable record, so a persisted or
+      // mismatched value can reach the decode path with a bogus padded length.
+      // Without the guard the Walsh-Hadamard butterfly reads past the buffer and
+      // silently returns NaN.
+      const quantized = turboQuantize(new Float32Array([1, 2, 3, 4, 5, 6]), { bits: 4, seed: 42 });
+      expect(quantized.paddedDimensions).toBe(8);
+
+      const tampered = { ...quantized, paddedDimensions: 6 };
+      expect(() => turboDequantize(tampered)).toThrow("paddedDimensions");
+      expect(() => turboQuantizedInnerProduct(tampered, quantized)).toThrow("paddedDimensions");
+      expect(() => turboQuantizedInnerProduct(quantized, tampered)).toThrow("paddedDimensions");
     });
 
     test("should improve quality with higher dimensions", () => {
@@ -289,6 +359,25 @@ describe("TurboQuantize", () => {
       // 3 dimensions pads to 4 (next power of 2), 3 bits: 4 * 3 / 8 = 1.5 -> 2 bytes
       expect(turboQuantizeStorageBytes(3, 3)).toBe(2);
     });
+
+    test("should reject out-of-range dimensions and bits", { timeout: 2000 }, () => {
+      // 2^30 + 1 previously spun forever inside the power-of-2 doubling loop
+      // (32-bit shift wrap), so a hang must fail the test rather than stall CI.
+      expect(() => turboQuantizeStorageBytes(2 ** 30 + 1, 4)).toThrow();
+      expect(() => turboQuantizeCompressionRatio(2 ** 30 + 1, 4)).toThrow();
+
+      expect(() => turboQuantizeStorageBytes(0, 4)).toThrow();
+      expect(() => turboQuantizeStorageBytes(-5, 4)).toThrow();
+      expect(() => turboQuantizeStorageBytes(NaN, 4)).toThrow();
+      expect(() => turboQuantizeStorageBytes(1.5, 4)).toThrow();
+
+      expect(() => turboQuantizeStorageBytes(768, 0)).toThrow();
+      expect(() => turboQuantizeStorageBytes(768, -5)).toThrow();
+      expect(() => turboQuantizeStorageBytes(768, 9)).toThrow();
+      expect(() => turboQuantizeStorageBytes(768, NaN)).toThrow();
+      expect(() => turboQuantizeCompressionRatio(768, 0)).toThrow();
+      expect(() => turboQuantizeCompressionRatio(768, 9)).toThrow();
+    });
   });
 
   describe("turboQuantizeCompressionRatio", () => {
@@ -313,13 +402,6 @@ describe("TurboQuantize", () => {
       expect(result.length).toBe(vector.length);
     });
 
-    test("should produce Uint8Array for UINT8 target", () => {
-      const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
-      const result = turboQuantizeToTypedArray(vector, TensorType.UINT8);
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(vector.length);
-    });
-
     test("should produce Int16Array for INT16 target", () => {
       const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
       const result = turboQuantizeToTypedArray(vector, TensorType.INT16);
@@ -327,21 +409,93 @@ describe("TurboQuantize", () => {
       expect(result.length).toBe(vector.length);
     });
 
-    test("should produce Uint16Array for UINT16 target", () => {
-      const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
-      const result = turboQuantizeToTypedArray(vector, TensorType.UINT16);
-      expect(result).toBeInstanceOf(Uint16Array);
-      expect(result.length).toBe(vector.length);
-    });
-
     test("should reject float target types", () => {
       const vector = new Float32Array([1, 2, 3, 4]);
       expect(() => turboQuantizeToTypedArray(vector, TensorType.FLOAT32)).toThrow(
-        "integer target types"
+        "signed integer targets only"
       );
       expect(() => turboQuantizeToTypedArray(vector, TensorType.FLOAT64)).toThrow(
-        "integer target types"
+        "signed integer targets only"
       );
+    });
+
+    test("should reject unsigned target types", () => {
+      // An unsigned target needs an affine map with a DC offset, and cosine
+      // similarity is not translation-invariant — see the DC-offset test below.
+      const vector = new Float32Array([1, 2, 3, 4]);
+      expect(() => turboQuantizeToTypedArray(vector, TensorType.UINT8)).toThrow(
+        "signed integer targets only"
+      );
+      expect(() => turboQuantizeToTypedArray(vector, TensorType.UINT16)).toThrow(
+        "signed integer targets only"
+      );
+    });
+
+    test("should reject prototype-chain target type names", () => {
+      // A bare `RANGES[targetType]` lookup resolves inherited Object.prototype
+      // keys, so a truthy-but-wrong "range" would slip past a `if (!range)` guard.
+      const vector = new Float32Array([1, 2, 3, 4]);
+      for (const name of ["constructor", "toString", "__proto__", "hasOwnProperty"]) {
+        expect(() => turboQuantizeToTypedArray(vector, name as TensorType)).toThrow(
+          "signed integer targets only"
+        );
+      }
+    });
+
+    test("should not encode a DC offset (signed output is zero-centred)", () => {
+      // Regression guard for the unsigned affine map: it shifted every stored
+      // coordinate by the type midpoint, which collapsed cosine similarity for
+      // unrelated vectors to ~0.90 and made negative similarities impossible.
+      const d = 1024;
+      const rnd = makeRandom(42);
+      const vector = new Float32Array(d);
+      for (let i = 0; i < d; i++) vector[i] = rnd() - 0.5;
+
+      const result = turboQuantizeToTypedArray(vector, TensorType.INT8, 42);
+
+      let sum = 0;
+      let negatives = 0;
+      for (let i = 0; i < result.length; i++) {
+        sum += result[i];
+        if (result[i] < 0) negatives++;
+      }
+      expect(Math.abs(sum / result.length)).toBeLessThan(2);
+      expect(negatives / result.length).toBeGreaterThanOrEqual(0.3);
+    });
+
+    test("should preserve cosine similarity across common embedding dimensions", () => {
+      // The rotation runs in nextPowerOf2(d) dimensions but only the first d
+      // coordinates are kept, so a non-power-of-2 d is a random projection.
+      // Bounds mirror the RMSE documented on turboQuantizeToTypedArray (x1.5).
+      const cases: readonly { readonly d: number; readonly rmse: number }[] = [
+        { d: 768, rmse: 0.019 },
+        { d: 1000, rmse: 0.006 },
+        { d: 1024, rmse: 0.001 },
+        { d: 1536, rmse: 0.013 },
+      ];
+
+      for (const { d, rmse } of cases) {
+        const rnd = makeRandom(d);
+        let squaredError = 0;
+        let maxError = 0;
+        const pairs = 40;
+        for (let p = 0; p < pairs; p++) {
+          const a = new Float32Array(d);
+          const b = new Float32Array(d);
+          for (let i = 0; i < d; i++) {
+            a[i] = rnd() - 0.5;
+            b[i] = rnd() - 0.5;
+          }
+          const trueSim = cosineSimilarity(a, b);
+          const qa = turboQuantizeToTypedArray(a, TensorType.INT8, 42);
+          const qb = turboQuantizeToTypedArray(b, TensorType.INT8, 42);
+          const error = Math.abs(cosineSimilarity(qa, qb) - trueSim);
+          squaredError += error * error;
+          if (error > maxError) maxError = error;
+        }
+        expect(Math.sqrt(squaredError / pairs)).toBeLessThan(rmse * 1.5);
+        expect(maxError).toBeLessThan(0.08);
+      }
     });
 
     test("should reject empty vectors", () => {
@@ -412,35 +566,43 @@ describe("TurboQuantize", () => {
 
     test("should handle zero vectors", () => {
       const vector = new Float32Array([0, 0, 0, 0]);
-      const result = turboQuantizeToTypedArray(vector, TensorType.INT8);
-      expect(result.length).toBe(4);
-      // All values should be 0 (or the midpoint for unsigned)
-      for (let i = 0; i < result.length; i++) {
-        expect(result[i]).toBe(0);
+
+      for (const targetType of [TensorType.INT8, TensorType.INT16] as const) {
+        const result = turboQuantizeToTypedArray(vector, targetType);
+        expect(result.length).toBe(4);
+        for (let i = 0; i < result.length; i++) {
+          expect(result[i]).toBe(0);
+        }
       }
+
+      expect(() => turboQuantizeToTypedArray(vector, TensorType.UINT8)).toThrow(
+        "signed integer targets only"
+      );
     });
 
     test("should produce values within type range for Int8", () => {
       const d = 256;
+      const rnd = makeRandom(7);
       const vector = new Float32Array(d);
-      for (let i = 0; i < d; i++) vector[i] = Math.random() * 10 - 5;
+      for (let i = 0; i < d; i++) vector[i] = rnd() * 10 - 5;
 
       const result = turboQuantizeToTypedArray(vector, TensorType.INT8);
       for (let i = 0; i < result.length; i++) {
-        expect(result[i]).toBeGreaterThanOrEqual(-128);
+        expect(result[i]).toBeGreaterThanOrEqual(-127);
         expect(result[i]).toBeLessThanOrEqual(127);
       }
     });
 
-    test("should produce values within type range for Uint8", () => {
+    test("should produce values within type range for Int16", () => {
       const d = 256;
+      const rnd = makeRandom(11);
       const vector = new Float32Array(d);
-      for (let i = 0; i < d; i++) vector[i] = Math.random() * 10 - 5;
+      for (let i = 0; i < d; i++) vector[i] = rnd() * 10 - 5;
 
-      const result = turboQuantizeToTypedArray(vector, TensorType.UINT8);
+      const result = turboQuantizeToTypedArray(vector, TensorType.INT16);
       for (let i = 0; i < result.length; i++) {
-        expect(result[i]).toBeGreaterThanOrEqual(0);
-        expect(result[i]).toBeLessThanOrEqual(255);
+        expect(result[i]).toBeGreaterThanOrEqual(-32767);
+        expect(result[i]).toBeLessThanOrEqual(32767);
       }
     });
   });

--- a/packages/util/src/vector/TurboQuantize.ts
+++ b/packages/util/src/vector/TurboQuantize.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,9 +30,9 @@ import type { TypedArray } from "./TypedArray";
  */
 export interface TurboQuantizeOptions {
   /** Number of bits per dimension (1-8). Lower = more compression, higher distortion. */
-  readonly bits?: number;
+  readonly bits: number | undefined;
   /** Seed for deterministic random rotation. If omitted, uses a fixed default seed. */
-  readonly seed?: number;
+  readonly seed: number | undefined;
 }
 
 /**
@@ -60,6 +60,45 @@ export interface TurboQuantizeResult {
 const DEFAULT_SEED = 42;
 
 /**
+ * Upper bound on the dimensionality this module will accept.
+ *
+ * Every entry point pads the input to `nextPowerOf2(dimensions)` and allocates a
+ * `Float64Array` of that length as the transform's working buffer. At 2^24 that
+ * buffer is 128 MB (2^24 * 8 bytes), which is already far beyond any real
+ * embedding. Rejecting anything larger keeps a bogus or hostile `dimensions`
+ * value from either exhausting memory or spinning inside the padding loop.
+ */
+const MAX_TURBO_DIMENSIONS = 2 ** 24;
+
+/** Number of (sign-flip + Walsh-Hadamard) rounds applied by the randomized rotation. */
+const SIGN_ROUNDS = 3;
+
+/**
+ * Validates a dimensionality before it is used to size any buffer.
+ * @param n - Candidate dimensionality
+ */
+function assertDimensions(n: number): void {
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`TurboQuant dimensions must be a positive integer, got ${n}`);
+  }
+  if (n > MAX_TURBO_DIMENSIONS) {
+    throw new Error(
+      `TurboQuant dimensions must be at most ${MAX_TURBO_DIMENSIONS}, got ${n} (the padded working buffer would exceed 128 MB)`
+    );
+  }
+}
+
+/**
+ * Validates a bit width before it is used to derive quantization levels.
+ * @param bits - Candidate bits per dimension
+ */
+function assertBits(bits: number): void {
+  if (!Number.isInteger(bits) || bits < 1 || bits > 8) {
+    throw new Error(`TurboQuant bits must be an integer between 1 and 8, got ${bits}`);
+  }
+}
+
+/**
  * Simple deterministic PRNG (xorshift32) for generating rotation seeds.
  * Produces deterministic sequences given a seed, suitable for reproducible rotations.
  *
@@ -74,11 +113,60 @@ function createPrng(seed: number): () => number {
   let state = (seed ^ 0x9e3779b9) >>> 0 || 1;
   return () => {
     state ^= state << 13;
-    state ^= state >> 17;
+    state ^= state >>> 17;
     state ^= state << 5;
     // Convert to [0, 1) range
     return (state >>> 0) / 4294967296;
   };
+}
+
+/** Maximum number of memoized sign tables. Bounded so a hostile seed stream cannot grow it. */
+const SIGN_TABLE_CACHE_LIMIT = 16;
+
+/** Memoized sign tables keyed by `${seed}:${paddedLen}` (insertion-ordered for eviction). */
+const signTableCache = new Map<string, readonly Uint8Array[]>();
+
+/**
+ * Returns the `SIGN_ROUNDS` Rademacher flip masks for a (seed, paddedLen) pair.
+ *
+ * Each mask holds one byte per coordinate: `1` means "flip the sign". The draws
+ * are made in exactly the order the forward rotation consumes them (round 0 for
+ * every coordinate, then round 1, then round 2), so the forward and inverse
+ * transforms see identical masks.
+ *
+ * The result is memoized because the inverse rotation would otherwise rebuild a
+ * `SIGN_ROUNDS x paddedLen` table on every single dequantization.
+ *
+ * @param seed - Rotation seed
+ * @param paddedLen - Padded (power-of-2) dimensionality
+ * @returns One flip mask per rotation round. The returned arrays must not be mutated.
+ */
+function getSignTable(seed: number, paddedLen: number): readonly Uint8Array[] {
+  const key = `${seed}:${paddedLen}`;
+  const cached = signTableCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const prng = createPrng(seed);
+  const table: Uint8Array[] = [];
+  for (let round = 0; round < SIGN_ROUNDS; round++) {
+    const mask = new Uint8Array(paddedLen);
+    for (let i = 0; i < paddedLen; i++) {
+      mask[i] = prng() < 0.5 ? 1 : 0;
+    }
+    table.push(mask);
+  }
+
+  if (signTableCache.size >= SIGN_TABLE_CACHE_LIMIT) {
+    // Map iteration is insertion-ordered, so this evicts the oldest entry.
+    const oldest = signTableCache.keys().next();
+    if (oldest.done !== true) {
+      signTableCache.delete(oldest.value);
+    }
+  }
+  signTableCache.set(key, table);
+  return table;
 }
 
 /**
@@ -100,13 +188,14 @@ function randomRotate(values: Float64Array, seed: number): Float64Array {
   const result = new Float64Array(paddedLen);
   result.set(values);
 
-  const prng = createPrng(seed);
+  const signs = getSignTable(seed, paddedLen);
 
   // Apply 3 rounds for good mixing (standard practice for randomized Hadamard)
-  for (let round = 0; round < 3; round++) {
+  for (let round = 0; round < SIGN_ROUNDS; round++) {
     // Random sign flips (diagonal Rademacher matrix)
+    const mask = signs[round];
     for (let i = 0; i < paddedLen; i++) {
-      if (prng() < 0.5) {
+      if (mask[i] === 1) {
         result[i] = -result[i];
       }
     }
@@ -128,26 +217,17 @@ function inverseRandomRotate(values: Float64Array, seed: number): Float64Array {
   const result = new Float64Array(paddedLen);
   result.set(values);
 
-  const prng = createPrng(seed);
-
-  // We need to collect all random values for 3 rounds, then apply in reverse
-  const signs: boolean[][] = [];
-  for (let round = 0; round < 3; round++) {
-    const roundSigns: boolean[] = [];
-    for (let i = 0; i < paddedLen; i++) {
-      roundSigns.push(prng() < 0.5);
-    }
-    signs.push(roundSigns);
-  }
+  const signs = getSignTable(seed, paddedLen);
 
   // Apply rounds in reverse order
-  for (let round = 2; round >= 0; round--) {
+  for (let round = SIGN_ROUNDS - 1; round >= 0; round--) {
     // WHT is its own inverse (up to scaling, which we handle)
     fastWalshHadamard(result);
 
     // Undo sign flips
+    const mask = signs[round];
     for (let i = 0; i < paddedLen; i++) {
-      if (signs[round][i]) {
+      if (mask[i] === 1) {
         result[i] = -result[i];
       }
     }
@@ -159,9 +239,15 @@ function inverseRandomRotate(values: Float64Array, seed: number): Float64Array {
 /**
  * In-place Fast Walsh-Hadamard Transform with normalization.
  * Runs in O(n log n) where n must be a power of 2.
+ *
+ * The power-of-2 requirement is enforced rather than assumed: at a non-power-of-2
+ * length the butterfly reads past the end of the buffer, silently producing NaN.
  */
 function fastWalshHadamard(data: Float64Array): void {
   const n = data.length;
+  if (n < 1 || (n & (n - 1)) !== 0) {
+    throw new Error(`fastWalshHadamard requires a power-of-2 length, got ${n}`);
+  }
   const norm = 1 / Math.sqrt(n);
 
   for (let halfSize = 1; halfSize < n; halfSize *= 2) {
@@ -181,9 +267,17 @@ function fastWalshHadamard(data: Float64Array): void {
   }
 }
 
+/**
+ * Smallest power of 2 that is >= n.
+ *
+ * Doubling uses `*= 2` rather than `<<= 1`: the shift operators coerce to 32-bit
+ * signed integers, so at p = 2^30 a shift wraps to -2147483648 and then to 0,
+ * leaving `p < n` true forever.
+ */
 function nextPowerOf2(n: number): number {
+  assertDimensions(n);
   let p = 1;
-  while (p < n) p <<= 1;
+  while (p < n) p *= 2;
   return p;
 }
 
@@ -208,6 +302,40 @@ function getQuantizationParams(
   const coverage = 3.0;
   const scale = coverage / Math.sqrt(paddedLen);
   return { levels, scale };
+}
+
+/**
+ * Normalizes a vector to unit length, returning both the unit-length coordinates
+ * and the original L2 norm.
+ *
+ * A non-finite norm means the input carried NaN or Infinity. That must throw:
+ * otherwise `norm > 0` is false for NaN and the freshly-allocated all-zero buffer
+ * is returned, silently discarding the bad input.
+ *
+ * A zero vector is not an error — it yields an all-zero `values` buffer and a
+ * norm of 0.
+ */
+function normalizeToUnit(vector: TypedArray): {
+  readonly values: Float64Array;
+  readonly norm: number;
+} {
+  const d = vector.length;
+  let sumSquares = 0;
+  for (let i = 0; i < d; i++) {
+    sumSquares += vector[i] * vector[i];
+  }
+  const norm = Math.sqrt(sumSquares);
+  if (!Number.isFinite(norm)) {
+    throw new Error("Cannot quantize a vector containing NaN or Infinity");
+  }
+
+  const values = new Float64Array(d);
+  if (norm > 0) {
+    for (let i = 0; i < d; i++) {
+      values[i] = vector[i] / norm;
+    }
+  }
+  return { values, norm };
 }
 
 /**
@@ -261,17 +389,21 @@ function packCodes(codes: number[], bits: number): Uint8Array {
 }
 
 /**
- * Unpacks codes from a compact Uint8Array back to an array of integers.
+ * Unpacks codes from a compact Uint8Array back to a Uint8Array of integers.
+ * Bit widths are capped at 8, so every code fits in one byte; returning a
+ * typed array keeps the per-comparison hot path free of boxed `number[]`
+ * allocations.
+ *
  * Throws if the buffer is too small for the requested count and bit width.
  */
-function unpackCodes(packed: Uint8Array, bits: number, count: number): number[] {
+function unpackCodes(packed: Uint8Array, bits: number, count: number): Uint8Array {
   const expectedBytes = Math.ceil((count * bits) / 8);
   if (packed.length < expectedBytes) {
     throw new Error(
       `unpackCodes: buffer too small - need ${expectedBytes} bytes for ${count} codes at ${bits} bits, got ${packed.length}`
     );
   }
-  const codes: number[] = new Array(count);
+  const codes = new Uint8Array(count);
 
   let bitPos = 0;
   for (let i = 0; i < count; i++) {
@@ -303,7 +435,7 @@ function unpackCodes(packed: Uint8Array, bits: number, count: number): number[] 
  * 3. Quantize each rotated coordinate using optimal scalar quantization
  * 4. Pack the codes into a compact bit representation
  *
- * @param vector - Input vector (any TypedArray)
+ * @param vector - Input vector (any TypedArray). Must not contain NaN or Infinity.
  * @param options - Quantization options (bits per dimension, optional seed)
  * @returns Compact quantized representation
  */
@@ -314,28 +446,16 @@ export function turboQuantize(
   const bits = options?.bits ?? 4;
   const seed = options?.seed ?? DEFAULT_SEED;
 
-  if (bits < 1 || bits > 8 || !Number.isInteger(bits)) {
-    throw new Error(`TurboQuant bits must be an integer between 1 and 8, got ${bits}`);
-  }
+  assertBits(bits);
 
   const d = vector.length;
   if (d === 0) {
     throw new Error("Cannot quantize an empty vector");
   }
+  assertDimensions(d);
 
   // Step 1: Compute norm and normalize
-  let norm = 0;
-  for (let i = 0; i < d; i++) {
-    norm += vector[i] * vector[i];
-  }
-  norm = Math.sqrt(norm);
-
-  const values = new Float64Array(d);
-  if (norm > 0) {
-    for (let i = 0; i < d; i++) {
-      values[i] = vector[i] / norm;
-    }
-  }
+  const { values, norm } = normalizeToUnit(vector);
 
   // Step 2: Random rotation — returns all paddedLen coordinates
   const paddedLen = nextPowerOf2(d);
@@ -362,6 +482,32 @@ export function turboQuantize(
 }
 
 /**
+ * Validates the scalar fields of a {@link TurboQuantizeResult}.
+ *
+ * `TurboQuantizeResult` is a plain, serializable interface intended for storage,
+ * so a value reaching the decode path may have been persisted, hand-built, or
+ * mismatched with a different record. Every field that sizes a buffer or drives
+ * the transform is therefore re-checked rather than trusted.
+ */
+function assertQuantizeResultShape(quantized: TurboQuantizeResult): void {
+  const { bits, dimensions, paddedDimensions, seed, norm } = quantized;
+  assertBits(bits);
+  assertDimensions(dimensions);
+  if (!Number.isInteger(seed)) {
+    throw new Error(`TurboQuant seed must be an integer, got ${seed}`);
+  }
+  if (!Number.isFinite(norm)) {
+    throw new Error(`TurboQuant norm must be a finite number, got ${norm}`);
+  }
+  const expectedPadded = nextPowerOf2(dimensions);
+  if (paddedDimensions !== expectedPadded) {
+    throw new Error(
+      `TurboQuant paddedDimensions must be nextPowerOf2(dimensions) = ${expectedPadded}, got ${paddedDimensions}`
+    );
+  }
+}
+
+/**
  * Dequantizes a TurboQuant result back to a Float32Array.
  *
  * Steps:
@@ -375,6 +521,8 @@ export function turboQuantize(
  */
 export function turboDequantize(quantized: TurboQuantizeResult): Float32Array {
   const { codes, bits, dimensions, paddedDimensions, seed, norm } = quantized;
+
+  assertQuantizeResultShape(quantized);
 
   // Step 1: Unpack all paddedDimensions codes
   const unpacked = unpackCodes(codes, bits, paddedDimensions);
@@ -418,6 +566,8 @@ export function turboQuantizedInnerProduct(a: TurboQuantizeResult, b: TurboQuant
   if (a.seed !== b.seed) {
     throw new Error("Vectors must use the same rotation seed");
   }
+  assertQuantizeResultShape(a);
+  assertQuantizeResultShape(b);
 
   const paddedLen = a.paddedDimensions;
   const { levels, scale } = getQuantizationParams(a.bits, paddedLen);
@@ -457,31 +607,64 @@ export function turboQuantizedCosineSimilarity(
   return turboQuantizedInnerProduct(a, b) / (a.norm * b.norm);
 }
 
-/** Integer target types supported by turboQuantizeToTypedArray */
-const INTEGER_TARGET_RANGES = {
-  [TensorType.INT8]: { signed: true, max: 127 },
-  [TensorType.UINT8]: { signed: false, max: 255 },
-  [TensorType.INT16]: { signed: true, max: 32767 },
-  [TensorType.UINT16]: { signed: false, max: 65535 },
+/**
+ * Signed integer target types supported by {@link turboQuantizeToTypedArray}.
+ *
+ * Unsigned targets are deliberately absent — see the function's documentation.
+ */
+const SIGNED_TARGET_RANGES = {
+  [TensorType.INT8]: { max: 127 },
+  [TensorType.INT16]: { max: 32767 },
 } as const;
 
 /**
  * Quantizes a vector using TurboQuant rotation directly into a byte-aligned TypedArray.
  *
- * Unlike the packed `turboQuantize`, this outputs a standard TypedArray (Int8Array,
- * Uint8Array, Int16Array, Uint16Array) with the **same `.length`** as the input vector.
- * This means the output works transparently with existing storage backends and
- * similarity search (cosineSimilarity requires matching lengths).
+ * Unlike the packed `turboQuantize`, this outputs a standard TypedArray (Int8Array or
+ * Int16Array) with the **same `.length`** as the input vector, so it drops into
+ * storage backends that expect a fixed-width vector column.
  *
  * The rotation spreads information across all coordinates and concentrates their
  * distribution, yielding better distortion than naive linear quantization at the
  * same byte width.
  *
+ * ## Signed targets only
+ *
+ * Only `int8` and `int16` are supported. An unsigned target would need the affine
+ * map `x -> (x + scale) / (2 * scale) * max`, whose DC offset (127.5 for uint8)
+ * lands on every stored coordinate. Cosine similarity is invariant to scaling but
+ * NOT to translation, so that shared component dominates the result: measured at
+ * d=1024 / uint8 / seed 42, a true cosine of 0.0559 reads 0.9071 and the whole
+ * range collapses to roughly [0.90, 1.00] — negatives become impossible and
+ * absolute thresholds meaningless. The offset cannot be subtracted back out at
+ * comparison time either: `cosineSimilarity(a, b)` receives only the two arrays,
+ * and pgvector / SQLite / DuckDB compute the distance server-side. Unsigned also
+ * buys no storage over the signed type of the same width.
+ *
+ * ## Comparability
+ *
+ * The output is cosine-comparable ONLY against other outputs of this function
+ * produced with the SAME seed. It is not comparable with the unrotated input
+ * vector, nor with linearly quantized vectors, nor across seeds — the rotation is
+ * a per-seed change of basis, so mixing them yields meaningless rankings with no
+ * error raised anywhere.
+ *
+ * ## Fidelity and non-power-of-2 dimensions
+ *
+ * The rotation operates on `nextPowerOf2(d)` coordinates but only the first `d`
+ * are kept (the output length must match the input length), so for a
+ * non-power-of-2 `d` this is a random projection rather than an orthogonal
+ * rotation, and cosine similarity is preserved only approximately. Measured
+ * cosine RMSE against the exact similarity (int8, seed 42, 40 random pairs):
+ * d=1024 -> 0.001, d=1000 -> 0.006, d=1536 -> 0.013, d=768 -> 0.019
+ * (worst single pair 0.052). When fidelity matters, zero-pad the vectors to a
+ * power of 2 at the call site.
+ *
  * Note: The vector norm is not preserved (cosine similarity is scale-invariant,
  * so this is fine for similarity search).
  *
- * @param vector - Input vector (any TypedArray)
- * @param targetType - Target integer type (INT8, UINT8, INT16, UINT16)
+ * @param vector - Input vector (any TypedArray). Must not contain NaN or Infinity.
+ * @param targetType - Target signed integer type (INT8 or INT16)
  * @param seed - Seed for the random rotation (default: 42). All vectors in the
  *   same collection must use the same seed for similarity search to work.
  * @returns TypedArray of the target type with `.length === vector.length`
@@ -491,61 +674,42 @@ export function turboQuantizeToTypedArray(
   targetType: TensorType,
   seed: number = DEFAULT_SEED
 ): TypedArray {
-  const range = INTEGER_TARGET_RANGES[targetType as keyof typeof INTEGER_TARGET_RANGES];
-  if (!range) {
+  // `Object.hasOwn` before indexing: a plain `[targetType]` lookup would resolve
+  // inherited Object.prototype keys, so a name like "constructor" would yield a
+  // truthy value and slip past the guard.
+  if (!Object.hasOwn(SIGNED_TARGET_RANGES, targetType)) {
     throw new Error(
-      `turboQuantizeToTypedArray only supports integer target types (int8, uint8, int16, uint16), got "${targetType}"`
+      `turboQuantizeToTypedArray supports signed integer targets only (int8, int16); "${targetType}" is unsupported. Unsigned targets would encode a DC offset that breaks cosineSimilarity.`
     );
   }
+  const { max } = SIGNED_TARGET_RANGES[targetType as keyof typeof SIGNED_TARGET_RANGES];
 
   const d = vector.length;
   if (d === 0) {
     throw new Error("Cannot quantize an empty vector");
   }
+  assertDimensions(d);
 
   // Step 1: Normalize to unit vector
-  let norm = 0;
-  for (let i = 0; i < d; i++) {
-    norm += vector[i] * vector[i];
-  }
-  norm = Math.sqrt(norm);
-
-  const values = new Float64Array(d);
-  if (norm > 0) {
-    for (let i = 0; i < d; i++) {
-      values[i] = vector[i] / norm;
-    }
-  }
+  const { values } = normalizeToUnit(vector);
 
   // Step 2: Random rotation (spreads information, concentrates distribution)
   // randomRotate returns all paddedLen coordinates; we only use the first d.
   const paddedLen = nextPowerOf2(d);
   const rotated = randomRotate(values, seed);
 
-  // Step 3: Map rotated coordinates to target integer range
+  // Step 3: Map rotated coordinates to the signed target range.
   // After rotation in paddedLen-dimensional space, coordinates have std dev ≈ 1/sqrt(paddedLen).
   const coverage = 3.0;
   const scale = coverage / Math.sqrt(paddedLen);
 
-  if (range.signed) {
-    // Map [-scale, scale] → [-max, max]
-    const max = range.max;
-    const result = targetType === TensorType.INT8 ? new Int8Array(d) : new Int16Array(d);
-    for (let i = 0; i < d; i++) {
-      const clamped = Math.max(-scale, Math.min(scale, rotated[i]));
-      result[i] = Math.round((clamped / scale) * max);
-    }
-    return result;
-  } else {
-    // Map [-scale, scale] → [0, max]
-    const max = range.max;
-    const result = targetType === TensorType.UINT8 ? new Uint8Array(d) : new Uint16Array(d);
-    for (let i = 0; i < d; i++) {
-      const clamped = Math.max(-scale, Math.min(scale, rotated[i]));
-      result[i] = Math.round(((clamped + scale) / (2 * scale)) * max);
-    }
-    return result;
+  // Map [-scale, scale] → [-max, max]
+  const result = targetType === TensorType.INT8 ? new Int8Array(d) : new Int16Array(d);
+  for (let i = 0; i < d; i++) {
+    const clamped = Math.max(-scale, Math.min(scale, rotated[i]));
+    result[i] = Math.round((clamped / scale) * max);
   }
+  return result;
 }
 
 /**
@@ -556,10 +720,12 @@ export function turboQuantizeToTypedArray(
  * therefore covers `nextPowerOf2(dimensions)` coordinates, not `dimensions`.
  *
  * @param dimensions - Vector dimensionality
- * @param bits - Bits per dimension
+ * @param bits - Bits per dimension (integer, 1-8)
  * @returns Storage size in bytes (codes only, excluding metadata)
  */
 export function turboQuantizeStorageBytes(dimensions: number, bits: number): number {
+  assertDimensions(dimensions);
+  assertBits(bits);
   return Math.ceil((nextPowerOf2(dimensions) * bits) / 8);
 }
 
@@ -567,10 +733,12 @@ export function turboQuantizeStorageBytes(dimensions: number, bits: number): num
  * Calculates the compression ratio compared to Float32 storage.
  *
  * @param dimensions - Vector dimensionality
- * @param bits - Bits per dimension
+ * @param bits - Bits per dimension (integer, 1-8)
  * @returns Compression ratio (e.g., 8.0 means 8x smaller)
  */
 export function turboQuantizeCompressionRatio(dimensions: number, bits: number): number {
+  assertDimensions(dimensions);
+  assertBits(bits);
   const originalBytes = dimensions * 4; // Float32 = 4 bytes per dim
   const quantizedBytes = turboQuantizeStorageBytes(dimensions, bits);
   return originalBytes / quantizedBytes;


### PR DESCRIPTION
Review fixes stacking on **#354** (`claude/integrate-arxiv-paper-VF55c`) — not on `main`. No PR template exists in this repo (`.github/`, root, `docs/`), so this uses plain headings.

## CRITICAL: unsigned turbo quantization encodes a DC offset that breaks cosine similarity

`turboQuantizeToTypedArray`'s unsigned branch mapped

```
x -> (x + scale) / (2 * scale) * max
```

an **affine** map. Its DC offset (127.5 for uint8) lands on every stored coordinate. Cosine similarity is invariant to *scaling* but **not** to *translation*, so that shared component dominates every comparison.

Measured on this branch (d=1024, uint8, seed 42, mulberry32 vectors), replicating the removed branch exactly:

| quantity | value |
| --- | --- |
| true cosine of the pair | **0.0139** |
| cosine after uint8 turbo | **0.9018** |
| range of uint8 cosine over 40 random pairs | **[0.8930, 0.9066]** |

The plan's independent measurement on a different random stream reported the same failure shape (true 0.0559 → 0.9071, range collapsing to ~[0.90, 1.00]). Negative similarities become impossible and absolute thresholds are meaningless — silently, with no error anywhere.

**Decision: reject unsigned targets outright.** `uint8` / `uint16` now throw; only `int8` and `int16` are supported.

The alternatives do not work:

- **Storing a per-vector offset** — `cosineSimilarity(a, b)` (`packages/util/src/vector/VectorSimilarityUtils.ts`) receives only the two arrays. There is nowhere to thread an offset.
- **A "subtract the midpoint first" contract** — cannot be honoured by pgvector / SQLite / DuckDB backends, which compute the distance server-side.

Nothing has landed on `main`, so there is no migration burden, and unsigned buys **zero** storage over the signed type of the same width.

## Each fix

| # | Fix | File |
| --- | --- | --- |
| T1 | `INTEGER_TARGET_RANGES` → `SIGNED_TARGET_RANGES` (int8/int16 only). Guard is now `Object.hasOwn(...)` **before** indexing — `INTEGER_TARGET_RANGES["constructor"]` previously resolved an inherited `Object.prototype` key, so `if (!range)` saw a truthy function and `turboQuantizeToTypedArray(v, "constructor")` returned an all-zero `Uint16Array` instead of throwing. Unsigned branch and `signed` flag deleted; JSDoc rewritten (signed-only, comparability caveats, the removed "works transparently with … similarity search" claim qualified). | `TurboQuantize.ts` |
| T2 | Extracted `normalizeToUnit()`, shared by `turboQuantize` and `turboQuantizeToTypedArray`, which throws on a non-finite norm. Previously `new Float32Array([1,2,NaN,4,5,6,7,8])` made `norm` NaN, failed `norm > 0`, and returned the freshly-allocated all-zero buffer — the NaN silently discarded. Zero-vector behaviour is preserved. | `TurboQuantize.ts` |
| T3 | `nextPowerOf2` used `p <<= 1`, a **32-bit signed** shift: at `p = 2^30` it wraps to `-2147483648`, then `0`, and `p < n` stays true forever. Changed to `p *= 2`, plus `MAX_TURBO_DIMENSIONS = 2**24` (the padded `Float64Array` working buffer is 128 MB there) and `assertDimensions` / `assertBits`, now called from both exported helpers. `turboQuantizeStorageBytes(1.5e9, 4)` hung the event loop permanently; `bits` of `0`, `-5`, `NaN` silently returned `1`. | `TurboQuantize.ts` |
| T4 | `fastWalshHadamard` assumed a power-of-2 length; at n=6 it read `data[j + halfSize]` past the end (`undefined` → NaN), so a `TurboQuantizeResult` with `paddedDimensions: 6` decoded to `[NaN x 6]` with **no error**. Since that interface is plain and serializable (intended for storage), a persisted or mismatched record corrupted silently. The transform now enforces the invariant, and `turboDequantize` / `turboQuantizedInnerProduct` re-validate `bits`, `dimensions`, `seed`, `norm` and `paddedDimensions === nextPowerOf2(dimensions)` before use. | `TurboQuantize.ts` |
| T5 | **Documented, not "fixed".** `randomRotate` returns `paddedLen` coordinates (correctly — that is what makes it invertible) but only the first `d` are kept, so for a non-power-of-2 `d` this is a random projection, not an orthogonal rotation. Fixed-length output makes that unavoidable, and 768/1536 are the two most common embedding dims among this repo's providers, so throwing is not acceptable. Measured cosine RMSE (int8, seed 42, 40 pairs) is now in the JSDoc: **d=1024 → 0.001, d=1000 → 0.006, d=1536 → 0.013, d=768 → 0.019** (worst single pair 0.052), with a recommendation to zero-pad at the call site. Mirrored into the `method` schema description. | `TurboQuantize.ts`, `VectorQuantizeTask.ts` |
| T6 | Extracted `getSignTable(seed, paddedLen)` returning three `Uint8Array` flip masks drawn in exactly the previous order, memoized in a **bounded** `Map` (16 entries, oldest evicted) so a hostile seed stream cannot grow it. `inverseRandomRotate` previously rebuilt a boxed `boolean[][]` of 3 × paddedLen on **every** dequantize. `unpackCodes` now returns a `Uint8Array` (bits ≤ 8) instead of a boxed `number[]` — `turboQuantizedInnerProduct`, documented as "faster than dequantizing", was allocating two 1024-element JS arrays per comparison. **Output bytes are unchanged** (pinned by the new golden test). | `TurboQuantize.ts` |
| T7 | `VectorQuantizeTaskOutput` carried only `vector`/`originalType`/`targetType`, so nothing downstream could tell a rotated `Int8Array` from a linear-quantized one — measured, `cosineSimilarity(a, turboQuantizeToTypedArray(a, INT8, 42))` ≈ 0.05, a vector near-orthogonal to *itself*. A collection re-indexed with `turboSeed` 42→43, or a row written with `method: "linear"`, produced garbage rankings with no error. `method` and `turboSeed` are now in `outputSchema` (with `method` required) and on the output type. The turbo branch rejects non-signed `targetType` early, and the `normalize` description notes it is ignored for turbo. | `VectorQuantizeTask.ts` |
| T8 | License year `2026` on the two files **created** 2026-04-01 (`TurboQuantize.ts`, `TurboQuantize.test.ts`); the pre-existing files stay at 2025 per CLAUDE.md. `TurboQuantizeOptions` fields → `readonly bits: number \| undefined` / `readonly seed: number \| undefined`. `createPrng`: `state ^= state >> 17` → `>>> 17` (cosmetic — the JSDoc calls it xorshift32 — but it changes output bytes, so it was done **before** the golden literals were generated). | `TurboQuantize.ts`, tests |

## Tests

10 new tests plus an extended zero-vector case. All fidelity/statistical tests use a local deterministic mulberry32 PRNG — never `Math.random`.

`TurboQuantize.test.ts`: unsigned rejection; DC-offset guard (d=1024 int8 — asserts `|mean| < 2` and ≥30% negative coordinates, both of which an affine map fails); NaN/Infinity on both entry points; out-of-range dimensions and bits (incl. `2**30 + 1` under a 2 s timeout so a hang fails rather than stalls CI); tampered `paddedDimensions` on `turboDequantize` **and** `turboQuantizedInnerProduct`; prototype-chain target names; cosine fidelity across d ∈ {768, 1000, 1024, 1536}; and hardcoded **golden bytes** (`[117, 165, 180, 133]` and a 16-value int8 prefix) — the existing determinism test only compared two in-process calls, which cannot detect a `Math.random` regression introduced elsewhere.

`VectorQuantizeTask.test.ts`: unsigned `targetType` rejection for turbo; `method`/`turboSeed` reported on the output.

## What was verified vs. not

**Verified — commands run, output seen:**

- `bun install` → 1830 packages installed.
- `bun run build:types` → **41/41 tasks successful** (full workspace, `tsgo`).
- `bunx vitest run packages/test/src/test/util/TurboQuantize.test.ts packages/test/src/test/rag/VectorQuantizeTask.test.ts` → **67 passed / 67**.
- **Fails-before check.** With the pre-change sources restored (`git show HEAD:…`) and the new tests in place: **9 of the new tests failed** — NaN/Infinity, golden bytes, tampered `paddedDimensions`, float-target message, unsigned rejection, prototype-chain names, zero-vector (uint8 arm), and both `VectorQuantizeTask` tests.
- **T3 fails-before, separately.** The out-of-range test could not be run under the old code at all: `turboQuantizeStorageBytes(2**30 + 1, 4)` spins synchronously, so it blocks the event loop and vitest's own timeout never fires — a first attempt burned a full 10-minute shell timeout. Isolated with `timeout 15 bun -e …` it exits **124** (hang) on the old source and throws immediately on the new one. That is the DoS, demonstrated.
- Both CRITICAL measurement tables above were produced by me on this branch, not copied from the plan.
- `prettier --write` and `eslint` clean on all four changed files (pre-commit `lint-staged` also ran).

**Not verified / caveats:**

- Two new tests (**DC-offset** and **cross-dimension cosine fidelity**) also pass against the *pre*-change sources. Both use `INT8`, whose signed map was already correct — they are forward regression guards (against reintroducing an affine map, and against the documented RMSE drifting), not reproductions of a current failure. Flagging this because the plan asked that every new test fail before.
- The documented RMSE figures are the plan's, kept because my independent measurement came in at or below every one of them (0.0164 / 0.0047 / 0.0008 / 0.0126 vs. documented 0.019 / 0.006 / 0.001 / 0.013), so the test's ×1.5 bound holds with margin. The one adjustment: worst single pair documented as **0.052** rather than the plan's 0.048, because I measured 0.0511 at d=768.
- Test execution requires `bun run use-source` (this repo's `use-source` rewrites `package.json` exports rather than writing `dist` stubs as CLAUDE.md describes). Those `package.json` edits were reverted before committing — the commit touches exactly 4 files. Under `dist` resolution the suite cannot run without a prior build.
- Only these two test files were run. The wider suite was not executed; `build:types` across all 41 packages is the only whole-workspace signal here.

## Deviation from the approved plan

One, stated explicitly. The plan asked to drop `?` from `method` / `turboSeed` on **`VectorQuantizeTaskInput`** (making them `readonly method: QuantizationMethod | undefined`). I added `readonly` but **kept the `?`**, because the task's `inputSchema` lists neither in `required` — they genuinely are optional inputs — and removing `?` makes every existing `vectorQuantize({ vector, targetType })` call site a type error, including the pre-existing tests in `VectorQuantizeTask.test.ts`. It would also have been inconsistent with the pre-existing `normalize?`, which the plan explicitly left alone. `TurboQuantizeOptions` **did** get the full treatment (`readonly bits: number | undefined`) as specified — it has no external callers, so the change is contained. On the **output** type, `method` is required and `turboSeed` is `number | undefined` (set to `undefined` for linear), exactly as planned.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhfGNbddCCJR71UvDw2c7f)_