### PR TITLE
fix(triggers): scope run state per start(), contain listener errors, per-run abort

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -410,6 +410,7 @@
         "@workglow/task-graph": "workspace:*",
         "@workglow/tasks": "workspace:*",
         "@workglow/tf-mediapipe": "workspace:*",
+        "@workglow/triggers": "workspace:*",
         "@workglow/util": "workspace:*",
         "@workglow/xai": "workspace:*",
         "tslog": "^5.1.0",

--- a/packages/task-graph/src/task-graph/IWorkflow.ts
+++ b/packages/task-graph/src/task-graph/IWorkflow.ts
@@ -24,6 +24,17 @@ export interface WorkflowRunConfig {
    * multiple runs, then dispose at app shutdown.
    */
   readonly resourceScope?: ResourceScope;
+  /**
+   * Caller-owned cancellation for THIS run only.
+   *
+   * It is bridged onto the run's own controller, so aborting it cancels this
+   * run and nothing else — the listener is removed when the run ends, so a
+   * long-lived signal driving many runs accumulates nothing. That is the
+   * difference from `Workflow.abort()`, which trips the single current-run
+   * controller and therefore cancels whichever run started last — the wrong
+   * granularity when several callers (e.g. two triggers) drive one workflow.
+   */
+  readonly signal?: AbortSignal | undefined;
 }
 
 export interface IWorkflow<

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -235,6 +235,9 @@ export class Workflow<
     this.events.emit("start");
     const ctx = new WorkflowRunContext();
     this._currentRun = ctx;
+    // A caller-supplied signal cancels only THIS run; `abort()` keeps working
+    // through the run's own controller, which both sources feed.
+    if (config?.signal) ctx.linkSignal(config.signal);
     // Streaming unsub lives on the context (not the bridge) so concurrent
     // run() calls don't clobber each other's subscriptions.
     ctx.unsubStreaming = this._bridge?.beginRun();

--- a/packages/task-graph/src/task-graph/WorkflowRunContext.ts
+++ b/packages/task-graph/src/task-graph/WorkflowRunContext.ts
@@ -21,14 +21,38 @@
 export class WorkflowRunContext {
   readonly abortController: AbortController;
   unsubStreaming?: () => void;
+  private detachSignal?: () => void;
 
   constructor() {
     this.abortController = new AbortController();
   }
 
-  /** Releases the streaming subscription if one is held. Idempotent. */
+  /**
+   * Bridges a caller-supplied per-run signal onto this run's controller, so the
+   * run is cancelled by either source and the graph still sees ONE signal.
+   *
+   * A removable listener rather than `AbortSignal.any([own, caller])`: the
+   * composite that `any` mints is retained by its sources until it is collected
+   * (measurably ~1.7 KB per composite on Node 22 even after a forced GC), and a
+   * long-lived caller signal — a trigger's, say — would collect one per fire.
+   * The listener installed here is detached by {@link dispose} at run end, so
+   * nothing accumulates however many runs a driver starts.
+   */
+  linkSignal(signal: AbortSignal): void {
+    if (signal.aborted) {
+      this.abortController.abort(signal.reason);
+      return;
+    }
+    const onAbort = (): void => this.abortController.abort(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    this.detachSignal = () => signal.removeEventListener("abort", onAbort);
+  }
+
+  /** Releases the streaming subscription and the caller-signal bridge. Idempotent. */
   dispose(): void {
     this.unsubStreaming?.();
     this.unsubStreaming = undefined;
+    this.detachSignal?.();
+    this.detachSignal = undefined;
   }
 }

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -171,6 +171,33 @@ describe("Workflow", () => {
 
       await expect(runPromise).rejects.toThrow();
     });
+
+    it("should abort a run through a caller-supplied runConfig.signal", async () => {
+      // Per-run cancellation: the caller aborts THIS run without touching the
+      // workflow's own current-run controller, which is what several
+      // independent drivers (e.g. triggers) on one workflow need.
+      workflow = workflow.longRunning();
+      const controller = new AbortController();
+
+      const runPromise = workflow.run({}, { registry, signal: controller.signal });
+      await sleep(1);
+      controller.abort();
+
+      await expect(runPromise).rejects.toThrow();
+    });
+
+    it("should still honour abort() when a runConfig.signal is supplied", async () => {
+      // Both sources stay live: combining them must not shadow `abort()`.
+      workflow = workflow.longRunning();
+      const controller = new AbortController();
+
+      const runPromise = workflow.run({}, { registry, signal: controller.signal });
+      await sleep(1);
+      workflow.abort();
+
+      await expect(runPromise).rejects.toThrow();
+      expect(controller.signal.aborted).toBe(false);
+    });
   });
 
   describe("pop", () => {

--- a/packages/test/src/test/trigger/CronSchedule.test.ts
+++ b/packages/test/src/test/trigger/CronSchedule.test.ts
@@ -137,6 +137,16 @@ describe("nextCronFireTime", () => {
     );
   });
 
+  test("finds a leap day across a century non-leap year", () => {
+    // 2100 is divisible by 100 but not 400, so it is NOT a leap year: the gap
+    // from 2096-02-29 to 2104-02-29 is just under eight years, longer than a
+    // five-year search horizon would reach.
+    const schedule = parseCronExpression("0 0 29 2 *");
+    expect(iso(nextCronFireTime(schedule, at("2097-03-01T00:00:00.000Z")))).toBe(
+      "2104-02-29T00:00:00.000Z"
+    );
+  });
+
   test("day-of-month and day-of-week use OR semantics when both are restricted", () => {
     // The 1st of the month, OR any Monday.
     const schedule = parseCronExpression("0 0 1 * 1");
@@ -146,6 +156,23 @@ describe("nextCronFireTime", () => {
     expect(iso(nextCronFireTime(schedule, at("2026-03-30T12:00:00.000Z")))).toBe(
       "2026-04-01T00:00:00.000Z"
     );
+  });
+
+  test("a day list plus a weekday still ORs", () => {
+    const schedule = parseCronExpression("0 0 1,15 * 1");
+    // 2026-03-10 is a Tuesday: the 15th (a Sunday) arrives before the 16th.
+    expect(iso(nextCronFireTime(schedule, anchor))).toBe("2026-03-15T00:00:00.000Z");
+  });
+
+  test("a day field beginning with * keeps AND semantics (Vixie parity)", () => {
+    // Vixie tests the LEADING character, so `*/2` is a "star" field: the
+    // expression means "an odd day of the month AND a Monday", not "or".
+    const schedule = parseCronExpression("0 0 */2 * 1");
+    expect(schedule.dayOfMonthRestricted).toBe(false);
+    expect(schedule.dayOfWeekRestricted).toBe(true);
+    // Mondays after the Tuesday anchor are the 16th (even, no match) and the
+    // 23rd (odd, match). Under OR semantics this would answer the 11th.
+    expect(iso(nextCronFireTime(schedule, anchor))).toBe("2026-03-23T00:00:00.000Z");
   });
 
   test("a restricted day-of-month alone must match (no OR fallback)", () => {

--- a/packages/test/src/test/trigger/CronTrigger.test.ts
+++ b/packages/test/src/test/trigger/CronTrigger.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CronExpressionError, CronTrigger } from "@workglow/triggers";
+import { CronExpressionError, CronTrigger, CronUnsatisfiableError } from "@workglow/triggers";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { advanceFakeTimers, flushAsyncWork } from "../helpers/advanceFakeTimers";
@@ -182,6 +182,39 @@ describe("CronTrigger", () => {
     await advanceFakeTimers(3 * MINUTE);
     expect(fires).toBe(3);
 
+    await trigger.stop();
+  });
+
+  test("a start() that cannot compute a first fire leaves the trigger stopped", async () => {
+    // `0 0 30 2 *` parses fine — February simply never has a 30th — so the
+    // failure surfaces on the FIRST schedule, which is where `start()` must
+    // leave the trigger untouched rather than half-live.
+    useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
+    const trigger = new CronTrigger({ expression: "0 0 30 2 *" });
+    let fires = 0;
+    const handler = (): void => {
+      fires += 1;
+    };
+
+    expect(() => trigger.start(handler)).toThrow(CronUnsatisfiableError);
+    expect(trigger.running).toBe(false);
+    // A trigger left reporting `running` would swallow every later start() as a
+    // no-op; this one must still report the real failure.
+    expect(() => trigger.start(handler)).toThrow(CronUnsatisfiableError);
+
+    await advanceFakeTimers(DAY);
+    expect(fires).toBe(0);
+
+    // A valid trigger started afterwards schedules normally.
+    const healthy = new CronTrigger({ expression: "* * * * *" });
+    let healthyFires = 0;
+    healthy.start(() => {
+      healthyFires += 1;
+    });
+    await advanceFakeTimers(2 * MINUTE);
+    expect(healthyFires).toBe(2);
+
+    await healthy.stop();
     await trigger.stop();
   });
 

--- a/packages/test/src/test/trigger/IntervalTrigger.test.ts
+++ b/packages/test/src/test/trigger/IntervalTrigger.test.ts
@@ -279,6 +279,88 @@ describe("IntervalTrigger", () => {
     });
   });
 
+  test("unrefTimer unrefs the scheduled timer without changing the schedule", async () => {
+    // A running trigger otherwise keeps a Node process alive; the opt-out must
+    // not change when it fires.
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD, unrefTimer: true });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(PERIOD * 3);
+    expect(fires).toBe(3);
+
+    await trigger.stop();
+  });
+
+  describe("listener errors", () => {
+    test("a throwing skip listener does not escape the timer callback", async () => {
+      // `skip` is emitted from inside a setTimeout callback, where a throw is an
+      // uncaughtException — a `metrics.inc(...)` on a torn-down client would
+      // take the whole process down.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      trigger.on("skip", () => {
+        throw new Error("skip listener boom");
+      });
+
+      let fires = 0;
+      trigger.start(async () => {
+        fires += 1;
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(fires).toBe(1);
+
+      await advanceFakeTimers(PERIOD);
+      expect(errors.map((error) => error.message)).toContain("skip listener boom");
+
+      // ...and the trigger is still a clock afterwards.
+      gate.open();
+      await flushAsyncWork();
+      await advanceFakeTimers(PERIOD);
+      expect(fires).toBe(2);
+      expect(trigger.running).toBe(true);
+
+      await trigger.stop();
+    });
+
+    test("a throwing stop listener does not produce an unhandled rejection", async () => {
+      const rejections: unknown[] = [];
+      const onRejection = (reason: unknown): void => {
+        rejections.push(reason);
+      };
+      process.on("unhandledRejection", onRejection);
+      try {
+        const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+        const errors: Error[] = [];
+        trigger.on("error", (error) => errors.push(error));
+        trigger.on("stop", () => {
+          throw new Error("stop listener boom");
+        });
+
+        const controller = new AbortController();
+        trigger.start(() => {}, { signal: controller.signal });
+        await advanceFakeTimers(PERIOD);
+
+        // The caller-signal path stops the trigger from an event listener,
+        // where there is no caller left to observe a rejected promise.
+        controller.abort();
+        await flushAsyncWork();
+
+        expect(trigger.running).toBe(false);
+        expect(errors.map((error) => error.message)).toContain("stop listener boom");
+        expect(rejections).toEqual([]);
+      } finally {
+        process.off("unhandledRejection", onRejection);
+      }
+    });
+  });
+
   describe("abort", () => {
     test("stop() aborts the signal handed to the handler and waits for it to settle", async () => {
       const trigger = new IntervalTrigger({ intervalMs: PERIOD });
@@ -358,6 +440,108 @@ describe("IntervalTrigger", () => {
       expect(secondFires).toBe(2);
 
       await trigger.stop();
+    });
+
+    test("a restart during stop() does not emit spurious skips (skip policy)", async () => {
+      // The first generation's handler is still gated when the second starts.
+      // Overlap state belongs to a RUN, not to the trigger: if the new
+      // generation's ticks could see the old handler's in-flight count, every
+      // one of them would be dropped as an overlap until the stale handler
+      // happened to settle.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const skips: number[] = [];
+      trigger.on("skip", (scheduledAt) => skips.push(scheduledAt));
+
+      let gen1Fires = 0;
+      trigger.start(async () => {
+        gen1Fires += 1;
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(gen1Fires).toBe(1);
+
+      const stopping = trigger.stop();
+      let gen2Fires = 0;
+      trigger.start(() => {
+        gen2Fires += 1;
+      });
+
+      // Advance BEFORE releasing the old handler: this is the window where the
+      // stale run is still counted as in flight.
+      await advanceFakeTimers(PERIOD * 2);
+      expect(skips).toEqual([]);
+      expect(gen2Fires).toBe(2);
+      expect(gen1Fires).toBe(1);
+
+      gate.open();
+      await stopping;
+      await trigger.stop();
+    });
+
+    test("a queued tick from the old generation is not delivered to the new handler", async () => {
+      // Under a shared queue the OLD chain drains a tick the NEW generation
+      // queued — invoking the new handler with the old, already-aborted signal.
+      const trigger = new IntervalTrigger({
+        intervalMs: PERIOD,
+        overlap: "queue",
+        maxQueuedFires: 1,
+      });
+      const gate = createGate();
+      trigger.start(async () => {
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      const stopping = trigger.stop();
+      const abortedOnArrival: boolean[] = [];
+      trigger.start((context) => {
+        abortedOnArrival.push(context.signal.aborted);
+      });
+
+      await advanceFakeTimers(PERIOD * 2);
+      gate.open();
+      await stopping;
+      await flushAsyncWork();
+
+      expect(abortedOnArrival.length).toBeGreaterThan(0);
+      expect(abortedOnArrival).not.toContain(true);
+
+      await trigger.stop();
+    });
+
+    test("stop() called twice concurrently resolves only after the handler settles", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      let settled = false;
+      trigger.start(async () => {
+        await gate.promise;
+        settled = true;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      const resolved: string[] = [];
+      const first = trigger.stop().then(() => {
+        resolved.push("first");
+      });
+      const second = trigger.stop().then(() => {
+        resolved.push("second");
+      });
+
+      await flushAsyncWork();
+      // Neither call may resolve while the handler is still running: `stop()`
+      // means "no handler of this run is still in flight".
+      expect(resolved).toEqual([]);
+      expect(settled).toBe(false);
+
+      gate.open();
+      await Promise.all([first, second]);
+
+      expect(settled).toBe(true);
+      expect(resolved).toHaveLength(2);
     });
 
     test("an already-aborted caller signal schedules nothing", async () => {

--- a/packages/test/src/test/trigger/PollingTrigger.test.ts
+++ b/packages/test/src/test/trigger/PollingTrigger.test.ts
@@ -220,6 +220,100 @@ describe("PollingTrigger", () => {
     expect(signals[0]?.aborted).toBe(true);
   });
 
+  test("a restart resets the change-detection baseline", async () => {
+    // The baseline belongs to a RUN. Carrying it across a stop/start would make
+    // the first poll of the new run look unchanged and swallow the very value
+    // the restarted trigger was meant to report.
+    let polls = 0;
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      poll: () => {
+        polls += 1;
+        return "steady";
+      },
+      shouldFire: firesOnChange,
+    });
+
+    const payloads: unknown[] = [];
+    const handler = (context: { payload: unknown }): void => {
+      payloads.push(context.payload);
+    };
+
+    trigger.start(handler);
+    await advanceFakeTimers(PERIOD * 2);
+    expect(payloads).toEqual(["steady"]);
+    await trigger.stop();
+
+    trigger.start(handler);
+    await advanceFakeTimers(PERIOD);
+    expect(payloads).toEqual(["steady", "steady"]);
+    expect(polls).toBe(3);
+
+    await trigger.stop();
+  });
+
+  describe("errorBackoff", () => {
+    test("rejects an invalid backoff", () => {
+      expect(
+        () =>
+          new PollingTrigger({
+            intervalMs: PERIOD,
+            poll: () => 1,
+            errorBackoff: { initialMs: 0, maxMs: 100 },
+          })
+      ).toThrow(TriggerConfigurationError);
+      expect(
+        () =>
+          new PollingTrigger({
+            intervalMs: PERIOD,
+            poll: () => 1,
+            errorBackoff: { initialMs: 200, maxMs: 100 },
+          })
+      ).toThrow(TriggerConfigurationError);
+    });
+
+    test("slows the loop down while the poll keeps failing, and recovers", async () => {
+      let polls = 0;
+      let failing = true;
+      const trigger = new PollingTrigger<number>({
+        intervalMs: PERIOD,
+        poll: () => {
+          polls += 1;
+          if (failing) throw new Error("dependency down");
+          return polls;
+        },
+        errorBackoff: { initialMs: PERIOD * 2, maxMs: PERIOD * 8 },
+      });
+      trigger.on("error", () => {});
+      trigger.start(() => {});
+
+      // Full-rate ticks at P and 2P (the tick after a failure is already
+      // scheduled), then backoff: 2P, 4P, 8P, 8P...
+      await advanceFakeTimers(PERIOD * 2);
+      expect(polls).toBe(2);
+      expect(trigger.consecutiveFailures).toBe(2);
+
+      await advanceFakeTimers(PERIOD * 2);
+      expect(polls).toBe(3);
+
+      // Without backoff the same window would have added 10 more polls.
+      await advanceFakeTimers(PERIOD * 10);
+      expect(polls).toBeLessThan(7);
+
+      failing = false;
+      await advanceFakeTimers(PERIOD * 8);
+      expect(trigger.consecutiveFailures).toBe(0);
+
+      // One backed-off gap is still outstanding (the tick after the recovering
+      // poll was scheduled before it succeeded); after that, full rate resumes.
+      const recovered = polls;
+      await advanceFakeTimers(PERIOD * 4);
+      expect(polls).toBeGreaterThanOrEqual(recovered + 3);
+
+      await trigger.stop();
+    });
+  });
+
   test("stop() halts polling", async () => {
     let polls = 0;
     const trigger = new PollingTrigger<number>({

--- a/packages/test/src/test/trigger/WorkflowTriggers.test.ts
+++ b/packages/test/src/test/trigger/WorkflowTriggers.test.ts
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { CachePolicy } from "@workglow/task-graph";
+import type { CachePolicy, IExecuteContext } from "@workglow/task-graph";
 import { Task, Workflow } from "@workglow/task-graph";
 import type { ITriggerListenerHandle } from "@workglow/triggers";
 import {
+  CronTrigger,
+  CronUnsatisfiableError,
   getWorkflowTriggers,
   IntervalTrigger,
   PollingTrigger,
@@ -24,9 +26,30 @@ const PERIOD = 100;
 type RecorderInput = { label: string };
 type RecorderOutput = { recorded: string };
 
+interface Gate {
+  readonly promise: Promise<void>;
+  readonly open: () => void;
+}
+
+function createGate(): Gate {
+  let open: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { promise, open };
+}
+
 /** Records every execution so a test can assert what each trigger fire ran with. */
 const executions: string[] = [];
 let failNextRuns = 0;
+/**
+ * When set, every execution parks on this gate until it opens or its run's
+ * signal aborts — which is how a test observes WHICH in-flight run a trigger's
+ * `stop()` cancelled.
+ */
+let holdGate: Gate | undefined;
+const completed: string[] = [];
+const abortedRuns: string[] = [];
 
 class RecorderTask extends Task<RecorderInput, RecorderOutput> {
   public static override type = "TriggerRecorderTask";
@@ -52,12 +75,28 @@ class RecorderTask extends Task<RecorderInput, RecorderOutput> {
     } as const satisfies DataPortSchema;
   }
 
-  override async execute(input: RecorderInput): Promise<RecorderOutput> {
+  override async execute(input: RecorderInput, context: IExecuteContext): Promise<RecorderOutput> {
     executions.push(input.label);
     if (failNextRuns > 0) {
       failNextRuns -= 1;
       throw new Error(`run failed for ${input.label}`);
     }
+    const gate = holdGate;
+    if (gate) {
+      await new Promise<void>((resolve) => {
+        const done = (): void => {
+          context.signal.removeEventListener("abort", done);
+          resolve();
+        };
+        context.signal.addEventListener("abort", done, { once: true });
+        void gate.promise.then(done);
+      });
+      if (context.signal.aborted) {
+        abortedRuns.push(input.label);
+        throw new Error(`aborted ${input.label}`);
+      }
+    }
+    completed.push(input.label);
     return { recorded: input.label };
   }
 }
@@ -69,6 +108,9 @@ function createWorkflow(): Workflow {
 describe("Workflow trigger bindings", () => {
   beforeEach(() => {
     executions.length = 0;
+    completed.length = 0;
+    abortedRuns.length = 0;
+    holdGate = undefined;
     failNextRuns = 0;
     vi.useFakeTimers();
     vi.setSystemTime(START);
@@ -282,6 +324,107 @@ describe("Workflow trigger bindings", () => {
     expect(trigger.running).toBe(false);
     await advanceFakeTimers(PERIOD * 3);
     expect(executions).toHaveLength(1);
+  });
+
+  test("a trigger whose start() throws leaves no started triggers and no handle", async () => {
+    const workflow = createWorkflow();
+    const healthy = new IntervalTrigger({ intervalMs: PERIOD, id: "healthy" });
+    // Parses fine; February has no 30th, so it fails on the first schedule.
+    const doomed = new CronTrigger({ expression: "0 0 30 2 *", id: "doomed" });
+    workflow.trigger(healthy, { input: () => ({ label: "healthy" }) });
+    workflow.trigger(doomed);
+
+    await expect(workflow.listen()).rejects.toBeInstanceOf(CronUnsatisfiableError);
+
+    expect(healthy.running).toBe(false);
+    await advanceFakeTimers(PERIOD * 3);
+    expect(executions).toEqual([]);
+
+    // No handle was registered, so the workflow is still bindable/listenable.
+    expect(() => workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }))).not.toThrow();
+  });
+
+  test("stopping a trigger cancels the run that trigger started", async () => {
+    // The trigger's signal is forwarded as `runConfig.signal`, so it cancels
+    // exactly the run this fire started — rather than `workflow.abort()`, which
+    // trips the workflow's single current-run controller and would cancel
+    // whichever run happens to be current, no matter who started it.
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD, id: "owner" });
+    workflow.trigger(trigger, { input: () => ({ label: "owned" }) });
+
+    const handle = await workflow.listen();
+    const gate = createGate();
+    holdGate = gate;
+
+    await advanceFakeTimers(PERIOD);
+    expect(executions).toEqual(["owned"]);
+    expect(abortedRuns).toEqual([]);
+
+    const stopping = trigger.stop();
+    await flushAsyncWork();
+    expect(abortedRuns).toEqual(["owned"]);
+    expect(completed).toEqual([]);
+
+    holdGate = undefined;
+    gate.open();
+    await stopping;
+
+    // The cancellation is the expected path, not an error to report.
+    expect(trigger.running).toBe(false);
+    await handle.stop();
+  });
+
+  test("a second trigger keeps running when the first one is stopped", async () => {
+    const workflow = createWorkflow();
+    const first = new IntervalTrigger({ intervalMs: PERIOD * 4, id: "first" });
+    const second = new IntervalTrigger({ intervalMs: PERIOD, id: "second" });
+    workflow.trigger(first, { input: () => ({ label: "first" }) });
+    workflow.trigger(second, { input: () => ({ label: "second" }) });
+
+    const handle = await workflow.listen();
+    await advanceFakeTimers(PERIOD * 4);
+    expect(executions).toContain("first");
+    expect(executions.filter((label) => label === "second")).toHaveLength(4);
+
+    await first.stop();
+    executions.length = 0;
+
+    await advanceFakeTimers(PERIOD * 4);
+    expect(executions).not.toContain("first");
+    expect(executions.filter((label) => label === "second")).toHaveLength(4);
+    expect(second.running).toBe(true);
+
+    await handle.stop();
+  });
+
+  test("a caller signal abort releases the handle so the workflow can listen again", async () => {
+    const workflow = createWorkflow();
+    workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }), {
+      input: () => ({ label: "before" }),
+    });
+    const controller = new AbortController();
+
+    await workflow.listen({ signal: controller.signal });
+    await advanceFakeTimers(PERIOD);
+    expect(executions).toEqual(["before"]);
+
+    controller.abort();
+    await flushAsyncWork();
+
+    // The handle must be gone, or binding stays locked and listen() keeps
+    // handing back a stale handle whose triggers are all dead.
+    expect(() =>
+      workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }), {
+        input: () => ({ label: "after" }),
+      })
+    ).not.toThrow();
+
+    const handle = await workflow.listen();
+    await advanceFakeTimers(PERIOD);
+    expect(executions).toContain("after");
+
+    await handle.stop();
   });
 
   test("a fire with no input mapping runs the workflow with its declared defaults", async () => {

--- a/packages/triggers/README.md
+++ b/packages/triggers/README.md
@@ -11,11 +11,11 @@ npm install @workglow/triggers
 
 ## Triggers
 
-| Trigger           | Fires                                                    |
-| ----------------- | -------------------------------------------------------- |
-| `IntervalTrigger` | every `intervalMs`, starting one full period after `start()` |
+| Trigger           | Fires                                                         |
+| ----------------- | ------------------------------------------------------------- |
+| `IntervalTrigger` | every `intervalMs`, starting one full period after `start()`  |
 | `PollingTrigger`  | only when a poll result is interesting (non-empty by default) |
-| `CronTrigger`     | on the UTC instants matching a 5-field cron expression   |
+| `CronTrigger`     | on the UTC instants matching a 5-field cron expression        |
 
 ```ts
 import { CronTrigger, IntervalTrigger, PollingTrigger } from "@workglow/triggers";
@@ -38,25 +38,30 @@ import { Workflow } from "@workglow/task-graph";
 const workflow = new Workflow().addTask(MyTask);
 
 workflow.trigger(new IntervalTrigger({ intervalMs: 60_000 }));
-workflow.trigger(
-  new PollingTrigger({ intervalMs: 5_000, poll: () => fetchPendingIds() }),
-  { input: (context) => ({ ids: context.payload }) }
-);
+workflow.trigger(new PollingTrigger({ intervalMs: 5_000, poll: () => fetchPendingIds() }), {
+  input: (context) => ({ ids: context.payload }),
+});
 
 await using handle = await workflow.listen();
 ```
 
 `listen()` **resolves as soon as the triggers are scheduled — it does not block
-until the process is interrupted.** Keeping the process alive is the host
-application's job. Stop with `handle.stop()`, `workflow.stopListening()`, or by
-letting an `await using` scope exit.
+until the process is interrupted.** It does not, however, leave the process free
+to exit: a scheduled `setTimeout` is a live handle, so under Node or Bun a
+started trigger keeps the process alive until it is stopped. A CLI or a test
+that forgets `stop()` therefore hangs. Pass `unrefTimer: true` to any trigger
+whose schedule should not by itself hold the process open. Stop with
+`handle.stop()`, `workflow.stopListening()`, or by letting an `await using`
+scope exit.
 
 ## Behavior worth knowing
 
 - **Abort** — `stop()` aborts the signal handed to handlers and resolves only
-  once in-flight handlers settle. A caller signal passed to `start()` is linked
-  with `AbortSignal.any`. Under the workflow bindings, stopping also aborts the
-  in-flight workflow run.
+  once in-flight handlers settle; concurrent `stop()` calls join the same drain.
+  A caller signal passed to `start()` is linked with `AbortSignal.any`. Under
+  the workflow bindings, stopping a trigger aborts only the workflow runs THAT
+  trigger started — the signal is forwarded as `runConfig.signal`, so a second
+  trigger bound to the same workflow keeps running.
 - **Overlap** — `overlap: "skip" | "queue" | "concurrent"`, default `"skip"`. A
   tick arriving while the previous handler runs is dropped (and emits `skip`); a
   trigger is a clock, not a work queue, so a slow handler cannot grow a backlog.
@@ -66,7 +71,10 @@ letting an `await using` scope exit.
   not from when its handler finished, so handler duration never accumulates.
   Waits longer than a timer's ~24.8-day ceiling are chunked.
 - **Cron** — 5 fields, **UTC only**, supporting `*`, `N`, `a,b`, `a-b`, `*/n`,
-  and `a-b/n`. Day-of-month and day-of-week use standard OR semantics when both
-  are restricted. Macros (`@daily`), names (`MON`), and `L`/`W`/`#` are rejected
-  rather than guessed at.
+  and `a-b/n`. Day-of-month and day-of-week use standard OR semantics only when
+  NEITHER field begins with `*`: `0 0 1 * 1` is "the 1st **or** any Monday",
+  while `0 0 */2 * 1` is "every other day **and** a Monday" — Vixie cron's
+  leading-`*` rule, so a crontab line ported here means what it meant there.
+  Macros (`@daily`), names (`MON`), and `L`/`W`/`#` are rejected rather than
+  guessed at.
 - **Delivery** — in-process and at most once. Nothing survives a restart.

--- a/packages/triggers/src/cron/CronSchedule.ts
+++ b/packages/triggers/src/cron/CronSchedule.ts
@@ -22,9 +22,12 @@ export interface CronSchedule {
   readonly months: ReadonlySet<number>;
   /** 0-6, Sunday = 0. A `7` in the expression is normalized to `0`. */
   readonly daysOfWeek: ReadonlySet<number>;
-  /** True when the day-of-month field is anything other than `*`. */
+  /**
+   * True when the day-of-month field does NOT begin with `*` — Vixie cron's
+   * `DOM_STAR` flag, inverted. See {@link matchesDay} for what it selects.
+   */
   readonly dayOfMonthRestricted: boolean;
-  /** True when the day-of-week field is anything other than `*`. */
+  /** True when the day-of-week field does NOT begin with `*`. */
   readonly dayOfWeekRestricted: boolean;
 }
 
@@ -45,8 +48,19 @@ const CRON_FIELD_COUNT = 5;
 
 const MINUTE_MS = 60_000;
 
-/** How far ahead {@link nextCronFireTime} searches before declaring an expression unsatisfiable. */
-const MAX_SEARCH_YEARS = 5;
+/**
+ * How far ahead {@link nextCronFireTime} searches before declaring an
+ * expression unsatisfiable.
+ *
+ * It has to clear the longest real gap between two matches, and leap day is
+ * that gap: century years divisible by 100 but not 400 are NOT leap years, so
+ * `0 0 29 2 *` jumps from 2096-02-29 straight to 2104-02-29 — just under eight
+ * years. Nine gives that margin without letting a genuinely impossible
+ * expression (`0 0 30 2 *`) search for long: the month and day fast-forwards in
+ * {@link nextCronFireTime} skip whole months and days at a time, so the horizon
+ * costs a few hundred iterations, not years of minutes.
+ */
+const MAX_SEARCH_YEARS = 9;
 
 /**
  * Parses a 5-field cron expression.
@@ -61,9 +75,11 @@ const MAX_SEARCH_YEARS = 5;
  * a year and zero times on another); UTC has no such gaps, so it is the only
  * dialect this package will guess at.
  *
- * Day-of-month and day-of-week use standard cron **OR** semantics: when both are
- * restricted a day matches if EITHER matches, so `0 0 1 * 1` fires on the 1st of
- * the month AND on every Monday.
+ * Day-of-month and day-of-week use standard cron **OR** semantics: when NEITHER
+ * field begins with `*`, a day matches if EITHER matches — so `0 0 1 * 1` fires
+ * on the 1st of the month AND on every Monday. A field beginning with `*`
+ * (including a step such as `*&#47;2`) switches back to AND, matching Vixie
+ * cron's `DOM_STAR`/`DOW_STAR` rule. See {@link matchesDay}.
  */
 export function parseCronExpression(expression: string): CronSchedule {
   if (typeof expression !== "string") {
@@ -102,8 +118,12 @@ export function parseCronExpression(expression: string): CronSchedule {
     daysOfMonth: parseField(dayOfMonthRaw, DAY_OF_MONTH_FIELD, normalized),
     months: parseField(monthRaw, MONTH_FIELD, normalized),
     daysOfWeek,
-    dayOfMonthRestricted: dayOfMonthRaw !== "*",
-    dayOfWeekRestricted: dayOfWeekRaw !== "*",
+    // Vixie tests the LEADING character, not the whole field: `*/2` is still a
+    // "star" field there, so it keeps AND semantics. Comparing against `"*"`
+    // instead made `0 0 */2 * 1` mean "every other day OR every Monday", which
+    // is not what the same crontab line does anywhere else.
+    dayOfMonthRestricted: !dayOfMonthRaw.startsWith("*"),
+    dayOfWeekRestricted: !dayOfWeekRaw.startsWith("*"),
   };
 }
 
@@ -261,13 +281,21 @@ export function nextCronFireTime(schedule: CronSchedule, afterMs: number): numbe
   );
 }
 
+/**
+ * Vixie cron's day rule: when BOTH day fields are restricted (neither begins
+ * with `*`) a day matches if EITHER set contains it; otherwise both sets must
+ * contain it — which, since `*` expands to every value, reduces to "the
+ * restricted field decides".
+ *
+ * The AND branch consults both sets deliberately. A field like `*&#47;2` is a
+ * star field for the OR/AND decision but still carries a narrowed set, so
+ * `0 0 *&#47;2 * 1` means "every other day of the month AND a Monday".
+ */
 function matchesDay(schedule: CronSchedule, date: Date): boolean {
-  const dayOfMonth = date.getUTCDate();
-  const dayOfWeek = date.getUTCDay();
+  const dayOfMonthMatches = schedule.daysOfMonth.has(date.getUTCDate());
+  const dayOfWeekMatches = schedule.daysOfWeek.has(date.getUTCDay());
   if (schedule.dayOfMonthRestricted && schedule.dayOfWeekRestricted) {
-    return schedule.daysOfMonth.has(dayOfMonth) || schedule.daysOfWeek.has(dayOfWeek);
+    return dayOfMonthMatches || dayOfWeekMatches;
   }
-  if (schedule.dayOfMonthRestricted) return schedule.daysOfMonth.has(dayOfMonth);
-  if (schedule.dayOfWeekRestricted) return schedule.daysOfWeek.has(dayOfWeek);
-  return true;
+  return dayOfMonthMatches && dayOfWeekMatches;
 }

--- a/packages/triggers/src/trigger/BaseTrigger.ts
+++ b/packages/triggers/src/trigger/BaseTrigger.ts
@@ -11,6 +11,7 @@ import type {
   OverlapPolicy,
   TriggerEventListener,
   TriggerEventListeners,
+  TriggerEventParameters,
   TriggerEvents,
   TriggerHandler,
   TriggerStartOptions,
@@ -32,6 +33,47 @@ export interface TriggerOptions {
   readonly overlap?: OverlapPolicy | undefined;
   /** Backlog bound for the `"queue"` policy. Defaults to `1`. */
   readonly maxQueuedFires?: number | undefined;
+  /**
+   * Call `unref()` on the scheduled timer where the host supports it (Node and
+   * Bun; a browser's numeric handle has no such method and is left alone).
+   *
+   * A running trigger otherwise keeps a Node process alive, which is the right
+   * default for a server but wrong for a CLI or a test that forgets `stop()`.
+   */
+  readonly unrefTimer?: boolean | undefined;
+}
+
+/**
+ * Everything one {@link BaseTrigger.start} owns: the handler, the abort
+ * plumbing, the pending timer, and the overlap counters.
+ *
+ * The OBJECT IDENTITY is the generation token. Every scheduling and dispatch
+ * path takes its run as a parameter instead of reading `this`, so a chain left
+ * over from a previous `start()` physically cannot see a newer run's counters,
+ * shift its queued ticks, or invoke its handler with a stale (already aborted)
+ * signal. A `stop()` that is still draining therefore cannot disturb a restart.
+ */
+export interface TriggerRun {
+  /** Handler registered by the `start()` that created this run. */
+  readonly handler: TriggerHandler;
+  /** Aborted by `stop()`; the source of {@link TriggerRun.signal}. */
+  readonly controller: AbortController;
+  /** Signal handed to handlers — the controller, linked with any caller signal. */
+  readonly signal: AbortSignal;
+  /** Scheduled instants held back by the `"queue"` overlap policy. */
+  readonly queued: number[];
+  /** Tick chains that have not settled yet; `stop()` awaits these. */
+  readonly pending: Set<Promise<void>>;
+  /** Handle of the pending tick, if one is scheduled. */
+  timer: ReturnType<typeof setTimeout> | undefined;
+  /** Handler invocations currently in flight. */
+  inFlight: number;
+  /** False from the moment `stop()` is entered; nothing new is scheduled after. */
+  active: boolean;
+  /** Detaches the caller-signal abort listener, when one was registered. */
+  removeExternalAbort: (() => void) | undefined;
+  /** The in-flight `stop()` for this run, so a second `stop()` joins it. */
+  stopping: Promise<void> | undefined;
 }
 
 /**
@@ -52,24 +94,10 @@ export abstract class BaseTrigger implements ITrigger {
 
   protected readonly overlap: OverlapPolicy;
   protected readonly maxQueuedFires: number;
+  protected readonly unrefTimer: boolean;
 
-  private _running = false;
-  private _handler: TriggerHandler | undefined;
-  private _controller: AbortController | undefined;
-  private _signal: AbortSignal | undefined;
-  private _externalAbort: (() => void) | undefined;
-  private _timer: ReturnType<typeof setTimeout> | undefined;
-  private _inFlight = 0;
-  private readonly _queued: number[] = [];
-  private readonly _pending = new Set<Promise<void>>();
-  /**
-   * Bumped by every {@link start}. `stop()` awaits in-flight handlers before
-   * releasing state, and a restart during that await belongs to a newer
-   * generation — without this token the old `stop()` would null out the NEW
-   * run's handler and signal, leaving a trigger that reports `running` but can
-   * never fire again.
-   */
-  private _generation = 0;
+  /** The current run, or `undefined` when the trigger is stopped and drained. */
+  private _run: TriggerRun | undefined;
 
   constructor(options: TriggerOptions = {}) {
     this.id = options.id ?? uuid4();
@@ -85,10 +113,11 @@ export abstract class BaseTrigger implements ITrigger {
         `maxQueuedFires must be a positive integer, received ${String(options.maxQueuedFires)}.`
       );
     }
+    this.unrefTimer = options.unrefTimer ?? false;
   }
 
   public get running(): boolean {
-    return this._running;
+    return this._run?.active === true;
   }
 
   public on<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
@@ -103,58 +132,86 @@ export abstract class BaseTrigger implements ITrigger {
     this.events.once(name, fn);
   }
 
+  /**
+   * @throws whatever {@link computeNextFireTime} throws (a `CronTrigger` whose
+   *   expression matches no instant within the search horizon raises
+   *   `CronUnsatisfiableError` here). The first fire time is computed BEFORE any
+   *   state is touched, so a throw leaves the trigger exactly as it was — still
+   *   stopped, with nothing scheduled and no listener attached.
+   */
   public start(handler: TriggerHandler, options: TriggerStartOptions = {}): void {
     // Starting twice is a no-op rather than an error, so a start/start/stop
     // sequence leaves no orphaned timer behind.
-    if (this._running) return;
+    if (this.running) return;
     // An already-aborted caller signal means "do not schedule anything".
     if (options.signal?.aborted) return;
 
-    this._running = true;
-    this._generation += 1;
-    this._handler = handler;
-    this._controller = new AbortController();
-    this._signal = options.signal
-      ? AbortSignal.any([this._controller.signal, options.signal])
-      : this._controller.signal;
+    // Compute first, mutate second. Setting `_run` before a computation that can
+    // throw would leave the trigger reporting `running` with no timer, and every
+    // later `start()` would be a silent no-op forever.
+    const firstFireAt = this.computeNextFireTime(Date.now());
+
+    const controller = new AbortController();
+    const run: TriggerRun = {
+      handler,
+      controller,
+      signal: options.signal
+        ? AbortSignal.any([controller.signal, options.signal])
+        : controller.signal,
+      queued: [],
+      pending: new Set(),
+      timer: undefined,
+      inFlight: 0,
+      active: true,
+      removeExternalAbort: undefined,
+      stopping: undefined,
+    };
+    this._run = run;
 
     if (options.signal) {
       const externalSignal = options.signal;
       const onExternalAbort = (): void => {
-        void this.stop();
+        // `.catch` rather than `void`: a `stop` listener that throws would
+        // otherwise reject a floating promise and take a Node host down with an
+        // unhandledRejection. `stop()` reports its own failures.
+        this.stop().catch(() => {});
       };
       externalSignal.addEventListener("abort", onExternalAbort, { once: true });
-      this._externalAbort = () => externalSignal.removeEventListener("abort", onExternalAbort);
+      run.removeExternalAbort = () => externalSignal.removeEventListener("abort", onExternalAbort);
     }
 
-    this.scheduleAt(this.computeNextFireTime(Date.now()));
-    this.events.emit("start");
+    this.scheduleAt(run, firstFireAt);
+    this.safeEmit("start");
   }
 
-  public async stop(): Promise<void> {
-    if (!this._running) return;
+  /**
+   * Cancels the pending tick, aborts the signal handed to handlers, and
+   * resolves once every in-flight handler for this run has settled.
+   *
+   * Concurrent calls join the same drain: the second call returns the first
+   * call's promise rather than resolving early, so `await stop()` always means
+   * "no handler of that run is still running".
+   */
+  public stop(): Promise<void> {
+    const run = this._run;
+    if (!run) return Promise.resolve();
+    if (run.stopping) return run.stopping;
 
-    const generation = this._generation;
-    this._running = false;
-    if (this._timer !== undefined) {
-      clearTimeout(this._timer);
-      this._timer = undefined;
+    run.active = false;
+    if (run.timer !== undefined) {
+      clearTimeout(run.timer);
+      run.timer = undefined;
     }
-    this._queued.length = 0;
-    this._externalAbort?.();
-    this._externalAbort = undefined;
-    this._controller?.abort();
+    run.queued.length = 0;
+    run.removeExternalAbort?.();
+    run.removeExternalAbort = undefined;
 
-    await Promise.allSettled([...this._pending]);
-
-    // A `start()` during the await above installed a fresh handler/controller
-    // for a newer generation; releasing them here would strand that run.
-    if (this._generation !== generation) return;
-
-    this._handler = undefined;
-    this._controller = undefined;
-    this._signal = undefined;
-    this.events.emit("stop");
+    // Record the drain BEFORE aborting: an abort listener that re-enters
+    // `stop()` must join this drain instead of starting a second one.
+    const stopping = this.releaseWhenIdle(run);
+    run.stopping = stopping;
+    run.controller.abort();
+    return stopping;
   }
 
   /**
@@ -169,53 +226,95 @@ export abstract class BaseTrigger implements ITrigger {
    * that resolves data first (see `PollingTrigger`) overrides this and may
    * decline to invoke the handler at all. A throw here is caught by the loop,
    * reported on the `error` event, and does not stop the trigger.
+   *
+   * The run is passed explicitly — read `run.signal`, never a field on `this` —
+   * so a chain belonging to a superseded generation stays on its own state.
    */
-  protected async runTick(scheduledAt: number, signal: AbortSignal): Promise<void> {
-    await this.invokeHandler({
+  protected async runTick(scheduledAt: number, run: TriggerRun): Promise<void> {
+    await this.invokeHandler(run, {
       triggerId: this.id,
       scheduledAt,
-      signal,
+      signal: run.signal,
       payload: undefined,
     });
   }
 
-  /** Emits `fire` and awaits the registered handler. */
-  protected async invokeHandler(context: ITriggerFireContext): Promise<void> {
-    const handler = this._handler;
-    if (!handler) return;
-    this.events.emit("fire", context);
-    await handler(context);
+  /** Emits `fire` and awaits the run's registered handler. */
+  protected async invokeHandler(run: TriggerRun, context: ITriggerFireContext): Promise<void> {
+    this.safeEmit("fire", context);
+    await run.handler(context);
   }
 
-  private scheduleAt(targetMs: number): void {
+  /**
+   * Called once a run has stopped and every handler it started has settled, so
+   * a subclass can release per-generation state (see `PollingTrigger`).
+   *
+   * NOT called when a newer `start()` has already taken over: that run owns the
+   * subclass state now, and resetting it here would corrupt it.
+   */
+  protected onRunStopped(): void {}
+
+  private async releaseWhenIdle(run: TriggerRun): Promise<void> {
+    // A loop, not a single `allSettled`: a chain draining queued ticks may still
+    // be adding work when the first snapshot is taken.
+    while (run.pending.size > 0) {
+      await Promise.allSettled([...run.pending]);
+    }
+
+    // A `start()` during the drain installed a newer run; releasing subclass
+    // state or clearing `_run` here would strand it.
+    if (this._run === run) {
+      this._run = undefined;
+      this.onRunStopped();
+    }
+    this.safeEmit("stop");
+  }
+
+  private scheduleAt(run: TriggerRun, targetMs: number): void {
     const remaining = Math.max(0, targetMs - Date.now());
-    this._timer = setTimeout(
+    const timer = setTimeout(
       () => {
-        this._timer = undefined;
-        if (!this._running) return;
+        run.timer = undefined;
+        if (!run.active) return;
         // A chunked wait (or an early host timer) lands before the target.
         if (Date.now() < targetMs) {
-          this.scheduleAt(targetMs);
+          this.scheduleAt(run, targetMs);
           return;
         }
-        this.onTick(targetMs);
+        this.onTick(run, targetMs);
       },
       Math.min(remaining, MAX_TIMER_DELAY_MS)
     );
+    run.timer = timer;
+    if (this.unrefTimer) {
+      // Node/Bun return a Timeout object; a browser returns a number.
+      (timer as unknown as { unref?: () => void }).unref?.();
+    }
   }
 
-  private onTick(scheduledAt: number): void {
-    this.scheduleAt(this.computeNextFireTime(scheduledAt));
-    this.dispatch(scheduledAt);
+  private onTick(run: TriggerRun, scheduledAt: number): void {
+    let nextFireAt: number;
+    try {
+      nextFireAt = this.computeNextFireTime(scheduledAt);
+    } catch (error) {
+      // Nothing can be scheduled, so there is no half-live state worth keeping:
+      // report and shut down rather than leave a trigger that reports `running`
+      // and will never fire again.
+      this.reportError(error, scheduledAt);
+      this.stop().catch(() => {});
+      return;
+    }
+    this.scheduleAt(run, nextFireAt);
+    this.dispatch(run, scheduledAt);
   }
 
-  private dispatch(scheduledAt: number): void {
-    if (this.overlap !== "concurrent" && (this._inFlight > 0 || this._queued.length > 0)) {
-      if (this.overlap === "queue" && this._queued.length < this.maxQueuedFires) {
-        this._queued.push(scheduledAt);
+  private dispatch(run: TriggerRun, scheduledAt: number): void {
+    if (this.overlap !== "concurrent" && (run.inFlight > 0 || run.queued.length > 0)) {
+      if (this.overlap === "queue" && run.queued.length < this.maxQueuedFires) {
+        run.queued.push(scheduledAt);
         return;
       }
-      this.events.emit("skip", scheduledAt);
+      this.safeEmit("skip", scheduledAt);
       getLogger().warn("Trigger fire skipped; previous handler still running", {
         triggerId: this.id,
         kind: this.kind,
@@ -225,48 +324,80 @@ export abstract class BaseTrigger implements ITrigger {
       return;
     }
 
-    const chain = this.runTickChain(scheduledAt);
-    this._pending.add(chain);
+    const chain = this.runTickChain(run, scheduledAt);
+    run.pending.add(chain);
     // `catch` before `finally`: `runTickChain` reports handler errors itself,
     // but an `error` LISTENER that throws rejects the chain, and a bare
     // `chain.finally(...)` would surface that as an unhandled rejection —
     // crashing a Node host whose only fault was a noisy listener. `stop()`
     // still awaits `chain` itself through `allSettled`.
-    void chain.catch(() => {}).finally(() => this._pending.delete(chain));
+    void chain.catch(() => {}).finally(() => run.pending.delete(chain));
   }
 
   /**
    * Runs a tick and then drains queued ticks iteratively — a recursive drain
    * would keep every queued frame alive for the lifetime of the trigger.
    */
-  private async runTickChain(first: number): Promise<void> {
-    // `stop()` clears the signal only after awaiting the pending chains, so the
-    // signal captured here stays valid for every tick in this chain.
-    const signal = this._signal;
-    if (!signal) return;
-
+  private async runTickChain(run: TriggerRun, first: number): Promise<void> {
     let scheduledAt: number | undefined = first;
     while (scheduledAt !== undefined) {
-      this._inFlight += 1;
+      run.inFlight += 1;
       try {
-        await this.runTick(scheduledAt, signal);
+        await this.runTick(scheduledAt, run);
       } catch (error) {
         this.reportError(error, scheduledAt);
       } finally {
-        this._inFlight -= 1;
+        run.inFlight -= 1;
       }
-      scheduledAt = this._running ? this._queued.shift() : undefined;
+      // Only this run's queue: a superseded chain must never shift a tick a
+      // newer generation queued, nor hand it the newer handler.
+      scheduledAt = run.active ? run.queued.shift() : undefined;
     }
   }
 
   private reportError(error: unknown, scheduledAt: number): void {
     const wrapped = error instanceof Error ? error : new Error(String(error));
-    this.events.emit("error", wrapped);
+    this.safeEmit("error", wrapped);
     getLogger().error("Trigger handler failed", {
       triggerId: this.id,
       kind: this.kind,
       scheduledAt,
       error: wrapped.message,
     });
+  }
+
+  /**
+   * Emits without letting a listener's throw escape.
+   *
+   * `EventEmitter.emit` deliberately RE-THROWS what listeners throw, which is
+   * load-bearing elsewhere in the monorepo but fatal here: most of these emits
+   * happen inside a `setTimeout` callback, where a throw is an
+   * uncaughtException that takes the process down — a `metrics.inc(...)` on a
+   * torn-down client is enough. A failing listener is reported on `error`
+   * instead, and an `error` listener that itself throws is only logged, so this
+   * can never recurse.
+   */
+  private safeEmit<Event extends TriggerEvents>(
+    name: Event,
+    ...args: TriggerEventParameters<Event>
+  ): void {
+    try {
+      this.events.emit(name, ...args);
+    } catch (error) {
+      const wrapped = error instanceof Error ? error : new Error(String(error));
+      if (name !== "error") {
+        try {
+          this.events.emit("error", wrapped);
+        } catch {
+          // Nowhere left to report it; the log below is the last word.
+        }
+      }
+      getLogger().error("Trigger event listener failed", {
+        triggerId: this.id,
+        kind: this.kind,
+        event: name,
+        error: wrapped.message,
+      });
+    }
   }
 }

--- a/packages/triggers/src/trigger/ITrigger.ts
+++ b/packages/triggers/src/trigger/ITrigger.ts
@@ -113,13 +113,21 @@ export interface ITrigger {
   /**
    * Begins scheduling. Calling this on an already-running trigger is a no-op,
    * so a start/start/stop sequence leaves nothing scheduled.
+   *
+   * @throws when the first fire time cannot be computed — a `CronTrigger` whose
+   *   expression matches no instant within the search horizon raises
+   *   `CronUnsatisfiableError`. The computation happens before any state is
+   *   touched, so a throwing `start()` leaves the trigger stopped with nothing
+   *   scheduled; callers that start several triggers should stop the ones they
+   *   already started.
    */
   start(handler: TriggerHandler, options?: TriggerStartOptions): void;
 
   /**
    * Cancels the pending tick, aborts the signal handed to handlers, and
    * resolves once any in-flight handler has settled — so a caller that awaits
-   * `stop()` knows no handler is still running.
+   * `stop()` knows no handler is still running. Concurrent calls join the same
+   * drain rather than resolving early.
    */
   stop(): Promise<void>;
 

--- a/packages/triggers/src/trigger/PollingTrigger.ts
+++ b/packages/triggers/src/trigger/PollingTrigger.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TriggerOptions } from "./BaseTrigger";
+import type { TriggerOptions, TriggerRun } from "./BaseTrigger";
 import { BaseTrigger } from "./BaseTrigger";
 import { assertValidIntervalMs, nextFixedIntervalFireTime } from "./fixedInterval";
 import { TRIGGER_KINDS } from "./ITrigger";
@@ -34,6 +34,17 @@ export function firesOnChange<Result>(result: Result, previous: Result | undefin
   return !Object.is(result, previous);
 }
 
+/**
+ * Exponential backoff applied after consecutive poll failures, so a dependency
+ * that is hard down is not hammered at the full poll rate indefinitely.
+ */
+export interface PollErrorBackoff {
+  /** Delay after the first failure, in milliseconds. A positive integer. */
+  readonly initialMs: number;
+  /** Ceiling the doubling stops at, in milliseconds. At least `initialMs`. */
+  readonly maxMs: number;
+}
+
 export interface PollingTriggerOptions<Result> extends TriggerOptions {
   /** Period between polls, in milliseconds. Must be a positive integer. */
   readonly intervalMs: number;
@@ -45,6 +56,12 @@ export interface PollingTriggerOptions<Result> extends TriggerOptions {
    * change-detection semantics.
    */
   readonly shouldFire?: PollResultPredicate<Result> | undefined;
+  /**
+   * Back off after consecutive poll failures instead of polling at the full
+   * rate. Omitted (the default) keeps the fixed period no matter how the poll
+   * fares. The counter resets on the first poll that does not throw.
+   */
+  readonly errorBackoff?: PollErrorBackoff | undefined;
 }
 
 /**
@@ -55,7 +72,8 @@ export interface PollingTriggerOptions<Result> extends TriggerOptions {
  * The poll result is handed to the handler as `context.payload`. A poll that
  * throws is reported on the `error` event and does not stop the loop; the
  * previous result is left unchanged so the next comparison is against the last
- * value actually observed.
+ * value actually observed. Pass `errorBackoff` to slow the loop down while a
+ * dependency stays down instead of polling it at full rate.
  */
 export class PollingTrigger<Result = unknown> extends BaseTrigger {
   public readonly kind = TRIGGER_KINDS.polling;
@@ -63,7 +81,9 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
 
   private readonly _poll: (signal: AbortSignal) => Result | Promise<Result>;
   private readonly _shouldFire: PollResultPredicate<Result>;
+  private readonly _errorBackoff: PollErrorBackoff | undefined;
   private _previous: Result | undefined;
+  private _consecutiveFailures = 0;
 
   constructor(options: PollingTriggerOptions<Result>) {
     super(options);
@@ -73,6 +93,9 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
     }
     this._poll = options.poll;
     this._shouldFire = options.shouldFire ?? ((result) => isNonEmptyPollResult(result));
+    this._errorBackoff = options.errorBackoff
+      ? assertValidErrorBackoff(options.errorBackoff)
+      : undefined;
   }
 
   /** Most recent successfully polled result, or `undefined` before the first poll. */
@@ -80,12 +103,33 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
     return this._previous;
   }
 
+  /** Consecutive poll failures since the last poll that did not throw. */
+  public get consecutiveFailures(): number {
+    return this._consecutiveFailures;
+  }
+
   protected computeNextFireTime(fromMs: number): number {
+    const backoff = this._errorBackoff;
+    if (backoff && this._consecutiveFailures > 0) {
+      // The next tick was already scheduled when the failing one started, so the
+      // backoff takes effect from the tick AFTER the first failure.
+      const exponent = Math.min(this._consecutiveFailures - 1, 31);
+      const delay = Math.min(backoff.maxMs, backoff.initialMs * 2 ** exponent);
+      return fromMs + delay;
+    }
     return nextFixedIntervalFireTime(fromMs, this.intervalMs);
   }
 
-  protected override async runTick(scheduledAt: number, signal: AbortSignal): Promise<void> {
-    const result = await this._poll(signal);
+  protected override async runTick(scheduledAt: number, run: TriggerRun): Promise<void> {
+    const signal = run.signal;
+    let result: Result;
+    try {
+      result = await this._poll(signal);
+    } catch (error) {
+      this._consecutiveFailures += 1;
+      throw error;
+    }
+    this._consecutiveFailures = 0;
     // Bail before recording the result: an aborted tick never fires, so keeping
     // its value as the baseline would make the NEXT `firesOnChange` comparison
     // see no change and swallow the very update this tick observed.
@@ -93,11 +137,36 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
     const previous = this._previous;
     this._previous = result;
     if (!this._shouldFire(result, previous)) return;
-    await this.invokeHandler({
+    await this.invokeHandler(run, {
       triggerId: this.id,
       scheduledAt,
       signal,
       payload: result,
     });
   }
+
+  /**
+   * The baseline and the failure streak belong to ONE run: a restart is a fresh
+   * observation window, and a `firesOnChange` trigger comparing against a
+   * baseline from the previous run would swallow the first change after it.
+   */
+  protected override onRunStopped(): void {
+    this._previous = undefined;
+    this._consecutiveFailures = 0;
+  }
+}
+
+function assertValidErrorBackoff(backoff: PollErrorBackoff): PollErrorBackoff {
+  if (!Number.isInteger(backoff.initialMs) || backoff.initialMs < 1) {
+    throw new TriggerConfigurationError(
+      `errorBackoff.initialMs must be a positive integer, received ${String(backoff.initialMs)}.`
+    );
+  }
+  if (!Number.isInteger(backoff.maxMs) || backoff.maxMs < backoff.initialMs) {
+    throw new TriggerConfigurationError(
+      `errorBackoff.maxMs must be an integer >= initialMs (${backoff.initialMs}), ` +
+        `received ${String(backoff.maxMs)}.`
+    );
+  }
+  return backoff;
 }

--- a/packages/triggers/src/workflow/WorkflowTriggers.ts
+++ b/packages/triggers/src/workflow/WorkflowTriggers.ts
@@ -6,6 +6,7 @@
 
 import type { DataPorts, WorkflowRunConfig } from "@workglow/task-graph";
 import { Workflow } from "@workglow/task-graph";
+import { getLogger } from "@workglow/util";
 import type { ITrigger, ITriggerFireContext } from "../trigger/ITrigger";
 import { WorkflowTriggerError } from "../trigger/TriggerError";
 
@@ -113,17 +114,25 @@ Workflow.prototype.listen = async function (
     );
   }
 
-  for (const binding of bindings) {
-    binding.trigger.start(
-      (context) => runWorkflowForFire(this, binding, context),
-      options.signal ? { signal: options.signal } : {}
-    );
-  }
-
   const triggers = bindings.map((binding) => binding.trigger);
-  const stop = async (): Promise<void> => {
-    await Promise.all(triggers.map((trigger) => trigger.stop()));
+  let detachAbort: (() => void) | undefined;
+
+  const releaseHandle = (): void => {
+    detachAbort?.();
+    detachAbort = undefined;
     if (workflowHandles.get(this) === handle) workflowHandles.delete(this);
+  };
+
+  const stop = async (): Promise<void> => {
+    // `allSettled`, not `all`: a trigger whose stop rejects must not leave the
+    // rest of them scheduling forever.
+    const results = await Promise.allSettled(triggers.map((trigger) => trigger.stop()));
+    releaseHandle();
+    for (const result of results) {
+      if (result.status === "rejected") {
+        getLogger().error("Trigger failed to stop", { error: String(result.reason) });
+      }
+    }
   };
   const handle: ITriggerListenerHandle = {
     triggers,
@@ -131,7 +140,42 @@ Workflow.prototype.listen = async function (
     [Symbol.asyncDispose]: stop,
   };
 
+  // Registered BEFORE the triggers start, so the rollback path below (and a
+  // caller-signal abort) can always find the handle to release.
   workflowHandles.set(this, handle);
+
+  if (options.signal) {
+    const signal = options.signal;
+    // Each trigger already stops itself on this signal, but the HANDLE also has
+    // to go: otherwise an aborted listen() leaves `workflow.trigger(...)`
+    // throwing forever and a later listen() returning dead triggers.
+    const onAbort = (): void => {
+      void stop();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    detachAbort = () => signal.removeEventListener("abort", onAbort);
+    // An already-aborted signal never fires the listener; nothing will start.
+    if (signal.aborted) void stop();
+  }
+
+  const started: ITrigger[] = [];
+  try {
+    for (const binding of bindings) {
+      binding.trigger.start(
+        (context) => runWorkflowForFire(this, binding, context),
+        options.signal ? { signal: options.signal } : {}
+      );
+      started.push(binding.trigger);
+    }
+  } catch (error) {
+    // A `start()` can throw (an unsatisfiable cron, say). Leaving the earlier
+    // triggers running would drive the workflow forever with no handle to stop
+    // them through.
+    await Promise.allSettled(started.map((trigger) => trigger.stop()));
+    releaseHandle();
+    throw error;
+  }
+
   return handle;
 };
 
@@ -146,20 +190,17 @@ async function runWorkflowForFire(
 ): Promise<void> {
   const input = binding.options.input ? await binding.options.input(context) : {};
 
-  // Stopping the trigger must also cancel the run it started, not merely stop
-  // scheduling the next one.
-  const onAbort = (): void => {
-    void workflow.abort();
-  };
-  context.signal.addEventListener("abort", onAbort, { once: true });
+  // Forward the trigger's signal into the run itself rather than calling
+  // `workflow.abort()`: that aborts the workflow's CURRENT run, which — with
+  // two triggers bound to one workflow — is whichever run started last, so
+  // stopping trigger A would cancel trigger B's in-flight run and leave A's own
+  // older run going. A per-run signal cancels exactly the run this fire started.
   try {
-    await workflow.run(input, binding.options.runConfig);
+    await workflow.run(input, { ...binding.options.runConfig, signal: context.signal });
   } catch (error) {
     // A run cancelled by our own stop() is the expected path, not a failure to
     // report on the trigger's `error` event.
     if (context.signal.aborted) return;
     throw error;
-  } finally {
-    context.signal.removeEventListener("abort", onAbort);
   }
 }

--- a/packages/workglow/package.json
+++ b/packages/workglow/package.json
@@ -264,6 +264,7 @@
     "@workglow/sqlite": "workspace:*",
     "@workglow/storage": "workspace:*",
     "@workglow/task-graph": "workspace:*",
+    "@workglow/triggers": "workspace:*",
     "@workglow/browser-control": "workspace:*",
     "@workglow/javascript": "workspace:*",
     "@workglow/mcp": "workspace:*",

--- a/packages/workglow/src/common.ts
+++ b/packages/workglow/src/common.ts
@@ -16,6 +16,10 @@ export * from "@workglow/postgres/job-queue";
 export * from "@workglow/duckdb/storage";
 export * from "@workglow/storage";
 export * from "@workglow/task-graph";
+// After task-graph: this package patches `Workflow.prototype` with
+// `.trigger()` / `.listen()`, so the meta-package must pull it in for a
+// consumer importing only `workglow` to get those methods at all.
+export * from "@workglow/triggers";
 export * from "@workglow/browser-control/task";
 export * from "@workglow/javascript/task";
 export * from "@workglow/mcp/tasks";

--- a/packages/workglow/tsconfig.json
+++ b/packages/workglow/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "../storage" },
     { "path": "../job-queue" },
     { "path": "../task-graph" },
+    { "path": "../triggers" },
     { "path": "../knowledge-base" },
     { "path": "../tasks" },
     { "path": "../ai" },


### PR DESCRIPTION
Review fixes stacking on #679. No PR template exists in this repo, so the headings below are my own.

## The five HIGH findings

**1. Cross-generation state leak (the root cause of two of the others).**
`_handler`, `_controller`/`_signal`, `_timer`, `_inFlight`, `_queued` and `_pending` all lived on the trigger and were read through `this` by `scheduleAt`, `onTick`, `dispatch` and `runTickChain`. The only cross-generation guard was the `_generation` integer, and it was compared exactly twice — both inside `stop()`'s teardown, never on the dispatch path. Two failures reproduced (both are now committed tests that fail on the base branch):

- *skip policy* — gen-1's handler is still running, `void t.stop(); t.start(newHandler)`, and the new generation's ticks see `_inFlight > 0` and emit `skip`: two spurious skips, **zero** fires, until the stale handler happens to settle.
- *queue policy* — the OLD chain's drain loop shifts a tick the **new** generation queued (because `_running` is true again) and invokes the new handler with the OLD, already-aborted signal.

**2. A throwing event listener kills the process.** `EventEmitter.emit` re-throws what listeners throw. Four of the five emit sites are reached from inside a `setTimeout` callback, where a throw is an uncaughtException (exit 9). A `skip` listener doing `metrics.inc(...)` on a torn-down client was enough. The fifth, `stop`, was reached through `void this.stop()` on the caller-signal path, where the same throw became an unhandledRejection with no caller left to observe it.

**3. `start()` mutates before it can throw.** It set `_running = true` and only then called `computeNextFireTime`. A `CronTrigger` whose expression matches nothing in the horizon left the trigger reporting `running` with no timer, so every later `start()` was a silent no-op forever. Worse inside `listen()`: the throw propagated after earlier triggers had started, `workflowHandles` was never set, those timers drove the workflow forever, and `stopListening()` was a no-op against them.

**4. A concurrent `stop()` resolves early.** `if (!this._running) return;` made a second concurrent `stop()` resolve without awaiting in-flight handlers — directly contradicting what `ITrigger.stop()` documents ("resolves once any in-flight handler has settled").

**5. Stopping one trigger aborts another's run.** `runWorkflowForFire` wired `context.signal` to `workflow.abort()`, which trips the workflow's single `_currentRun` controller — "last-run-wins". Stopping trigger A cancelled whichever run was current, no matter who started it.

## The three design decisions

**Decision 1 — object identity as the generation token.** The `_generation` integer is replaced by a `TriggerRun` object holding the handler, controller/signal, timer, queue, pending set, in-flight count and an `active` flag. `start()` builds one; `scheduleAt` / `onTick` / `dispatch` / `runTickChain` / `runTick` / `invokeHandler` all take it as a parameter and test `run.active` instead of `this._running`; `stop()` captures it, flips `active`, and clears `this._run` only if it is still that object. A stale chain physically cannot see a newer run's counters or shift its queue. The protected extension points therefore change shape — `runTick(scheduledAt, run)` and `invokeHandler(run, context)` — and a `protected onRunStopped()` hook is added (only `PollingTrigger` overrides either).

**Decision 2 — contain listener errors in the triggers package, do not touch `EventEmitter`.** The re-throw at `packages/util/src/events/EventEmitter.ts:203-234` is load-bearing across `Workflow.events`, the task-graph event bridge and job-queue; changing it needs its own PR and a monorepo audit. Instead a private `safeEmit` wraps all five emit sites: a failing listener is reported on `error` and logged, and an `error` listener that itself throws is only logged — never re-entered, never rethrown. The caller-signal path uses `stop().catch(...)`, and `Workflow.listen`'s teardown uses `Promise.allSettled` so one bad trigger cannot leave the rest running.

**Decision 3 — a per-run signal on `WorkflowRunConfig`, not `workflow.abort()`.** `WorkflowRunConfig` gains `readonly signal?: AbortSignal`, and `runWorkflowForFire` forwards `context.signal` through it instead of wiring `workflow.abort()`. Aborting it cancels exactly the run that fire started; `abort()` keeps working through the run's own controller.

> **Deviation from the plan, stated explicitly.** The plan specified combining the signals with `AbortSignal.any([ctx.abortController.signal, config.signal])` at `Workflow.ts:244`, and flagged "check `ctx.dispose()` leaves no leak under many runs" as a risk. It does not. Measured on Node 22.22 with `--expose-gc`, 100k `AbortSignal.any([perRun, longLived])` calls against one long-lived source retain **~1,760 B each even after a forced GC** (a trigger firing once a second would retain ~150 MB/day); an add/remove listener pair on the same source retains 0.6 B. `AbortSignal.any` also has no un-link, so `dispose()` has nothing to call. I therefore bridge the caller signal onto the run's own controller with a removable listener, installed by a new `WorkflowRunContext.linkSignal()` and detached in the existing `dispose()`. Semantics are identical (one signal reaches the graph, either source cancels the run, `abort()` unaffected) and the retention is provably zero.

## Also in this PR

- `start()` computes the first fire time before touching any state, and `listen()` wraps the start loop: on a throw it stops the triggers it already started, deletes the handle, and rethrows. `ITrigger.start()` gains a `@throws`.
- `onTick` catches a failing `computeNextFireTime` → reports on `error` and stops, rather than keeping a half-live trigger.
- `stop()` stores its drain on the run and hands it to a concurrent caller; it resolves immediately only when there is genuinely no run.
- `unrefTimer` option on `TriggerOptions` (guarded `unref?.()`, so browser builds are unaffected).
- `PollingTrigger`: reads `run.signal`, resets its `firesOnChange` baseline in `onRunStopped` (a restart used to compare against a stale baseline), and gains an optional `errorBackoff: { initialMs, maxMs }` so a hard-down dependency is not polled at full rate indefinitely.
- `listen()` now also releases its handle when the caller signal aborts. Previously the handle was deleted only inside `handle.stop()`, so an aborted `listen({signal})` left `workflow.trigger(...)` throwing `WorkflowTriggerError` forever and `listen()` returning a stale handle full of dead triggers.
- The meta-package (`packages/workglow`) re-exports `@workglow/triggers` — it never did, so a `workglow`-only consumer got neither the exports nor the `Workflow.prototype` patch. Verified against `assertNoExportCollisions` by building that package.
- README: `listen()` still resolves immediately, but a started trigger *does* keep a Node process alive unless `unrefTimer: true` (the old text said process liveness was purely the host's job, which actively misleads); the abort bullet now says stopping aborts only the runs that trigger started.

## ⚠️ Intentional behavior change: Vixie day semantics

`CronSchedule` computed `dayOfMonthRestricted` / `dayOfWeekRestricted` as `raw !== "*"`. Vixie cron tests the **leading character** (`DOM_STAR` / `DOW_STAR`), so `*/2` counts as a star field there and keeps AND semantics. Under the old rule `0 0 */2 * 1` flipped to OR and meant "every other day **or** any Monday" — not what the same crontab line does anywhere else. It now means "an odd day of the month **and** a Monday". `matchesDay` was rewritten to consult both sets in the AND branch (a star field can still carry a narrowed set); the OR case for two genuinely restricted fields — `0 0 1 * 1`, `0 0 1,15 * 1` — is unchanged and pinned by tests.

`MAX_SEARCH_YEARS` also goes 5 → 9: a leap-day gap reaches ~7.9 years across a century non-leap year (2096-02-29 → 2104-02-29, since 2100 is not a leap year), so `0 0 29 2 *` evaluated in 2097 wrongly threw `CronUnsatisfiableError`.

## Verification

Ran, and saw pass:

- `bun install`, then `bun run use-source` (source-mode stubs; the repo's `dist` was absent).
- `bunx vitest run packages/test/src/test/trigger` — **125 passed** (108 pre-existing + 17 new).
- `bunx vitest run packages/test/src/test/task-graph` — **1215 passed across 131 files**, the blast radius of the `Workflow` / `WorkflowRunContext` change.
- `bun run build:types` — 42/42 tasks green.
- `bun run --cwd packages/workglow build-js` — `assertNoExportCollisions` clean with `@workglow/triggers` added to the barrel.
- `bunx eslint` and `bunx prettier --check` on every changed file.

**Fail-before/pass-after**: I reverted the seven implementation files, kept the new tests, and re-ran. **11 of the new tests failed** on the base branch and pass on this one — both generation-leak cases, both listener-error cases, the concurrent `stop()`, the throwing `start()` (trigger and `listen()` variants), the caller-signal re-`listen()`, the century leap day, the Vixie `*/2` case, and the `runConfig.signal` abort. Four more new tests pass on both branches by design (regression guards, not repros): "stopping a trigger cancels the run that trigger started", "a second trigger keeps running when the first is stopped", `abort()`-still-works-with-a-run-signal, and the retained `1,15` OR case.

**Second risk checked**: widening `MAX_SEARCH_YEARS` to 9 does not make the scan expensive — the existing month/day fast-forwards skip whole months and days, so the worst case (an unsatisfiable expression scanning the full horizon) measures **63 µs per call**, and the 7-year leap-day search 48 µs.

### What I could NOT verify

- **The plan's T7 as written — "two triggers on one workflow, stopping one does not abort the other's *in-flight* run" — is not reachable.** `TaskGraph` rejects a concurrent run on the same graph ("Graph is already running"), so one workflow can never have two runs in flight, and the second trigger's fire errors out rather than parking. I adapted: the triggers-layer test asserts that a trigger's `stop()` cancels *its own* run (the mechanism Decision 3 installs) and that a second trigger keeps scheduling, and the per-run-vs-`abort()` distinction is pinned directly at the `Workflow` level in `Workflow.test.ts` instead. The finding itself stands — `workflow.abort()` targeting `_currentRun` is the wrong granularity — it just cannot be demonstrated through two simultaneous trigger runs.
- **Node 24.** The container ships Node 22.22 (`/opt/node22`) and Bun 1.3.11; the `AbortSignal.any` retention numbers above are Node 22's. Bun's own implementation showed ~0.2 B/call. The chosen removable-listener approach is leak-free on any runtime, so this does not gate the change.
- I did not run the repo's full `bun run test` (bun-native suites, provider integration tests) — only the trigger and task-graph vitest suites plus the full type build.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhfGNbddCCJR71UvDw2c7f)_