### PR TITLE
fix(util): last complete object wins when skipping JSON preamble

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -247,10 +247,29 @@ sequence of partial deltas cannot supply.
 Do **not** accumulate the JSON text to produce it. Feed the deltas to
 `createPartialJsonStream()` (`@workglow/util/worker`, or `/schema` off-worker):
 `push(chunk)` is O(chunk) and returns the partial object to emit as an
-`object-delta`, and `finish()` returns the value for `finish.data.object`.
+`object-delta`, and `finishObject()` returns the value for `finish.data.object`.
 Re-parsing a growing buffer on every delta is O(n²) and blocks the worker
 thread. Use the `skipPreamble` option for providers that emit prose, a
 `<think>` block, or a code fence ahead of the JSON.
+
+Use `finishObject()`, not `finish()`. `finish()` is typed `JsonValue` because it
+honestly returns whatever the document had at its root — an array or a scalar
+for a malformed response — and `StructuredGenerationTask` requires an object.
+`finishObject()` yields `{}` for a non-object root, so validation fails loudly on
+the missing required keys instead of the task receiving a value whose "keys" are
+array indices.
+
+`skipPreamble` is **last-complete-wins**: a closed root is provisional, so a
+later `{` starts a fresh candidate that supersedes it and the LAST complete
+object is what `finish()` returns. A thinking model that restates the schema or
+shows a few-shot example before answering would otherwise lock onto the prose
+object — and a schema-shaped one passes re-validation, so the wrong record gets
+persisted with no error anywhere. The cost is that trailing prose containing its
+own complete object supersedes the payload, so keep asking for the JSON last;
+trailing prose with no `{` in it never restarts anything. Nothing is re-scanned
+(a restart begins at the `{` that triggered it), so the parser stays O(total
+input) — but it does keep scanning trailing text for the life of the stream
+rather than exiting early at the first close.
 
 `push()` returns the parser's **live** root, which later pushes mutate — that
 aliasing is what keeps it linear. It is safe for the `object-delta` path

--- a/packages/task-graph/src/cache/resolveRef.ts
+++ b/packages/task-graph/src/cache/resolveRef.ts
@@ -114,92 +114,101 @@ export async function resolveOutput<T>(
   resolver: CacheRefResolver,
   options?: ResolveOutputOptions
 ): Promise<T> {
-  if (!hasRef(output, new WeakSet())) return output;
+  if (isCacheRef(output)) {
+    const limit = createLimiter(options?.concurrency);
+    return (await walk(output, resolver, limit, new WeakSet(), undefined, new WeakSet())) as T;
+  }
+  const scan = scanContainers(output);
+  if (!scan.hasRef) return output;
   const limit = createLimiter(options?.concurrency);
   // Acyclic values (the norm) memoize each container's resolution promise so a
   // subtree shared between two slots resolves ONCE and both slots receive the
   // same resolved copy — a plain visited-set would hand the second slot the
   // original, unresolved object. Cyclic values keep the conservative
   // visited-set behavior: cycles are returned by reference, unrewritten.
-  const memo = containsCycle(output) ? undefined : new WeakMap<object, Promise<unknown>>();
-  return (await walk(output, resolver, limit, new WeakSet(), memo)) as T;
+  const memo = scan.hasCycle ? undefined : new WeakMap<object, Promise<unknown>>();
+  return (await walk(output, resolver, limit, new WeakSet(), memo, scan.refBearing)) as T;
+}
+
+/** What one traversal of the output tells the walker. */
+interface ContainerScan {
+  /** Containers from which a {@link CacheRef} is reachable. */
+  readonly refBearing: WeakSet<object>;
+  /** Whether any ref is reachable at all — lets `resolveOutput` preserve identity. */
+  readonly hasRef: boolean;
+  /** Whether a back-edge exists, which disables resolution memoization. */
+  readonly hasCycle: boolean;
+}
+
+/** Children the walker would descend into, in walk order. */
+function childrenOf(value: object): readonly unknown[] {
+  if (Array.isArray(value)) return value;
+  if (value instanceof Map) return Array.from(value.values());
+  if (value instanceof Set) return Array.from(value);
+  return Object.values(value as Record<string, unknown>);
 }
 
 /**
- * Depth-first cycle probe over the same container vocabulary as the walker
- * (plain objects, Array, Map, Set; leaves are opaque). Gray/black coloring:
- * an object seen again while still on the current path is a back-edge.
- */
-function containsCycle(
-  value: unknown,
-  gray: WeakSet<object> = new WeakSet(),
-  black: WeakSet<object> = new WeakSet()
-): boolean {
-  if (value === null || typeof value !== "object" || isLeaf(value)) return false;
-  const obj = value as object;
-  if (black.has(obj)) return false;
-  if (gray.has(obj)) return true;
-  gray.add(obj);
-  const children: Iterable<unknown> = Array.isArray(value)
-    ? value
-    : value instanceof Map
-      ? value.values()
-      : value instanceof Set
-        ? value
-        : Object.values(value);
-  for (const child of children) {
-    if (containsCycle(child, gray, black)) return true;
-  }
-  gray.delete(obj);
-  black.add(obj);
-  return false;
-}
-
-/**
- * Cheap pre-scan: returns `true` if any {@link CacheRef} is reachable inside
- * `value`. Lets `resolveOutput` short-circuit and preserve identity when
- * nothing needs resolving.
+ * Single iterative pass over the walker's container vocabulary (plain objects,
+ * Array, Map, Set; leaves are opaque) answering everything the walk needs to
+ * know up front: which containers hold a reachable {@link CacheRef}, whether
+ * any ref exists at all, and whether the graph has a back-edge.
  *
- * `visited` short-circuits cyclic and shared-subtree structures: revisiting an
- * already-seen object answers `false` instead of recursing forever. The
- * pre-scan is a containment check, so reporting `false` on a revisit is safe —
- * if a ref were reachable through that subtree, the FIRST visit would have
- * found it.
+ * One pass, not three: a per-container `hasRef` probe inside the walk re-scanned
+ * each node's whole subtree, making resolution O(n·depth). It is iterative for
+ * the same reason — a deeply nested model output (thousands of levels) blew the
+ * stack in the recursive probe, surfacing as a `RangeError` from cache
+ * resolution rather than a cache miss.
+ *
+ * Cycles keep the pre-existing approximation: a container reached again while
+ * still on the current path contributes nothing to its parent's answer. A ref
+ * reachable ONLY through a back-edge can therefore go unnoticed, which is
+ * consistent with the walker returning cycles by reference, unrewritten.
  */
-function hasRef(value: unknown, visited: WeakSet<object>): boolean {
-  if (isCacheRef(value)) return true;
-  if (value === null || value === undefined) return false;
-  if (isLeaf(value)) return false;
-  if (typeof value === "object") {
-    if (visited.has(value as object)) return false;
-    visited.add(value as object);
+function scanContainers(root: unknown): ContainerScan {
+  const refBearing = new WeakSet<object>();
+  if (root === null || typeof root !== "object" || isLeaf(root)) {
+    return { refBearing, hasRef: false, hasCycle: false };
   }
-  if (Array.isArray(value)) {
-    for (const v of value) {
-      if (hasRef(v, visited)) return true;
+  const done = new WeakSet<object>();
+  const onPath = new WeakSet<object>();
+  let hasCycle = false;
+
+  type Frame = { readonly node: object; readonly children: readonly unknown[]; index: number };
+  const stack: Frame[] = [{ node: root, children: childrenOf(root), index: 0 }];
+  onPath.add(root);
+
+  while (stack.length > 0) {
+    const frame = stack[stack.length - 1]!;
+    if (frame.index >= frame.children.length) {
+      stack.pop();
+      onPath.delete(frame.node);
+      done.add(frame.node);
+      const parent = stack[stack.length - 1];
+      if (parent !== undefined && refBearing.has(frame.node)) refBearing.add(parent.node);
+      continue;
     }
-    return false;
-  }
-  if (value instanceof Map) {
-    for (const v of value.values()) {
-      if (hasRef(v, visited)) return true;
+    const child = frame.children[frame.index++];
+    if (isCacheRef(child)) {
+      refBearing.add(frame.node);
+      continue;
     }
-    return false;
-  }
-  if (value instanceof Set) {
-    for (const v of value) {
-      if (hasRef(v, visited)) return true;
+    if (child === null || typeof child !== "object" || isLeaf(child)) continue;
+    const obj = child as object;
+    if (onPath.has(obj)) {
+      hasCycle = true;
+      continue;
     }
-    return false;
-  }
-  if (typeof value === "object") {
-    const source = value as Record<string, unknown>;
-    for (const k of Object.keys(source)) {
-      if (hasRef(source[k], visited)) return true;
+    if (done.has(obj)) {
+      // Shared subtree: its answer is already final, so reuse it.
+      if (refBearing.has(obj)) refBearing.add(frame.node);
+      continue;
     }
-    return false;
+    onPath.add(obj);
+    stack.push({ node: obj, children: childrenOf(obj), index: 0 });
   }
-  return false;
+
+  return { refBearing, hasRef: refBearing.has(root), hasCycle };
 }
 
 async function walk(
@@ -207,7 +216,8 @@ async function walk(
   resolver: CacheRefResolver,
   limit: Limiter,
   visited: WeakSet<object>,
-  memo: WeakMap<object, Promise<unknown>> | undefined
+  memo: WeakMap<object, Promise<unknown>> | undefined,
+  refBearing: WeakSet<object>
 ): Promise<unknown> {
   if (isCacheRef(value)) {
     return limit.run(() => resolver(value));
@@ -226,14 +236,16 @@ async function walk(
     // topology, including any unresolved refs the cycle contains.
     return value;
   }
-  if (!hasRef(value, new WeakSet())) return value;
+  // Answered by the single up-front scan; probing the subtree here made
+  // resolution O(n·depth) and recursed once per level.
+  if (!refBearing.has(obj)) return value;
   if (memo) {
-    const promise = walkContainer(value, resolver, limit, visited, memo);
+    const promise = walkContainer(value, resolver, limit, visited, memo, refBearing);
     memo.set(obj, promise);
     return promise;
   }
   visited.add(obj);
-  return walkContainer(value, resolver, limit, visited, memo);
+  return walkContainer(value, resolver, limit, visited, memo, refBearing);
 }
 
 async function walkContainer(
@@ -241,16 +253,19 @@ async function walkContainer(
   resolver: CacheRefResolver,
   limit: Limiter,
   visited: WeakSet<object>,
-  memo: WeakMap<object, Promise<unknown>> | undefined
+  memo: WeakMap<object, Promise<unknown>> | undefined,
+  refBearing: WeakSet<object>
 ): Promise<unknown> {
   if (Array.isArray(value)) {
-    return Promise.all(value.map((v) => walk(v, resolver, limit, visited, memo)));
+    return Promise.all(value.map((v) => walk(v, resolver, limit, visited, memo, refBearing)));
   }
   if (value instanceof Map) {
     const out = new Map();
     const entries = Array.from(value.entries());
     const resolved = await Promise.all(
-      entries.map(async ([k, v]) => [k, await walk(v, resolver, limit, visited, memo)] as const)
+      entries.map(
+        async ([k, v]) => [k, await walk(v, resolver, limit, visited, memo, refBearing)] as const
+      )
     );
     for (const [k, v] of resolved) out.set(k, v);
     return out;
@@ -258,7 +273,7 @@ async function walkContainer(
   if (value instanceof Set) {
     const out = new Set();
     const resolved = await Promise.all(
-      Array.from(value).map((v) => walk(v, resolver, limit, visited, memo))
+      Array.from(value).map((v) => walk(v, resolver, limit, visited, memo, refBearing))
     );
     for (const v of resolved) out.add(v);
     return out;
@@ -273,7 +288,7 @@ async function walkContainer(
     // matches the input even though resolutions race.
     const keys = Object.keys(source);
     const resolvedValues = await Promise.all(
-      keys.map((k) => walk(source[k], resolver, limit, visited, memo))
+      keys.map((k) => walk(source[k], resolver, limit, visited, memo, refBearing))
     );
     for (let i = 0; i < keys.length; i++) out[keys[i]!] = resolvedValues[i];
     return out;

--- a/packages/task-graph/src/task-graph/__tests__/resolveOutput.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/resolveOutput.test.ts
@@ -192,4 +192,53 @@ describe("resolveOutput", () => {
     expect(out.target instanceof URL).toBe(true);
     expect(resolver).not.toHaveBeenCalled();
   });
+
+  describe("deep values", () => {
+    /** A left-spine chain `{child:{child:…{bottom}}}`, `width` scalars per level. */
+    const chain = (
+      depth: number,
+      bottom: Record<string, unknown>,
+      width = 0
+    ): Record<string, unknown> => {
+      let node = bottom;
+      for (let i = 0; i < depth; i++) {
+        const next: Record<string, unknown> = { child: node };
+        for (let k = 0; k < width; k++) next[`f${k}`] = `v${k}`;
+        node = next;
+      }
+      return node;
+    };
+
+    it("scans a 50k-deep ref-free value without overflowing the stack", async () => {
+      // The pre-scan recursed once per level, so a deeply nested model output
+      // raised a RangeError out of cache resolution instead of answering "no
+      // refs here". Identity is still preserved: nothing needed resolving, and
+      // the walker is never entered.
+      const resolver = vi.fn<CacheRefResolver>();
+      const input = chain(50_000, { leaf: "bottom" });
+      const out = await resolveOutput(input, resolver);
+      expect(out).toBe(input);
+      expect(resolver).not.toHaveBeenCalled();
+    });
+
+    it("resolves a ref under a deep chain without re-scanning each level", async () => {
+      // A per-container pre-scan inside the walk re-read each node's whole
+      // subtree, making resolution O(n·depth). The bound is loose enough that
+      // only an algorithmic regression trips it: ~590ms before, ~30ms after.
+      const depth = 400;
+      const blob = new Blob([new Uint8Array([1])]);
+      const input = chain(depth, { payload: ref("cache://deep") as unknown as Blob }, 100);
+      const started = performance.now();
+      const out = (await resolveOutput(input, fakeResolver({ "cache://deep": blob }))) as Record<
+        string,
+        unknown
+      >;
+      const elapsed = performance.now() - started;
+
+      let cursor: Record<string, unknown> = out;
+      for (let i = 0; i < depth; i++) cursor = cursor.child as Record<string, unknown>;
+      expect(cursor.payload).toBe(blob);
+      expect(elapsed).toBeLessThan(250);
+    });
+  });
 });

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -1,5 +1,40 @@
 # @workglow/util
 
+## Unreleased
+
+### Bug Fixes
+
+#### util
+
+- `createPartialJsonStream({ skipPreamble: true })`: **last complete object wins**.
+  A closed root is now provisional — it is retained and scanning resumes, so a
+  later `{` starts a fresh candidate that supersedes it. Previously the parser
+  latched onto the FIRST syntactically valid object in the preamble and ignored
+  the real payload, while still reporting `complete: true`. A thinking model that
+  restates the schema (`{"type":"object"}`) or shows a few-shot example
+  (`{"name":"Alice"}`) before answering therefore returned the wrong document —
+  and a schema-shaped one passes re-validation, so it was persisted silently.
+  Nothing is re-scanned, so the parser stays O(total input); the accepted
+  trade-off is that trailing prose containing a complete object now supersedes
+  the payload. `Mode.Done` is no longer reachable in this mode, so the parser
+  keeps scanning trailing text for the life of the stream (bounded, no buffering).
+- `PartialJsonStream.complete` no longer reports `true` for a root that only
+  closed because `finish()` repaired a truncated token (`push('"abc')`).
+
+### BREAKING
+
+#### util
+
+- `PartialJsonStream.finish()` is now declared as `JsonValue` (a new exported
+  type) instead of `Record<string, unknown>`. The runtime behavior is unchanged
+  — an array- or scalar-rooted document was always returned as such — but the
+  declared type was a lie, so `Object.keys(stream.finish())` on an array root
+  type-checked and silently produced `["0","1","2"]`. Callers feeding a consumer
+  that requires an object should switch to the new
+  `PartialJsonStream.finishObject()`, which yields `{}` for an array or scalar
+  root; all in-repo provider run-fns have been migrated. Third-party run-fns
+  calling `finish()` will see a compile break — intentionally.
+
 ## 0.3.38
 
 ### Features

--- a/packages/util/src/json-schema/PartialJsonStream.ts
+++ b/packages/util/src/json-schema/PartialJsonStream.ts
@@ -25,7 +25,11 @@ const Mode = {
   Number: 6,
   /** Inside a `true` / `false` / `null` token. */
   Literal: 7,
-  /** The root value closed; further input is ignored. */
+  /**
+   * The root value closed; further input is ignored. Unreachable while skipping
+   * preamble, where a closed root is provisional and scanning resumes in
+   * {@link Mode.Seek} — see {@link PartialJsonStreamOptions.skipPreamble}.
+   */
   Done: 8,
   /** Malformed input; further input is ignored and the partial root is kept. */
   Invalid: 9,
@@ -112,11 +116,31 @@ type PendingSlot =
   | { readonly kind: "array"; readonly target: unknown[]; readonly index: number }
   | { readonly kind: "root" };
 
+/** Any value `JSON.parse` can produce. */
+export type JsonValue =
+  string | number | boolean | null | readonly JsonValue[] | { readonly [key: string]: JsonValue };
+
 export interface PartialJsonStreamOptions {
   /**
    * Discard any text before the first `{`. Use for providers that emit prose,
-   * a `<think>` block, or a Markdown fence ahead of the JSON. Once the root
-   * value closes, trailing text is ignored either way.
+   * a `<think>` block, or a Markdown fence ahead of the JSON.
+   *
+   * **Last complete object wins.** A closed root is provisional in this mode,
+   * not final: it is retained and scanning resumes, so a later `{` starts a
+   * fresh candidate that supersedes it. A thinking model that restates the
+   * schema (`{"type":"object"}`) or shows a few-shot example
+   * (`{"name":"Alice"}`) before emitting the real payload would otherwise
+   * latch onto the prose object — and a schema-shaped one is indistinguishable
+   * from the payload, so it would pass validation and be persisted. The cost
+   * is that trailing prose containing its own complete object supersedes the
+   * payload; prompts that ask for the JSON last make that far rarer than the
+   * preamble case, and trailing prose without a `{` never restarts anything.
+   *
+   * Nothing is re-scanned: a restart begins at the `{` that triggered it, so
+   * the parser stays O(total input). A candidate abandoned this way leaves the
+   * already-emitted object deltas in place; the next {@link push} that opens
+   * the replacement returns a fresh empty root, and object-delta folding
+   * replaces wholesale, so the consumer's accumulator resets on its own.
    *
    * A `[` never starts the payload in this mode: prose is full of bracketed
    * asides that parse as valid arrays, and the object-only contract makes an
@@ -149,17 +173,40 @@ export interface PartialJsonStream {
    * has an array or scalar at its root. Mirrors {@link parsePartialJson}'s
    * object-only contract, so a caller can emit the result as an object delta
    * without first checking for an array.
+   *
+   * While skipping preamble it also reports `undefined` once a candidate closes
+   * — nothing is live until the next `{` — so the last object delta a stream
+   * emits may lag the closing chunk. {@link finish} is the authoritative
+   * document; do not reconstruct it from deltas.
    */
   push(chunk: string): Record<string, unknown> | undefined;
   /**
    * Closes any open strings and containers and returns the parsed document.
    * A trailing incomplete token (`1.`, `tru`, a partial key) is dropped, matching
    * {@link parsePartialJson}'s repair. Idempotent; input after it is ignored.
+   *
+   * The result is a {@link JsonValue}, not necessarily an object: a document
+   * with an array or scalar at its root is repaired and returned as such, even
+   * though {@link push} reports `undefined` for those. Use
+   * {@link finishObject} when the caller requires an object.
+   *
+   * While skipping preamble this returns the last complete candidate unless the
+   * one in flight already carries data — see
+   * {@link PartialJsonStreamOptions.skipPreamble}.
    */
-  finish(): Record<string, unknown>;
+  finish(): JsonValue;
+  /**
+   * {@link finish}, narrowed to the object-only contract {@link push} follows:
+   * an array or scalar root yields `{}` rather than a value whose keys are
+   * array indices. Prefer this when feeding a consumer that requires an object.
+   */
+  finishObject(): Record<string, unknown>;
   /** A detached deep copy of the current live root; O(size of the value). */
   snapshot(): Record<string, unknown> | undefined;
-  /** Whether the root value closed on its own (as opposed to being truncated). */
+  /**
+   * Whether the value {@link finish} would return closed on its own, as opposed
+   * to being truncated and repaired. End-of-stream repair never sets it.
+   */
   readonly complete: boolean;
 }
 
@@ -177,8 +224,13 @@ class PartialJsonStreamImpl implements PartialJsonStream {
   private unicodeValue = 0;
   /** Raw hex digits of the `\uXXXX` escape in flight, kept so an invalid one replays verbatim. */
   private unicodeText = "";
-  private closed = false;
+  /** Set only when real input closed a root value — never by {@link finish}'s repair. */
+  private sawClose = false;
+  /** Last root that closed on its own while skipping preamble; superseded by a later one. */
+  private lastComplete: unknown = undefined;
   private finished = false;
+  /** True while {@link finish} flushes, so repaired tokens do not report a close. */
+  private finishing = false;
 
   constructor(skipPreamble: boolean) {
     this.skipPreamble = skipPreamble;
@@ -186,7 +238,12 @@ class PartialJsonStreamImpl implements PartialJsonStream {
   }
 
   get complete(): boolean {
-    return this.closed;
+    if (!this.skipPreamble) return this.sawClose;
+    // Last-complete-wins: a candidate carrying data is the answer and it has
+    // not closed (a closed one is moved to `lastComplete`), so only a retained
+    // complete candidate counts as a closed document.
+    if (!this.rootIsEmpty()) return false;
+    return this.lastComplete !== undefined;
   }
 
   push(chunk: string): Record<string, unknown> | undefined {
@@ -196,14 +253,28 @@ class PartialJsonStreamImpl implements PartialJsonStream {
     return this.liveRoot();
   }
 
-  finish(): Record<string, unknown> {
+  finish(): JsonValue {
     if (!this.finished) {
       this.finished = true;
+      this.finishing = true;
       this.flushPendingToken();
+      this.finishing = false;
       this.stack.length = 0;
     }
+    // A candidate that already carries data is a genuinely truncated payload
+    // and outranks an earlier complete one; an empty or absent candidate is
+    // prose the scan never resolved, so the retained candidate stands.
+    if (this.skipPreamble && this.lastComplete !== undefined && this.rootIsEmpty()) {
+      return this.lastComplete as JsonValue;
+    }
     const root = this.root;
-    return root === undefined ? {} : (root as Record<string, unknown>);
+    return root === undefined ? {} : (root as JsonValue);
+  }
+
+  finishObject(): Record<string, unknown> {
+    const value = this.finish();
+    if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
+    return value as Record<string, unknown>;
   }
 
   snapshot(): Record<string, unknown> | undefined {
@@ -255,20 +326,30 @@ class PartialJsonStreamImpl implements PartialJsonStream {
    * candidate that did produce data is kept rather than gambling on a better one.
    */
   private fail(index: number): number {
-    if (this.skipPreamble && !this.closed && this.rootIsEmpty()) {
-      this.stack.length = 0;
-      this.pending = undefined;
-      this.buf = "";
-      this.escaped = false;
-      this.unicodeRemaining = 0;
-      this.unicodeValue = 0;
-      this.unicodeText = "";
-      this.root = undefined;
-      this.mode = Mode.Seek;
+    if (this.skipPreamble && this.rootIsEmpty()) {
+      this.restartCandidate();
       return index;
     }
     this.mode = Mode.Invalid;
     return index;
+  }
+
+  /**
+   * Abandons the candidate in flight and resumes scanning for the payload.
+   * Only the candidate's state is cleared — {@link lastComplete} survives, so a
+   * completed object followed by unparseable prose braces keeps its result.
+   */
+  private restartCandidate(): void {
+    this.stack.length = 0;
+    this.pending = undefined;
+    this.buf = "";
+    this.stringIsKey = false;
+    this.escaped = false;
+    this.unicodeRemaining = 0;
+    this.unicodeValue = 0;
+    this.unicodeText = "";
+    this.root = undefined;
+    this.mode = Mode.Seek;
   }
 
   private rootIsEmpty(): boolean {
@@ -330,8 +411,19 @@ class PartialJsonStreamImpl implements PartialJsonStream {
 
   private afterValue(): void {
     if (this.stack.length === 0) {
+      // `finish()` repairs a truncated token by committing it; that is not the
+      // document closing on its own, so it must not be reported as one.
+      if (!this.finishing) {
+        this.sawClose = true;
+        if (this.skipPreamble) {
+          // Provisional: retain it and keep scanning, so a payload behind a
+          // prose object still wins. See `skipPreamble`.
+          this.lastComplete = this.root;
+          this.restartCandidate();
+          return;
+        }
+      }
       this.mode = Mode.Done;
-      this.closed = true;
       return;
     }
     this.mode = Mode.Comma;
@@ -393,10 +485,10 @@ class PartialJsonStreamImpl implements PartialJsonStream {
    * Scans past preamble to the start of the payload. Only `{` opens a
    * candidate: the parser's contract is object-only, and prose is full of
    * bracketed asides (`[1]`, `[2024 figures]`) that parse as a perfectly
-   * valid array. A complete one would close the root and make the parser
-   * ignore the real payload behind it; an incomplete one leaves a non-empty
-   * root, which {@link fail} then refuses to discard. Neither is recoverable,
-   * so a bracket never starts a candidate here.
+   * valid array. An incomplete one leaves a non-empty root, which {@link fail}
+   * then refuses to discard, hiding the real payload behind it; a complete one
+   * would be retained as the answer for a document that has no object at all.
+   * So a bracket never starts a candidate here.
    */
   private consumeSeek(chunk: string, start: number, len: number): number {
     for (let i = start; i < len; i++) {

--- a/packages/util/src/json-schema/__tests__/PartialJsonStream.test.ts
+++ b/packages/util/src/json-schema/__tests__/PartialJsonStream.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { JsonValue } from "@workglow/util/schema";
 import { createPartialJsonStream, parsePartialJson } from "@workglow/util/schema";
 import { describe, expect, it } from "vitest";
 
@@ -22,7 +23,7 @@ const DOCS: readonly string[] = [
   '{"pretty": {\n  "x": 1,\n  "y": [ 2, 3 ]\n}}',
 ];
 
-function pushAll(chunks: readonly string[], skipPreamble = false): Record<string, unknown> {
+function pushAll(chunks: readonly string[], skipPreamble = false): JsonValue {
   const stream = createPartialJsonStream(skipPreamble ? { skipPreamble: true } : {});
   for (const chunk of chunks) stream.push(chunk);
   return stream.finish();
@@ -215,6 +216,111 @@ describe("createPartialJsonStream", () => {
     });
   });
 
+  describe("preamble skipping: last complete object wins", () => {
+    it("prefers the payload over a complete object inside a <think> block", () => {
+      // A thinking model that restates the schema emits a syntactically valid
+      // object before the answer. Latching onto it silently returns the wrong
+      // document — and reports `complete`, so nothing downstream notices.
+      expect(
+        pushAll(
+          ['<think>the schema is {"type":"object"} so I will emit</think>{"name":"Bob"}'],
+          true
+        )
+      ).toEqual({ name: "Bob" });
+    });
+
+    it("prefers the payload over a schema-shaped few-shot example", () => {
+      // The worst case: the preamble object validates against the same schema
+      // as the payload, so a re-validating consumer accepts and persists it.
+      expect(pushAll(['<think>e.g. {"name":"Alice"}</think>{"name":"Bob"}'], true)).toEqual({
+        name: "Bob",
+      });
+    });
+
+    it("keeps the last complete object when trailing prose braces fail", () => {
+      const stream = createPartialJsonStream({ skipPreamble: true });
+      stream.push('{"ok":true} note: {not json}');
+      expect(stream.finish()).toEqual({ ok: true });
+      expect(stream.complete).toBe(true);
+    });
+
+    it("keeps the completed payload when a restarted candidate is truncated", () => {
+      // The restart produced no data, so the completed candidate stands.
+      expect(pushAll(['{"ok":true} then {'], true)).toEqual({ ok: true });
+    });
+
+    it("prefers a restarted candidate that carries data over the completed one", () => {
+      // Data in flight outranks an earlier complete object: it is the later,
+      // genuinely truncated payload rather than prose.
+      const stream = createPartialJsonStream({ skipPreamble: true });
+      stream.push('{"ok":true} then {"name":"Bo');
+      expect(stream.finish()).toEqual({ name: "Bo" });
+      expect(stream.complete).toBe(false);
+    });
+
+    it("restarting a candidate replaces the emitted delta", () => {
+      // Object deltas are folded with replace semantics, so the fresh empty
+      // root the restart returns resets the consumer's accumulator; the
+      // abandoned object never has to be retracted.
+      const stream = createPartialJsonStream({ skipPreamble: true });
+      expect(stream.push('<think>{"name":"Ali')).toEqual({ name: "Ali" });
+      // Closing the prose candidate retires it: nothing is live to emit.
+      expect(stream.push('ce"}</think>')).toBeUndefined();
+      // The chunk carrying the real `{` opens a fresh root, which replaces it.
+      expect(stream.push('{"name"')).toEqual({});
+      expect(stream.push(':"Bob"}')).toBeUndefined();
+      expect(stream.finish()).toEqual({ name: "Bob" });
+    });
+
+    it("still reports `complete` false when no candidate ever closed", () => {
+      const stream = createPartialJsonStream({ skipPreamble: true });
+      stream.push('prose {"a":1');
+      expect(stream.complete).toBe(false);
+      expect(stream.finish()).toEqual({ a: 1 });
+    });
+  });
+
+  describe("finish() typing", () => {
+    it("is typed as JsonValue for an array root", () => {
+      const stream = createPartialJsonStream();
+      stream.push("[1,2,3]");
+      const value = stream.finish();
+      expect(Array.isArray(value)).toBe(true);
+      expect(value).toEqual([1, 2, 3]);
+      // @ts-expect-error finish() is a JsonValue, so object-style use of an
+      // array or scalar root no longer type-checks silently.
+      const keys: string[] = Object.keys(stream.finish());
+      // The runtime behavior is unchanged and deliberately still wrong-looking,
+      // which is precisely why the compile error above matters.
+      expect(keys).toEqual(["0", "1", "2"]);
+    });
+
+    it("finishObject() returns {} for an array root", () => {
+      const stream = createPartialJsonStream();
+      stream.push("[1,2,3]");
+      expect(stream.finishObject()).toEqual({});
+    });
+
+    it("finishObject() returns {} for a scalar root but keeps an object root", () => {
+      const scalar = createPartialJsonStream();
+      scalar.push('"abc"');
+      expect(scalar.finishObject()).toEqual({});
+
+      const object = createPartialJsonStream();
+      object.push('{"a":1}');
+      expect(object.finishObject()).toEqual({ a: 1 });
+    });
+
+    it("complete is false for a truncated scalar root", () => {
+      // End-of-stream repair commits the unterminated string; that is not the
+      // document closing on its own.
+      const stream = createPartialJsonStream();
+      stream.push('"abc');
+      expect(stream.finish()).toBe("abc");
+      expect(stream.complete).toBe(false);
+    });
+  });
+
   describe("live root and snapshot", () => {
     it("returns undefined until a top-level object opens", () => {
       const stream = createPartialJsonStream();
@@ -252,7 +358,7 @@ describe("createPartialJsonStream", () => {
     });
 
     it("creates __proto__ as an own property without polluting Object.prototype", () => {
-      const result = pushAll(['{"__proto__":{"polluted":1},"x":2}']);
+      const result = pushAll(['{"__proto__":{"polluted":1},"x":2}']) as Record<string, unknown>;
       expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(true);
       expect(({} as Record<string, unknown>).polluted).toBeUndefined();
       expect(result.x).toBe(2);

--- a/providers/anthropic/src/ai/common/Anthropic_StructuredGeneration.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_StructuredGeneration.ts
@@ -69,7 +69,7 @@ export const Anthropic_StructuredGeneration_Stream: AiProviderRunFn<
 
   emit({
     type: "finish",
-    data: { object: json.finish() } as StructuredGenerationTaskOutput,
+    data: { object: json.finishObject() } as StructuredGenerationTaskOutput,
     usage: usageCollector.result(),
   });
 };

--- a/providers/chrome-ai/src/ai/common/WebBrowser_StructuredGeneration.ts
+++ b/providers/chrome-ai/src/ai/common/WebBrowser_StructuredGeneration.ts
@@ -113,7 +113,7 @@ export const WebBrowser_StructuredGeneration: AiProviderRunFn<
 
     emit({
       type: "finish",
-      data: { object: json.finish() } as StructuredGenerationTaskOutput,
+      data: { object: json.finishObject() } as StructuredGenerationTaskOutput,
     });
   } finally {
     try {

--- a/providers/deepseek/src/ai/common/DeepSeek_StructuredGeneration.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_StructuredGeneration.ts
@@ -105,7 +105,7 @@ export const DeepSeek_StructuredGeneration_Stream: AiProviderRunFn<
 
   emit({
     type: "finish",
-    data: { object: json.finish() } as StructuredGenerationTaskOutput,
+    data: { object: json.finishObject() } as StructuredGenerationTaskOutput,
     usage,
   });
 };

--- a/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
@@ -97,7 +97,7 @@ export const Gemini_StructuredGeneration_Stream: AiProviderRunFn<
   // json-mode finish exception: populate finish.data.object with parsed result.
   emit({
     type: "finish",
-    data: { object: json.finish() } as StructuredGenerationTaskOutput,
+    data: { object: json.finishObject() } as StructuredGenerationTaskOutput,
     usage: mapGeminiUsage(lastUsageMetadata),
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_StructuredGeneration.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_StructuredGeneration.ts
@@ -102,6 +102,9 @@ export const HFT_StructuredGeneration: AiProviderRunFn<
       stopping_criteria: [stopping_criteria],
     });
 
-    emit({ type: "finish", data: { object: json.finish() } as StructuredGenerationTaskOutput });
+    emit({
+      type: "finish",
+      data: { object: json.finishObject() } as StructuredGenerationTaskOutput,
+    });
   });
 };

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_StructuredGeneration.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_StructuredGeneration.ts
@@ -121,7 +121,7 @@ export const LlamaCpp_StructuredGeneration_Stream: AiProviderRunFn<
 
           emit({
             type: "finish",
-            data: { object: json.finish() } as StructuredGenerationTaskOutput,
+            data: { object: json.finishObject() } as StructuredGenerationTaskOutput,
           });
         },
         { signal }

--- a/providers/ollama/src/ai/common/Ollama_StructuredGeneration.ts
+++ b/providers/ollama/src/ai/common/Ollama_StructuredGeneration.ts
@@ -76,7 +76,7 @@ export function createOllamaStructuredGenerationStream(
 
     emit({
       type: "finish",
-      data: { object: json.finish() } as StructuredGenerationTaskOutput,
+      data: { object: json.finishObject() } as StructuredGenerationTaskOutput,
       usage,
     });
   };

--- a/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
+++ b/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
@@ -102,7 +102,7 @@ export const OpenAI_StructuredGeneration_Stream: AiProviderRunFn<
 
   emit({
     type: "finish",
-    data: { object: json.finish() } as StructuredGenerationTaskOutput,
+    data: { object: json.finishObject() } as StructuredGenerationTaskOutput,
     usage,
   });
 };

--- a/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
@@ -80,7 +80,7 @@ export const OpenRouter_StructuredGeneration_Stream: AiProviderRunFn<
 
   emit({
     type: "finish",
-    data: { object: json.finish() } as StructuredGenerationTaskOutput,
+    data: { object: json.finishObject() } as StructuredGenerationTaskOutput,
     usage,
   });
 };

--- a/providers/tf-mediapipe/src/ai/common/TFMP_StructuredGeneration.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_StructuredGeneration.ts
@@ -92,5 +92,5 @@ export const TFMP_StructuredGeneration: AiProviderRunFn<
     });
   });
 
-  emit({ type: "finish", data: { object: json.finish() } as StructuredGenerationTaskOutput });
+  emit({ type: "finish", data: { object: json.finishObject() } as StructuredGenerationTaskOutput });
 };

--- a/providers/xai/src/ai/common/Xai_StructuredGeneration.ts
+++ b/providers/xai/src/ai/common/Xai_StructuredGeneration.ts
@@ -76,7 +76,7 @@ export const Xai_StructuredGeneration_Stream: AiProviderRunFn<
 
   emit({
     type: "finish",
-    data: { object: json.finish() } as StructuredGenerationTaskOutput,
+    data: { object: json.finishObject() } as StructuredGenerationTaskOutput,
     usage,
   });
 };


### PR DESCRIPTION
## The defect

`packages/util/src/json-schema/PartialJsonStream.ts` (`consumeSeek`). With `skipPreamble: true` the parser latched onto the FIRST syntactically valid `{…}` in the preamble and permanently ignored the real payload. Reproduced by execution on `main`:

```
input : '<think>the schema is {"type":"object"} so I will emit</think>{"name":"Bob"}'
finish: {"type":"object"}   complete: true
```

`consumeSeek` starts a candidate at the first `{`; when it CLOSES, `afterValue()` sets `Mode.Done` and `consume()` returns on every later chunk. The `fail()` recovery only rescued candidates that produced NO data (`rootIsEmpty()`), so a well-formed prose object was unrecoverable — and `complete` reported `true`, so nothing downstream signalled a problem.

**Impact.** `HFT_StructuredGeneration.ts:54` and `TFMP_StructuredGeneration.ts:81` both pass `skipPreamble: true` — precisely the local/thinking models that restate the schema or a few-shot example before answering. A model emitting `{"name":"Alice"}` as an illustrative example in its `<think>` block, then the real `{"name":"Bob"}`, yielded `finish.data.object = {"name":"Alice"}` — schema-valid, so `StructuredGenerationTask`'s re-validation accepted it and the WRONG record was persisted. When the preamble object is not schema-shaped the failure is loud (retry → dead-letter), which is why this had not surfaced. Existing tests covered the invalid-brace and bracketed-array cases only; the valid-object case was untested.

## Decision: a closed root is PROVISIONAL under `skipPreamble` — last complete candidate wins

When a candidate closes it is retained as `lastComplete` and the parser returns to `Mode.Seek`; the next `{` at depth 0 starts a fresh candidate from that character forward. No buffered text is ever re-scanned, so the parser stays O(total input) and the `push()`-returns-live-root contract is untouched.

`finish()` selection rule: the live root if non-empty (a genuinely truncated real payload at EOF), else `lastComplete`, else `{}`. Every prose-brace shape (`{braces}`, `{"a" 1`) fails and is discarded by the existing `fail()` → `rootIsEmpty()` path, leaving `lastComplete` intact.

**Rejected alternatives.** A predicate / root-shape gate cannot distinguish a few-shot `{"name":"Alice"}` from the real `{"name":"Bob"}` — the exact case that persists a wrong, schema-valid record. Lexical `<think>` / fence stripping only covers tagged preambles: HFT already strips `<think>` blocks upstream and STILL reproduced the bug via untagged prose.

**Accepted regression.** Trailing prose that itself contains a complete object (`{"name":"Bob"} e.g. {"name":"Alice"}`) now picks the last one. Far rarer than preamble few-shots — both affected prompts end with "Output ONLY the JSON object" and models stop after the payload — and trailing prose WITHOUT a `{` (the common `Hope that helps.` case, already tested) never triggers a restart.

**Delta retraction is not needed.** `foldObjectDelta` replaces wholesale for non-array deltas, so the next `push()` that opens the new candidate returns a fresh live `{}` and the accumulator resets — the same mechanism `StructuredGenerationTask` already uses between retries. During the gap between an abandoned close and the restarting `{`, `push()` returns `undefined` and HFT/TFMP emit `text-delta` instead. Cosmetic — `StructuredGenerationTask` prefers `finish.data.object` over `lastObject`, so the validated and persisted value is always the parser's authoritative `finish()`.

One nuance worth flagging to reviewers, which follows from the same mechanism: under `skipPreamble` the push that CLOSES the real payload also returns `undefined` (the root has just been retired to `lastComplete`), so the last `object-delta` a stream emits can lag the closing chunk by one delta. Documented on `push()`. `finish()` is unaffected and remains authoritative.

## Second finding — `finish()`'s declared type was a lie, and `complete` contradicted its doc

`finish()` declared `Record<string, unknown>` but returned arrays and scalars (verified: `push('[1,2,3]'); finish()` → `[1,2,3]`; `push('"abc'); finish()` → `"abc"`). The behavior is deliberate and asserted by an existing test, but the type contradicted `push()`, which returns `undefined` for the same documents; a caller doing `Object.keys(stream.finish())` on an array root got `["0","1","2"]` with no type error.

Widened, not narrowed: a new exported `JsonValue` union (none existed in `packages/util/src` — verified), plus `finishObject()` returning the root when it is a plain object and `{}` otherwise. All 11 provider call sites migrated to `finishObject()` — they all feed `StructuredGenerationTask`, which requires an object; an array root now fails `required`-key validation loudly rather than reaching `Object.keys()` in a caller.

`complete` also no longer reports `true` for a root that only closed because `finish()`'s flush repaired a truncated token (`push('"abc')`), which contradicted its JSDoc ("closed ON ITS OWN"). Closure is now tracked explicitly and never set from `finish()`'s repair.

## Third finding — `packages/task-graph/src/cache/resolveRef.ts`

`walk()` called `hasRef(value, new WeakSet())` on EVERY container it visited, re-scanning that node's whole subtree, so `resolveOutput` was O(n·depth) not O(n); `containsCycle` added a second full traversal up front, and both it and `hasRef` were non-tail-recursive, raising a `RangeError` out of cache resolution on a deeply nested value.

Replaced by a single iterative pass (`scanContainers`) answering all three questions up front: which containers hold a reachable `CacheRef`, whether any ref exists at all, and whether there is a back-edge. The memoized `walk` path itself is unchanged apart from consulting the precomputed set instead of re-probing.

Measured: 4 000-deep chain **590ms → 30ms**; a 50 000-deep ref-free value no longer overflows (it did on `main`).

### Deviations from the plan — stated explicitly

1. **The plan said to "hoist the `hasRef` pre-scan out of `walk` (`resolveOutput:117` already ran it)". That is not equivalent** and I did not do it literally. The top-level scan answers "does the whole output contain a ref"; the per-container probe answers it *per node*, and that is what preserves identity for ref-free subtrees inside a ref-bearing tree. Simply deleting the call would clone every ref-free container. `scanContainers` precomputes the per-container answer instead, so semantics are preserved and the cost is O(n).
2. **The planned test "resolves a ref inside a 20k-deep nested value without overflowing" is not achievable in this PR and was not added.** The `RangeError` is *not* only in `containsCycle`/`hasRef`: `walk` → `walkContainer` → `Promise.all(map(walk))` also recurses once per level, and it is the binding constraint. Binary-searched under plain Bun, the max depth is **~6 500 both before and after** this change — identical. Making `walk` stack-safe means rewriting the memoized async walker, which the plan explicitly put out of scope. Two tests were added instead, both of which fail on `main` and pass here:
   - *"scans a 50k-deep ref-free value without overflowing the stack"* — this path never enters `walk`, so the scan fix alone makes it pass.
   - *"resolves a ref under a deep chain without re-scanning each level"* — a 400-deep × 100-wide value, guarding the O(n·depth) regression (~590ms → ~30ms).

   **Follow-up recommended:** making `walk` iterative to raise the ~6.5k nesting ceiling. Note the ceiling is much lower under vitest's worker stack — a ref-bearing chain of depth 1 000 intermittently overflowed there — so the effective limit in-process is environment-dependent.
3. **Two of the planned PartialJsonStream tests already pass on `main`** (`keeps the last complete object when trailing prose braces fail`, `keeps the completed payload when a restarted candidate is truncated`): the old code reaches `Mode.Done` on the first close and ignores all trailing text, so it gets the right answer for the wrong reason. They are kept as guards that the new restart path does not regress them. The other 7 new tests do fail on `main` (verified by reverting the source file and re-running).
4. **The resolveRef tests were added to the existing `packages/test/src/test/task-graph/resolveOutput.test.ts`** rather than a new `resolveRef.test.ts` — same subject, same imports, and the repo already has `resolveOutput.test.ts` + `resolveRef.opaque-types.test.ts`.

## Key risk

**Neither HFT nor TFMP has a fixture exercising multiple top-level objects**, so their existing suites pass either way and can neither confirm the fix nor catch a regression in it. The coverage here is the parser's own unit suite.

Also: **`Mode.Done` is no longer terminal under `skipPreamble`**, so the parser keeps scanning trailing text for the life of the stream. Bounded O(chars), no buffering, but it removes the current early-exit.

## Out of scope — follow-ups for their own PRs

- `packages/util/src/worker/WorkerServerBase.ts:251-273`: stream `emit` transfers (detaches) a fully-owned `ArrayBuffer`, so a run-fn that re-emits gets a silently zero-length `binary-delta` (`ownsWholeBuffer` is false on the detached buffer, so it structured-clones an empty one). No in-repo provider emits `binaryDelta` yet, so this is forward-looking; it wants a doc/CHANGELOG migration note plus an optional detached-buffer guard.
- `packages/tasks/src/task/FetchUrlCredentials.ts:66, 103-110`: `credential_scheme: "header"` with no `credential_header` silently defaults to `Authorization` and sends the raw secret with no scheme prefix. One-line throw, but a BREAKING config change for anyone relying on the default — wants its own PR with a CHANGELOG entry.

## Verification

Ran and observed passing:

| what | result |
| --- | --- |
| `bun install` | ok |
| `bunx vitest run packages/test/src/test/util/PartialJsonStream.test.ts` | **53 passed** (42 pre-existing + 11 new) |
| same, with only `PartialJsonStream.ts` reverted to `main` | **7 of the new tests fail** — confirms they are genuine repros |
| `bunx vitest run packages/test/src/test/util packages/test/src/test/task-graph` | **1 769 passed, 6 skipped, 171 files** |
| same, with only `resolveRef.ts` reverted to `main` | the 2 new deep-value tests fail |
| all 36 files of `packages/test/src/test/ai` (run in four batches) | **305 passed** |
| `packages/test/src/test/ai-provider*` (112 files, incl. the `-api` / `-hft` / `-nodellama` / `-cactus` trees) | **1 136 passed, 72 skipped, 1 failed** — see below |
| `packages/test/src/test/schema`, `ai-model/InMemoryModelRepository` | passed |
| `bun run build:types` | **41/41 packages successful** |
| `prettier --check`, `eslint` on every changed file | clean |

`build:types` covers `@workglow/test`, so the `@ts-expect-error` in the new typing test is genuinely checked — verified by removing the directive and observing `TS2769`.

**The one failure**, `ai-provider-nodellama/LlamaCpp_Generic.integration.test.ts > streaming run-fn terminates within abortGraceMs * 4 when aborted mid-stream`, is a wall-clock abort-latency assertion (`elapsed < abortGraceMs * 4 + 2000`) on the `text.generation` run-fn of a real local GGUF model — it touches neither `PartialJsonStream` nor `resolveRef`. Its test file took 712s in that sweep on a saturated sandbox. **Re-run in isolation on this branch it passes** (1 passed, 18 skipped), so it is a load-sensitive flake, not a regression.

**Could not verify:** running `packages/test/src/test/ai` as a single vitest invocation, and `packages/test/src/test/ai-model` as a whole, do not complete in this environment (33 min at ~24s CPU — network/DB-blocked on the IndexedDB/Postgres model-repository integration tests). Every individual file in `.../ai` was run and passed in batches; `ai-model` was only covered by `InMemoryModelRepository`. No provider integration test exercising a real HFT or TF-MediaPipe structured-generation model was run — those are the two `skipPreamble` call sites, and no fixture for them exists (see Key risk).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)