### PR TITLE
test(exports): flag condition branches that declare no types at all

### DIFF
--- a/packages/test/src/test/util/ExportTypesPairing.test.ts
+++ b/packages/test/src/test/util/ExportTypesPairing.test.ts
@@ -6,13 +6,15 @@
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
- * Every condition branch in an `exports` map that declares `types` must point at
- * the declaration file belonging to the implementation named *in that same
- * branch*. A branch whose `types` names a different target hands TypeScript the
- * wrong module: browser consumers of `@workglow/openai/ai` were type-checked
+ * Every condition branch in an `exports` map that names an implementation must
+ * declare the `types` target belonging to the implementation named *in that same
+ * branch*. A branch whose `types` names a different target — or that declares no
+ * `types` at all, so resolution falls through to an outer one — hands TypeScript
+ * the wrong module: browser consumers of `@workglow/openai/ai` were type-checked
  * against the node build, which exports `_testOnly`,
  * `registerOpenAiImageValidator` and `OpenAI_ModelSearch_Stream` — symbols the
  * browser bundle genuinely does not export.
@@ -22,6 +24,12 @@ import { describe, expect, it } from "vitest";
 const IMPLEMENTATION_KEYS = ["import", "require", "default"] as const;
 
 /**
+ * A string branch value that is a module rather than a plain asset, so
+ * `"./package.json": "./package.json"` is not treated as a missing declaration.
+ */
+const MODULE_PATH = /\.[cm]?js$/;
+
+/**
  * Branches allowed to pair a `types` target with a differently-named
  * implementation. Each entry must say why the declaration genuinely describes
  * the other file. Empty on purpose: do not add an entry to silence drift — fix
@@ -29,17 +37,39 @@ const IMPLEMENTATION_KEYS = ["import", "require", "default"] as const;
  */
 const ALLOWED_MISMATCHES: ReadonlySet<string> = new Set<string>([]);
 
-interface Branch {
+interface BranchLocation {
   readonly manifest: string;
   readonly subpath: string;
   readonly condition: string;
-  readonly types: string;
   readonly implementation: string;
   readonly expectedTypes: string;
 }
 
+/**
+ * A branch that declares `types`. It can only fail by naming the wrong
+ * declaration, so its violation reason is fixed at collection time.
+ */
+interface DeclaredBranch extends BranchLocation {
+  readonly reason: "mismatch";
+  readonly types: string;
+}
+
+/** A branch naming an implementation with no `types` beside it. */
+interface UndeclaredBranch extends BranchLocation {
+  readonly reason: "missing";
+  readonly types: undefined;
+}
+
+type Branch = DeclaredBranch | UndeclaredBranch;
+
+/**
+ * TypeScript honors a declaration extension only when it matches the module's:
+ * `.cjs` is described by `.d.cts` and `.mjs` by `.d.mts`, not by `.d.ts`.
+ */
 function declarationFor(implementation: string): string {
-  return implementation.replace(/\.[cm]?js$/, ".d.ts");
+  if (implementation.endsWith(".cjs")) return implementation.replace(/\.cjs$/, ".d.cts");
+  if (implementation.endsWith(".mjs")) return implementation.replace(/\.mjs$/, ".d.mts");
+  return implementation.replace(/\.js$/, ".d.ts");
 }
 
 function collectBranches(
@@ -49,38 +79,114 @@ function collectBranches(
   node: unknown,
   out: Branch[]
 ): void {
-  if (typeof node !== "object" || node === null || Array.isArray(node)) return;
-  const entry = node as Record<string, unknown>;
-  const types = entry.types;
-  if (typeof types === "string") {
-    const implementation = IMPLEMENTATION_KEYS.map((key) => entry[key]).find(
-      (value): value is string => typeof value === "string"
-    );
-    if (implementation !== undefined) {
+  const condition = conditionPath.join(" > ") || "(default)";
+  // Shorthand: the condition's value *is* the implementation, so nothing beside
+  // it can declare types and resolution falls through to an outer `types`.
+  if (typeof node === "string") {
+    if (MODULE_PATH.test(node)) {
       out.push({
         manifest,
         subpath,
-        condition: conditionPath.join(" > ") || "(default)",
-        types,
-        implementation,
-        expectedTypes: declarationFor(implementation),
+        condition,
+        types: undefined,
+        reason: "missing",
+        implementation: node,
+        expectedTypes: declarationFor(node),
       });
     }
+    return;
+  }
+  if (typeof node !== "object" || node === null || Array.isArray(node)) return;
+  const entry = node as Record<string, unknown>;
+  const implementation = IMPLEMENTATION_KEYS.map((key) => entry[key]).find(
+    (value): value is string => typeof value === "string"
+  );
+  if (implementation !== undefined) {
+    const location: BranchLocation = {
+      manifest,
+      subpath,
+      condition,
+      implementation,
+      expectedTypes: declarationFor(implementation),
+    };
+    const types = entry.types;
+    out.push(
+      typeof types === "string"
+        ? { ...location, types, reason: "mismatch" }
+        : { ...location, types: undefined, reason: "missing" }
+    );
   }
   for (const [key, value] of Object.entries(entry)) {
-    if (key === "types" || (IMPLEMENTATION_KEYS as readonly string[]).includes(key)) continue;
+    if (key === "types") continue;
+    // An implementation key holding a string is this branch's implementation,
+    // already recorded above. Holding an object it is a nested condition — the
+    // `{ "import": { "types": …, "default": … } }` dual-package form — and its
+    // pairing has to be checked like any other branch's.
+    const isImplementationString =
+      (IMPLEMENTATION_KEYS as readonly string[]).includes(key) && typeof value === "string";
+    if (isImplementationString) continue;
     collectBranches(manifest, subpath, [...conditionPath, key], value, out);
   }
 }
 
-function repoRoot(): string {
+function label(branch: Branch): string {
+  return `${branch.manifest} exports["${branch.subpath}"] [${branch.condition}]`;
+}
+
+function isViolation(branch: Branch): boolean {
+  if (branch.reason === "missing") return true;
+  return branch.types !== branch.expectedTypes;
+}
+
+function violationMessage(branch: Branch): string {
+  if (branch.reason === "missing") {
+    return (
+      `${label(branch)}: implementation "${branch.implementation}" declares no types ` +
+      `(expected types="${branch.expectedTypes}")`
+    );
+  }
+  return (
+    `${label(branch)}: types="${branch.types}" but implementation is ` +
+    `"${branch.implementation}" (expected types="${branch.expectedTypes}")`
+  );
+}
+
+function branchesFor(manifest: string, exportsMap: Record<string, unknown>): Branch[] {
+  const branches: Branch[] = [];
+  for (const [subpath, value] of Object.entries(exportsMap)) {
+    collectBranches(manifest, subpath, [], value, branches);
+  }
+  return branches;
+}
+
+/** Every branch of one `exports` map that pairs its implementation wrongly. */
+function findViolations(manifest: string, exportsMap: Record<string, unknown>): string[] {
+  return branchesFor(manifest, exportsMap)
+    .filter(isViolation)
+    .filter((branch) => !ALLOWED_MISMATCHES.has(label(branch)))
+    .map(violationMessage);
+}
+
+interface WorkspaceRoot {
+  readonly dir: string;
+  /** Directories holding workspace packages, from the root `workspaces` globs. */
+  readonly groups: readonly string[];
+}
+
+function workspaceRoot(): WorkspaceRoot {
   // Walk up from this file until the workspace root manifest is found.
-  let dir = dirname(new URL(import.meta.url).pathname);
+  let dir = dirname(fileURLToPath(import.meta.url));
   for (let i = 0; i < 10; i++) {
     const candidate = join(dir, "package.json");
     if (existsSync(candidate)) {
       const pkg = JSON.parse(readFileSync(candidate, "utf8")) as { workspaces?: unknown };
-      if (pkg.workspaces !== undefined) return dir;
+      if (Array.isArray(pkg.workspaces)) {
+        const groups = pkg.workspaces
+          .filter((pattern): pattern is string => typeof pattern === "string")
+          .map((pattern) => pattern.replace(/^\.\//, "").replace(/\/\*+$/, ""))
+          .filter((group) => !group.includes("*"));
+        return { dir, groups };
+      }
     }
     dir = dirname(dir);
   }
@@ -88,10 +194,10 @@ function repoRoot(): string {
 }
 
 /** Every workspace manifest, as a repo-root-relative path. */
-function workspaceManifests(root: string): string[] {
+function workspaceManifests(root: WorkspaceRoot): string[] {
   const manifests: string[] = [];
-  for (const group of ["packages", "providers", "examples"]) {
-    const groupDir = join(root, group);
+  for (const group of root.groups) {
+    const groupDir = join(root.dir, group);
     if (!existsSync(groupDir)) continue;
     for (const entry of readdirSync(groupDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) continue;
@@ -103,27 +209,29 @@ function workspaceManifests(root: string): string[] {
   return manifests.sort();
 }
 
-function allBranches(): Branch[] {
-  const root = repoRoot();
-  const branches: Branch[] = [];
+interface Manifest {
+  readonly relative: string;
+  readonly exports: Record<string, unknown>;
+}
+
+function manifestsWithExports(): Manifest[] {
+  const root = workspaceRoot();
+  const found: Manifest[] = [];
   for (const relative of workspaceManifests(root)) {
-    const pkg = JSON.parse(readFileSync(join(root, relative), "utf8")) as {
+    const pkg = JSON.parse(readFileSync(join(root.dir, relative), "utf8")) as {
       exports?: Record<string, unknown>;
     };
     if (!pkg.exports) continue;
-    for (const [subpath, value] of Object.entries(pkg.exports)) {
-      collectBranches(relative, subpath, [], value, branches);
-    }
+    found.push({ relative, exports: pkg.exports });
   }
-  return branches;
-}
-
-function label(branch: Branch): string {
-  return `${branch.manifest} exports["${branch.subpath}"] [${branch.condition}]`;
+  return found;
 }
 
 describe("workspace exports maps", () => {
-  const branches = allBranches();
+  const manifests = manifestsWithExports();
+  const branches = manifests.flatMap((manifest) =>
+    branchesFor(manifest.relative, manifest.exports)
+  );
 
   it("finds condition branches to check", () => {
     // Guards against the scan silently finding nothing and the suite passing vacuously.
@@ -131,22 +239,85 @@ describe("workspace exports maps", () => {
   });
 
   it("pairs every `types` target with the implementation beside it", () => {
-    const mismatched = branches
-      .filter((branch) => branch.types !== branch.expectedTypes)
-      .filter((branch) => !ALLOWED_MISMATCHES.has(label(branch)))
-      .map(
-        (branch) =>
-          `${label(branch)}: types="${branch.types}" but implementation is ` +
-          `"${branch.implementation}" (expected types="${branch.expectedTypes}")`
-      );
-    expect(mismatched).toEqual([]);
+    const violations = manifests.flatMap((manifest) =>
+      findViolations(manifest.relative, manifest.exports)
+    );
+    expect(violations).toEqual([]);
   });
 
   it("keeps the allowlist free of entries that no longer mismatch", () => {
     const stale = [...ALLOWED_MISMATCHES].filter(
-      (entry) =>
-        !branches.some((branch) => label(branch) === entry && branch.types !== branch.expectedTypes)
+      (entry) => !branches.some((branch) => label(branch) === entry && isViolation(branch))
     );
     expect(stale).toEqual([]);
+  });
+});
+
+/**
+ * No manifest violates these rules today, so the code paths that catch them would
+ * ship untested. These fixtures exercise them directly.
+ */
+describe("exports map violation detection", () => {
+  it("catches a string-shorthand branch that declares no types", () => {
+    expect(
+      findViolations("fixture/package.json", {
+        ".": {
+          browser: "./dist/ai.browser.js",
+          types: "./dist/ai.node.d.ts",
+          import: "./dist/ai.node.js",
+        },
+      })
+    ).toEqual([
+      'fixture/package.json exports["."] [browser]: implementation "./dist/ai.browser.js" ' +
+        'declares no types (expected types="./dist/ai.browser.d.ts")',
+    ]);
+  });
+
+  it("catches an object branch with an implementation but no types", () => {
+    expect(
+      findViolations("fixture/package.json", {
+        ".": {
+          browser: { import: "./dist/ai.browser.js" },
+          types: "./dist/ai.node.d.ts",
+          import: "./dist/ai.node.js",
+        },
+      })
+    ).toEqual([
+      'fixture/package.json exports["."] [browser]: implementation "./dist/ai.browser.js" ' +
+        'declares no types (expected types="./dist/ai.browser.d.ts")',
+    ]);
+  });
+
+  it("accepts a `.cjs`/`.mjs` implementation declared by its own extension", () => {
+    expect(
+      findViolations("fixture/package.json", {
+        ".": {
+          require: { types: "./dist/ai.d.cts", default: "./dist/ai.cjs" },
+          types: "./dist/ai.d.mts",
+          import: "./dist/ai.mjs",
+        },
+      })
+    ).toEqual([]);
+  });
+
+  it("rejects a `.cjs` implementation declared by a `.d.ts`", () => {
+    expect(
+      findViolations("fixture/package.json", {
+        ".": {
+          require: { types: "./dist/ai.d.ts", default: "./dist/ai.cjs" },
+          types: "./dist/ai.d.mts",
+          import: "./dist/ai.mjs",
+        },
+      })
+    ).toEqual([
+      'fixture/package.json exports["."] [require]: types="./dist/ai.d.ts" but implementation ' +
+        'is "./dist/ai.cjs" (expected types="./dist/ai.d.cts")',
+    ]);
+  });
+
+  it("ignores a non-module string value such as the package manifest itself", () => {
+    expect(findViolations("fixture/package.json", { "./package.json": "./package.json" })).toEqual(
+      []
+    );
   });
 });


### PR DESCRIPTION
Stacked on #717 — review that one first; this targets its branch, not `main`.

#717's manifest fix is correct and complete. All 25 provider/shim export branches are enumerated there, and re-scanning the merged tree finds 0 remaining `types`/implementation mismatches. Nothing about it needs changing. What this PR fixes is a hole in the **guard** it added, which lets the same defect back in through two manifest shapes the walk never records.

## The hole

`collectBranches` recorded a branch only when the node was an object that already had a `types` string. So both of these are invisible to it:

```jsonc
// 1. string shorthand — returns at the `typeof node !== "object"` bail-out
{ ".": { "browser": "./dist/ai.browser.js",
         "types": "./dist/ai.node.d.ts", "import": "./dist/ai.node.js" } }

// 2. object with an implementation but no `types` — walked past
{ ".": { "browser": { "import": "./dist/ai.browser.js" },
         "types": "./dist/ai.node.d.ts", "import": "./dist/ai.node.js" } }
```

In both, a browser consumer resolves the browser implementation and then falls through to the **outer** `types`, so it is type-checked against the node build — exactly the defect #717 fixes for `@workglow/openai/ai` and friends — while the suite stays green.

The rule is now: a branch that names an implementation must declare the declaration beside it, whether it declares the wrong one or none at all. Both kinds feed the single `mismatched` array, so the assertion and the `ALLOWED_MISMATCHES` semantics are unchanged; `Branch` becomes a discriminated union on `reason: "mismatch" | "missing"` with `types: string | undefined`, and the missing case reads:

```
providers/x/package.json exports["./ai"] [browser]: implementation "./dist/ai.browser.js" declares no types (expected types="./dist/ai.browser.d.ts")
```

The module-path test (`/\.[cm]?js$/`) is what keeps `"./package.json": "./package.json"` out of the missing bucket — asserted by a fixture rather than assumed.

## `declarationFor` derived the wrong extension for `.cjs`/`.mjs`

It mapped `/\.[cm]?js$/ → ".d.ts"`, so a **correct** node16 manifest pairing `"require": "./dist/x.cjs"` with `"types": "./dist/x.d.cts"` would have failed the guard and pushed the author toward the allowlist or toward an extension TypeScript will not honor. `.cjs` → `.d.cts`, `.mjs` → `.d.mts`, `.js` → `.d.ts`. No manifest uses `.cjs`/`.mjs` today — pre-emptive.

## The walk skipped nested implementation keys

While pinning the `.cjs` case it became clear the walk skipped `import`/`require`/`default` wholesale during recursion, so the standard dual-package form `{ "import": { "types": …, "default": … } }` was never checked at all — the same class of hole as the two above. It is now recursed into when the value is an object (a string there is still this branch's own implementation, already recorded). This is what makes the `.cjs` fixture a real assertion rather than a vacuous one. No manifest uses that form today, so the repo scan is unaffected.

## The guard needed its own guard

Since no manifest violates any of these rules, every new code path would have shipped untested. The walk is extracted into `findViolations(manifest, exportsMap)`, used by both the repo scan and five fixtures:

| fixture | expected |
| --- | --- |
| `browser` string shorthand | 1 violation naming `ai.browser` |
| `browser: { import: … }`, no `types` | 1 violation naming `ai.browser` |
| `.cjs`/`.d.cts` + `.mjs`/`.d.mts` | none |
| `.cjs` declared by a `.d.ts` | 1 violation, expects `.d.cts` |
| `"./package.json": "./package.json"` | none |

`findViolations` takes the manifest path as a first parameter rather than the one-argument form, because the violation message is labelled with it at every call site and defaulting it would make the repo scan's labels depend on an omitted argument.

**Demonstrating the hole is real.** Reverting `collectBranches` and `declarationFor` to their pre-fix bodies while keeping the fixtures, 4 of the 5 fail and the 3 repo-scan tests keep passing — which is the point:

```
❯ packages/test/src/test/util/ExportTypesPairing.test.ts (8 tests | 4 failed)
AssertionError: expected [] to deeply equal [ Array(1) ]
-   "…[browser]: implementation \"./dist/ai.browser.js\" declares no types (expected types=\"./dist/ai.browser.d.ts\")"
AssertionError: expected [] to deeply equal [ Array(1) ]
-   "…[browser]: implementation \"./dist/ai.browser.js\" declares no types (expected types=\"./dist/ai.browser.d.ts\")"
AssertionError: expected [ Array(1) ] to deeply equal []
+   "…[(default)]: types=\"./dist/ai.d.mts\" but implementation is \"./dist/ai.mjs\" (expected types=\"./dist/ai.d.ts\")"
AssertionError: expected [ Array(1) ] to deeply equal [ Array(1) ]
-   "…[require]: types=\"./dist/ai.d.ts\" but implementation is \"./dist/ai.cjs\" (expected types=\"./dist/ai.d.cts\")"
```

With the fix in place, all 8 pass:

```
$ bunx vitest run packages/test/src/test/util/ExportTypesPairing.test.ts --reporter=verbose
 ✓ workspace exports maps > finds condition branches to check
 ✓ workspace exports maps > pairs every `types` target with the implementation beside it
 ✓ workspace exports maps > keeps the allowlist free of entries that no longer mismatch
 ✓ exports map violation detection > catches a string-shorthand branch that declares no types
 ✓ exports map violation detection > catches an object branch with an implementation but no types
 ✓ exports map violation detection > accepts a `.cjs`/`.mjs` implementation declared by its own extension
 ✓ exports map violation detection > rejects a `.cjs` implementation declared by a `.d.ts`
 ✓ exports map violation detection > ignores a non-module string value such as the package manifest itself
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

**The real repo scan still reports 0** — it must, since no manifest violates the new rule. An independent scan of every workspace manifest under the stricter walk agrees:

```
workspace groups derived from root globs: packages, providers, examples
manifest branches collected: 163
violations: 0
```

The `branches.length > 50` vacuity guard is unchanged.

## Two smaller cleanups

- `repoRoot` used `new URL(import.meta.url).pathname`, which yields a wrong root for a percent-encoded path; it is now `fileURLToPath`. Note the sibling `BunExportConditions.test.ts` cited as the precedent no longer exists on this base — it was removed by #711 — but `Cactus_BrowserBundles.test.ts` and `Cactus_ModelCatalog.test.ts` in this package use `fileURLToPath`, so the convention still holds. The `> 50` guard would have turned a bad root into a loud failure either way.
- The workspace group list was hardcoded `["packages", "providers", "examples"]`, so a fourth group would have been dropped from the scan with no failure. It is now derived from the root manifest's own `workspaces` globs (`"./packages/*"` → `packages`), which the walk already reads to locate the root. It is **not** derived from `scripts/lib/util.ts#findWorkspaces`: that function resolves `./package.json` relative to `process.cwd()`, uses Bun's `Glob`, and filters to `publishConfig.access === "public"` — which would silently drop private manifests (`examples/*`, `packages/test`) from a guard whose whole job is to miss nothing.

## Verification

- `bunx vitest run packages/test/src/test/util/ExportTypesPairing.test.ts` — 8 passed (output above).
- `bun scripts/test.ts util vitest` — 1409 passed, 20 skipped, 1 failed: `CredentialStore > should provide a default in-memory store`, which is pre-existing, unrelated, and was collected out of a stale `.claude/worktrees/triggers-lifecycle` checkout rather than this branch.
- `bunx tsgo --noEmit -p packages/test/tsconfig.json` — 14 errors, all pre-existing: identical count on the base with the change stashed, and none in the edited file.
- `bunx eslint` and `bunx prettier --check` on the edited file — clean.

## Rebase observation (no action taken here)

#717's `packages/workglow` `"./worker"` hunk — `types: "./dist/worker-browser.d.ts"` → `"./dist/worker-node.d.ts"` — is already on `origin/main`, fixed independently after this branch's base. On merge it is a redundant no-op hunk. Flagging only; #717 was deliberately not rebased.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz)_