### PR TITLE
fix(indexeddb): keep a null equality criterion out of IDBKeyRange

### DIFF
--- a/packages/indexeddb/src/storage/IndexedDbTabularStorage.ts
+++ b/packages/indexeddb/src/storage/IndexedDbTabularStorage.ts
@@ -29,6 +29,7 @@ import {
   normalizeCriterion,
   pickCoveringIndex,
   safeEmit,
+  StorageUnsupportedError,
   type ITabularMigration,
   type ITabularMigrationApplier,
 } from "@workglow/storage";
@@ -36,6 +37,7 @@ import { createServiceToken, deepEqual, makeFingerprint, uuid4 } from "@workglow
 import type {
   DataPortSchemaObject,
   FromSchema,
+  JsonSchema,
   TypedArraySchemaOptions,
 } from "@workglow/util/schema";
 import type { ExpectedIndexDefinition, MigrationOptions } from "./IndexedDbTable";
@@ -114,10 +116,11 @@ export class IndexedDbTabularStorage<
   };
   /**
    * Indexes safe for cursor-based narrowing. An IDB index excludes records
-   * whose keyPath has any undefined component, so iterating an index can miss
-   * records when an indexed column is optional in the schema. Native
+   * whose keyPath has any undefined component, and equally any null one (null
+   * is not a valid key), so iterating an index can miss records when an indexed
+   * column is optional in the schema or its type admits null. Native
    * `count(range)` and cursor scans are only correct over indexes whose every
-   * column is required. Computed lazily on first use.
+   * column is required and non-nullable. Computed lazily on first use.
    */
   private cursorSafeIndexes: Array<Array<keyof Entity>> | undefined;
 
@@ -690,20 +693,27 @@ export class IndexedDbTabularStorage<
 
   /**
    * Returns the subset of configured indexes safe to use for cursor-based
-   * narrowing — those whose every column is required by the schema. IDB
-   * excludes records with undefined keyPath components from indexes, so
-   * iterating an index would silently miss records when any indexed column
-   * is optional.
+   * narrowing — those whose every column is required by the schema AND cannot
+   * hold null. IDB excludes a record from an index when the keyPath component
+   * is undefined, and equally when it is null (null is not a valid key), so
+   * iterating an index would silently miss records for either shape.
+   *
+   * A required-but-nullable column is the second case: legal here, impossible
+   * in SQL (a required column is emitted `NOT NULL`), and invisible to the
+   * caller because the scan returns fewer rows rather than failing.
    */
   private getCursorSafeIndexes(): Array<Array<keyof Entity>> {
     if (this.cursorSafeIndexes) return this.cursorSafeIndexes;
     const required = new Set(this.schema.required ?? []);
+    const properties = this.schema.properties as Record<string, JsonSchema | undefined>;
     // Unique tuples are materialized as real IDB indexes (see `performSetup`)
     // under the same `cols.join("_")` name the planner derives, so they can
     // narrow scans exactly like regular indexes. The base class guarantees no
     // tuple appears in both lists, so the union has no duplicate.
     this.cursorSafeIndexes = [...this.indexes, ...this.uniqueIndexes].filter((columns) =>
-      columns.every((column) => required.has(String(column)))
+      columns.every(
+        (column) => required.has(String(column)) && !schemaAdmitsNull(properties[String(column)])
+      )
     );
     return this.cursorSafeIndexes;
   }
@@ -883,7 +893,11 @@ export class IndexedDbTabularStorage<
 
       // `=` and `!=` carry their own null semantics (see the matches* helpers);
       // every ordering operator is UNKNOWN against null, so the row is excluded.
-      if (operator !== "=" && operator !== "!=" && (recordValue === null || recordValue === undefined)) {
+      if (
+        operator !== "=" &&
+        operator !== "!=" &&
+        (recordValue === null || recordValue === undefined)
+      ) {
         return false;
       }
 
@@ -1057,8 +1071,17 @@ export class IndexedDbTabularStorage<
     // returning undefined sends it to the in-cursor filter instead.
     if (isSearchInCondition(criterion)) return undefined;
     if (isSearchCondition(criterion)) {
-      return criterion.operator === "=" ? (criterion.value as Entity[keyof Entity]) : undefined;
+      if (criterion.operator !== "=") return undefined;
+      // `null` is not a valid IDB key, so `IDBKeyRange.only`/`bound` would throw
+      // a DataError on it. No range could serve the criterion anyway: IDB omits
+      // a record from an index entirely when its indexed value is null, so the
+      // rows being asked for are not in the index to be scanned. Report the
+      // criterion as unusable for narrowing and let `matchesEqualityCriterion`
+      // in the cursor filter decide it.
+      if (criterion.value === null) return undefined;
+      return criterion.value as Entity[keyof Entity];
     }
+    if (criterion === null) return undefined;
     return criterion as Entity[keyof Entity];
   }
 
@@ -1241,6 +1264,13 @@ export class IndexedDbTabularStorage<
    *
    * Throws {@link CoveringIndexMissingError} when no registered index can serve
    * the request (i.e. the index does not cover all select + orderBy columns).
+   *
+   * A `null` equality criterion on a column of the chosen index is rejected with
+   * {@link StorageUnsupportedError}. IndexedDB omits a record from an index when
+   * its indexed value is null, so those rows exist in no index and a projection
+   * reading values out of `cursor.key` can never produce them — the request
+   * would return silently-empty results rather than the matching rows. Use
+   * {@link query}, which reads whole records and filters them in the cursor.
    */
   override async queryIndex<K extends keyof Entity & string>(
     criteria: SearchCriteria<Entity>,
@@ -1266,6 +1296,21 @@ export class IndexedDbTabularStorage<
       primaryKeyColumns: this.primaryKeyColumns().map(String),
     });
 
+    for (const col of picked.keyPath) {
+      const criterion = (criteria as Record<string, unknown>)[col];
+      const isNullEquality = isSearchCondition(criterion)
+        ? criterion.operator === "=" && criterion.value === null
+        : criterion === null;
+      if (isNullEquality) {
+        throw new StorageUnsupportedError(
+          `A null equality criterion on indexed column "${col}" (IndexedDB omits ` +
+            `null-valued records from an index, so an index scan can never reach ` +
+            `them — use query() instead)`,
+          "IndexedDbTabularStorage"
+        );
+      }
+    }
+
     const db = await this.getDb();
     return new Promise((resolve, reject) => {
       const tx = db.transaction(this.table, "readonly");
@@ -1284,8 +1329,12 @@ export class IndexedDbTabularStorage<
         if (isSearchInCondition(c)) break;
         if (isSearchCondition(c)) {
           if (c.operator !== "=") break;
+          // Defense in depth: the guard above already rejected a null equality
+          // on a key-path column, and `null` is not a valid IDB key.
+          if (c.value === null) break;
           prefix.push(c.value);
         } else {
+          if (c === null) break;
           prefix.push(c);
         }
       }
@@ -1447,6 +1496,23 @@ export class IndexedDbTabularStorage<
 }
 
 /**
+ * Whether a column's schema admits `null`, in any of the spellings JSON Schema
+ * offers for it. Mirrors the nullability test the SQL backends use to decide
+ * between `NULL` and `NOT NULL`.
+ */
+function schemaAdmitsNull(typeDef: JsonSchema | undefined): boolean {
+  if (typeDef === undefined) return false;
+  if (typeof typeDef === "boolean") return typeDef;
+  if (typeDef.type === "null") return true;
+  if (Array.isArray(typeDef.type)) return typeDef.type.includes("null");
+  const branches = typeDef.anyOf ?? typeDef.oneOf;
+  if (Array.isArray(branches)) {
+    return branches.some((branch) => typeof branch !== "boolean" && branch.type === "null");
+  }
+  return false;
+}
+
+/**
  * Compare two values using a SearchOperator. Used by queryIndex to evaluate
  * non-equality criteria that cannot be expressed as an IDBKeyRange prefix.
  */
@@ -1455,7 +1521,8 @@ function compareWithOperator(a: unknown, op: SearchOperator, b: unknown): boolea
   const bv = b as string | number;
   switch (op) {
     case "=":
-      return av === bv;
+      // Same rule `matchesCriteria` applies, so the two agree on every input.
+      return matchesEqualityCriterion(av, bv);
     case "!=":
       return matchesInequalityCriterion(av, bv);
     case "<":

--- a/packages/test/src/test/storage-tabular/CachedTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/CachedTabularStorage.integration.test.ts
@@ -50,13 +50,22 @@ describe("CachedTabularStorage", () => {
           ["category", "subcategory"],
           ["subcategory", "category"],
           "value",
+          "tag",
+          ["category", "tag"],
         ]);
         return new CachedTabularStorage<typeof SearchSchema, typeof SearchPrimaryKeyNames>(
           durable,
           undefined,
           SearchSchema,
           SearchPrimaryKeyNames,
-          ["category", ["category", "subcategory"], ["subcategory", "category"], "value"]
+          [
+            "category",
+            ["category", "subcategory"],
+            ["subcategory", "category"],
+            "value",
+            "tag",
+            ["category", "tag"],
+          ]
         );
       }
     );

--- a/packages/test/src/test/storage-tabular/DuckDbTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/DuckDbTabularStorage.integration.test.ts
@@ -51,7 +51,14 @@ describe("DuckDbTabularStorage", () => {
         `sql_test_${uuid4().replace(/-/g, "_")}`,
         SearchSchema,
         SearchPrimaryKeyNames,
-        ["category", ["category", "subcategory"], ["subcategory", "category"], "value"]
+        [
+          "category",
+          ["category", "subcategory"],
+          ["subcategory", "category"],
+          "value",
+          "tag",
+          ["category", "tag"],
+        ]
       ),
     async () => {
       const repo = new DuckDbTabularStorage<typeof AllTypesSchema, typeof AllTypesPrimaryKeyNames>(

--- a/packages/test/src/test/storage-tabular/FsFolderTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/FsFolderTabularStorage.integration.test.ts
@@ -75,7 +75,14 @@ describe("FsFolderTabularStorage", () => {
           testDir,
           SearchSchema,
           SearchPrimaryKeyNames,
-          ["category", ["category", "subcategory"], ["subcategory", "category"], "value"]
+          [
+            "category",
+            ["category", "subcategory"],
+            ["subcategory", "category"],
+            "value",
+            "tag",
+            ["category", "tag"],
+          ]
         );
       } catch (error) {
         expect(error).toBeDefined();

--- a/packages/test/src/test/storage-tabular/HttpTabularProxyStorage.test.ts
+++ b/packages/test/src/test/storage-tabular/HttpTabularProxyStorage.test.ts
@@ -612,14 +612,28 @@ describe("HttpTabularProxyStorage — generic contract (CompoundSchema/SearchSch
     const backing = new InMemoryTabularStorage<typeof SearchSchema, typeof SearchPrimaryKeyNames>(
       SearchSchema,
       SearchPrimaryKeyNames,
-      ["category", ["category", "subcategory"], ["subcategory", "category"], "value"]
+      [
+        "category",
+        ["category", "subcategory"],
+        ["subcategory", "category"],
+        "value",
+        "tag",
+        ["category", "tag"],
+      ]
     );
     return new HttpTabularProxyStorage<typeof SearchSchema, typeof SearchPrimaryKeyNames>({
       fetch: makeFakeServer(backing as never),
       table: "search",
       schema: SearchSchema,
       primaryKey: SearchPrimaryKeyNames,
-      indexes: ["category", ["category", "subcategory"], ["subcategory", "category"], "value"],
+      indexes: [
+        "category",
+        ["category", "subcategory"],
+        ["subcategory", "category"],
+        "value",
+        "tag",
+        ["category", "tag"],
+      ],
     });
   };
   const makeAllTypes = async () => {

--- a/packages/test/src/test/storage-tabular/InMemoryTabularStorage.test.ts
+++ b/packages/test/src/test/storage-tabular/InMemoryTabularStorage.test.ts
@@ -48,7 +48,14 @@ describe("InMemoryTabularStorage", () => {
       new InMemoryTabularStorage<typeof SearchSchema, typeof SearchPrimaryKeyNames>(
         SearchSchema,
         SearchPrimaryKeyNames,
-        ["category", ["category", "subcategory"], ["subcategory", "category"], "value"]
+        [
+          "category",
+          ["category", "subcategory"],
+          ["subcategory", "category"],
+          "value",
+          "tag",
+          ["category", "tag"],
+        ]
       ),
     async () =>
       new InMemoryTabularStorage<typeof AllTypesSchema, typeof AllTypesPrimaryKeyNames>(

--- a/packages/test/src/test/storage-tabular/IndexedDbTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/IndexedDbTabularStorage.integration.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { IndexedDbTabularStorage } from "@workglow/indexeddb/storage";
+import { StorageUnsupportedError } from "@workglow/storage";
 import { setLogger, uuid4 } from "@workglow/util";
 import type { DataPortSchemaObject, FromSchema } from "@workglow/util/schema";
 import "fake-indexeddb/auto";
@@ -49,7 +50,14 @@ describe("IndexedDbTabularStorage", () => {
         `${dbName}_compound`,
         SearchSchema,
         SearchPrimaryKeyNames,
-        ["category", ["category", "subcategory"], ["subcategory", "category"], "value"]
+        [
+          "category",
+          ["category", "subcategory"],
+          ["subcategory", "category"],
+          "value",
+          "tag",
+          ["category", "tag"],
+        ]
       ),
     async () => {
       const repo = new IndexedDbTabularStorage<
@@ -342,6 +350,71 @@ describe("IndexedDbTabularStorage", () => {
         expect(results?.length).toBe(3);
         expect(results?.map((e) => e.id).sort()).toEqual(["1", "2", "3"]);
       });
+    });
+  });
+
+  // A column can be listed in `required` and still hold null when its schema
+  // admits null — legal in IndexedDB, impossible in SQL (a required column is
+  // emitted `NOT NULL`). That combination is the only one that reaches the
+  // index planner with a null equality value, because `getCursorSafeIndexes`
+  // keeps only indexes whose every column is required.
+  describe("null equality on a required-but-nullable indexed column", () => {
+    const NullableStatusSchema = {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        category: { type: "string" },
+        status: { anyOf: [{ type: "string" }, { type: "null" }] },
+      },
+      required: ["id", "category", "status"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchemaObject;
+    const NullableStatusPK = ["id"] as const;
+
+    let storage: IndexedDbTabularStorage<typeof NullableStatusSchema, typeof NullableStatusPK>;
+
+    beforeEach(async () => {
+      storage = new IndexedDbTabularStorage<typeof NullableStatusSchema, typeof NullableStatusPK>(
+        `${dbName}_nullable_status_${uuid4().replace(/-/g, "_")}`,
+        NullableStatusSchema,
+        NullableStatusPK,
+        ["status", ["category", "status"]]
+      );
+      await storage.setupDatabase();
+      await storage.put({ id: "1", category: "a", status: null });
+      await storage.put({ id: "2", category: "a", status: "open" });
+    });
+
+    afterEach(async () => {
+      await storage.deleteAll();
+      storage.destroy();
+    });
+
+    it("query resolves the null row instead of rejecting with DataError", async () => {
+      const rows = await storage.query({ status: null });
+      expect(rows?.map((r) => r.id)).toEqual(["1"]);
+    });
+
+    it("query narrows a compound prefix without pushing null into the key range", async () => {
+      const rows = await storage.query({ category: "a", status: null });
+      expect(rows?.map((r) => r.id)).toEqual(["1"]);
+    });
+
+    it("count matches the null row", async () => {
+      expect(await storage.count({ status: null })).toBe(1);
+      expect(await storage.count({ status: "open" })).toBe(1);
+    });
+
+    it("updateWhere patches the null row", async () => {
+      const updated = await storage.updateWhere({ status: null }, { category: "b" });
+      expect(updated?.id).toBe("1");
+      expect((await storage.get({ id: "1" }))?.category).toBe("b");
+    });
+
+    it("queryIndex rejects a null criterion rather than scanning past it", async () => {
+      await expect(
+        storage.queryIndex({ status: null }, { select: ["id", "status"] })
+      ).rejects.toThrow(StorageUnsupportedError);
     });
   });
 

--- a/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
@@ -58,7 +58,14 @@ describe("PostgresTabularStorage", () => {
         `sql_test_${uuid4().replace(/-/g, "_")}`,
         SearchSchema,
         SearchPrimaryKeyNames,
-        ["category", ["category", "subcategory"], ["subcategory", "category"], "value"]
+        [
+          "category",
+          ["category", "subcategory"],
+          ["subcategory", "category"],
+          "value",
+          "tag",
+          ["category", "tag"],
+        ]
       ),
     async () => {
       const repo = new PostgresTabularStorage<

--- a/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
@@ -50,7 +50,14 @@ describe("SqliteTabularStorage", async () => {
         `sql_test_${uuid4().replace(/-/g, "_")}`,
         SearchSchema,
         SearchPrimaryKeyNames,
-        ["category", ["category", "subcategory"], ["subcategory", "category"], "value"]
+        [
+          "category",
+          ["category", "subcategory"],
+          ["subcategory", "category"],
+          "value",
+          "tag",
+          ["category", "tag"],
+        ]
       ),
     async () => {
       const repo = new SqliteTabularStorage<typeof AllTypesSchema, typeof AllTypesPrimaryKeyNames>(

--- a/packages/test/src/test/storage-tabular/SupabaseTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/SupabaseTabularStorage.integration.test.ts
@@ -46,7 +46,14 @@ describe("SupabaseTabularStorage", () => {
         `supabase_test_${uuid4().replace(/-/g, "_")}`,
         SearchSchema,
         SearchPrimaryKeyNames,
-        ["category", ["category", "subcategory"], ["subcategory", "category"], "value"]
+        [
+          "category",
+          ["category", "subcategory"],
+          ["subcategory", "category"],
+          "value",
+          "tag",
+          ["category", "tag"],
+        ]
       ),
     async () => {
       const repo = new SupabaseTabularStorage<

--- a/packages/test/src/test/storage-tabular/genericTabularStorageTests.ts
+++ b/packages/test/src/test/storage-tabular/genericTabularStorageTests.ts
@@ -44,6 +44,12 @@ export const SearchSchema = {
     category: { type: "string" },
     subcategory: { type: "string" },
     kind: { type: "string" },
+    // Indexed and optional, so a null criterion on it exercises the index
+    // planner on every backend. `kind` stays deliberately unindexed — two tests
+    // below rely on that to cover the no-covering-index and partial-narrowing
+    // paths. Keep `tag` out of `required`: a required column is emitted
+    // `NOT NULL` in SQL, which would reject every existing `put`.
+    tag: { type: "string" },
     value: { type: "number" },
     createdAt: { type: "string", format: "date-time" },
     updatedAt: { type: "string", format: "date-time" },
@@ -379,6 +385,47 @@ export function runGenericTabularStorageTests(
         // The non-null side must keep working unchanged.
         const setMatches = await searchableRepo.query({ kind: "premium" } as never);
         expect(setMatches?.map((r) => r.id)).toEqual(["set-kind"]);
+      });
+
+      it("matches NULL on an indexed column with a null criterion", async () => {
+        // The same rule as above, but on a column the backend has an index for.
+        // That is the path the previous test never reached: it used `kind`,
+        // which is in no index, so every backend answered it with a scan and
+        // the cross-backend claim went untested against an index planner.
+        const now = new Date().toISOString();
+        await searchableRepo.put({
+          id: "no-tag",
+          category: "electronics",
+          subcategory: "phones",
+          value: 100,
+          createdAt: now,
+          updatedAt: now,
+        });
+        await searchableRepo.put({
+          id: "with-tag",
+          category: "electronics",
+          subcategory: "phones",
+          tag: "a",
+          value: 200,
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        const nullMatches = await searchableRepo.query({ tag: null } as never);
+        expect(nullMatches?.map((r) => r.id)).toEqual(["no-tag"]);
+
+        // Compound-index prefix shape: a non-null leading column plus a null
+        // one, which is what a "look up by tuple, else create" repo issues.
+        const compound = await searchableRepo.query({
+          category: "electronics",
+          tag: null,
+        } as never);
+        expect(compound?.map((r) => r.id)).toEqual(["no-tag"]);
+
+        expect(await searchableRepo.count({ tag: null } as never)).toBe(1);
+
+        const setMatches = await searchableRepo.query({ tag: "a" } as never);
+        expect(setMatches?.map((r) => r.id)).toEqual(["with-tag"]);
       });
 
       it("supports != , including its null form", async () => {


### PR DESCRIPTION
## The bug

9135d06b made `{col: null}` a supported, documented cross-backend criterion — "matches null OR an absent column" — and taught IndexedDB's in-cursor matcher the rule. But `getEqualityCriterionValue` in `IndexedDbTabularStorage.ts` still returned the value as-is; only `undefined` breaks the planner's prefix loop. So `null` was pushed into `prefixValues` and handed to `IDBKeyRange.only()` / `IDBKeyRange.bound()`.

`null` is not a valid IndexedDB key. The `DataError` is thrown synchronously inside the promise executor, so `query()`, `count()` and `updateWhere()` all **rejected** rather than returning the matching rows.

## Why the test added alongside 9135d06b did not catch it

That commit added `"matches NULL columns with a null criterion"` to the generic cross-backend suite — but it used `kind`, which appears in **no** backend's index list. Every backend therefore answered it with a plain scan, and the parity claim was asserted without ever being run through an index planner. The IndexedDB planner is the only place the criterion breaks, and it was the one path the test could not reach.

## Scope

`getCursorSafeIndexes()` keeps only indexes whose every column is in `schema.required`, so the `query`/`count`/`updateWhere` crash is reachable only for a **required-but-nullable** column (`{anyOf: [{type: "string"}, {type: "null"}]}` listed in `required`). That is legal in IndexedDB and impossible in SQL — `BaseSqlTabularStorage` emits `NOT NULL` for a required column. `queryIndex` uses `pickCoveringIndex` with no such filter, so any nullable indexed column reaches `IDBKeyRange` there.

### One thing beyond the reported scope

Confirming the scope surfaced a second, quieter failure in the same shape. A required-but-nullable indexed column is unsound for **any** index scan, not just a null criterion: IDB omits a record from an index when the indexed value is null, exactly as it does for an undefined one. With indexes `["status"]` and `["category", "status"]` over a nullable `status`, plain `query({category: "a"})` narrows through `category_status` and silently drops every row holding `status: null`.

`getCursorSafeIndexes` already excluded indexes over *optional* columns for precisely this reason; it now also excludes indexes over columns whose type admits null (`schemaAdmitsNull`, mirroring the SQL backends' `NULL`/`NOT NULL` test). This is what makes the compound `{category, tag: null}` case in the new test correct rather than empty. Fixing only the throw would have converted a loud failure into a silent under-return.

## Why `queryIndex` throws rather than scanning

Skipping the `prefix.push` there is necessary but **not sufficient**. `queryIndex` projects values out of `cursor.key` and never reads `cursor.value`; null-valued rows are absent from the index, so an unbounded scan returns silently-empty results — strictly worse than the throw. It now rejects with `StorageUnsupportedError` naming the column and pointing at `query()`, guarded immediately after `pickCoveringIndex(...)` and before the transaction opens. The `break`-on-null in the prefix loop stays as defense in depth.

Every in-repo `queryIndex(` call site was checked: `ScopedTabularStorage`, `CachedTabularStorage`, `SharedInMemoryTabularStorage` and `TelemetryTabularStorage` all forward criteria unchanged (Scoped adds a string `kb_id`); the remainder are tests. None passes a null criterion.

## Consistency migration

`compareWithOperator`'s `"="` case now calls `matchesEqualityCriterion`, so it agrees with `matchesCriteria`. Confirmed behavior-preserving against the code: the function has exactly one call site — `queryIndex`'s in-cursor filter — where `a` is always a component of `cursor.key` (a valid IDB key, so never null/undefined) and the loop only visits key-path columns, which the new guard has already cleared of null equalities. The two implementations differ only when the criterion value is `null`.

## Tests

**Cross-backend** (`genericTabularStorageTests.ts`): added an indexed, **non-required** `tag` column to `SearchSchema` — deliberately not in `required`, since that would emit `NOT NULL` in SQL and reject every existing `put` — plus `"tag"` and `["category", "tag"]` to every searchable index list. New case `"matches NULL on an indexed column with a null criterion"` covers `query({tag: null})`, the compound `{category, tag: null}` prefix shape, `count({tag: null})`, and the non-null side. `kind` is untouched: two existing tests depend on it staying unindexed (the no-covering-index and partial-narrowing paths).

**IndexedDB-local** (`IndexedDbTabularStorage.integration.test.ts`): the only schema shape that reaches the planner with a null value — `status: {anyOf: [{type: "string"}, {type: "null"}]}` listed in `required`, indexes `["status"]` and `["category", "status"]`.

## Verification

`fake-indexeddb` does reproduce a real `DataError` for `IDBKeyRange.only(null)` and `IDBKeyRange.bound([null], ...)`, so the regression test had a genuine red state.

**RED — new tests written, before the fix:**

```
$ WORKGLOW_TEST_TIER=all npx vitest run --config vitest.config.ts --project test \
    packages/test/src/test/storage-tabular/IndexedDbTabularStorage.integration.test.ts

DataError: Data provided to an operation does not meet requirements.
 ❯ Function.only .../fake-indexeddb/build/esm/FDBKeyRange.js:10:13
 ❯ IndexedDbTabularStorage.createIndexedRange ../indexeddb/src/storage/IndexedDbTabularStorage.ts:775:21
 ❯ IndexedDbTabularStorage.count ../indexeddb/src/storage/IndexedDbTabularStorage.ts:801:12

AssertionError: expected error to be instance of StorageUnsupportedError
+ Received: DataError { "message": "Data provided to an operation does not meet requirements." }

 Test Files  1 failed (1)
      Tests  5 failed | 161 passed | 1 skipped (167)
```

**GREEN — same command after the fix:**

```
 Test Files  1 passed (1)
      Tests  166 passed | 1 skipped (167)
```

**Backends that actually ran the new cross-backend case** (`-t "matches NULL on an indexed column with a null criterion" --reporter=verbose`) — Postgres, Supabase and DuckDB were all reachable in this environment, so none of them was skipped:

```
✓ IndexedDbTabularStorage    ... 74ms
✓ DuckDbTabularStorage       ... 423ms
✓ PostgresTabularStorage     ... 9568ms
✓ CachedTabularStorage       ... 6ms
✓ InMemoryTabularStorage     ... 12ms
✓ HttpTabularProxyStorage    ... 122ms
✓ SupabaseTabularStorage     ... 5465ms
✓ SqliteTabularStorage       ... 64ms

 Test Files  8 passed | 9 skipped (17)
```

**Whole `storage-tabular` directory, all tiers:**

```
$ WORKGLOW_TEST_TIER=all npx vitest run --config vitest.config.ts --project test \
    packages/test/src/test/storage-tabular/

 Test Files  17 passed (17)
      Tests  1387 passed | 22 skipped (1409)
```

**Whole `storage` section via the repo runner:**

```
$ bun scripts/test.ts storage vitest
Running all tests in sections [storage] — 69 file(s)

 Test Files  68 passed | 1 skipped (69)
      Tests  1946 passed | 24 skipped (1970)
```

**Typecheck:**

```
$ bun run build:types
 Tasks:    41 successful, 41 total
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz)_