### PR TITLE
fix(triggers): serialize workflow fires, register ticks before running them, scope poll state per run

### DIFF
--- a/packages/test/src/test/trigger/IntervalTrigger.test.ts
+++ b/packages/test/src/test/trigger/IntervalTrigger.test.ts
@@ -45,6 +45,13 @@ describe("IntervalTrigger", () => {
     );
   });
 
+  test("rejects a handler that is not a function", () => {
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    expect(() => trigger.start(undefined as never)).toThrow(TriggerConfigurationError);
+    // Nothing was touched: no timer, and the trigger is still startable.
+    expect(trigger.running).toBe(false);
+  });
+
   test("rejects an unknown overlap policy", () => {
     expect(() => new IntervalTrigger({ intervalMs: PERIOD, overlap: "whenever" as never })).toThrow(
       TriggerConfigurationError
@@ -277,6 +284,26 @@ describe("IntervalTrigger", () => {
         () => new IntervalTrigger({ intervalMs: PERIOD, overlap: "queue", maxQueuedFires: 0 })
       ).toThrow(TriggerConfigurationError);
     });
+  });
+
+  test("a period past the host timer ceiling is served in chunks", async () => {
+    // A delay over 2^31-1 ms overflows a host timer and fires IMMEDIATELY, so
+    // an unchunked wait would turn a very long period into a hot loop.
+    const maxTimerDelay = 2_147_483_647;
+    const intervalMs = 2 ** 31 + PERIOD;
+    const trigger = new IntervalTrigger({ intervalMs });
+    const fires: number[] = [];
+    trigger.start((context) => {
+      fires.push(context.scheduledAt);
+    });
+
+    await advanceFakeTimers(maxTimerDelay);
+    expect(fires).toEqual([]);
+
+    await advanceFakeTimers(intervalMs - maxTimerDelay);
+    expect(fires).toEqual([START + intervalMs]);
+
+    await trigger.stop();
   });
 
   test("unrefTimer unrefs the scheduled timer without changing the schedule", async () => {
@@ -542,6 +569,45 @@ describe("IntervalTrigger", () => {
 
       expect(settled).toBe(true);
       expect(resolved).toHaveLength(2);
+    });
+
+    test("stop() called from a fire listener still waits for the handler", async () => {
+      // `trigger.once("fire", () => trigger.stop())` is the ordinary idiom for
+      // "run once". The fire emit and the handler's synchronous head run inside
+      // the tick chain, so a stop() begun there must still see that chain as
+      // pending — otherwise it drains an empty set and resolves while the
+      // handler is running, which is the opposite of what stop() promises.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const order: string[] = [];
+      trigger.on("stop", () => order.push("stop-event"));
+
+      let stopping: Promise<void> | undefined;
+      trigger.once("fire", () => {
+        stopping = trigger.stop();
+      });
+      trigger.start(async () => {
+        order.push("handler-start");
+        await new Promise<void>((resolve) => setTimeout(resolve, PERIOD / 2));
+        order.push("handler-end");
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(order).toEqual(["handler-start"]);
+      expect(stopping).toBeDefined();
+
+      let stopResolved = false;
+      void stopping!.then(() => {
+        stopResolved = true;
+      });
+      await flushAsyncWork();
+      expect(stopResolved).toBe(false);
+
+      // Let the handler's own timer run out.
+      await advanceFakeTimers(PERIOD);
+      await stopping;
+
+      expect(order).toEqual(["handler-start", "handler-end", "stop-event"]);
+      expect(trigger.running).toBe(false);
     });
 
     test("an already-aborted caller signal schedules nothing", async () => {

--- a/packages/test/src/test/trigger/PollingTrigger.test.ts
+++ b/packages/test/src/test/trigger/PollingTrigger.test.ts
@@ -17,6 +17,19 @@ import { advanceFakeTimers } from "../helpers/advanceFakeTimers";
 const START = Date.UTC(2026, 0, 1, 0, 0, 0);
 const PERIOD = 100;
 
+interface Gate {
+  readonly promise: Promise<void>;
+  readonly open: () => void;
+}
+
+function createGate(): Gate {
+  let open: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { promise, open };
+}
+
 describe("PollingTrigger", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -249,6 +262,51 @@ describe("PollingTrigger", () => {
     expect(payloads).toEqual(["steady", "steady"]);
     expect(polls).toBe(3);
 
+    await trigger.stop();
+  });
+
+  test("a restart while stop() is still draining also resets the baseline", async () => {
+    // The awaited restart above is the easy half. A stop() that is NOT awaited
+    // hands the trigger to the new run while the old one is still draining, and
+    // per-run state that lives on the trigger would carry the old baseline into
+    // it — leaving a firesOnChange poller that never fires again.
+    let polls = 0;
+    const gate = createGate();
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      poll: () => {
+        polls += 1;
+        return "steady";
+      },
+      shouldFire: firesOnChange,
+    });
+
+    const firstPayloads: unknown[] = [];
+    trigger.start(async (context) => {
+      firstPayloads.push(context.payload);
+      await gate.promise;
+    });
+
+    await advanceFakeTimers(PERIOD);
+    expect(firstPayloads).toEqual(["steady"]);
+    expect(trigger.lastResult).toBe("steady");
+
+    // NOT awaited: the gated handler keeps the old run draining.
+    const stopping = trigger.stop();
+    const secondPayloads: unknown[] = [];
+    trigger.start((context) => {
+      secondPayloads.push(context.payload);
+    });
+
+    expect(trigger.lastResult).toBeUndefined();
+    expect(trigger.consecutiveFailures).toBe(0);
+
+    await advanceFakeTimers(PERIOD);
+    expect(secondPayloads).toEqual(["steady"]);
+    expect(polls).toBe(2);
+
+    gate.open();
+    await stopping;
     await trigger.stop();
   });
 

--- a/packages/test/src/test/trigger/WorkflowTriggers.test.ts
+++ b/packages/test/src/test/trigger/WorkflowTriggers.test.ts
@@ -50,6 +50,9 @@ let failNextRuns = 0;
 let holdGate: Gate | undefined;
 const completed: string[] = [];
 const abortedRuns: string[] = [];
+/** Highest number of executions ever in flight at once. */
+let peakConcurrency = 0;
+let inFlight = 0;
 
 class RecorderTask extends Task<RecorderInput, RecorderOutput> {
   public static override type = "TriggerRecorderTask";
@@ -77,32 +80,49 @@ class RecorderTask extends Task<RecorderInput, RecorderOutput> {
 
   override async execute(input: RecorderInput, context: IExecuteContext): Promise<RecorderOutput> {
     executions.push(input.label);
-    if (failNextRuns > 0) {
-      failNextRuns -= 1;
-      throw new Error(`run failed for ${input.label}`);
-    }
-    const gate = holdGate;
-    if (gate) {
-      await new Promise<void>((resolve) => {
-        const done = (): void => {
-          context.signal.removeEventListener("abort", done);
-          resolve();
-        };
-        context.signal.addEventListener("abort", done, { once: true });
-        void gate.promise.then(done);
-      });
-      if (context.signal.aborted) {
-        abortedRuns.push(input.label);
-        throw new Error(`aborted ${input.label}`);
+    inFlight += 1;
+    peakConcurrency = Math.max(peakConcurrency, inFlight);
+    try {
+      if (failNextRuns > 0) {
+        failNextRuns -= 1;
+        throw new Error(`run failed for ${input.label}`);
       }
+      const gate = holdGate;
+      if (gate) {
+        await new Promise<void>((resolve) => {
+          const done = (): void => {
+            context.signal.removeEventListener("abort", done);
+            resolve();
+          };
+          context.signal.addEventListener("abort", done, { once: true });
+          void gate.promise.then(done);
+        });
+        if (context.signal.aborted) {
+          abortedRuns.push(input.label);
+          throw new Error(`aborted ${input.label}`);
+        }
+      }
+      completed.push(input.label);
+      return { recorded: input.label };
+    } finally {
+      inFlight -= 1;
     }
-    completed.push(input.label);
-    return { recorded: input.label };
   }
 }
 
 function createWorkflow(): Workflow {
   return new Workflow().addTask(RecorderTask, { label: "default" });
+}
+
+/**
+ * Flushes microtasks until `predicate` holds. Serialized runs hand off to each
+ * other over several microtask turns, and advancing the clock instead would
+ * deliver more fires — which is exactly what these tests are counting.
+ */
+async function drainUntil(predicate: () => boolean): Promise<void> {
+  for (let pass = 0; pass < 50 && !predicate(); pass += 1) {
+    await flushAsyncWork();
+  }
 }
 
 describe("Workflow trigger bindings", () => {
@@ -112,6 +132,8 @@ describe("Workflow trigger bindings", () => {
     abortedRuns.length = 0;
     holdGate = undefined;
     failNextRuns = 0;
+    peakConcurrency = 0;
+    inFlight = 0;
     vi.useFakeTimers();
     vi.setSystemTime(START);
   });
@@ -212,6 +234,75 @@ describe("Workflow trigger bindings", () => {
 
     expect(executions.filter((label) => label === "fast")).toHaveLength(2);
     expect(executions.filter((label) => label === "slow")).toHaveLength(1);
+
+    await handle.stop();
+  });
+
+  test("genuinely overlapping fires run one at a time instead of colliding", async () => {
+    // `overlap: "concurrent"` invokes the handler on every tick regardless of
+    // what is in flight, so with a handler slower than the period the fires
+    // really do overlap. One Workflow owns one TaskGraph, which refuses to be
+    // run re-entrantly, so an unserialized second fire is lost to a
+    // "Graph is already running" error on the trigger's `error` event.
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD, overlap: "concurrent" });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+    workflow.trigger(trigger, {
+      input: (context) => ({ label: `fire@${context.scheduledAt - START}` }),
+      maxPendingFires: 5,
+    });
+
+    const gate = createGate();
+    holdGate = gate;
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD * 3);
+    // Three fires dispatched; only the first is executing.
+    expect(executions).toEqual(["fire@100"]);
+    expect(peakConcurrency).toBe(1);
+
+    holdGate = undefined;
+    gate.open();
+    await drainUntil(() => completed.length >= 3);
+
+    expect(executions).toEqual(["fire@100", "fire@200", "fire@300"]);
+    expect(completed).toEqual(["fire@100", "fire@200", "fire@300"]);
+    // Strictly sequential: no run ever started while another was executing.
+    expect(peakConcurrency).toBe(1);
+    expect(errors).toEqual([]);
+
+    await handle.stop();
+  });
+
+  test("a fire past maxPendingFires is dropped and reported on the error event", async () => {
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD, overlap: "concurrent" });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+    workflow.trigger(trigger, {
+      input: (context) => ({ label: `fire@${context.scheduledAt - START}` }),
+      maxPendingFires: 1,
+    });
+
+    const gate = createGate();
+    holdGate = gate;
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD * 3);
+    // fire@100 is running and fire@200 is waiting, so fire@300 exceeds the bound.
+    expect(executions).toEqual(["fire@100"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(WorkflowTriggerError);
+    expect(errors[0]?.message).toContain("maxPendingFires");
+
+    holdGate = undefined;
+    gate.open();
+    await drainUntil(() => completed.length >= 2);
+
+    // The dropped fire never runs; the bounded one still does.
+    expect(executions).toEqual(["fire@100", "fire@200"]);
+    expect(errors).toHaveLength(1);
 
     await handle.stop();
   });

--- a/packages/triggers/README.md
+++ b/packages/triggers/README.md
@@ -65,6 +65,12 @@ scope exit.
 - **Overlap** — `overlap: "skip" | "queue" | "concurrent"`, default `"skip"`. A
   tick arriving while the previous handler runs is dropped (and emits `skip`); a
   trigger is a clock, not a work queue, so a slow handler cannot grow a backlog.
+  The policy governs handler INVOCATION. A handler bound to a workflow still
+  serializes at the workflow — one `Workflow` owns one task graph, and a graph
+  cannot run re-entrantly — so `"concurrent"` plus a workflow binding degrades
+  to queue semantics, bounded by the binding's `maxPendingFires` (default `1`).
+  A fire past that bound is dropped and reported on `error`. When queueing is
+  what you want, ask for it: `overlap: "queue"` with `maxQueuedFires`.
 - **Errors** — a handler rejection never stops the loop. It is emitted on
   `error` as the real `Error` and logged through `getLogger()`.
 - **Drift** — each tick is scheduled from the previous tick's scheduled instant,

--- a/packages/triggers/package.json
+++ b/packages/triggers/package.json
@@ -14,17 +14,15 @@
   "homepage": "https://workglow.dev",
   "scripts": {
     "watch": "concurrently -c 'auto' 'bun:watch-*'",
-    "watch-js": "concurrently -c 'auto' -n 'browser,node,bun' 'bun run watch-browser' 'bun run watch-node' 'bun run watch-bun'",
+    "watch-js": "concurrently -c 'auto' -n 'browser,node' 'bun run watch-browser' 'bun run watch-node'",
     "watch-browser": "bun build --watch --no-clear-screen --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/browser.ts",
     "watch-node": "bun build --watch --no-clear-screen --target=node --sourcemap=external --packages=external --outdir ./dist ./src/node.ts",
-    "watch-bun": "bun build --watch --no-clear-screen --target=bun --sourcemap=external --packages=external --outdir ./dist ./src/bun.ts",
     "watch-types": "tsc --watch --preserveWatchOutput",
-    "build-package": "concurrently -c 'auto' -n 'browser,node,bun,types' 'bun run build-browser' 'bun run build-node' 'bun run build-bun' 'bun run build-types'",
-    "build-js": "concurrently -m 12 --timings -c 'auto' -n 'browser,node,bun' 'bun run build-browser' 'bun run build-node' 'bun run build-bun'",
+    "build-package": "concurrently -c 'auto' -n 'browser,node,types' 'bun run build-browser' 'bun run build-node' 'bun run build-types'",
+    "build-js": "concurrently -m 12 --timings -c 'auto' -n 'browser,node' 'bun run build-browser' 'bun run build-node'",
     "build-clean": "rm -fr dist/* tsconfig.tsbuildinfo",
     "build-browser": "bun build --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/browser.ts",
     "build-node": "bun build --target=node --sourcemap=external --packages=external --outdir ./dist ./src/node.ts",
-    "build-bun": "bun build --target=bun --sourcemap=external --packages=external --outdir ./dist ./src/bun.ts",
     "build-types": "rm -f tsconfig.tsbuildinfo && tsgo",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "bun test"
@@ -38,10 +36,6 @@
       "browser": {
         "types": "./dist/browser.d.ts",
         "import": "./dist/browser.js"
-      },
-      "bun": {
-        "types": "./dist/bun.d.ts",
-        "import": "./dist/bun.js"
       },
       "types": "./dist/node.d.ts",
       "import": "./dist/node.js"

--- a/packages/triggers/src/bun.ts
+++ b/packages/triggers/src/bun.ts
@@ -1,9 +1,0 @@
-/**
- * @license
- * Copyright 2026 Steven Roussey <sroussey@gmail.com>
- * SPDX-License-Identifier: Apache-2.0
- */
-
-// organize-imports-ignore
-
-export * from "./common";

--- a/packages/triggers/src/trigger/BaseTrigger.ts
+++ b/packages/triggers/src/trigger/BaseTrigger.ts
@@ -140,16 +140,19 @@ export abstract class BaseTrigger implements ITrigger {
    *   stopped, with nothing scheduled and no listener attached.
    */
   public start(handler: TriggerHandler, options: TriggerStartOptions = {}): void {
+    // Validated before anything else: a non-function handler otherwise starts a
+    // trigger that reports `running` and emits a TypeError on `error` once per
+    // period forever, with no way to tell it apart from a failing handler.
+    if (typeof handler !== "function") {
+      throw new TriggerConfigurationError(
+        `start() requires a handler function, received ${typeof handler}.`
+      );
+    }
     // Starting twice is a no-op rather than an error, so a start/start/stop
     // sequence leaves no orphaned timer behind.
     if (this.running) return;
     // An already-aborted caller signal means "do not schedule anything".
     if (options.signal?.aborted) return;
-
-    // Compute first, mutate second. Setting `_run` before a computation that can
-    // throw would leave the trigger reporting `running` with no timer, and every
-    // later `start()` would be a silent no-op forever.
-    const firstFireAt = this.computeNextFireTime(Date.now());
 
     const controller = new AbortController();
     const run: TriggerRun = {
@@ -166,6 +169,12 @@ export abstract class BaseTrigger implements ITrigger {
       removeExternalAbort: undefined,
       stopping: undefined,
     };
+
+    // The run is built first so the hook has one to key its state off, but it is
+    // published to `this._run` only after the computation that can throw. Setting
+    // `_run` first would leave the trigger reporting `running` with no timer, and
+    // every later `start()` would be a silent no-op forever.
+    const firstFireAt = this.computeNextFireTime(Date.now(), run);
     this._run = run;
 
     if (options.signal) {
@@ -218,8 +227,12 @@ export abstract class BaseTrigger implements ITrigger {
    * Absolute instant (ms since epoch) of the tick following `fromMs`. Must be
    * strictly greater than `fromMs` so a computation landing exactly on a
    * boundary advances instead of firing the same tick forever.
+   *
+   * The run whose schedule is being computed is passed explicitly, so a subclass
+   * whose next instant depends on per-generation state (see `PollingTrigger`'s
+   * error backoff) keys that state off the run rather than off `this`.
    */
-  protected abstract computeNextFireTime(fromMs: number): number;
+  protected abstract computeNextFireTime(fromMs: number, run: TriggerRun): number;
 
   /**
    * Runs one tick. The default invokes the handler with no payload; a subclass
@@ -245,14 +258,10 @@ export abstract class BaseTrigger implements ITrigger {
     await run.handler(context);
   }
 
-  /**
-   * Called once a run has stopped and every handler it started has settled, so
-   * a subclass can release per-generation state (see `PollingTrigger`).
-   *
-   * NOT called when a newer `start()` has already taken over: that run owns the
-   * subclass state now, and resetting it here would corrupt it.
-   */
-  protected onRunStopped(): void {}
+  /** The run installed by the latest {@link start}, or `undefined` when stopped and drained. */
+  protected get currentRun(): TriggerRun | undefined {
+    return this._run;
+  }
 
   private async releaseWhenIdle(run: TriggerRun): Promise<void> {
     // A loop, not a single `allSettled`: a chain draining queued ticks may still
@@ -261,12 +270,9 @@ export abstract class BaseTrigger implements ITrigger {
       await Promise.allSettled([...run.pending]);
     }
 
-    // A `start()` during the drain installed a newer run; releasing subclass
-    // state or clearing `_run` here would strand it.
-    if (this._run === run) {
-      this._run = undefined;
-      this.onRunStopped();
-    }
+    // A `start()` during the drain installed a newer run; clearing `_run` here
+    // would strand it.
+    if (this._run === run) this._run = undefined;
     this.safeEmit("stop");
   }
 
@@ -295,7 +301,7 @@ export abstract class BaseTrigger implements ITrigger {
   private onTick(run: TriggerRun, scheduledAt: number): void {
     let nextFireAt: number;
     try {
-      nextFireAt = this.computeNextFireTime(scheduledAt);
+      nextFireAt = this.computeNextFireTime(scheduledAt, run);
     } catch (error) {
       // Nothing can be scheduled, so there is no half-live state worth keeping:
       // report and shut down rather than leave a trigger that reports `running`
@@ -324,7 +330,15 @@ export abstract class BaseTrigger implements ITrigger {
       return;
     }
 
-    const chain = this.runTickChain(run, scheduledAt);
+    // The microtask hop is load-bearing, not ceremony. Called directly,
+    // `runTickChain` runs its whole synchronous prefix — the `fire` emit and the
+    // handler's own synchronous head — BEFORE `run.pending.add` below, so a
+    // `stop()` begun from a `fire` listener (or by the handler itself) would see
+    // an empty `pending`, drain instantly, and resolve while that handler was
+    // still running. Deferring by one microtask puts all of `runTickChain`
+    // behind the registration. The schedule is unaffected: the next tick was
+    // already scheduled in `onTick` before this call.
+    const chain = Promise.resolve().then(() => this.runTickChain(run, scheduledAt));
     run.pending.add(chain);
     // `catch` before `finally`: `runTickChain` reports handler errors itself,
     // but an `error` LISTENER that throws rejects the chain, and a bare

--- a/packages/triggers/src/trigger/CronTrigger.ts
+++ b/packages/triggers/src/trigger/CronTrigger.ts
@@ -6,7 +6,7 @@
 
 import type { CronSchedule } from "../cron/CronSchedule";
 import { nextCronFireTime, parseCronExpression } from "../cron/CronSchedule";
-import type { TriggerOptions } from "./BaseTrigger";
+import type { TriggerOptions, TriggerRun } from "./BaseTrigger";
 import { BaseTrigger } from "./BaseTrigger";
 import { TRIGGER_KINDS } from "./ITrigger";
 
@@ -45,7 +45,7 @@ export class CronTrigger extends BaseTrigger {
     return this.schedule.expression;
   }
 
-  protected computeNextFireTime(fromMs: number): number {
+  protected computeNextFireTime(fromMs: number, _run: TriggerRun): number {
     // Anchoring on the later of the tick's own instant and now means a host
     // that stalled past several cron instants resumes at the next FUTURE one
     // instead of replaying the missed ones back to back.

--- a/packages/triggers/src/trigger/ITrigger.ts
+++ b/packages/triggers/src/trigger/ITrigger.ts
@@ -26,6 +26,13 @@ export type TriggerKind = (typeof TRIGGER_KINDS)[keyof typeof TRIGGER_KINDS];
  *   bounded by `maxQueuedFires`. Ticks past that bound behave like `skip`.
  * - `concurrent` — the handler is invoked immediately regardless of what is
  *   still in flight. Overlap becomes the handler's problem.
+ *
+ * The policy governs HANDLER INVOCATION only. A handler bound to a workflow
+ * (`workflow.trigger(...)`) still serializes at the workflow, because one
+ * `Workflow` owns one task graph and a graph cannot run re-entrantly — so
+ * `concurrent` there degrades to queue semantics bounded by
+ * `maxPendingFires`. Prefer `"queue"` with `maxQueuedFires` when queueing is
+ * what you actually want.
  */
 export const OVERLAP_POLICIES = ["skip", "queue", "concurrent"] as const;
 

--- a/packages/triggers/src/trigger/IntervalTrigger.ts
+++ b/packages/triggers/src/trigger/IntervalTrigger.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TriggerOptions } from "./BaseTrigger";
+import type { TriggerOptions, TriggerRun } from "./BaseTrigger";
 import { BaseTrigger } from "./BaseTrigger";
 import { assertValidIntervalMs, nextFixedIntervalFireTime } from "./fixedInterval";
 import { TRIGGER_KINDS } from "./ITrigger";
@@ -34,7 +34,7 @@ export class IntervalTrigger extends BaseTrigger {
     this.intervalMs = assertValidIntervalMs(options.intervalMs);
   }
 
-  protected computeNextFireTime(fromMs: number): number {
+  protected computeNextFireTime(fromMs: number, _run: TriggerRun): number {
     return nextFixedIntervalFireTime(fromMs, this.intervalMs);
   }
 }

--- a/packages/triggers/src/trigger/PollingTrigger.ts
+++ b/packages/triggers/src/trigger/PollingTrigger.ts
@@ -45,6 +45,20 @@ export interface PollErrorBackoff {
   readonly maxMs: number;
 }
 
+/**
+ * Change-detection baseline and failure streak for ONE run.
+ *
+ * Both belong to a single `start()`: a restart is a fresh observation window,
+ * and a `firesOnChange` trigger comparing against the previous run's baseline
+ * would swallow the first change after it. Keying them off the run object makes
+ * that structural — a run that ends unnoticed (because a newer `start()` took
+ * over while it was still draining) cannot leave its baseline behind.
+ */
+interface PollRunState<Result> {
+  previous: Result | undefined;
+  failures: number;
+}
+
 export interface PollingTriggerOptions<Result> extends TriggerOptions {
   /** Period between polls, in milliseconds. Must be a positive integer. */
   readonly intervalMs: number;
@@ -82,8 +96,7 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
   private readonly _poll: (signal: AbortSignal) => Result | Promise<Result>;
   private readonly _shouldFire: PollResultPredicate<Result>;
   private readonly _errorBackoff: PollErrorBackoff | undefined;
-  private _previous: Result | undefined;
-  private _consecutiveFailures = 0;
+  private readonly _runState = new WeakMap<TriggerRun, PollRunState<Result>>();
 
   constructor(options: PollingTriggerOptions<Result>) {
     super(options);
@@ -98,22 +111,28 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
       : undefined;
   }
 
-  /** Most recent successfully polled result, or `undefined` before the first poll. */
+  /**
+   * Most recent result successfully polled by the CURRENT run, or `undefined`
+   * before its first poll and while the trigger is stopped.
+   */
   public get lastResult(): Result | undefined {
-    return this._previous;
+    const run = this.currentRun;
+    return run ? this._runState.get(run)?.previous : undefined;
   }
 
-  /** Consecutive poll failures since the last poll that did not throw. */
+  /** Consecutive poll failures of the current run since its last poll that did not throw. */
   public get consecutiveFailures(): number {
-    return this._consecutiveFailures;
+    const run = this.currentRun;
+    return (run ? this._runState.get(run)?.failures : 0) ?? 0;
   }
 
-  protected computeNextFireTime(fromMs: number): number {
+  protected computeNextFireTime(fromMs: number, run: TriggerRun): number {
     const backoff = this._errorBackoff;
-    if (backoff && this._consecutiveFailures > 0) {
+    const failures = this.stateFor(run).failures;
+    if (backoff && failures > 0) {
       // The next tick was already scheduled when the failing one started, so the
       // backoff takes effect from the tick AFTER the first failure.
-      const exponent = Math.min(this._consecutiveFailures - 1, 31);
+      const exponent = Math.min(failures - 1, 31);
       const delay = Math.min(backoff.maxMs, backoff.initialMs * 2 ** exponent);
       return fromMs + delay;
     }
@@ -122,20 +141,21 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
 
   protected override async runTick(scheduledAt: number, run: TriggerRun): Promise<void> {
     const signal = run.signal;
+    const state = this.stateFor(run);
     let result: Result;
     try {
       result = await this._poll(signal);
     } catch (error) {
-      this._consecutiveFailures += 1;
+      state.failures += 1;
       throw error;
     }
-    this._consecutiveFailures = 0;
+    state.failures = 0;
     // Bail before recording the result: an aborted tick never fires, so keeping
     // its value as the baseline would make the NEXT `firesOnChange` comparison
     // see no change and swallow the very update this tick observed.
     if (signal.aborted) return;
-    const previous = this._previous;
-    this._previous = result;
+    const previous = state.previous;
+    state.previous = result;
     if (!this._shouldFire(result, previous)) return;
     await this.invokeHandler(run, {
       triggerId: this.id,
@@ -145,14 +165,12 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
     });
   }
 
-  /**
-   * The baseline and the failure streak belong to ONE run: a restart is a fresh
-   * observation window, and a `firesOnChange` trigger comparing against a
-   * baseline from the previous run would swallow the first change after it.
-   */
-  protected override onRunStopped(): void {
-    this._previous = undefined;
-    this._consecutiveFailures = 0;
+  private stateFor(run: TriggerRun): PollRunState<Result> {
+    const existing = this._runState.get(run);
+    if (existing) return existing;
+    const created: PollRunState<Result> = { previous: undefined, failures: 0 };
+    this._runState.set(run, created);
+    return created;
   }
 }
 

--- a/packages/triggers/src/workflow/WorkflowTriggers.ts
+++ b/packages/triggers/src/workflow/WorkflowTriggers.ts
@@ -24,6 +24,17 @@ export interface WorkflowTriggerOptions {
     | undefined;
   /** Run configuration forwarded to {@link Workflow.run} on every fire. */
   readonly runConfig?: WorkflowRunConfig | undefined;
+  /**
+   * How many fires may wait for the workflow's current run before one is
+   * dropped. Defaults to `1`.
+   *
+   * One `Workflow` owns one task graph, which can only be running once, so
+   * fires against a workflow are run one at a time no matter what overlap
+   * policy the trigger uses. This is the bound on that backlog: a fire arriving
+   * past it is dropped and reported on the trigger's `error` event rather than
+   * queued forever behind a handler that cannot keep up.
+   */
+  readonly maxPendingFires?: number | undefined;
 }
 
 /** Options for {@link Workflow.listen}. */
@@ -50,10 +61,19 @@ interface TriggerBinding {
   readonly options: WorkflowTriggerOptions;
 }
 
+/** Backlog bound applied when a binding does not set {@link WorkflowTriggerOptions.maxPendingFires}. */
+const DEFAULT_MAX_PENDING_FIRES = 1;
+
 // Prototype methods cannot reach Workflow's private fields, so bindings live
 // beside the instance. A WeakMap keeps a discarded workflow collectable.
 const workflowBindings = new WeakMap<Workflow, TriggerBinding[]>();
 const workflowHandles = new WeakMap<Workflow, ITriggerListenerHandle>();
+/**
+ * Tail of the serialized run chain per workflow, and the number of fires
+ * waiting on it. See {@link runWorkflowForFire}.
+ */
+const workflowRunChains = new WeakMap<Workflow, Promise<void>>();
+const workflowPendingFires = new WeakMap<Workflow, number>();
 
 /** The triggers bound to `workflow` via {@link Workflow.trigger}, in binding order. */
 export function getWorkflowTriggers(workflow: Workflow): readonly ITrigger[] {
@@ -65,8 +85,12 @@ declare module "@workglow/task-graph" {
     /**
      * Binds a trigger to this workflow. Bindings accumulate; nothing is
      * scheduled until {@link Workflow.listen} is called.
+     *
+     * Returns `this`, not `Workflow`: a declared return type would collapse a
+     * `Workflow<Input, Output>` to the default `Workflow<DataPorts, DataPorts>`
+     * on the first chained call and lose both port types.
      */
-    trigger(trigger: ITrigger, options?: WorkflowTriggerOptions): Workflow;
+    trigger(trigger: ITrigger, options?: WorkflowTriggerOptions): this;
 
     /**
      * Starts every bound trigger and RESOLVES IMMEDIATELY — it does not block
@@ -183,24 +207,72 @@ Workflow.prototype.stopListening = async function (this: Workflow): Promise<void
   await workflowHandles.get(this)?.stop();
 };
 
+/**
+ * Runs the workflow for one fire, serialized against every other fire on the
+ * SAME workflow.
+ *
+ * A `Workflow` owns exactly one `TaskGraph`, and a graph refuses to be run
+ * re-entrantly, so two fires landing on one workflow at once — two triggers
+ * whose periods share a boundary, or one trigger with `overlap: "concurrent"`
+ * and a handler slower than its period — would lose the second fire to a
+ * "Graph is already running" error. Deriving a fresh graph per fire is not an
+ * option: `TaskGraph` has no clone, `toJSON` cannot carry closures, attached
+ * caches, or user-attached task listeners, and a copy would break the identity
+ * the trigger bindings and `workflow.abort()` are keyed on.
+ */
 async function runWorkflowForFire(
   workflow: Workflow,
   binding: TriggerBinding,
   context: ITriggerFireContext
 ): Promise<void> {
   const input = binding.options.input ? await binding.options.input(context) : {};
+  const predecessor = workflowRunChains.get(workflow);
 
-  // Forward the trigger's signal into the run itself rather than calling
-  // `workflow.abort()`: that aborts the workflow's CURRENT run, which — with
-  // two triggers bound to one workflow — is whichever run started last, so
-  // stopping trigger A would cancel trigger B's in-flight run and leave A's own
-  // older run going. A per-run signal cancels exactly the run this fire started.
-  try {
+  if (predecessor !== undefined) {
+    const limit = binding.options.maxPendingFires ?? DEFAULT_MAX_PENDING_FIRES;
+    const waiting = workflowPendingFires.get(workflow) ?? 0;
+    if (waiting >= limit) {
+      // Thrown rather than dropped in silence: this is the one place the old
+      // "Graph is already running" failure was observable, and a backlog the
+      // workflow cannot work off is worth reporting on the `error` event.
+      throw new WorkflowTriggerError(
+        `Dropped a trigger fire scheduled for ${new Date(context.scheduledAt).toISOString()}: ` +
+          `${waiting} fire(s) are already waiting for this workflow's run to finish ` +
+          `(maxPendingFires: ${limit}).`
+      );
+    }
+    workflowPendingFires.set(workflow, waiting + 1);
+  }
+
+  const chain = (async (): Promise<void> => {
+    if (predecessor !== undefined) {
+      // `catch`, not a bare await: a fire whose run rejected must not take the
+      // fires queued behind it down with it.
+      await predecessor.catch(() => {});
+      workflowPendingFires.set(workflow, (workflowPendingFires.get(workflow) ?? 1) - 1);
+      // The wait can outlast the trigger. A fire that queued behind a slow run
+      // must not start a new one after `stop()`.
+      if (context.signal.aborted) return;
+    }
+    // Forward the trigger's signal into the run itself rather than calling
+    // `workflow.abort()`: that aborts the workflow's CURRENT run, which — with
+    // two triggers bound to one workflow — is whichever run started last, so
+    // stopping trigger A would cancel trigger B's in-flight run and leave A's own
+    // older run going. A per-run signal cancels exactly the run this fire started.
     await workflow.run(input, { ...binding.options.runConfig, signal: context.signal });
+  })();
+
+  workflowRunChains.set(workflow, chain);
+
+  try {
+    await chain;
   } catch (error) {
     // A run cancelled by our own stop() is the expected path, not a failure to
     // report on the trigger's `error` event.
     if (context.signal.aborted) return;
     throw error;
+  } finally {
+    // Identity check: a later fire may already have claimed the tail.
+    if (workflowRunChains.get(workflow) === chain) workflowRunChains.delete(workflow);
   }
 }

--- a/packages/triggers/tsconfig.json
+++ b/packages/triggers/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src/common.ts", "src/*/**/*"],
-  "files": ["./src/browser.ts", "./src/node.ts", "./src/bun.ts"],
+  "files": ["./src/browser.ts", "./src/node.ts"],
   "exclude": ["dist", "node_modules"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
Stacked on #679 — this PR targets `claude/libs-issues-triage-prs-mh6x2o-237`, not `main`.

Four defects in the new `@workglow/triggers` package, each reproduced before it was fixed.

## Overlapping fires collided on one shared graph

`runWorkflowForFire` called `workflow.run(...)` per fire, but a `Workflow` owns exactly one `TaskGraph` with one memoized `TaskGraphRunner`, whose `handleStart` throws `TaskConfigurationError("Graph is already running")` on re-entry. Two documented patterns hit it: `workflow.trigger(a).trigger(b)` on periods that share a boundary, and `overlap: "concurrent"` with any handler slower than the period. The second fire was silently lost, surfaced only on the `error` event.

Fires against one workflow now run one at a time. A `WeakMap` beside the existing binding maps holds the chain tail; a rejected predecessor is caught so it cannot poison the queue; the abort check is repeated **after** the wait so a fire queued behind a slow run does not start one after `stop()`; and the tail entry is deleted under the same identity check `listen()` already uses for its handle.

### Why serialize rather than clone

Deriving a fresh graph per fire was the obvious alternative and is not available:

- A `Workflow` is more than its `_graph`. `Workflow.run` also writes the single-slot `_currentRun` and calls `_bridge?.beginRun()`, and the graph's task instances carry per-run state (`runInputData`, status, provenance).
- `TaskGraph` has **no `clone` / `fromJSON`** — only `toJSON`, which is lossy: closures (`LambdaTask`, `JavaScriptTask`), attached caches, and user-attached task event listeners do not survive it.
- A copy would break the identity APIs that are keyed on the instance: `getWorkflowTriggers`, `workflow.abort()`.

Serializing is ~15 lines confined to this package and touches no `task-graph` code.

The backlog is bounded by a new per-binding `maxPendingFires` (default `1`). A fire past the bound throws `WorkflowTriggerError`, which surfaces on the trigger's `error` event — the one place the old collision was observable.

### `overlap: "concurrent"` semantics, stated

The policy governs **handler invocation**. A workflow-bound handler still serializes at the workflow, because one `Workflow` owns one task graph and a graph cannot run re-entrantly. So `concurrent` plus a workflow binding degrades to queue semantics bounded by `maxPendingFires`; the README and `OverlapPolicy` now say so and point at `overlap: "queue"` with `maxQueuedFires` for the intended shape.

## `stop()` resolved while a handler was still running

`dispatch` added the tick chain to `run.pending` only *after* `runTickChain` returned — that is, after its synchronous prefix, which includes the `fire` emit and the handler's own synchronous head. A `stop()` begun in that window (the ordinary `trigger.once("fire", () => trigger.stop())` idiom) saw `run.pending.size === 0`, drained instantly, and resolved with the handler still running; it finished later, after `stop` had been emitted.

One microtask of deferral (`Promise.resolve().then(() => this.runTickChain(...))`) moves all of `runTickChain` behind the registration. No schedule impact: `scheduleAt` for the next tick already ran in `onTick` before `dispatch`. A comment says why the hop exists, so it is not "simplified" away later.

## Polling baseline survived a restart during a drain

`onRunStopped()` reset `_previous` / `_consecutiveFailures`, but it is deliberately skipped when a newer `start()` took over during the drain — so the two restart paths disagreed. A `firesOnChange` poller, handler in flight, `stop()` **not** awaited, then `start(newHandler)`: `lastResult` stayed on the old baseline and the new handler never fired. The existing test at `PollingTrigger.test.ts:223` covered only the awaited path.

`computeNextFireTime` now takes the run it is computing for, and `PollingTrigger` keys its baseline and failure streak off that run through a `WeakMap`. `onRunStopped` is deleted outright — with per-run state there is nothing whose reset could be skipped, so the asymmetry is structurally impossible rather than fixed by hand. `lastResult` / `consecutiveFailures` read the current run's state and report `undefined` / `0` when stopped.

**Breaking for out-of-tree subclasses**: `protected abstract computeNextFireTime(fromMs: number)` becomes `computeNextFireTime(fromMs: number, run: TriggerRun)`. Acceptable — the package is new and unpublished. In-tree `IntervalTrigger` and `CronTrigger` widen the signature and ignore the parameter.

## Redundant `bun` export condition

`src/bun.ts` was byte-identical to `src/node.ts` (both `export * from "./common"`), so the `"bun"` condition bought a third bundle and a third `.d.ts` for no behavior change. `main`'s `BunExportConditions.test.ts` asserts an exact three-entry set, so merging #679 as-is fails it. Removed: the entry point, its `build-bun` / `watch-bun` scripts (and `bun` from the `-n` lists), the `"bun"` block in `exports["."]`, and the tsconfig `files` entry.

## Also fixed

- `start()` never validated its handler. `start(undefined)` returned normally with `running === true` and emitted a `TypeError` on `error` once per period forever; it now throws `TriggerConfigurationError` before touching any state.
- `Workflow.trigger()` was declared to return `Workflow`, collapsing `Workflow<Input, Output>` to `Workflow<DataPorts, DataPorts>` on the first chained call. It returns `this`.

## Microtask-hop risk check

The hop makes `fire` no longer synchronous with the timer callback, so any assertion relying on synchronous emission inside a non-`Async` `vi.advanceTimersByTime` would break. Grepped all four trigger test files:

```
$ grep -n "advanceTimersByTime\|runAllTimers\|runOnlyPendingTimers\|vi\.advance" \
    packages/test/src/test/trigger/*.ts
(no matches)
```

Every one of them goes through the shared `advanceFakeTimers` helper, which prefers `vi.advanceTimersByTimeAsync` under Vitest. **Nothing needed converting.**

## Verification

All commands run in a clean worktree of this branch.

**New tests fail against the unfixed sources** (`git stash push -- packages/triggers/src`, tests kept):

```
 × genuinely overlapping fires run one at a time instead of colliding
 × a fire past maxPendingFires is dropped and reported on the error event
 × rejects a handler that is not a function
 × stop() called from a fire listener still waits for the handler
 × a restart while stop() is still draining also resets the baseline
 Test Files  3 failed | 2 passed (5)
      Tests  5 failed | 126 passed (131)
```

with the predicted causes, verbatim:

```
  error: 'Graph is already running'          (x8)
AssertionError: expected [ 'fire@100' ] to deeply equal [ 'fire@100', 'fire@200', 'fire@300' ]
AssertionError: expected [ 'stop-event', 'handler-start' ] to deeply equal [ 'handler-start' ]
AssertionError: expected 'steady' to be undefined
```

**Trigger section, with the fixes** (`bun scripts/test.ts trigger vitest`):

```
Running all tests in sections [trigger] — 5 file(s)
 Test Files  5 passed (5)
      Tests  131 passed (131)
   Duration  44.47s
```

**Typecheck** (`npx tsc -b packages/triggers`, then `npx tsc -b packages/test`, which includes the trigger tests via `src/**/*`):

```
=== tsc -b packages/triggers ===
exit=0

$ npx tsc -b packages/test
real	3m38.659s
exit=0
```

**Lint / format**: `npx eslint packages/triggers/src packages/test/src/test/trigger` → `exit=0`; `npx prettier --check` → `All matched files use Prettier code style!`

**`BunExportConditions.test.ts` from `main`, unmodified, against this branch merged with `main`.** Merged `origin/main` into the branch in a scratch worktree (one conflict, in `scripts/test.ts`, unrelated — resolved to main's refactored runner), confirmed the test file is byte-identical to main (`git diff origin/main -- …BunExportConditions.test.ts` → 0 lines), then:

```
 RUN  v4.1.10 …/merge-check
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Re-adding the `"bun"` block to `packages/triggers/package.json` on that same merged tree fails it, so the check is not vacuous:

```
AssertionError: expected [ '@workglow/sqlite ./storage', …(3) ] to deeply equal [ … …(2) ]
+   "@workglow/triggers .",
 Tests  1 failed | 2 passed (3)
```

The trigger section also passes on the merged tree: `Test Files 5 passed (5) / Tests 131 passed (131)`.

## Tests added

- `WorkflowTriggers.test.ts` — a genuinely overlapping case (one `IntervalTrigger` with `overlap: "concurrent"` whose handler outlasts the period; the pre-existing `PERIOD` / `PERIOD*2` test never actually overlaps). Asserts every fire runs, executions are strictly sequential (peak concurrency 1), and no error reaches the `error` event. Plus: exceeding `maxPendingFires` emits `WorkflowTriggerError` and drops exactly one fire.
- `IntervalTrigger.test.ts` — `stop()` from a `fire` listener completes the handler before resolving and before the `stop` event; a non-function handler throws; an `intervalMs` above `2**31` is served in chunks and fires once at the target rather than immediately (previously only `CronTrigger` exercised the chunking).
- `PollingTrigger.test.ts` — the **unawaited** restart. The awaited test is kept.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz)_