### PR TITLE
fix(tasks): stop notify tasks leaking webhook tokens and mass-pinging

### DIFF
--- a/packages/tasks/README.md
+++ b/packages/tasks/README.md
@@ -139,17 +139,17 @@ output schema and error messages report only the endpoint's origin.
 
 **Input Schema:**
 
-- `url` (string, optional): Webhook endpoint to POST to
+- `url` (string, optional): Webhook endpoint to POST to. Kept out of errors and output, but a value set here is stored verbatim in the graph JSON — use `url_credential_key` to keep the secret out of the saved workflow.
 - `payload` (object, required): JSON body to send
 - `headers` (object, optional): Additional headers, merged over the JSON content type
-- `timeout` (number, optional): Request timeout in milliseconds
-- `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`.
+- `timeout` (number, optional): Request timeout in milliseconds. Default: `30000`
+- `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`. A value that is not an absolute `http(s)` URL (e.g. a bearer token) is rejected with a configuration error.
 
 **Output Schema:**
 
-- `success` (boolean): True when the endpoint answered with a 2xx status
+- `success` (boolean): Always `true`; a non-2xx response throws
 - `status` (number): HTTP status code returned by the endpoint
-- `response` (string): Response body, truncated to 1KB
+- `response` (string): Response body, truncated to 1KB. Always empty for a private/internal destination
 
 **Examples:**
 
@@ -172,7 +172,11 @@ const workflow = new Workflow()
 
 - Runs inline through the SSRF-aware `safeFetch` wrapper
 - Private/internal destinations require the scoped `network:private` entitlement
-- 429/503 and 5xx responses raise retryable errors carrying a `Retry-After` retry date
+- A private/internal destination is reachable but its response body is **never echoed** — `response` is always `""`. Notification needs no reply body, and returning one would make this task an SSRF read primitive (e.g. POSTing to a cloud metadata endpoint and reading the answer back into the graph)
+- 429/503 and 5xx raise `RetryableJobError`; retries require a `@workglow/job-queue` consumer, which these inline tasks do not have
+- Response bodies are read as a stream and abandoned past 1MB, so an endpoint answering with an unbounded body cannot exhaust runner memory — on the failure path too
+- Requests time out after 30s by default (`timeout`); a caller abort surfaces as an abort error rather than a retryable network failure
+- A configured `url_credential_key` upgrades the `credential` entitlement from optional to enforced
 - Never cached — the task is side-effecting (`cachePolicy: { kind: "none" }`)
 
 ### SlackNotifyTask
@@ -181,16 +185,18 @@ Sends a message to a Slack incoming webhook.
 
 **Input Schema:**
 
-- `url` (string, optional): Slack incoming webhook URL
+- `url` (string, optional): Slack incoming webhook URL. Kept out of errors and output, but a value set here is stored verbatim in the graph JSON — use `url_credential_key` to keep the secret out of the saved workflow.
 - `text` (string, required): Message text, also used as the notification fallback for block messages
 - `blocks` (array, optional): Slack Block Kit blocks
 - `username` (string, optional): Overrides the display name of the posting bot
 - `icon_emoji` (string, optional): Overrides the bot icon, e.g. `:rocket:`
+- `allow_mentions` (boolean, optional): Send `text` unmodified. Default: `false`
+- `timeout` (number, optional): Request timeout in milliseconds. Default: `30000`
 - `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`.
 
 **Output Schema:**
 
-- `success` (boolean): True when Slack accepted the message
+- `success` (boolean): Always `true`; a non-2xx response throws
 - `status` (number): HTTP status code returned by Slack
 
 **Examples:**
@@ -222,7 +228,10 @@ const workflow = new Workflow().slackNotify({
 
 - Absent optional fields are omitted from the payload rather than sent as `null`
 - Slack answers `200` with the body `ok`; failure bodies (`invalid_payload`, `no_service`) are surfaced in the error message
-- Webhook token never appears in errors, output, or logs
+- **Channel-wide broadcasts in `text` are neutralized by default.** Slack has no `allowed_mentions`; its documented control is HTML-entity escaping, so the literal `<!` is escaped to `&lt;!`. That defuses `<!channel>`, `<!here>`, `<!everyone>` and `<!subteam^ID>` while leaving `<https://…|label>` links and single-user `<@U123>` mentions intact, and `link_names: false` is sent explicitly. `blocks` is a caller-authored structure, not a piped string, so it is **not** rewritten — a broadcast written inside a block still pings. Set `allow_mentions: true` to send `text` verbatim
+- Requests time out after 30s by default (`timeout`)
+- Response bodies are capped at 1MB while being read
+- Webhook token never appears in error messages, `error.url`, `error.stack`, or task output
 
 ### DiscordNotifyTask
 
@@ -230,16 +239,18 @@ Sends a message to a Discord webhook.
 
 **Input Schema:**
 
-- `url` (string, optional): Discord webhook URL
+- `url` (string, optional): Discord webhook URL. Kept out of errors and output, but a value set here is stored verbatim in the graph JSON — use `url_credential_key` to keep the secret out of the saved workflow.
 - `content` (string, required): Message content
 - `username` (string, optional): Overrides the display name of the webhook
 - `avatar_url` (string, optional): Overrides the avatar of the webhook
 - `embeds` (array, optional): Discord embed objects
+- `allow_mentions` (boolean, optional): Let the message ping. Default: `false`
+- `timeout` (number, optional): Request timeout in milliseconds. Default: `30000`
 - `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`.
 
 **Output Schema:**
 
-- `success` (boolean): True when Discord accepted the message
+- `success` (boolean): Always `true`; a non-2xx response throws
 - `status` (number): HTTP status code returned by Discord, `204` on success
 
 **Examples:**
@@ -270,8 +281,11 @@ const workflow = new Workflow().discordNotify({
 **Features:**
 
 - A successful post answers `204 No Content`, so no response body is read or parsed
-- Rate limits arrive as `429` and may carry the delay as `{"retry_after": <seconds>}` in the body instead of a `Retry-After` header; both are honored
-- Webhook token never appears in errors, output, or logs
+- Rate limits arrive as `429` and may carry the delay as `{"retry_after": <seconds>}` in the body instead of a `Retry-After` header; both are parsed onto the raised `RetryableJobError`. Nothing acts on the value — retries require a `@workglow/job-queue` consumer, which these inline tasks do not have
+- **Mass mentions are suppressed by default** — `allowed_mentions: { parse: [] }` is sent, so `@everyone`/`@here`, role and user pings in `content` do nothing even when the content was piped in from a fetch or a model. Set `allow_mentions: true` to let the message ping
+- Requests time out after 30s by default (`timeout`)
+- Response bodies are capped at 1MB while being read
+- Webhook token never appears in error messages, `error.url`, `error.stack`, or task output
 
 ### DebugLogTask
 

--- a/packages/tasks/src/task/DiscordNotifyTask.ts
+++ b/packages/tasks/src/task/DiscordNotifyTask.ts
@@ -28,7 +28,7 @@ const inputSchema = {
       format: "uri",
       title: "Webhook URL",
       description:
-        "Discord webhook URL. The token is part of the path, so it is treated as a secret and never echoed back.",
+        "Discord webhook URL. The token is part of the path, so it is kept out of errors and output — but a value set here is stored verbatim in the graph JSON. Use 'url_credential_key' to keep the secret out of the saved workflow.",
     },
     content: {
       type: "string",
@@ -52,6 +52,19 @@ const inputSchema = {
       title: "Embeds",
       description: "Discord embed objects",
     },
+    allow_mentions: {
+      type: "boolean",
+      default: false,
+      title: "Allow Mentions",
+      description:
+        "Let the message ping. By default `allowed_mentions: { parse: [] }` is sent, suppressing @everyone/@here, role and user pings so piped or model-generated content cannot notify a whole server.",
+    },
+    timeout: {
+      type: "number",
+      default: 30000,
+      title: "Timeout",
+      description: "Request timeout in milliseconds",
+    },
     url_credential_key: {
       type: "string",
       format: "credential",
@@ -71,7 +84,7 @@ const outputSchema = {
     success: {
       type: "boolean",
       title: "Success",
-      description: "True when Discord accepted the message",
+      description: "Always true; a non-2xx response throws.",
     },
     status: {
       type: "number",
@@ -135,9 +148,14 @@ export class DiscordNotifyTask<
         username: input.username,
         avatar_url: input.avatar_url,
         embeds: input.embeds,
+        // `parse: []` suppresses @everyone/@here plus every role and user
+        // mention, so content piped in from a fetch or a model cannot turn a
+        // notification into a server-wide ping (and a retry loop into an
+        // amplifier). Opt back in with `allow_mentions`.
+        allowed_mentions: input.allow_mentions === true ? undefined : { parse: [] },
       }),
       headers: undefined,
-      timeout: undefined,
+      timeout: input.timeout,
       signal: context.signal,
       readSuccessBody: false,
       includeBodyInError: true,

--- a/packages/tasks/src/task/SlackNotifyTask.ts
+++ b/packages/tasks/src/task/SlackNotifyTask.ts
@@ -28,7 +28,7 @@ const inputSchema = {
       format: "uri",
       title: "Webhook URL",
       description:
-        "Slack incoming webhook URL. The token is part of the path, so it is treated as a secret and never echoed back.",
+        "Slack incoming webhook URL. The token is part of the path, so it is kept out of errors and output — but a value set here is stored verbatim in the graph JSON. Use 'url_credential_key' to keep the secret out of the saved workflow.",
     },
     text: {
       type: "string",
@@ -51,6 +51,19 @@ const inputSchema = {
       title: "Icon Emoji",
       description: "Overrides the bot icon, e.g. :robot_face:",
     },
+    allow_mentions: {
+      type: "boolean",
+      default: false,
+      title: "Allow Mentions",
+      description:
+        "Send 'text' unmodified. By default channel-wide broadcasts (<!channel>, <!here>, <!everyone>, <!subteam^ID>) are neutralized so piped or model-generated text cannot notify a whole workspace.",
+    },
+    timeout: {
+      type: "number",
+      default: 30000,
+      title: "Timeout",
+      description: "Request timeout in milliseconds",
+    },
     url_credential_key: {
       type: "string",
       format: "credential",
@@ -70,7 +83,7 @@ const outputSchema = {
     success: {
       type: "boolean",
       title: "Success",
-      description: "True when Slack accepted the message",
+      description: "Always true; a non-2xx response throws.",
     },
     status: {
       type: "number",
@@ -84,6 +97,23 @@ const outputSchema = {
 
 export type SlackNotifyTaskInput = FromSchema<typeof inputSchema>;
 export type SlackNotifyTaskOutput = FromSchema<typeof outputSchema>;
+
+/**
+ * Defuses Slack's channel-wide broadcast sequences in caller-supplied text.
+ *
+ * Slack has no `allowed_mentions` equivalent; its documented control is
+ * HTML-entity escaping. Broadcasts are all written `<!…>` — `<!channel>`,
+ * `<!here>`, `<!everyone>` and the group form `<!subteam^ID>` — so escaping
+ * just the opening `<!` kills every one of them while leaving `<https://…|label>`
+ * links and single-user `<@U123>` mentions intact, which full `<`/`>` escaping
+ * would break.
+ *
+ * `link_names` is NOT a substitute: it governs auto-linking of bare `@name`
+ * text, not these control sequences.
+ */
+export function neutralizeSlackBroadcasts(text: string): string {
+  return text.split("<!").join("&lt;!");
+}
 
 /**
  * Posts a message to a Slack incoming webhook.
@@ -127,16 +157,21 @@ export class SlackNotifyTask<
 
   override async execute(input: Input, context: IExecuteContext): Promise<Output> {
     const url = resolveWebhookUrl(input.url, input.url_credential_key, "SlackNotifyTask");
+    const allowMentions = input.allow_mentions === true;
     const result = await postWebhookJson({
       url,
       payload: compactPayload({
-        text: input.text,
+        // `blocks` is a caller-authored structure rather than a piped string,
+        // so it is passed through unchanged — a broadcast written inside a
+        // block is NOT neutralized.
+        text: allowMentions ? input.text : neutralizeSlackBroadcasts(input.text),
         blocks: input.blocks,
         username: input.username,
         icon_emoji: input.icon_emoji,
+        link_names: allowMentions ? undefined : false,
       }),
       headers: undefined,
-      timeout: undefined,
+      timeout: input.timeout,
       signal: context.signal,
       readSuccessBody: false,
       includeBodyInError: true,

--- a/packages/tasks/src/task/WebhookNotifyTask.ts
+++ b/packages/tasks/src/task/WebhookNotifyTask.ts
@@ -12,6 +12,7 @@ import type {
 } from "@workglow/task-graph";
 import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
+import { classifyUrl } from "../util/UrlClassifier";
 import {
   postWebhookJson,
   resolveWebhookUrl,
@@ -26,7 +27,8 @@ const inputSchema = {
       type: "string",
       format: "uri",
       title: "URL",
-      description: "Webhook endpoint to POST to. Treated as a secret and never echoed back.",
+      description:
+        "Webhook endpoint to POST to. Kept out of errors and output — but a value set here is stored verbatim in the graph JSON. Use 'url_credential_key' to keep the secret out of the saved workflow.",
     },
     payload: {
       type: "object",
@@ -42,6 +44,7 @@ const inputSchema = {
     },
     timeout: {
       type: "number",
+      default: 30000,
       title: "Timeout",
       description: "Request timeout in milliseconds",
     },
@@ -64,7 +67,7 @@ const outputSchema = {
     success: {
       type: "boolean",
       title: "Success",
-      description: "True when the endpoint answered with a 2xx status",
+      description: "Always true; a non-2xx response throws.",
     },
     status: {
       type: "number",
@@ -74,7 +77,8 @@ const outputSchema = {
     response: {
       type: "string",
       title: "Response",
-      description: "Response body, truncated to 1KB",
+      description:
+        "Response body, truncated to 1KB. Always empty for a private/internal destination, which is reachable but never echoed back.",
     },
   },
   required: ["success", "status", "response"],
@@ -124,18 +128,29 @@ export class WebhookNotifyTask<
 
   override async execute(input: Input, context: IExecuteContext): Promise<Output> {
     const url = resolveWebhookUrl(input.url, input.url_credential_key, "WebhookNotifyTask");
+    // Reachability of a private destination matches FetchUrlTask (gated by the
+    // `network:private` entitlement), but the `response` port would additionally
+    // turn this task into an SSRF *read* primitive: a POST to
+    // http://169.254.169.254/latest/meta-data/iam/security-credentials/ would
+    // hand a kilobyte of the reply back into the graph. Notification needs no
+    // reply body, so the private path never reads one.
+    const isPrivate = classifyUrl(url).kind === "private";
     const result = await postWebhookJson({
       url,
       payload: input.payload,
       headers: input.headers,
       timeout: input.timeout,
       signal: context.signal,
-      readSuccessBody: true,
+      readSuccessBody: !isPrivate,
       includeBodyInError: false,
       retryAfterFromJsonBody: false,
       label: "webhook",
     });
-    return { success: true, status: result.status, response: result.body } as Output;
+    return {
+      success: true,
+      status: result.status,
+      response: isPrivate ? "" : result.body,
+    } as Output;
   }
 }
 

--- a/packages/tasks/src/util/WebhookPost.ts
+++ b/packages/tasks/src/util/WebhookPost.ts
@@ -10,14 +10,23 @@
  * token) the URL must never reach an error message, task output, or log line.
  * Every message produced here is built from {@link redactWebhookUrl}, and any
  * error bubbling out of `safeFetch` (whose messages do embed the full URL) is
- * rewritten through {@link redactWebhookUrlIn} before it escapes.
+ * rewritten through {@link redactWebhookUrlIn} — message, `url` field AND
+ * `stack` — before it escapes.
+ *
+ * `safeFetch`'s own messages are only "trusted non-secret" for callers whose
+ * URL is not itself a credential (e.g. {@link FetchUrlTask}, where the URL is
+ * the most useful diagnostic there is). This module is the one layer that
+ * knows the URL IS the credential, so redaction belongs here rather than in
+ * the shared transport.
  */
 
 import { AbortSignalJobError } from "@workglow/job-queue";
 import type { TaskEntitlements } from "@workglow/task-graph";
 import { Entitlements, mergeEntitlements } from "@workglow/task-graph";
+import { SECURITY_LIMITS } from "@workglow/util";
 import type { FetchUrlJobErrorInstance } from "../task/FetchUrlJobError";
 import {
+  createFetchUrlAbortedError,
   createFetchUrlJobError,
   FetchUrlErrorCode,
   httpStatusToFetchUrlErrorCode,
@@ -61,6 +70,38 @@ export function redactWebhookUrlIn(text: string, url: string): string {
 }
 
 /**
+ * Builds a redacted `.stack` for a rewritten error.
+ *
+ * `BaseError` never overrides `stack`, so V8 materializes it as
+ * `"<name>: <message>\n    at …"` — the message is baked into the string.
+ * Copying an unredacted stack across therefore re-imports the very webhook
+ * token the rewrite just stripped from `.message` and `.url`, and stacks are
+ * persisted (see `formatErrorChainForDiagnostics`), so "logs are trusted" is
+ * not an available defence.
+ *
+ * The header is replaced wholesale rather than patched: a message may itself
+ * contain newlines, so the split point is the first stack FRAME (`    at …`),
+ * not the first line. Frames can embed the URL independently (a module
+ * specifier, a fetch wrapper argument), so the assembled result gets a second
+ * redaction pass.
+ *
+ * Fails CLOSED on runtimes whose stacks carry no `    at ` frames
+ * (JavaScriptCore's `fn@file:line:col` form): only the redacted header is
+ * kept, losing frames rather than risking the secret.
+ */
+export function redactedStackFrom(original: unknown, rebuilt: Error, url: string): string {
+  const header = `${rebuilt.name}: ${rebuilt.message}`;
+  const originalStack =
+    original instanceof Error && typeof original.stack === "string" ? original.stack : "";
+  const lines = originalStack.split("\n");
+  const firstFrame = lines.findIndex((line) => /^\s+at /.test(line));
+  if (firstFrame < 0) {
+    return redactWebhookUrlIn(header, url);
+  }
+  return redactWebhookUrlIn([header, ...lines.slice(firstFrame)].join("\n"), url);
+}
+
+/**
  * Picks the webhook URL, preferring a resolved credential over the plain
  * `url` port. Credential values arrive already resolved by the input
  * resolver, so the key name never reaches the network.
@@ -75,6 +116,22 @@ export function resolveWebhookUrl(
     throw createFetchUrlJobError(
       FetchUrlErrorCode.CONFIGURATION,
       `${label}: no webhook URL provided. Set the 'url' input or the 'url_credential_key' input.`
+    );
+  }
+  // A bearer token wired into `url_credential_key` is the likely mistake here:
+  // these tasks expect the credential to BE the whole webhook URL. Say so, but
+  // never echo the value — it is a secret whichever kind it turns out to be.
+  let protocol: string;
+  try {
+    protocol = new URL(resolved).protocol;
+  } catch {
+    protocol = "";
+  }
+  if (protocol !== "http:" && protocol !== "https:") {
+    throw createFetchUrlJobError(
+      FetchUrlErrorCode.CONFIGURATION,
+      `${label}: the resolved webhook value must be an absolute http(s) URL. ` +
+        `If 'url_credential_key' holds a bearer token rather than a full webhook URL, use FetchUrlTask instead.`
     );
   }
   return resolved;
@@ -151,10 +208,33 @@ function leaksUrl(error: FetchUrlJobErrorInstance, url: string): boolean {
  * message cannot contain the webhook secret. Already-typed errors keep their
  * code (and therefore their retryable/permanent classification) and are passed
  * through untouched unless they embed the URL.
+ *
+ * `callerSignal` is the task's own abort signal, kept separate from the
+ * composed timeout signal so a cancellation can be told apart from a timeout.
  */
-function toRedactedWebhookError(error: unknown, url: string, label: string): unknown {
+function toRedactedWebhookError(
+  error: unknown,
+  url: string,
+  label: string,
+  callerSignal: AbortSignal
+): unknown {
   if (error instanceof AbortSignalJobError) {
     return error;
+  }
+  // `fetch` rejects an aborted or timed-out request with a DOMException, which
+  // would otherwise fall through to the retryable NETWORK_ERROR below — making
+  // a cancelled workflow look like a transient failure worth retrying.
+  const name = error instanceof Error ? error.name : "";
+  if (name === "AbortError" || name === "TimeoutError") {
+    if (callerSignal.aborted || name === "AbortError") {
+      return createFetchUrlAbortedError();
+    }
+    // Only a timeout that the caller did not also abort is a transient failure.
+    return createFetchUrlJobError(
+      FetchUrlErrorCode.NETWORK_ERROR,
+      `Timed out posting ${label} to ${redactWebhookUrl(url)}`,
+      { url: redactWebhookUrl(url) }
+    );
   }
   if (isFetchUrlJobError(error)) {
     if (!leaksUrl(error, url)) {
@@ -166,7 +246,12 @@ function toRedactedWebhookError(error: unknown, url: string, label: string): unk
       httpStatusText: error.httpStatusText,
       retryDate: error.retryDate,
     });
-    rebuilt.stack = error.stack;
+    // Deliberately NOT copying `error.cause`: `formatErrorChainForDiagnostics`
+    // walks the cause chain and pushes every link's `.message` + `.stack` into
+    // a PERSISTED job-error string, which would re-import the unredacted URL
+    // this rebuild just stripped. `createFetchUrlJobError` sets no cause today
+    // and none must be added here.
+    rebuilt.stack = redactedStackFrom(error, rebuilt, url);
     return rebuilt;
   }
   const detail = error instanceof Error ? error.message : String(error);
@@ -177,11 +262,52 @@ function toRedactedWebhookError(error: unknown, url: string, label: string): unk
   );
 }
 
-async function readBodyText(response: Response): Promise<string> {
+/**
+ * Reads a response body with a hard byte ceiling.
+ *
+ * `response.text()` buffers the whole body before any truncation constant can
+ * apply, so a hostile (or merely broken) endpoint answering with a multi-GB
+ * body would OOM the runner — including on the failure path, which buffers
+ * unconditionally for all three notification tasks. Streaming lets the read be
+ * abandoned mid-body: once the cap is passed the reader is cancelled and
+ * whatever arrived so far is returned.
+ */
+async function readBodyText(
+  response: Response,
+  maxBytes: number = SECURITY_LIMITS.webhookMaxResponseBodyBytes
+): Promise<string> {
+  const body = response.body;
+  if (body === null || body === undefined || typeof body.getReader !== "function") {
+    // A bodiless response (204) or a runtime without streaming support.
+    try {
+      return await response.text();
+    } catch {
+      return "";
+    }
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  let bytes = 0;
   try {
-    return await response.text();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return text + decoder.decode();
+      }
+      if (value === undefined) {
+        continue;
+      }
+      bytes += value.byteLength;
+      text += decoder.decode(value, { stream: true });
+      if (bytes >= maxBytes) {
+        await reader.cancel().catch(() => {});
+        return text;
+      }
+    }
   } catch {
-    return "";
+    return text;
   }
 }
 
@@ -222,7 +348,7 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
       privateResourceScopes: isPrivate ? [urlResourcePattern(url)] : undefined,
     });
   } catch (err) {
-    throw toRedactedWebhookError(err, url, label);
+    throw toRedactedWebhookError(err, url, label, request.signal);
   }
 
   if (response.ok) {
@@ -257,7 +383,15 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
   );
 }
 
-/** Static entitlements shared by every webhook notification task. */
+/**
+ * Static entitlements shared by every webhook notification task.
+ *
+ * `credential` is declared optional HERE because the static shape describes the
+ * task class, which may or may not be configured to use the store. An optional
+ * entitlement is skipped outright by `evaluatePolicy`, so this declaration is
+ * documentation only; {@link webhookPrivateEntitlements} upgrades it to a real
+ * requirement on the instance that actually configures a credential key.
+ */
 export function webhookBaseEntitlements(reason: string): TaskEntitlements {
   return {
     entitlements: [
@@ -290,8 +424,21 @@ export function webhookPrivateEntitlements(
   credentialKey: unknown
 ): TaskEntitlements {
   const credentialWins = typeof credentialKey === "string" && credentialKey.length > 0;
+  // A configured credential key is no longer a "may": this instance WILL read
+  // the credential store. `mergeEntitlements` keeps the most restrictive
+  // `optional`, so this upgrades the base declaration into an enforced one.
+  const withCredential = credentialWins
+    ? mergeEntitlements(base, {
+        entitlements: [
+          {
+            id: Entitlements.CREDENTIAL,
+            reason: "Resolves the webhook URL — the secret itself — from the credential store",
+          },
+        ],
+      })
+    : base;
   if (credentialWins || typeof url !== "string" || url.length === 0) {
-    return mergeEntitlements(base, {
+    return mergeEntitlements(withCredential, {
       entitlements: [
         {
           id: Entitlements.NETWORK_PRIVATE,
@@ -304,9 +451,9 @@ export function webhookPrivateEntitlements(
   }
   const classification = classifyUrl(url);
   if (classification.kind !== "private") {
-    return base;
+    return withCredential;
   }
-  return mergeEntitlements(base, {
+  return mergeEntitlements(withCredential, {
     entitlements: [
       {
         id: Entitlements.NETWORK_PRIVATE,

--- a/packages/test/src/test/task/NotifyTask.test.ts
+++ b/packages/test/src/test/task/NotifyTask.test.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PermanentJobError, RetryableJobError } from "@workglow/job-queue";
+import {
+  AbortSignalJobError,
+  formatErrorChainForDiagnostics,
+  PermanentJobError,
+  RetryableJobError,
+} from "@workglow/job-queue";
 import { TaskRegistry, Workflow } from "@workglow/task-graph";
 import {
   createFetchUrlJobError,
@@ -20,6 +25,7 @@ import {
   type SafeFetchFn,
   type SafeFetchOptions,
 } from "@workglow/tasks";
+import { getGlobalCredentialStore } from "@workglow/util";
 import { validateSchema } from "@workglow/util/schema";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -126,7 +132,7 @@ describe("Webhook notification tasks", () => {
       expect(url).toBe(SLACK_URL);
       expect(options.method).toBe("POST");
       expect(requestHeaders()["Content-Type"]).toBe("application/json");
-      expect(options.body).toBe(JSON.stringify({ text: "deploy finished" }));
+      expect(options.body).toBe(JSON.stringify({ text: "deploy finished", link_names: false }));
     });
 
     // An unset array port materializes as `[]`, which Slack rejects, so an
@@ -135,7 +141,7 @@ describe("Webhook notification tasks", () => {
       await slackNotify({ url: SLACK_URL, text: "hi" });
 
       const body = lastCall().options.body as string;
-      expect(body).toBe('{"text":"hi"}');
+      expect(body).toBe('{"text":"hi","link_names":false}');
       expect(body).not.toContain("username");
       expect(body).not.toContain("blocks");
       expect(body).not.toContain("undefined");
@@ -156,6 +162,7 @@ describe("Webhook notification tasks", () => {
           blocks: [{ type: "section" }],
           username: "deploybot",
           icon_emoji: ":rocket:",
+          link_names: false,
         })
       );
     });
@@ -236,6 +243,7 @@ describe("Webhook notification tasks", () => {
           username: "ci",
           avatar_url: "https://example.com/a.png",
           embeds: [{ title: "build" }],
+          allowed_mentions: { parse: [] },
         })
       );
     });
@@ -251,6 +259,25 @@ describe("Webhook notification tasks", () => {
       expect(result).toEqual({ success: true, status: 204 });
       expect(jsonSpy).not.toHaveBeenCalled();
       expect(textSpy).not.toHaveBeenCalled();
+    });
+
+    // Slack answers 200 with a body it does not want read. The success read now
+    // streams via `getReader()`, so a `text()` spy alone would be vacuous —
+    // assert the stream is never opened, and IS released.
+    test("a body it will not read is cancelled rather than opened", async () => {
+      const response = new Response("ok", { status: 200 });
+      const textSpy = vi.spyOn(response, "text");
+      const readerSpy = vi.spyOn(response.body!, "getReader");
+      const cancelSpy = vi.spyOn(response.body!, "cancel");
+      mockFetch.mockImplementation(() => Promise.resolve(response));
+
+      await slackNotify({ url: SLACK_URL, text: "hi" });
+
+      expect(textSpy).not.toHaveBeenCalled();
+      expect(readerSpy).not.toHaveBeenCalled();
+      expect(cancelSpy).toHaveBeenCalled();
+      // A second cancel of an already-cancelled body must stay quiet.
+      await expect(response.body!.cancel()).resolves.toBeUndefined();
     });
 
     test("429 with a JSON retry_after body produces a retryable error with a retry date", async () => {
@@ -328,6 +355,36 @@ describe("Webhook notification tasks", () => {
       expect(error).not.toBeInstanceOf(RetryableJobError);
     });
 
+    // A rewritten `.message` is not enough: V8 bakes the ORIGINAL message into
+    // `.stack`, and stacks are persisted (formatErrorChainForDiagnostics feeds
+    // them into the stored job error), so a copied stack re-exports the token.
+    test("a rewritten error's .stack never contains the webhook token", async () => {
+      mockFetch.mockImplementation((url: string) =>
+        Promise.reject(
+          createFetchUrlJobError(
+            FetchUrlErrorCode.PRIVATE_DENIED,
+            `Refusing to fetch private/internal URL ${url}: resolves into RFC1918 space`,
+            { url }
+          )
+        )
+      );
+
+      const error = (await slackNotify({ url: SLACK_URL, text: "hi" }).catch(
+        (e: unknown) => e
+      )) as PermanentJobError & { url?: string };
+
+      const stack = String(error.stack);
+      expect(stack).not.toContain("SECRETTOKEN");
+      expect(stack).toContain("https://hooks.slack.com");
+      // Frames are retained, not thrown away, on a V8 stack.
+      expect(stack.split("\n").length).toBeGreaterThan(1);
+
+      // The persisted diagnostics dump walks the cause chain and re-serializes
+      // every message + stack it finds — it must find no token, and no cause.
+      expect(formatErrorChainForDiagnostics(error)).not.toContain("SECRETTOKEN");
+      expect(error.cause).toBeUndefined();
+    });
+
     test("the webhook URL is absent from every output schema", () => {
       for (const taskClass of [WebhookNotifyTask, SlackNotifyTask, DiscordNotifyTask]) {
         const schema = taskClass.outputSchema();
@@ -381,7 +438,9 @@ describe("Webhook notification tasks", () => {
       const results = await workflow.run();
 
       expect(results).toEqual({ success: true, status: 200 });
-      expect(lastCall().options.body).toBe(JSON.stringify({ text: "from workflow" }));
+      expect(lastCall().options.body).toBe(
+        JSON.stringify({ text: "from workflow", link_names: false })
+      );
     });
 
     test("Workflow.webhookNotify and Workflow.discordNotify are installed", () => {
@@ -424,6 +483,253 @@ describe("Webhook notification tasks", () => {
       const task = new WebhookNotifyTask();
       task.runInputData = { payload: {} } as any;
       expect(requiresPrivate(task)).toBe(true);
+    });
+
+    // `optional: true` entitlements are skipped outright by evaluatePolicy, so
+    // a decorative declaration is no gate at all on the instance that really
+    // reaches into the credential store.
+    test("a configured credential key makes the credential entitlement enforced", () => {
+      const task = new WebhookNotifyTask();
+      task.runInputData = { payload: {}, url_credential_key: "hook" } as any;
+      const credential = task.entitlements().entitlements.find((e) => e.id === "credential");
+      expect(credential).toBeDefined();
+      expect(credential!.optional).not.toBe(true);
+    });
+
+    test("without a credential key the credential entitlement stays optional", () => {
+      const task = new WebhookNotifyTask();
+      task.runInputData = { url: WEBHOOK_URL, payload: {} } as any;
+      const credential = task.entitlements().entitlements.find((e) => e.id === "credential");
+      expect(credential?.optional).toBe(true);
+    });
+  });
+
+  // A workflow piping a fetch result or a model summary into `content`/`text`
+  // would otherwise ping an entire server on every run — and a retry loop turns
+  // that into a mass-notification amplifier the caller cannot switch off, since
+  // `additionalProperties: false` means no caller can supply `allowed_mentions`
+  // themselves.
+  describe("mention neutering", () => {
+    test("Discord suppresses every mention class by default", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+
+      await discordNotify({ url: DISCORD_URL, content: "@everyone deploy done" });
+
+      expect(lastCall().options.body as string).toContain('"allowed_mentions":{"parse":[]}');
+    });
+
+    test("Discord honors allow_mentions", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+
+      await discordNotify({
+        url: DISCORD_URL,
+        content: "@everyone deploy done",
+        allow_mentions: true,
+      });
+
+      expect(lastCall().options.body as string).not.toContain("allowed_mentions");
+    });
+
+    test("Slack neutralizes channel-wide broadcasts by default", async () => {
+      await slackNotify({ url: SLACK_URL, text: "<!channel> deploy done" });
+
+      const body = lastCall().options.body as string;
+      expect(body).toContain("&lt;!channel>");
+      expect(body).not.toContain("<!channel>");
+      expect(body).toContain('"link_names":false');
+    });
+
+    test("Slack neutralizes here, everyone and subteam broadcasts too", async () => {
+      await slackNotify({
+        url: SLACK_URL,
+        text: "<!here> <!everyone> <!subteam^S123>",
+      });
+
+      const body = lastCall().options.body as string;
+      for (const form of ["<!here>", "<!everyone>", "<!subteam^S123>"]) {
+        expect(body).not.toContain(form);
+      }
+    });
+
+    // The narrow `<!` escape must not break the sequences that make Slack
+    // messages useful: links and single-user mentions.
+    test("Slack leaves links and single-user mentions intact", async () => {
+      await slackNotify({
+        url: SLACK_URL,
+        text: "<https://x/|y> pinged <@U1>",
+      });
+
+      const body = lastCall().options.body as string;
+      expect(body).toContain("<https://x/|y>");
+      expect(body).toContain("<@U1>");
+    });
+
+    test("Slack honors allow_mentions", async () => {
+      await slackNotify({
+        url: SLACK_URL,
+        text: "<!channel> deploy done",
+        allow_mentions: true,
+      });
+
+      const body = lastCall().options.body as string;
+      expect(body).toContain("<!channel>");
+      expect(body).not.toContain("&lt;!");
+      expect(body).not.toContain("link_names");
+    });
+  });
+
+  describe("request timeouts", () => {
+    // Vitest's fake timers do not drive `AbortSignal.timeout` (Node implements
+    // it on an internal timer, not the patched global), so the default is
+    // asserted at the point it is armed and the behavior with a real short one.
+    test("arms an abort signal from the default timeout", async () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+      try {
+        await slackNotify({ url: SLACK_URL, text: "hi" });
+        expect(timeoutSpy).toHaveBeenLastCalledWith(30000);
+        expect(lastCall().options.signal).toBeInstanceOf(AbortSignal);
+
+        mockFetch.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+        await discordNotify({ url: DISCORD_URL, content: "hi" });
+        expect(timeoutSpy).toHaveBeenLastCalledWith(30000);
+
+        mockFetch.mockImplementation(() => Promise.resolve(new Response("ok", { status: 200 })));
+        await webhookNotify({ url: WEBHOOK_URL, payload: {} });
+        expect(timeoutSpy).toHaveBeenLastCalledWith(30000);
+      } finally {
+        timeoutSpy.mockRestore();
+      }
+    });
+
+    test("an endpoint that never answers is aborted by the timeout", async () => {
+      mockFetch.mockImplementation(
+        (_url, options) =>
+          new Promise<Response>((_resolve, reject) => {
+            options.signal!.addEventListener("abort", () => {
+              reject((options.signal as AbortSignal).reason);
+            });
+          })
+      );
+
+      const error = await slackNotify({ url: SLACK_URL, text: "hi", timeout: 50 }).catch(
+        (e: unknown) => e
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect(String((error as Error).message)).not.toContain("SECRETTOKEN");
+    });
+
+    test("a caller abort surfaces as an abort error, not a retryable network error", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.reject(new DOMException("The operation was aborted.", "AbortError"))
+      );
+
+      const error = await slackNotify({ url: SLACK_URL, text: "hi" }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(AbortSignalJobError);
+      expect(error).not.toBeInstanceOf(RetryableJobError);
+      expect((error as { code?: string }).code).not.toBe(FetchUrlErrorCode.NETWORK_ERROR);
+    });
+  });
+
+  describe("response body cap", () => {
+    /** An endless body; `cancelled` flips when the consumer gives up on it. */
+    function endlessBody(status: number): { response: Response; cancelled: () => boolean } {
+      let cancelled = false;
+      const chunk = new Uint8Array(2 * 1024 * 1024).fill(120); // 2MB of "x"
+      const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.enqueue(chunk.slice());
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+      return {
+        response: new Response(stream, { status, statusText: "Server Error" }),
+        cancelled: () => cancelled,
+      };
+    }
+
+    test("caps the buffered response body", async () => {
+      const { response, cancelled } = endlessBody(200);
+      mockFetch.mockImplementation(() => Promise.resolve(response));
+
+      const result = await webhookNotify({ url: WEBHOOK_URL, payload: {} });
+
+      expect(result.response.length).toBeLessThanOrEqual(1024 + 3);
+      expect(cancelled()).toBe(true);
+    });
+
+    test("caps the failure body too", async () => {
+      const { response, cancelled } = endlessBody(500);
+      mockFetch.mockImplementation(() => Promise.resolve(response));
+
+      const error = (await slackNotify({ url: SLACK_URL, text: "hi" }).catch(
+        (e: unknown) => e
+      )) as RetryableJobError;
+
+      expect(error).toBeInstanceOf(RetryableJobError);
+      expect(error.message.length).toBeLessThan(2048);
+      expect(cancelled()).toBe(true);
+    });
+  });
+
+  describe("private destinations", () => {
+    // Reachability matches FetchUrlTask, but the `response` port would make
+    // this a working SSRF READ primitive against a metadata endpoint.
+    test("does not echo the response body for a private destination", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response("AKIAEXAMPLESECRET", { status: 200 }))
+      );
+
+      const result = await webhookNotify({
+        url: "http://169.254.169.254/latest/meta-data/",
+        payload: { ping: true },
+      });
+
+      expect(result.response).toBe("");
+      expect(JSON.stringify(result)).not.toContain("AKIA");
+      expect(result.status).toBe(200);
+    });
+
+    test("still echoes a public destination's body", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(new Response("pong", { status: 200 })));
+
+      const result = await webhookNotify({ url: WEBHOOK_URL, payload: {} });
+
+      expect(result.response).toBe("pong");
+    });
+  });
+
+  describe("credential misconfiguration", () => {
+    // Wiring a bearer token into `url_credential_key` is the likely mistake:
+    // for these tasks the credential must BE the whole webhook URL.
+    test("a bearer-token credential value fails with a configuration error", async () => {
+      const store = getGlobalCredentialStore();
+      await store.put("bearer-hook", "Bearer abc123");
+      const error = await webhookNotify({
+        payload: {},
+        url_credential_key: "bearer-hook",
+      })
+        .catch((e: unknown) => e)
+        .finally(() => store.delete("bearer-hook"));
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect((error as PermanentJobError).code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect((error as PermanentJobError).message).toContain("absolute http(s) URL");
+      expect((error as PermanentJobError).message).not.toContain("abc123");
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    test("a non-http scheme is rejected before any request is made", async () => {
+      const error = await webhookNotify({ url: "file:///etc/passwd", payload: {} }).catch(
+        (e: unknown) => e
+      );
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect((error as PermanentJobError).code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect(mockFetch.mock.calls.length).toBe(0);
     });
   });
 });

--- a/packages/util/src/limits.ts
+++ b/packages/util/src/limits.ts
@@ -64,6 +64,13 @@ export const SECURITY_LIMITS = {
   imageMaxInputBytesBrowser: 32 * 1024 * 1024,
   /** Max redirect hops followed by the SSRF-aware `safeFetch` wrapper. */
   safeFetchMaxRedirectHops: 20,
+  /**
+   * Max bytes buffered from a webhook response body before the read is
+   * abandoned. Truncation constants apply only after a body is fully in
+   * memory, so without this ceiling a hostile endpoint answering with an
+   * unbounded body would OOM the runner.
+   */
+  webhookMaxResponseBodyBytes: 1024 * 1024,
   /** Max accepted length (characters) of an encoded tabular storage pagination cursor. */
   tabularMaxCursorLength: 8 * 1024,
 } as const satisfies Record<string, number>;


### PR DESCRIPTION
Security follow-up on the webhook / Slack / Discord notification tasks added in the base branch. Two HIGH findings plus five hardening fixes.

*(Angle brackets below are written as HTML entities — an earlier revision of this description had them eaten by the API.)*

## HIGH — credential disclosure via `error.stack`

`BaseError` calls `Error.captureStackTrace` and never overrides `stack`, so V8 materializes it as `name: message` followed by newline-separated `at …` frames — the message is baked into the string. `SafeFetch` / `SafeFetch.server` interpolate the raw URL into seven message templates, and `toRedactedWebhookError` rewrote `.message` and `.url` but then did `rebuilt.stack = error.stack`, re-importing the very URL the surrounding function had just stripped.

**Concrete scenario:** a Slack webhook whose host resolves into RFC1918 space throws `PRIVATE_DENIED`. `.message` correctly reads `https://hooks.slack.com`, but `.stack` line 1 contains `.../services/T00/B00/SECRETTOKEN`. This is not a "logs are trusted" problem — `formatErrorChainForDiagnostics` walks the error and its `.cause` chain and pushes every `.message` + `.stack` into a **persisted** job-error string.

**Fix** — `redactedStackFrom(original, rebuilt, url)` in `WebhookPost.ts`:

1. splits the original stack and discards everything before the first frame matching `/^\s+at /` (the header can span several lines when a message contains newlines, so the split point is the first *frame*, not the first line);
2. re-prefixes the rebuilt error's own `name: message`;
3. runs the whole result through `redactWebhookUrlIn` as a second pass, covering frames that embed the URL independently;
4. **fails closed** on runtimes whose stacks carry no `at` frames — header only, never the original string.

`error.cause` is deliberately **not** copied onto the rebuilt error, with a comment at the rebuild site so it is not "helpfully" added later.

Why here and not in `SafeFetch.server.ts`: pushing redaction lower means editing message templates shared with `FetchUrlTask`, where the URL is *not* a secret and is the most useful diagnostic there is — and it would still miss undici/DNS errors that carry the hostname independently. `WebhookPost.ts` is the only layer that knows "this URL *is* the credential", and a comment now says so.

## HIGH — mention injection / mass-notification amplifier

`content` / `text` was forwarded verbatim with no mention controls. Because both input schemas are `additionalProperties: false` and `Task.setInput` only copies declared properties, a caller **could not** supply `allowed_mentions` even knowing they should.

**Concrete scenario:** a workflow pipes `FetchUrlTask` output or an LLM summary into `content`. Any `@everyone` in that text pings the whole server on every run, and a retry loop makes it an unmutable mass-notification amplifier.

- **Discord** — default `allowed_mentions: { parse: [] }`, which suppresses `@everyone` / `@here`, roles and users.
- **Slack** — Slack has **no** `allowed_mentions`, and `link_names` only governs auto-linking of bare `@name` text, so it is insufficient. Slack's documented control is HTML-entity escaping. This uses the **narrow** form: the literal two-character sequence &lt;! is replaced with &amp;lt;!, which kills all four broadcast forms (&lt;!channel&gt;, &lt;!here&gt;, &lt;!everyone&gt;, &lt;!subteam^ID&gt;) while preserving &lt;https://…|label&gt; links and &lt;@U123&gt; single-user mentions that full escaping would break. `link_names: false` is also sent explicitly. `blocks` is a caller-authored structure rather than a piped string and is **not** rewritten — documented as a limitation in the README.
- Both tasks gain an opt-in `allow_mentions` boolean (default `false`). When `true`, Discord omits `allowed_mentions` entirely and Slack sends `text` unescaped with no `link_names`.

## Decision 3 — no response echo for private destinations

Reachability parity with `FetchUrlTask` is deliberate prior art and is kept. What is removed is the **read primitive** the `response` output port created: a POST to `http://169.254.169.254/latest/meta-data/iam/security-credentials/` returned up to 1KB of the reply straight back into the graph. `WebhookNotifyTask.execute` now classifies the resolved URL and, for a private classification, passes `readSuccessBody: false` and returns an empty `response`. That costs nothing for a notification. Documented in the README Features list.

## Other hardening in this PR

- **Body cap.** `readBodyText` called `response.text()` with no ceiling; the truncation constants applied only *after* the whole body was in memory, so a 500 with a multi-GB body OOMed the runner — and the failure path buffers unconditionally for all three tasks. It now streams `response.body` via `getReader()`, decodes with a streaming `TextDecoder`, and cancels the reader past `SECURITY_LIMITS.webhookMaxResponseBodyBytes` (1MB, new).
- **Abort classification.** `fetch` rejects an aborted/timed-out request with a `DOMException`, which previously fell through to a retryable `FETCH_NETWORK_ERROR` — so cancelling a workflow looked like a transient failure. `AbortError` now yields `createFetchUrlAbortedError()`; `TimeoutError` yields an abort error when the caller's own signal is aborted and a `NETWORK_ERROR` timeout otherwise.
- **Timeouts.** Slack and Discord hard-coded `timeout: undefined` and exposed no port, and `WebhookNotifyTask.timeout` had no default, so an endpoint that completed the handshake and never answered hung the task and held a slot forever. All three now default to **30000 ms** and Slack/Discord gain `timeout` ports.
- **Credential misconfiguration.** A resolved `url_credential_key` that is not an absolute `http(s)` URL now fails with `FETCH_CONFIGURATION` naming the likely mistake ("…use FetchUrlTask instead") and **never** echoing the value. Previously a bearer token wired into that port failed with a confusing runtime `INVALID_URL`.
- **Entitlement.** The `credential` entitlement was declared `optional: true`, which `evaluatePolicy` skips outright — decorative. It is now upgraded to enforced by `webhookPrivateEntitlements` whenever `url_credential_key` is set. Checked for grant sets in `packages/test`: these three tasks have no consumers outside `packages/tasks/src` and their own test file, so nothing that only grants `network:http` breaks.
- **Descriptions.** `success` is now documented as "Always true; a non-2xx response throws" (no non-throwing mode added). `url` port descriptions no longer imply the value is safe to set inline — they say it is stored verbatim in the graph JSON and point at `url_credential_key`. No `x-ui-hidden` on `url`; it is the primary field in the builder.

## Intentional behavior changes worth a reviewer's attention

1. **Slack broadcast escaping is on by default.** A message that today pings `@channel` will stop doing so unless `allow_mentions: true` is set. This changes the wire payload (`text`, plus a new `link_names: false`), which existing payload-equality tests were updated for.
2. **Requests now time out after 30 s by default.** A previously-hanging call becomes a failure. `AbortSignal.timeout` is armed on every request, not only when a `timeout` was supplied.
3. Discord payloads now always carry `allowed_mentions` unless opted out.

## README corrections

- "429/503 and 5xx responses raise retryable errors carrying a `Retry-After` retry date" was wrong on the second half: these tasks run **inline** and `task-graph` has no retry consumer (`grep -rE 'RetryableJobError|retryDate' packages/task-graph/src` returns nothing). Replaced with "…retries require a `@workglow/job-queue` consumer, which these inline tasks do not have". Same correction applied to the Discord `retry_after` bullet — the value is parsed onto the error, not acted on.
- "never appears in errors, output, or logs" → "…in error messages, `error.url`, `error.stack`, or task output" (true only after the stack fix above).
- New bullets for `allow_mentions` and the default neutering (noting `blocks` are not rewritten), the timeout defaults, the 1MB cap, and the private-destination no-echo rule.

## Tests

`packages/test/src/test/task/NotifyTask.test.ts` grows from 26 to 45 tests, covering: the redacted `.stack` (incl. `formatErrorChainForDiagnostics` and an undefined `error.cause`), Discord/Slack default neutering and the `allow_mentions` opt-out, link and single-user-mention survival, the armed default timeout and a real short one, caller-abort classification, the 1MB cap on both the success and failure paths (with stream-cancellation assertions), the private-destination no-echo, and the bearer-token configuration error.

The pre-existing "204 without parsing a body" test's `response.text()` spy would have gone vacuous under `getReader()`; a sibling test now asserts, on a Slack 200 that *does* have a body, that neither `text()` nor `getReader()` is called, that `body.cancel()` is, and that a double-cancel does not throw.

## Verified / not verified

**Verified (commands run, output seen):**

- `bun install` — clean.
- `bunx vitest run packages/test/src/test/task/NotifyTask.test.ts` — **45 passed**.
- Same file under **`bun test`** (JavaScriptCore) — **45 passed**. The stack rebuild is heuristic across engines, so it was run under both; Bun emits `at` frames, so it keeps them rather than degrading, and the fail-closed branch is the documented behavior for engines that do not.
- Every new test was confirmed to **fail before** the fix (`git stash` of `packages/tasks/src` + `packages/util/src`, re-run): 12 failures plus a worker crash on the uncapped-body test, which is the OOM the cap now prevents.
- `bunx vitest run packages/test/src/test/task packages/test/src/test/task-graph` — 2264 passed, 1 failed: `OwnTask.test.ts` → "owns and disowns a pipe function" (`Class extends value undefined` in `Conversions.ts`), confirmed **pre-existing** on the base branch with all changes stashed.
- `bun run build:types` — 41/41 packages successful.
- `bunx eslint` + `prettier` on every changed file — clean.

**Adapted from the plan (and why):**

- The plan's T3 specified fake timers. Vitest's fake timers do **not** drive `AbortSignal.timeout` (Node implements it on an internal timer, not the patched global) — probed and confirmed `aborted === false` after advancing 5 s past a 1 s signal. The default is therefore asserted by spying on `AbortSignal.timeout` (called with `30000` for all three tasks) and the behavior by a real `timeout: 50`.
- The plan's T2 expected the Slack body to contain the fully escaped `&amp;lt;!channel&amp;gt;`, which is inconsistent with the narrow &lt;! transform the same plan prescribes (escaping the closing bracket too is what breaks links). The test asserts the half-escaped form is present and the raw broadcast absent — the broadcast is defused either way.
- The plan's T4 rejects with an `AbortError` while the caller's signal is *not* aborted, which its own "NETWORK_ERROR when `request.signal` was not aborted" rule would classify as retryable. Resolved by making the DOMException **name** the primary discriminator (`AbortError` = caller abort, `TimeoutError` = timeout) with `request.signal.aborted` as the refinement — which is what those names actually mean.
- T7 supplies the bearer token through the credential **store** (`getGlobalCredentialStore().put(...)`) rather than as a literal port value: the credential resolver returns `undefined` for an unknown key and never echoes the key back, so a raw string would have hit the "no webhook URL provided" path instead of the new one.

**Not verified:** nothing in this PR was left unrun. The one failing test in the wider sweep is pre-existing and unrelated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)