### PR TITLE
chore(bootstrap): publishing metadata, required registry param, exports test, docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -51,6 +51,7 @@ dataset, tasks                        (KnowledgeBase, documents, chunks; utility
     ↓
 ai                                    (AI task base classes, model registry, provider helpers)
     ↓
+bootstrap                             (installs every built-in default onto a service registry)
 providers/*                           (concrete provider implementations: anthropic, openai, gemini, ollama, ...)
     ↓
 test                                  (integration tests across all packages)
@@ -294,6 +295,16 @@ chat-vs-prompt). Schema invariants (e.g. `TextGenerationTask` requires
 ### `@workglow/tasks` — utility tasks
 
 Pre-built tasks: `InputTask`, `OutputTask`, `LambdaTask`, `DelayTask`, `FetchUrlTask`, `JavaScriptTask`, `JsonTask`, `MergeTask`, `SplitTask`, `ArrayTask`, MCP tasks, scalar/vector math tasks. Register all via `registerCommonTasks()`.
+
+### `@workglow/bootstrap` — default registration
+
+Nothing self-registers at import time, so a runtime has to install the defaults before any task runs. This package is that seam, and **the implementation lives here** — `packages/workglow/src/bootstrap.ts` is now a pure `export * from "@workglow/bootstrap"` re-export shim. Add a new default registration in `packages/bootstrap/src/bootstrap/registerAllDefaults.ts`; editing the shim does nothing.
+
+- `bootstrapWorkglow(opts?)` — installs defaults onto the global registry, idempotent. The normal application entry point.
+- `createOrchestrationContext(opts?)` — a fresh, disposable registry backed by its own container (tests, multi-tenant servers, embedded use).
+- `registerAllDefaults(registry)` — the 14 `register*Defaults` calls in dependency order. The registry parameter is **required**: the function mutates whichever container it is handed, so the target is stated at the call site rather than silently defaulting to the global one.
+
+`vitest.setup.ts` calls `bootstrapWorkglow()` by source path — the isolated linker keeps workspace packages out of the repo root's `node_modules`, so neither `@workglow/bootstrap` nor `@workglow/util` resolves from there.
 
 ## Testing patterns
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -298,7 +298,7 @@ Pre-built tasks: `InputTask`, `OutputTask`, `LambdaTask`, `DelayTask`, `FetchUrl
 
 ### `@workglow/bootstrap` — default registration
 
-Nothing self-registers at import time, so a runtime has to install the defaults before any task runs. This package is that seam, and **the implementation lives here** — `packages/workglow/src/bootstrap.ts` is now a pure `export * from "@workglow/bootstrap"` re-export shim. Add a new default registration in `packages/bootstrap/src/bootstrap/registerAllDefaults.ts`; editing the shim does nothing.
+Each registrar self-registers on the **global** registry when its module happens to be imported — `registerModelDefaults()`, `registerTabularStorageDefaults()` and the twelve others run at module scope, and default their `registry` parameter to the global one. What is populated therefore depends on which modules your import graph has pulled in, which is import-order dependent and easy to mis-diagnose. `bootstrapWorkglow()` is the guarantee: it installs the full set in dependency order, idempotently. An isolated registry gets **nothing** until `registerAllDefaults(registry)` (or `createOrchestrationContext()`) is called explicitly. This package is that seam, and **the implementation lives here** — `packages/workglow/src/bootstrap.ts` is now a pure `export * from "@workglow/bootstrap"` re-export shim. Add a new default registration in `packages/bootstrap/src/bootstrap/registerAllDefaults.ts`; editing the shim does nothing.
 
 - `bootstrapWorkglow(opts?)` — installs defaults onto the global registry, idempotent. The normal application entry point.
 - `createOrchestrationContext(opts?)` — a fresh, disposable registry backed by its own container (tests, multi-tenant servers, embedded use).

--- a/bun.lock
+++ b/bun.lock
@@ -174,7 +174,7 @@
     },
     "packages/bootstrap": {
       "name": "@workglow/bootstrap",
-      "version": "0.3.37",
+      "version": "0.3.38",
       "devDependencies": {
         "@workglow/ai": "workspace:*",
         "@workglow/knowledge-base": "workspace:*",
@@ -337,6 +337,7 @@
         "@workglow/ai": "workspace:*",
         "@workglow/anthropic": "workspace:*",
         "@workglow/aws": "workspace:*",
+        "@workglow/bootstrap": "workspace:*",
         "@workglow/browser-control": "workspace:*",
         "@workglow/bun-webview": "workspace:*",
         "@workglow/cactus": "workspace:*",

--- a/packages/bootstrap/CHANGELOG.md
+++ b/packages/bootstrap/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 0.3.38
+
+### Features
+
+#### bootstrap
+
+- Initial release. `registerAllDefaults`, `bootstrapWorkglow`, and
+  `createOrchestrationContext` moved here from the `workglow` meta-package and
+  from the test harness's private `bootstrapTestRegistry`, which had drifted
+  into two copies of the same 14 registration calls.
+- `registerAllDefaults(registry)` takes a **required** registry. It mutates
+  whichever container it is handed, so the target is always stated at the call
+  site rather than defaulting to the global one.

--- a/packages/bootstrap/LICENSE
+++ b/packages/bootstrap/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright 2025 Steven Roussey
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/bootstrap/README.md
+++ b/packages/bootstrap/README.md
@@ -2,11 +2,19 @@
 
 Runtime bootstrap for Workglow: registers every built-in default onto a service registry.
 
-Workglow does not self-register defaults at import time. Something has to install
-the logger, telemetry, worker-manager, credential, model, provider, knowledge-base,
-MCP, storage, task, and transform factories before any task runs — this package is
-that something, sitting below both the `workglow` meta-package and the test harness
-so neither has to own its own copy.
+Each registrar self-registers on the **global** registry when its module happens to
+be imported — `registerModelDefaults()`, `registerTabularStorageDefaults()` and the
+twelve others run at module scope, and default their `registry` parameter to the
+global one. What is populated therefore depends on which modules your import graph
+has pulled in, which is import-order dependent and easy to mis-diagnose.
+`bootstrapWorkglow()` is the guarantee: it installs the full set — logger,
+telemetry, worker-manager, credential, model, provider, knowledge-base, MCP,
+storage, task, and transform factories — in dependency order, idempotently. An
+isolated registry gets **nothing** until `registerAllDefaults(registry)` (or
+`createOrchestrationContext()`) is called explicitly.
+
+This package is that seam, sitting below both the `workglow` meta-package and the
+test harness so neither has to own its own copy.
 
 ## Installation
 
@@ -51,11 +59,16 @@ import { createOrchestrationContext } from "@workglow/bootstrap";
 
 const ctx = createOrchestrationContext();
 try {
-  await task.run({ context: ctx });
+  await task.run({}, { registry: ctx.registry });
 } finally {
   await ctx.dispose();
 }
 ```
+
+The registry travels in the **run config** — `run()`'s second argument. The first
+argument is input overrides, so passing a context there silently becomes an input
+named `context`, the run uses the global registry, and `ctx.dispose()` tears down a
+registry nothing ever touched.
 
 ### Registering onto a registry you already have
 

--- a/packages/bootstrap/README.md
+++ b/packages/bootstrap/README.md
@@ -1,0 +1,113 @@
+# @workglow/bootstrap
+
+Runtime bootstrap for Workglow: registers every built-in default onto a service registry.
+
+Workglow does not self-register defaults at import time. Something has to install
+the logger, telemetry, worker-manager, credential, model, provider, knowledge-base,
+MCP, storage, task, and transform factories before any task runs — this package is
+that something, sitting below both the `workglow` meta-package and the test harness
+so neither has to own its own copy.
+
+## Installation
+
+```bash
+npm install @workglow/bootstrap
+# or
+bun add @workglow/bootstrap
+```
+
+## Usage
+
+### Global runtime
+
+Call once at application startup, before running any task.
+
+```typescript
+import { bootstrapWorkglow } from "@workglow/bootstrap";
+
+bootstrapWorkglow();
+```
+
+Pass a logger to replace the env-driven default:
+
+```typescript
+import { bootstrapWorkglow } from "@workglow/bootstrap";
+import { TsLogLogger } from "workglow";
+
+bootstrapWorkglow({ logger: new TsLogLogger() });
+```
+
+`bootstrapWorkglow()` is idempotent — defaults register with `registerIfAbsent`,
+so an earlier explicit registration (a custom storage backend, say) is never
+overwritten, and repeat calls are harmless.
+
+### Isolated context
+
+For tests, multi-tenant servers, and embedded use: a fresh registry backed by its
+own container, disposable without touching global state.
+
+```typescript
+import { createOrchestrationContext } from "@workglow/bootstrap";
+
+const ctx = createOrchestrationContext();
+try {
+  await task.run({ context: ctx });
+} finally {
+  await ctx.dispose();
+}
+```
+
+### Registering onto a registry you already have
+
+```typescript
+import { registerAllDefaults } from "@workglow/bootstrap";
+import { globalServiceRegistry } from "@workglow/util";
+
+registerAllDefaults(globalServiceRegistry);
+```
+
+The registry parameter is **required**, deliberately. The function mutates
+whichever container it is handed, so which one that is belongs at the call site —
+a defaulted global would let a caller reach for an isolated context and silently
+mutate process-wide state instead. Prefer `bootstrapWorkglow()` or
+`createOrchestrationContext()`; reach for `registerAllDefaults` only when the
+registry is one you constructed yourself.
+
+## Dependency weight
+
+This package registers **all** defaults by design — that is the whole point of a
+single bootstrap seam, and splitting it into per-tier entry points would just move
+the drift problem it was extracted to solve. The cost is that it depends on
+`@workglow/ai`, `@workglow/knowledge-base`, and `@workglow/mcp`, and the last of
+those carries a hard runtime dependency on `@modelcontextprotocol/sdk`. A consumer
+that wants only, say, logger + task + storage defaults therefore installs the MCP
+SDK and the full AI layer for nothing.
+
+If that weight matters, do not depend on this package. Call the individual
+`register*Defaults(registry)` functions directly from the packages you actually
+use — they are all exported, and `registerAllDefaults` is nothing more than the
+14 of them in dependency order:
+
+```typescript
+import { registerTabularStorageDefaults } from "@workglow/storage";
+import { registerTaskDefaults } from "@workglow/task-graph";
+import { registerLoggerDefaults } from "@workglow/util";
+
+registerLoggerDefaults(registry);
+registerTabularStorageDefaults(registry);
+registerTaskDefaults(registry);
+```
+
+Order matters: the primitive containers (input resolvers/compactors, logger,
+telemetry, worker manager) must register before anything that stores into them.
+See `src/bootstrap/registerAllDefaults.ts` for the canonical ordering.
+
+## Relationship to `workglow`
+
+`packages/workglow/src/bootstrap.ts` is a pure re-export of this package, so
+`workglow/bootstrap` and the `workglow` root barrel keep exposing the same API.
+Add a new default registration **here**, not there.
+
+## License
+
+Apache 2.0 - See [LICENSE](./LICENSE) for details.

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@workglow/bootstrap",
   "type": "module",
-  "version": "0.3.37",
+  "version": "0.3.38",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/workglow-dev/libs.git",

--- a/packages/bootstrap/src/bootstrap/bootstrapWorkglow.ts
+++ b/packages/bootstrap/src/bootstrap/bootstrapWorkglow.ts
@@ -72,7 +72,10 @@ export function bootstrapWorkglow(opts: BootstrapOptions = {}): WorkglowContext 
  * ```ts
  * const ctx = createOrchestrationContext({ logger: new MyLogger() });
  * try {
- *   await task.run({ ..., context: ctx });
+ *   // The registry travels in the run config — `run()`'s FIRST argument is
+ *   // input overrides, so a context passed there is just an input named
+ *   // `context` and the run still uses the global registry.
+ *   await task.run({}, { registry: ctx.registry });
  * } finally {
  *   await ctx.dispose();
  * }

--- a/packages/bootstrap/src/bootstrap/registerAllDefaults.ts
+++ b/packages/bootstrap/src/bootstrap/registerAllDefaults.ts
@@ -9,13 +9,13 @@ import { registerKnowledgeBaseDefaults } from "@workglow/knowledge-base";
 import { registerMcpServerDefaults } from "@workglow/mcp/util";
 import { registerTabularStorageDefaults } from "@workglow/storage";
 import { registerTaskDefaults, registerTransformDefaults } from "@workglow/task-graph";
+import type { ServiceRegistry } from "@workglow/util";
 import {
   registerCredentialDefaults,
   registerInputCompactorDefaults,
   registerInputResolverDefaults,
   registerLoggerDefaults,
   registerTelemetryDefaults,
-  ServiceRegistry,
 } from "@workglow/util";
 import { registerImageDefaults } from "@workglow/util/media";
 import { registerWorkerManagerDefaults } from "@workglow/util/worker";

--- a/packages/bootstrap/src/bootstrap/registerAllDefaults.ts
+++ b/packages/bootstrap/src/bootstrap/registerAllDefaults.ts
@@ -10,7 +10,6 @@ import { registerMcpServerDefaults } from "@workglow/mcp/util";
 import { registerTabularStorageDefaults } from "@workglow/storage";
 import { registerTaskDefaults, registerTransformDefaults } from "@workglow/task-graph";
 import {
-  globalServiceRegistry,
   registerCredentialDefaults,
   registerInputCompactorDefaults,
   registerInputResolverDefaults,
@@ -28,8 +27,13 @@ import { registerWorkerManagerDefaults } from "@workglow/util/worker";
  * Idempotent — safe to call multiple times. `registerIfAbsent` ensures
  * earlier explicit registrations (e.g. a custom storage backend) are not
  * overwritten.
+ *
+ * The registry is required, never defaulted: this mutates whichever container
+ * it is handed, so the target is always stated at the call site. Pass
+ * `globalServiceRegistry` explicitly for process-wide defaults, or
+ * prefer `bootstrapWorkglow()` / `createOrchestrationContext()`.
  */
-export function registerAllDefaults(registry: ServiceRegistry = globalServiceRegistry): void {
+export function registerAllDefaults(registry: ServiceRegistry): void {
   // Primitive containers first — resolvers/compactors are stored in maps
   // registered by these calls.
   registerInputResolverDefaults(registry);

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -39,6 +39,7 @@
     "@workglow/ai": "workspace:*",
     "@workglow/anthropic": "workspace:*",
     "@workglow/aws": "workspace:*",
+    "@workglow/bootstrap": "workspace:*",
     "@workglow/browser-control": "workspace:*",
     "@workglow/bun-webview": "workspace:*",
     "@workglow/cactus": "workspace:*",

--- a/packages/test/src/test/util/BootstrapPackageExports.test.ts
+++ b/packages/test/src/test/util/BootstrapPackageExports.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Guards the *published* contract of `@workglow/bootstrap`.
+ *
+ * The vitest harness bootstraps from the package's raw source, and the only
+ * other consumer of its build output is the meta-package's export-collision
+ * detector. So nothing else in CI would notice a typo in the `exports` map or a
+ * `build-*` script that silently emitted no file — `import { bootstrapWorkglow }
+ * from "@workglow/bootstrap"` would throw ERR_PACKAGE_PATH_NOT_EXPORTED for
+ * consumers with no prior signal.
+ *
+ * Requires a build (CI's `test-vitest-unit` job downloads the `build-output`
+ * artifact); `bun run use-source` stubs satisfy it too.
+ */
+
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+const PACKAGE_DIR = join(REPO_ROOT, "packages/bootstrap");
+
+/** The `exports` map's leaves are relative target paths; its branches are condition objects. */
+type ExportsNode = string | { readonly [condition: string]: ExportsNode };
+
+interface BootstrapPackageJson {
+  readonly name: string;
+  readonly exports: Record<string, ExportsNode>;
+}
+
+/** Every leaf string reachable in the exports map, paired with the condition path that reaches it. */
+function collectExportTargets(
+  node: ExportsNode,
+  path: readonly string[] = []
+): { readonly path: readonly string[]; readonly target: string }[] {
+  if (typeof node === "string") return [{ path, target: node }];
+  return Object.entries(node).flatMap(([condition, child]) =>
+    collectExportTargets(child, [...path, condition])
+  );
+}
+
+/** Resolves a subpath the way a plain Node `import` does: no react-native/browser/bun condition. */
+function resolveNodeImport(node: ExportsNode): string | undefined {
+  if (typeof node === "string") return node;
+  for (const [condition, child] of Object.entries(node)) {
+    if (condition === "react-native" || condition === "browser" || condition === "bun") continue;
+    if (condition === "types") continue;
+    if (condition === "import" || condition === "default" || condition === "node") {
+      const resolved = resolveNodeImport(child);
+      if (resolved !== undefined) return resolved;
+    }
+  }
+  return undefined;
+}
+
+let pkg: BootstrapPackageJson;
+
+beforeAll(async () => {
+  pkg = JSON.parse(await readFile(join(PACKAGE_DIR, "package.json"), "utf8"));
+});
+
+describe("@workglow/bootstrap published exports", () => {
+  it("declares an exports map", () => {
+    expect(pkg.name).toBe("@workglow/bootstrap");
+    expect(Object.keys(pkg.exports).length).toBeGreaterThan(0);
+  });
+
+  it("points every exports-map target at a file that exists", () => {
+    const missing = Object.entries(pkg.exports)
+      .flatMap(([subpath, node]) =>
+        collectExportTargets(node).map((entry) => ({ subpath, ...entry }))
+      )
+      .filter(({ target }) => !existsSync(join(PACKAGE_DIR, target)))
+      .map(({ subpath, path, target }) => `"${subpath}" [${path.join(".")}] -> ${target}`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it("exposes the bootstrap API from the resolved node entry point", async () => {
+    const target = resolveNodeImport(pkg.exports["."]!);
+    expect(target).toBeDefined();
+
+    // Imported by file URL rather than by the `@workglow/bootstrap` specifier:
+    // the isolated linker keeps workspace packages out of the repo root's
+    // node_modules, so the bare specifier does not resolve from here.
+    const entryUrl = pathToFileURL(join(PACKAGE_DIR, target!)).href;
+    const mod: Record<string, unknown> = await import(/* @vite-ignore */ entryUrl);
+
+    expect(Object.keys(mod)).toEqual(
+      expect.arrayContaining([
+        "bootstrapWorkglow",
+        "createOrchestrationContext",
+        "registerAllDefaults",
+      ])
+    );
+    expect(typeof mod.bootstrapWorkglow).toBe("function");
+  });
+});

--- a/packages/test/src/test/util/BootstrapReadme.test.ts
+++ b/packages/test/src/test/util/BootstrapReadme.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Executable transcription of the "Isolated context" example in
+ * `packages/bootstrap/README.md` (and the matching `createOrchestrationContext`
+ * JSDoc example).
+ *
+ * The README used to show `await task.run({ context: ctx })`. `Task.run` takes
+ * input overrides first and a run config second, and neither `IRunConfig` nor
+ * `TaskGraphRunConfig` has a `context` key — so with a loosely typed `Input`
+ * that object is an input override named `context`, the run keeps the global
+ * registry, and `ctx.dispose()` tears down a registry the task never touched.
+ * Both halves are pinned below so the snippet cannot silently rot back.
+ */
+
+import { createOrchestrationContext } from "@workglow/bootstrap";
+import type { IExecuteContext, TaskInput, TaskOutput } from "@workglow/task-graph";
+import { Task } from "@workglow/task-graph";
+import type { ServiceRegistry } from "@workglow/util";
+import { globalServiceRegistry } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+
+interface RegistryProbeOutput extends TaskOutput {
+  isGlobal: boolean;
+}
+
+/** Reports whether the run resolved against the process-wide registry. */
+class RegistryProbeTask extends Task<TaskInput, RegistryProbeOutput> {
+  public static override readonly type = "RegistryProbeTask";
+  public static override readonly category = "Test";
+  public static override readonly title = "Registry probe";
+  public static override readonly description = "Reports which service registry the run used.";
+  public static override readonly cacheable = false;
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {},
+      additionalProperties: true,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { isGlobal: { type: "boolean" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public seenRegistry: ServiceRegistry | undefined;
+
+  public override async execute(
+    _input: TaskInput,
+    context: IExecuteContext
+  ): Promise<RegistryProbeOutput> {
+    this.seenRegistry = context.registry;
+    return { isGlobal: context.registry === globalServiceRegistry };
+  }
+}
+
+describe("the @workglow/bootstrap README isolated-context example", () => {
+  it("routes the run to the isolated registry when the context is passed in the run config", async () => {
+    const ctx = createOrchestrationContext();
+    const task = new RegistryProbeTask();
+    try {
+      const output = await task.run({}, { registry: ctx.registry });
+
+      expect(output.isGlobal).toBe(false);
+      expect(task.seenRegistry).toBe(ctx.registry);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  it("keeps the global registry when a context is passed as an input override instead", async () => {
+    const ctx = createOrchestrationContext();
+    const task = new RegistryProbeTask();
+    try {
+      // The shape the README used to document. It type-checks only because this
+      // task's input schema is open; the run silently ignores it.
+      const output = await task.run({ context: ctx });
+
+      expect(output.isGlobal).toBe(true);
+      expect(task.seenRegistry).not.toBe(ctx.registry);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "../indexeddb" },
     { "path": "../mcp" },
     { "path": "../browser-control" },
+    { "path": "../bootstrap" },
     { "path": "../../providers/anthropic" },
     { "path": "../../providers/bun-webview" },
     { "path": "../../providers/deepseek" },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -11,5 +11,11 @@ import "./scripts/lib/preload-credentials";
 // the global registry being populated, so bootstrap once here. Imported by
 // source path rather than as `@workglow/bootstrap`: the isolated linker keeps
 // workspace packages out of the repo root's node_modules.
-import { registerAllDefaults } from "./packages/bootstrap/src/bootstrap/registerAllDefaults";
-registerAllDefaults();
+//
+// `bootstrapWorkglow()` rather than `registerAllDefaults(globalServiceRegistry)`
+// because `globalServiceRegistry` is likewise unresolvable from this file: a
+// root-level `@workglow/util` import fails outright, and reaching into
+// `packages/util/src` would load a second copy of the module — a different
+// registry object from the one the tests read through `@workglow/util`.
+import { bootstrapWorkglow } from "./packages/bootstrap/src/bootstrap/bootstrapWorkglow";
+bootstrapWorkglow();


### PR DESCRIPTION
## Severity

**Every item here is MEDIUM or LOW. This is publishing hygiene, API shape, CI coverage, and docs — polish, not a gate.**

PR #672 has no correctness, security, or data-integrity defect. A reviewer verified that:

- the registration set **and order** are identical across the old production body, the old test body, and the new `registerAllDefaults` (14 calls, no security delta);
- all 14 `register*Defaults` genuinely forward the `registry` parameter, with none falling back to the global;
- there is no dependency cycle;
- the re-export shim preserves the full public surface, including types.

## A1 — missing `license` field (MEDIUM) — **plan premise was wrong, adapted**

`packages/bootstrap/package.json` had no `license` key while setting `publishConfig.access: "public"`. Without it, `bun run publish-workspaces` pushes to npm with license metadata absent, so the registry page and every SBOM/license scanner report it unlicensed — contradicting the SPDX Apache-2.0 headers in its own source.

**Correction to the plan I was given:** it asserted "all 13 existing `packages/*` declare `Apache-2.0`". They do not. `grep -n '"license"' packages/*/package.json providers/*/package.json package.json` returns **zero** matches — no workspace in this repo declares a `license` field, and the cited key-order anchor (`packages/knowledge-base/package.json:4-5`) is `version` / `repository`, not a license key.

I applied the fix anyway, because it stands on its own merits for a package that is `access: "public"` and carries SPDX headers — but flagging that this is now the **only** package with the field, and that the same gap exists across the other 13 packages and 28 providers. Worth a separate repo-wide sweep; deliberately out of scope here.

Also added `packages/bootstrap/LICENSE` (byte-identical to `packages/knowledge-base/LICENSE`). 8 of 14 packages ship one; npm includes `LICENSE` regardless of the `files` field.

## A2 — version drift (MEDIUM)

`packages/bootstrap` was `0.3.37`; root and every other workspace are `0.3.38`. Set to `0.3.38`.

Left alone, `bun run bunset` (`--patch --all`) would bump bootstrap to 0.3.38 while everything else went to 0.3.39, so `workglow@0.3.39` would publish a `@workglow/bootstrap@0.3.38` dependency and the offset would persist across every future release.

## A3 — restored the required `registry` parameter (MEDIUM)

`registerAllDefaults` was module-private on main with a **required** `(registry: ServiceRegistry)`. #672 exported it from `@workglow/bootstrap`, from `workglow/bootstrap`, **and** from the `workglow` root barrel (`packages/workglow/src/common.ts:30`) — while making the argument optional (`= globalServiceRegistry`).

Dropped the default. `globalServiceRegistry` is no longer imported in that file.

**Rationale:** the repo's own convention is "`T | undefined` over `T?` optional — force callers to be explicit", and a defaulted global-container argument is exactly the implicit ambient state that rule prevents. Making the parameter optional at the same moment the function goes from module-private to triple-exported converts a compile error into a silent cross-tenant registry mutation: a caller who builds an isolated context and then calls `registerAllDefaults()` gets no diagnostic, just defaults installed on the wrong registry. The convenience saved one identifier at one call site in the entire repo.

The root-barrel export is kept — with a required parameter it is no longer hazardous.

**Consumer consequence:** `registerAllDefaults()` with no argument is now a TypeScript error. Callers write `registerAllDefaults(globalServiceRegistry)` or, preferably, `bootstrapWorkglow()` / `createOrchestrationContext()`. `@workglow/bootstrap` has never been published, so this breaks zero real consumers — and the window to fix it closes at first publish.

### A3 caller update — **plan instruction was wrong, adapted**

The plan said to update `vitest.setup.ts` to `import { globalServiceRegistry } from "@workglow/util"` and call `registerAllDefaults(globalServiceRegistry)`. **That does not work**, for the same reason #672's own comment in that file gives for importing by source path: the isolated linker keeps workspace packages out of the repo root's `node_modules`. Verified directly —

```
createRequire("<root>/vitest.setup.ts").resolve("@workglow/util")
  → MODULE_NOT_FOUND
```

Reaching into `packages/util/src/di/ServiceRegistry` instead would be worse: that loads a **second copy** of the module, so the setup file would populate a different `globalServiceRegistry` object than the one tests read through `@workglow/util`, and every test depending on registered defaults would fail.

So the setup file now calls `bootstrapWorkglow()` from the bootstrap package's source path. It is exactly equivalent — with no `logger` option, `bootstrapWorkglow` is a call to `registerAllDefaults(globalServiceRegistry)` and nothing else — and it resolves `@workglow/util` correctly, because the import happens from inside `packages/bootstrap`, where the linker did place it. It is also the public entry point, which is what a bootstrap harness should be using.

## A4 — CI coverage of the published contract (MEDIUM)

Nothing in CI exercised the package's build output. The vitest harness imports the raw source module; the package ships no test files despite `"test": "bun test"`; the only dist consumer is `workglow/build.ts`'s collision detector. So a typo in the `exports` map, or a `build-browser` that silently emitted no `dist/browser.js`, would ship to npm and `import { bootstrapWorkglow } from "@workglow/bootstrap"` would throw `ERR_PACKAGE_PATH_NOT_EXPORTED` with no CI signal.

Added one file: `packages/test/src/test/util/BootstrapPackageExports.test.ts`. Both routing claims verified before relying on them — `scripts/test.ts:79` maps section `util` to `packages/test/src/test/util`, and `.github/workflows/test.yml:195-211` runs `test-vitest-unit` with `needs: build`, downloading the `build-output` artifact, so real `dist/` is present.

It asserts:

1. every leaf string under `exports` (recursing through the `react-native` / `browser` / `bun` condition objects) resolves to a file that exists — catching a typo'd path **and** a build that emitted nothing;
2. the `"."` → default `import` target (`dist/node.js`) exports `bootstrapWorkglow`, `createOrchestrationContext`, and `registerAllDefaults`. Imported **by file URL** via `pathToFileURL`, not by the `@workglow/bootstrap` specifier, sidestepping the isolated-linker problem above.

`bun run use-source` stubs satisfy both assertions, so source mode is unaffected.

## A5 — docs (LOW)

- New `packages/bootstrap/README.md` and `packages/bootstrap/CHANGELOG.md` (13 of 14 packages already had both; bootstrap was the only one without).
- `.claude/CLAUDE.md`: `bootstrap` added to the dependency-graph block, and a new "Key packages" entry stating that the implementation lives in `@workglow/bootstrap` and that `packages/workglow/src/bootstrap.ts` is now a pure re-export shim — otherwise a contributor adding a default registration edits the dead shim.

On the `files` array (`["dist", "src/**/*.md"]`, which does not list root-level `.md`): all 13 sibling packages ship root-level `README.md` / `CHANGELOG.md` under the identical array, so bootstrap now matches sibling tarball behavior exactly — npm always includes `README` and `LICENSE` regardless of `files`. No `files` change made.

Note on the graph placement: bootstrap depends on `ai` / `knowledge-base` / `mcp`, **not** on `providers/*`, so it is listed as a sibling of `providers/*` on the tier below `ai`, rather than beneath it.

## A6 — dependency weight (LOW, documented only)

`@workglow/bootstrap` pulls `@workglow/mcp` (which has a hard `dependencies` entry on `@modelcontextprotocol/sdk` — verified), `@workglow/ai`, and `@workglow/knowledge-base`. A light consumer wanting only logger/task/storage defaults installs the MCP SDK and the full AI layer.

**Entry points deliberately not split** — the package registers all defaults by design, and splitting would reintroduce the drift #672 was extracted to fix. The tradeoff is recorded in the new README, with the guidance that consumers wanting a subset should call the individual `register*Defaults(registry)` functions directly.

## A7 — build ordering (LOW, note only — `turbo.json` unchanged)

`turbo.json:7-10` gives `build-js` only `^build-types`, while `packages/workglow/build.ts:30` runtime-imports every barrel star-spec via `assertNoExportCollisions` — now including `./bootstrap` → `@workglow/bootstrap` → `dist/node.js`. On a cold `bun run rebuild` with unlucky scheduling this can fail to resolve. Pre-existing for `@workglow/ai`; this PR's parent adds one more edge.

Proposed follow-up (**not** applied here): `"build-js": { "dependsOn": ["^build-types", "^build-js"] }`. The concurrency cost should be measured before adopting it.

## Verification

Ran, and observed passing:

- `bun install` — clean, `bun.lock` unchanged.
- `bun run build` — 86/86 tasks, exit 0 (includes `build-types`).
- `bun run build:types` — 42/42 tasks.
- `npx turbo run build-types --filter @workglow/test --force` — 37/37, confirming the new test file type-checks (`packages/test` had it cached otherwise).
- `npx vitest run packages/test/src/test/util/BootstrapPackageExports.test.ts` — 3/3 passed.
- **A4 negative check, actually performed:** temporarily rewrote the `"."` import target to `./dist/nodee.js`; 2 of 3 assertions failed (`missing` reported `"." [import] -> ./dist/nodee.js`, and the dynamic import threw `Cannot find module`). Restored and re-verified.
- `rg -n 'registerAllDefaults\(\s*\)' --type ts` — no matches outside `dist/`.
- `jq -r .version packages/*/package.json providers/*/package.json examples/*/package.json package.json | sort -u` — exactly one line, `0.3.38`.
- `jq -r .license packages/bootstrap/package.json` — `Apache-2.0`.
- `npx prettier --check` on all changed files — clean. `npx eslint` on changed sources — clean (`vitest.setup.ts` is not covered by the eslint config).
- Full vitest unit tier (`bun run test:vitest:unit`) — **434 files passed | 2 skipped (436), 5048 tests passed | 47 skipped, exit 0**, including the new `BootstrapPackageExports` file. This also proves the reworked `vitest.setup.ts` still populates the global registry: the suite depends on those defaults being present, and a second-copy `globalServiceRegistry` would have failed it broadly.

Not verified: behavior of `bun run bunset` / `publish-workspaces` against a real npm registry (neither was executed); CI itself, which will run on this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhfGNbddCCJR71UvDw2c7f)_