### PR TITLE
fix(tasks): refuse webhook redirects and withhold private failure bodies

### DIFF
--- a/packages/tasks/README.md
+++ b/packages/tasks/README.md
@@ -33,7 +33,7 @@ bun add @workglow/tasks
 ## Quick Start
 
 ```typescript
-import { Workflow, fetch, debugLog, delay } from "@workglow/tasks";
+import { Workflow } from "@workglow/tasks";
 
 // Simple workflow example (fluent API)
 const workflow = new Workflow()
@@ -45,18 +45,26 @@ const results = await workflow.run();
 ```
 
 ```typescript
-import { FetchUrlTask, DebugLogTask, DelayTask } from "@workglow/tasks";
+import { fetchUrl, debugLog, delay } from "@workglow/tasks";
 
-// Simple sequence using Task classes directly
-const fetchResult = await new FetchUrlTask({
+// Simple sequence using the exported helpers
+const fetchResult = await fetchUrl({
   url: "https://api.example.com/data",
   response_type: "json",
-}).run();
+});
 
-await new DebugLogTask({ console: fetchResult.json }, { log_level: "info" }).run();
+await debugLog({ console: fetchResult.json }, { log_level: "info" });
 
-await new DelayTask({}, { delay: 1000 }).run();
+await delay({}, { delay: 1000 });
 ```
+
+> **Inputs go to `run()`, not to the constructor.** A task constructor takes
+> `(config, runConfig)`, and `TaskConfigSchema` is `additionalProperties: false`,
+> so `new SomeTask({ url: "…" })` throws a `TaskConfigurationError` before any
+> work happens. Each helper above (`fetchUrl`, `debugLog`, `slackNotify`, …) is
+> just `new SomeTask(config).run(input)` with the two arguments in the right
+> places. To bake input values into an instance, put them under the config's
+> `defaults` key — see the [WebhookNotifyTask](#webhooknotifytask) examples.
 
 ```typescript
 import { fetch, debugLog, delay } from "@workglow/tasks";
@@ -95,14 +103,14 @@ Makes HTTP requests with built-in retry logic, progress tracking, and multiple r
 
 ```typescript
 // Simple GET request
-const response = await new FetchUrlTask({
+const response = await fetchUrl({
   url: "https://api.example.com/users",
   response_type: "json",
-}).run();
+});
 console.log(response.json);
 
 // POST request with headers
-const postResponse = await new FetchUrlTask({
+const postResponse = await fetchUrl({
   url: "https://api.example.com/users",
   method: "POST",
   headers: {
@@ -111,13 +119,13 @@ const postResponse = await new FetchUrlTask({
   },
   body: JSON.stringify({ name: "John", email: "john@example.com" }),
   response_type: "json",
-}).run();
+});
 
 // Text response
-const textResponse = await new FetchUrlTask({
+const textResponse = await fetchUrl({
   url: "https://example.com/readme.txt",
   response_type: "text",
-}).run();
+});
 console.log(textResponse.text);
 ```
 
@@ -155,12 +163,20 @@ output schema and error messages report only the endpoint's origin.
 
 ```typescript
 // Direct task usage
-const result = await new WebhookNotifyTask({
+const result = await webhookNotify({
   url: "https://example.com/hooks/abc123",
   payload: { event: "deploy", version: "1.4.2" },
   headers: { "X-Signature": "sha256=..." },
-}).run();
+});
 console.log(result.status);
+
+// Config vs. input: the constructor takes CONFIG, so a fixed endpoint belongs
+// under `defaults` — the per-run payload is still passed to `run()`.
+const notifier = new WebhookNotifyTask({
+  title: "Deploy hook",
+  defaults: { url: "https://example.com/hooks/abc123" },
+});
+await notifier.run({ payload: { event: "deploy", version: "1.4.2" } });
 
 // In a workflow
 const workflow = new Workflow()
@@ -171,6 +187,7 @@ const workflow = new Workflow()
 **Features:**
 
 - Runs inline through the SSRF-aware `safeFetch` wrapper
+- **Redirects are refused** — a webhook that answers `3xx` fails rather than re-sending the payload and headers to the new origin. Point `url` at the final endpoint
 - Private/internal destinations require the scoped `network:private` entitlement
 - A private/internal destination is reachable but its response body is **never echoed** — `response` is always `""`. Notification needs no reply body, and returning one would make this task an SSRF read primitive (e.g. POSTing to a cloud metadata endpoint and reading the answer back into the graph)
 - 429/503 and 5xx raise `RetryableJobError`; retries require a `@workglow/job-queue` consumer, which these inline tasks do not have
@@ -203,19 +220,19 @@ Sends a message to a Slack incoming webhook.
 
 ```typescript
 // Plain message
-await new SlackNotifyTask({
+await slackNotify({
   url: "https://hooks.slack.com/services/T000/B000/xxx",
   text: "Deploy finished",
-}).run();
+});
 
 // Block Kit message with a bot identity
-await new SlackNotifyTask({
+await slackNotify({
   url: "https://hooks.slack.com/services/T000/B000/xxx",
   text: "Deploy finished",
   blocks: [{ type: "section", text: { type: "mrkdwn", text: "*Deploy finished*" } }],
   username: "deploybot",
   icon_emoji: ":rocket:",
-}).run();
+});
 
 // In a workflow
 const workflow = new Workflow().slackNotify({
@@ -227,7 +244,8 @@ const workflow = new Workflow().slackNotify({
 **Features:**
 
 - Absent optional fields are omitted from the payload rather than sent as `null`
-- Slack answers `200` with the body `ok`; failure bodies (`invalid_payload`, `no_service`) are surfaced in the error message
+- **Redirects are refused** — a webhook that answers `3xx` fails rather than re-sending the payload and headers to the new origin. Point `url` at the final endpoint
+- Slack answers `200` with the body `ok`; failure bodies (`invalid_payload`, `no_service`) are surfaced in the error message — but **only for a public destination**. A private/internal endpoint's reply body is never spliced into the error, which would otherwise make the task an SSRF read primitive; its status is still reported
 - **Channel-wide broadcasts in `text` are neutralized by default.** Slack has no `allowed_mentions`; its documented control is HTML-entity escaping, so the literal `<!` is escaped to `&lt;!`. That defuses `<!channel>`, `<!here>`, `<!everyone>` and `<!subteam^ID>` while leaving `<https://…|label>` links and single-user `<@U123>` mentions intact, and `link_names: false` is sent explicitly. `blocks` is a caller-authored structure, not a piped string, so it is **not** rewritten — a broadcast written inside a block still pings. Set `allow_mentions: true` to send `text` verbatim
 - Requests time out after 30s by default (`timeout`)
 - Response bodies are capped at 1MB while being read
@@ -257,19 +275,19 @@ Sends a message to a Discord webhook.
 
 ```typescript
 // Plain message
-await new DiscordNotifyTask({
+await discordNotify({
   url: "https://discord.com/api/webhooks/123/xxx",
   content: "Build passed",
-}).run();
+});
 
 // Embed with a custom identity
-await new DiscordNotifyTask({
+await discordNotify({
   url: "https://discord.com/api/webhooks/123/xxx",
   content: "Build passed",
   username: "ci",
   avatar_url: "https://example.com/ci.png",
   embeds: [{ title: "workglow", description: "All checks green" }],
-}).run();
+});
 
 // In a workflow
 const workflow = new Workflow().discordNotify({
@@ -281,6 +299,8 @@ const workflow = new Workflow().discordNotify({
 **Features:**
 
 - A successful post answers `204 No Content`, so no response body is read or parsed
+- **Redirects are refused** — a webhook that answers `3xx` fails rather than re-sending the payload and headers to the new origin. Point `url` at the final endpoint
+- A failure body is surfaced in the error message **only for a public destination**; a private/internal endpoint's reply body is never spliced in, which would otherwise make the task an SSRF read primitive
 - Rate limits arrive as `429` and may carry the delay as `{"retry_after": <seconds>}` in the body instead of a `Retry-After` header; both are parsed onto the raised `RetryableJobError`. Nothing acts on the value — retries require a `@workglow/job-queue` consumer, which these inline tasks do not have
 - **Mass mentions are suppressed by default** — `allowed_mentions: { parse: [] }` is sent, so `@everyone`/`@here`, role and user pings in `content` do nothing even when the content was piped in from a fetch or a model. Set `allow_mentions: true` to let the message ping
 - Requests time out after 30s by default (`timeout`)

--- a/packages/tasks/src/task/DiscordNotifyTask.ts
+++ b/packages/tasks/src/task/DiscordNotifyTask.ts
@@ -62,8 +62,10 @@ const inputSchema = {
     timeout: {
       type: "number",
       default: 30000,
+      minimum: 1,
       title: "Timeout",
-      description: "Request timeout in milliseconds",
+      description:
+        "Request timeout in milliseconds. There is no 'wait forever' setting: a black-holed endpoint would pin the task until the caller aborts.",
     },
     url_credential_key: {
       type: "string",

--- a/packages/tasks/src/task/SlackNotifyTask.ts
+++ b/packages/tasks/src/task/SlackNotifyTask.ts
@@ -61,8 +61,10 @@ const inputSchema = {
     timeout: {
       type: "number",
       default: 30000,
+      minimum: 1,
       title: "Timeout",
-      description: "Request timeout in milliseconds",
+      description:
+        "Request timeout in milliseconds. There is no 'wait forever' setting: a black-holed endpoint would pin the task until the caller aborts.",
     },
     url_credential_key: {
       type: "string",

--- a/packages/tasks/src/task/WebhookNotifyTask.ts
+++ b/packages/tasks/src/task/WebhookNotifyTask.ts
@@ -45,8 +45,10 @@ const inputSchema = {
     timeout: {
       type: "number",
       default: 30000,
+      minimum: 1,
       title: "Timeout",
-      description: "Request timeout in milliseconds",
+      description:
+        "Request timeout in milliseconds. There is no 'wait forever' setting: a black-holed endpoint would pin the task until the caller aborts.",
     },
     url_credential_key: {
       type: "string",

--- a/packages/tasks/src/util/WebhookPost.ts
+++ b/packages/tasks/src/util/WebhookPost.ts
@@ -147,9 +147,19 @@ export interface WebhookPostRequest {
   /** Request timeout in milliseconds. */
   readonly timeout: number | undefined;
   readonly signal: AbortSignal;
-  /** Read and return the success body. Endpoints replying 204 pass `false`. */
+  /**
+   * Read and return the success body. Endpoints replying 204 pass `false`.
+   *
+   * A ceiling, not a switch: {@link postWebhookJson} forces it to `false` for a
+   * private/internal destination, whose body is never surfaced.
+   */
   readonly readSuccessBody: boolean;
-  /** Include a truncated failure body in the thrown error message. */
+  /**
+   * Include a truncated failure body in the thrown error message.
+   *
+   * A ceiling, not a switch: {@link postWebhookJson} forces it to `false` for a
+   * private/internal destination, whose body is never surfaced.
+   */
   readonly includeBodyInError: boolean;
   /** Also read `retry_after` (seconds) from a JSON failure body. */
   readonly retryAfterFromJsonBody: boolean;
@@ -204,6 +214,20 @@ function leaksUrl(error: FetchUrlJobErrorInstance, url: string): boolean {
 }
 
 /**
+ * Recognizes the rejection `safeFetch` raises for a 3xx under
+ * `redirect: "error"`.
+ *
+ * Both transports throw a bare `TypeError` there — the shape `fetch` itself
+ * uses for the same refusal — so there is no code to match on, only the shape:
+ * a `TypeError` that names a redirect. Nothing else on this path produces one;
+ * a connection failure names the socket, and every SSRF refusal arrives as a
+ * typed {@link FetchUrlJobErrorInstance}.
+ */
+function isRedirectRefusal(error: unknown): boolean {
+  return error instanceof Error && error.name === "TypeError" && /redirect/i.test(error.message);
+}
+
+/**
  * Normalizes anything thrown while posting into a typed fetch error whose
  * message cannot contain the webhook secret. Already-typed errors keep their
  * code (and therefore their retryable/permanent classification) and are passed
@@ -233,6 +257,18 @@ function toRedactedWebhookError(
     return createFetchUrlJobError(
       FetchUrlErrorCode.NETWORK_ERROR,
       `Timed out posting ${label} to ${redactWebhookUrl(url)}`,
+      { url: redactWebhookUrl(url) }
+    );
+  }
+  // Built from scratch rather than rewritten: the transport's message embeds
+  // the requested URL (the secret), and the `Location` it refused to follow is
+  // never read at all, so neither can reach the caller.
+  if (isRedirectRefusal(error)) {
+    return createFetchUrlJobError(
+      FetchUrlErrorCode.INVALID_URL,
+      `Refusing to post ${label} to ${redactWebhookUrl(url)}: the endpoint answered with a ` +
+        `redirect. A webhook POST is never re-sent to another origin, because the payload ` +
+        `and any credentials would go with it. Configure the final URL instead.`,
       { url: redactWebhookUrl(url) }
     );
   }
@@ -303,7 +339,9 @@ async function readBodyText(
       text += decoder.decode(value, { stream: true });
       if (bytes >= maxBytes) {
         await reader.cancel().catch(() => {});
-        return text;
+        // Flush the decoder here too: abandoning the read mid-body can leave a
+        // partial multi-byte sequence buffered, which is dropped otherwise.
+        return text + decoder.decode();
       }
     }
   } catch {
@@ -315,9 +353,18 @@ async function readBodyText(
  * POSTs `payload` as JSON to a webhook endpoint through {@link safeFetch}.
  *
  * Private/loopback destinations are permitted only when the URL classifies as
- * private, in which case the granted scope is re-enforced on every redirect
- * hop — mirroring how {@link FetchUrlTask} threads the `network:private`
- * entitlement down to the transport.
+ * private, mirroring how {@link FetchUrlTask} threads the `network:private`
+ * entitlement down to the transport. A private destination additionally
+ * overrides `readSuccessBody` and `includeBodyInError` to `false`: those flags
+ * are a ceiling set by the calling task, and no reply from an internal host is
+ * ever surfaced — otherwise a notification task doubles as an SSRF read
+ * primitive with the answer smuggled out through an error message.
+ *
+ * Redirects are refused rather than followed. Following one would re-issue this
+ * exact request — method, serialized payload and caller headers — at whatever
+ * origin the `Location` names, handing the notification payload and any
+ * credentials to a host the caller never configured, and repeating the message
+ * once per hop. No mainstream webhook receiver answers a POST with a 3xx.
  */
 export async function postWebhookJson(request: WebhookPostRequest): Promise<WebhookPostResult> {
   const { url, label } = request;
@@ -337,13 +384,33 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
       : undefined;
   const signal = timeoutSignal ? AbortSignal.any([request.signal, timeoutSignal]) : request.signal;
 
+  // Built BEFORE the request `try`. A payload carrying a circular reference or
+  // a `BigInt` is a caller mistake no retry can fix, but the catch below has to
+  // treat anything it does not recognize as a transient network failure — so a
+  // throw from here would be retried forever under a misleading message.
+  let body: string | undefined;
+  let headers: Record<string, string>;
+  try {
+    body = JSON.stringify(request.payload);
+    headers = { "Content-Type": "application/json", ...request.headers };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw createFetchUrlJobError(
+      FetchUrlErrorCode.CONFIGURATION,
+      `Cannot build the ${label} request for ${redactWebhookUrl(url)}: ` +
+        `${redactWebhookUrlIn(detail, url)}`,
+      { url: redactWebhookUrl(url) }
+    );
+  }
+
   let response: Response;
   try {
     response = await safeFetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json", ...request.headers },
-      body: JSON.stringify(request.payload),
+      headers,
+      body,
       signal,
+      redirect: "error",
       allowPrivate: isPrivate,
       privateResourceScopes: isPrivate ? [urlResourcePattern(url)] : undefined,
     });
@@ -352,7 +419,7 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
   }
 
   if (response.ok) {
-    if (!request.readSuccessBody) {
+    if (!request.readSuccessBody || isPrivate) {
       // Slack answers 200 with a short `ok` body even though we don't want it.
       // An unconsumed body keeps the underlying connection out of the agent's
       // pool until GC, so cancel it explicitly instead of dropping it.
@@ -366,8 +433,10 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
   const failureBody = await readBodyText(response);
   const retryDate = retryDateFromResponse(response, failureBody, request.retryAfterFromJsonBody);
   const redacted = redactWebhookUrl(url);
+  // The status is still reported for a private destination — the reply BODY is
+  // what would turn a POST at an internal service into a read of it.
   const bodySuffix =
-    request.includeBodyInError && failureBody.length > 0
+    request.includeBodyInError && !isPrivate && failureBody.length > 0
       ? `: ${truncate(redactWebhookUrlIn(failureBody, url), MAX_ERROR_BODY_CHARS)}`
       : "";
 

--- a/packages/test/src/test/task/NotifyTask.test.ts
+++ b/packages/test/src/test/task/NotifyTask.test.ts
@@ -25,7 +25,7 @@ import {
   type SafeFetchFn,
   type SafeFetchOptions,
 } from "@workglow/tasks";
-import { getGlobalCredentialStore } from "@workglow/util";
+import { getGlobalCredentialStore, SECURITY_LIMITS } from "@workglow/util";
 import { validateSchema } from "@workglow/util/schema";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -37,6 +37,20 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vit
 const SLACK_URL = "https://hooks.slack.com/services/T00000000/B00000000/SECRETTOKEN";
 const DISCORD_URL = "https://discord.com/api/webhooks/123456789/SECRETTOKEN";
 const WEBHOOK_URL = "https://example.com/hooks/SECRETTOKEN";
+
+/** Where a redirecting (or compromised) endpoint would send the payload. */
+const REDIRECT_TARGET = "https://attacker.example/collect";
+
+/**
+ * Reproduces what both `safeFetch` transports do for a 3xx under
+ * `redirect: "error"`: a bare `TypeError` naming the URL that was requested,
+ * raised without ever reading the `Location` header.
+ */
+function redirectRefusal(url: string): Promise<Response> {
+  return Promise.reject(
+    new TypeError(`Fetch for ${url} failed because redirect mode was set to 'error'.`)
+  );
+}
 
 const mockFetch = vi.fn((_url: string, _options: SafeFetchOptions) =>
   Promise.resolve(new Response("ok", { status: 200 }))
@@ -729,6 +743,246 @@ describe("Webhook notification tasks", () => {
 
       expect(error).toBeInstanceOf(PermanentJobError);
       expect((error as PermanentJobError).code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+  });
+
+  // Following a redirect re-issues the SAME request — method, serialized
+  // payload and caller headers — at whatever origin the `Location` names. For a
+  // notification whose URL (or `Authorization` header) is the credential, one
+  // `302` from a merely-misconfigured partner hands the payload to a third
+  // party, and every hop re-delivers the message.
+  describe("redirect refusal", () => {
+    test("every task asks the transport to refuse redirects", async () => {
+      await slackNotify({ url: SLACK_URL, text: "hi" });
+      expect(lastCall().options.redirect).toBe("error");
+
+      mockFetch.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+      await discordNotify({ url: DISCORD_URL, content: "hi" });
+      expect(lastCall().options.redirect).toBe("error");
+
+      mockFetch.mockImplementation(() => Promise.resolve(new Response("ok", { status: 200 })));
+      await webhookNotify({ url: WEBHOOK_URL, payload: {} });
+      expect(lastCall().options.redirect).toBe("error");
+    });
+
+    test("a refused redirect is a permanent failure and is never re-sent", async () => {
+      mockFetch.mockImplementation((url: string) => redirectRefusal(url));
+
+      const error = (await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: { event: "deploy" },
+      }).catch((e: unknown) => e)) as PermanentJobError & { url?: string };
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error).not.toBeInstanceOf(RetryableJobError);
+      expect(error.code).toBe(FetchUrlErrorCode.INVALID_URL);
+      expect(error.code).not.toBe(FetchUrlErrorCode.NETWORK_ERROR);
+      expect(error.message).toContain("redirect");
+      // The payload must not be replayed at the redirect target.
+      expect(mockFetch.mock.calls.length).toBe(1);
+    });
+
+    test("the refusal leaks neither the webhook token nor the redirect target", async () => {
+      mockFetch.mockImplementation((url: string) => redirectRefusal(url));
+
+      const error = (await slackNotify({ url: SLACK_URL, text: "hi" }).catch(
+        (e: unknown) => e
+      )) as PermanentJobError & { url?: string };
+
+      expect(error.message).not.toContain("SECRETTOKEN");
+      expect(error.message).not.toContain(REDIRECT_TARGET);
+      expect(error.message).not.toContain("attacker.example");
+      expect(error.message).toContain("https://hooks.slack.com");
+      expect(error.url).not.toContain("SECRETTOKEN");
+      expect(String(error.stack)).not.toContain("SECRETTOKEN");
+      expect(formatErrorChainForDiagnostics(error)).not.toContain("SECRETTOKEN");
+    });
+
+    test("Discord's refusal is permanent too", async () => {
+      mockFetch.mockImplementation((url: string) => redirectRefusal(url));
+
+      const error = await discordNotify({ url: DISCORD_URL, content: "hi" }).catch(
+        (e: unknown) => e
+      );
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect((error as PermanentJobError).code).toBe(FetchUrlErrorCode.INVALID_URL);
+      expect(mockFetch.mock.calls.length).toBe(1);
+    });
+  });
+
+  // `includeBodyInError` is set unconditionally by the Slack and Discord tasks,
+  // so the private-destination gate has to live at the shared choke point:
+  // without it, posting to an internal service returns that service's detailed
+  // reply through the error message — the SSRF read the `response` port is
+  // already suppressed to prevent.
+  describe("private destination failure bodies", () => {
+    const PRIVATE_URL = "http://127.0.0.1:9200/_search";
+    const ES_BODY = JSON.stringify({
+      error: { type: "parsing_exception", reason: "cluster secrets index shard 3" },
+    });
+
+    test("Slack does not echo a private endpoint's failure body", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(ES_BODY, { status: 400, statusText: "Bad Request" }))
+      );
+
+      const error = (await slackNotify({ url: PRIVATE_URL, text: "x" }).catch(
+        (e: unknown) => e
+      )) as PermanentJobError & { httpStatus?: number };
+
+      expect(error.message).not.toContain("parsing_exception");
+      expect(error.message).not.toContain("cluster secrets index");
+      // The status still reports; only the body is withheld.
+      expect(error.message).toContain("400");
+      expect(error.httpStatus).toBe(400);
+    });
+
+    test("Discord does not echo a private endpoint's failure body", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(ES_BODY, { status: 400, statusText: "Bad Request" }))
+      );
+
+      const error = (await discordNotify({ url: PRIVATE_URL, content: "x" }).catch(
+        (e: unknown) => e
+      )) as PermanentJobError;
+
+      expect(error.message).not.toContain("parsing_exception");
+      expect(error.message).toContain("400");
+    });
+
+    test("a public endpoint's failure body is still surfaced", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response("invalid_payload", { status: 400, statusText: "Bad Request" }))
+      );
+
+      const error = (await slackNotify({ url: SLACK_URL, text: "x" }).catch(
+        (e: unknown) => e
+      )) as PermanentJobError;
+
+      expect(error.message).toContain("invalid_payload");
+    });
+
+    test("a private endpoint's success body is not read at all", async () => {
+      const response = new Response("AKIAEXAMPLESECRET", { status: 200 });
+      const readerSpy = vi.spyOn(response.body!, "getReader");
+      mockFetch.mockImplementation(() => Promise.resolve(response));
+
+      const result = await webhookNotify({ url: PRIVATE_URL, payload: {} });
+
+      expect(result.response).toBe("");
+      expect(readerSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("response body read ceiling", () => {
+    test("abandons a failure body past the byte ceiling", async () => {
+      const CHUNK_BYTES = 64 * 1024;
+      const TOTAL_CHUNKS = 40; // 2.5MB available, well past the 1MB ceiling
+      const chunk = new Uint8Array(CHUNK_BYTES).fill(121); // "y"
+      let pulled = 0;
+      const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulled += 1;
+          if (pulled > TOTAL_CHUNKS) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(chunk.slice());
+        },
+      });
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(stream, { status: 500, statusText: "Server Error" }))
+      );
+
+      const error = (await slackNotify({ url: SLACK_URL, text: "hi" }).catch(
+        (e: unknown) => e
+      )) as RetryableJobError;
+
+      expect(error).toBeInstanceOf(RetryableJobError);
+      // The read stops at the ceiling rather than buffering the whole body.
+      expect(pulled).toBeLessThan(TOTAL_CHUNKS);
+      expect(pulled * CHUNK_BYTES).toBeLessThanOrEqual(
+        SECURITY_LIMITS.webhookMaxResponseBodyBytes + CHUNK_BYTES
+      );
+      // What survives is still truncated for the message.
+      expect(error.message.length).toBeLessThan(2048);
+    });
+  });
+
+  // The catch around the request classifies anything it does not recognize as a
+  // retryable network failure, so building the request there would turn a
+  // caller mistake into an error that is retried forever.
+  describe("request construction failures", () => {
+    test("a circular payload is a permanent configuration error", async () => {
+      const payload: Record<string, unknown> = { event: "deploy" };
+      payload.self = payload;
+
+      const error = await webhookNotify({ url: WEBHOOK_URL, payload }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error).not.toBeInstanceOf(RetryableJobError);
+      expect((error as PermanentJobError).code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect((error as PermanentJobError).code).not.toBe(FetchUrlErrorCode.NETWORK_ERROR);
+      expect((error as PermanentJobError).message).not.toContain("SECRETTOKEN");
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    test("a BigInt in the payload is a permanent configuration error", async () => {
+      const error = await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: { size: BigInt(9007199254740993n) } as never,
+      }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error).not.toBeInstanceOf(RetryableJobError);
+      expect((error as PermanentJobError).code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+  });
+
+  // The README's snippets are copy-paste material; a constructor call that
+  // throws before any request is a documentation bug with a runtime cost.
+  describe("documented usage forms", () => {
+    test("the helper form documented for all three tasks runs", async () => {
+      expect(await webhookNotify({ url: WEBHOOK_URL, payload: { event: "deploy" } })).toEqual({
+        success: true,
+        status: 200,
+        response: "ok",
+      });
+
+      expect(await slackNotify({ url: SLACK_URL, text: "Deploy finished" })).toEqual({
+        success: true,
+        status: 200,
+      });
+
+      mockFetch.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+      expect(await discordNotify({ url: DISCORD_URL, content: "Build passed" })).toEqual({
+        success: true,
+        status: 204,
+      });
+    });
+
+    test("the documented `defaults` config form runs", async () => {
+      const notifier = new WebhookNotifyTask({
+        title: "Deploy hook",
+        defaults: { url: WEBHOOK_URL },
+      });
+
+      const result = await notifier.run({ payload: { event: "deploy", version: "1.4.2" } });
+
+      expect(result.status).toBe(200);
+      expect(lastCall().url).toBe(WEBHOOK_URL);
+      expect(lastCall().options.body).toBe(JSON.stringify({ event: "deploy", version: "1.4.2" }));
+    });
+
+    // Why the snippets had to change: the constructor's first argument is
+    // CONFIG, whose schema is `additionalProperties: false`.
+    test("passing inputs as the constructor config throws before any request", () => {
+      expect(() => new WebhookNotifyTask({ url: WEBHOOK_URL, payload: {} } as never)).toThrow();
+      expect(() => new SlackNotifyTask({ url: SLACK_URL, text: "hi" } as never)).toThrow();
+      expect(() => new DiscordNotifyTask({ url: DISCORD_URL, content: "hi" } as never)).toThrow();
       expect(mockFetch.mock.calls.length).toBe(0);
     });
   });


### PR DESCRIPTION
Stacked on #678 — please review that one first.

#678 did the hard part of this surface: it routes the notify tasks through the SSRF-aware `safeFetch`/`classifyUrl` plumbing instead of bare `fetch`, treats the webhook URL as the credential it actually is (redacting it out of `message`, `error.url` **and** `error.stack`, which V8 bakes the message into), neuters Slack broadcasts and Discord mass mentions, caps response bodies at 1MB while streaming, and suppresses `WebhookNotifyTask`'s `response` port for private destinations so the task cannot serve as an SSRF read primitive. This PR is not a rebuttal of any of that — it is three gaps that remain once the payload leaves the process, plus a documentation bug the new examples inherited.

## 1. A secret-bearing POST followed redirects cross-origin

`safeFetch` was called with no `redirect` option, so the default `"follow"` applied. Concretely, with `url` pointing at a partner endpoint:

```
POST https://partner.example/hooks/T000/B000/TOKEN
  → 302 Location: https://attacker.example/collect
POST https://attacker.example/collect     ← same method, same serialized payload,
                                             same caller-supplied headers
  → 200
```

The task returns `{ success: true, status: 200 }`. Nothing in the result or the logs says the destination changed. Each hop re-classifies as PUBLIC so no SSRF check fires, there is no same-origin check and no 303 method downgrade, and the chain runs to 20 hops — so a redirect loop also re-delivers the same notification up to 20 times. The partner does not have to be malicious; a CDN migration or a vanity-domain redirect is enough, and a compromised one gets the payload plus any `Authorization` header the caller wired into `headers`.

**Fix: `redirect: "error"`, fail closed.** No mainstream receiver needs a redirect on POST — Slack answers 200 at the posted URL, Discord 204, GitHub/Stripe/PagerDuty-shaped endpoints likewise. The one plausible legitimate hop is an `http:`→`https:` upgrade of the same host, which is a URL that should be fixed rather than followed with the secret attached. Both transports already honor the mode and throw at the first 3xx (`SafeFetch.ts`, `SafeFetch.server.ts`), so nothing in the transport changed; the refusal is mapped to a permanent `INVALID_URL` whose message names the problem and the remedy, with the endpoint reduced to its origin. The `Location` header is never read on that path, so it cannot reach the message either — asserted in the tests.

## 2. Slack/Discord echoed a private destination's failure body

Both tasks set `includeBodyInError: true` with no private/public gate, splicing up to 256 chars of the endpoint's reply into the thrown error — the read primitive `WebhookNotifyTask` already refuses to be. It is reachable by default: entitlement enforcement is opt-in (`TaskGraphRunner` gates on `config?.enforceEntitlements`), and `postWebhookJson` self-grants `allowPrivate` from the URL it actually uses. So

```ts
await slackNotify({ url: "http://127.0.0.1:9200/_search", text: "x" });
```

threw an error carrying Elasticsearch's detailed 400 body, into the task error and any persisted diagnostics.

**The gate belongs at the `postWebhookJson` choke point, not in the two task files.** That function already computes `isPrivate` — it needs it for `allowPrivate` and the scope pattern — so one condition there covers Slack, Discord and every future caller, and cannot be forgotten by the next task that copies `includeBodyInError: true` from its neighbour. Fixing it in `SlackNotifyTask`/`DiscordNotifyTask` would be two edits that each have to be repeated. `readSuccessBody` and `includeBodyInError` are now documented as a **ceiling** set by the calling task, overridden to `false` for a private destination; `WebhookNotifyTask`'s own `isPrivate` gate stays as defense in depth. The HTTP status still reports — the reply *body* is what turns a POST at an internal service into a read of it.

## 3. Every README "Direct task usage" example threw at construction

The new snippets (and the pre-existing `FetchUrlTask` ones above them) passed task INPUTS as the constructor's first argument. That argument is the CONFIG, whose schema is `additionalProperties: false`, and `validateAndApplyConfigDefaults` throws `TaskConfigurationError` on unknown keys — so copy-pasting

```ts
await new WebhookNotifyTask({ url: "...", payload: {...} }).run();
```

threw before any request was made. Every snippet now uses the exported helper (`webhookNotify`, `slackNotify`, `discordNotify`, `fetchUrl`), which is how the test file and the README's own fluent Quick Start invoke tasks, plus one `new WebhookNotifyTask({ defaults: { url } })` example making the config-vs-input distinction explicit. A test asserts each documented form constructs and runs — and that the old form throws, so the reason for the change stays pinned.

## Also fixed (small, same area)

- **A bad payload was retried forever.** `JSON.stringify(request.payload)` and the header map were built *inside* the `try` around `safeFetch`, and the catch labels anything it does not recognize `NETWORK_ERROR`, which is retryable. A circular reference or a `BigInt` therefore surfaced as a *retryable* "Network error posting webhook". Both are now built before the `try` and raise a permanent `CONFIGURATION` error.
- **`timeout: 0` armed no timeout at all.** The guard is `timeout > 0` and the port had no `minimum`, so `0` silently meant "wait forever" and a black-holed endpoint pinned the task. The three ports now declare `minimum: 1` and say so in their description.
- **The capped body read dropped a trailing multi-byte character** — it returned without the final `decoder.decode()` flush that the `done` branch performs. Not observable through the public surface (a body that hits the 1MB ceiling is always truncated to 1KB/256 chars for output), so it carries no test; the fix is one line.

## Behavior change to note for the package CHANGELOG

`redirect: "error"` is a **behavior change** for anyone whose webhook endpoint currently answers a 3xx — most plausibly an `http:`→`https:` upgrade. Those calls now fail with a permanent `INVALID_URL` instead of silently succeeding at the redirect target. **Remediation is one line: point `url` (or the stored credential) at the final URL.** The three tasks' Features lists in `packages/tasks/README.md` state the new rule.

## Verification

Run in an isolated worktree off #678's head (`b4707d94`), in source mode (`bun run use-source`):

- `npx vitest run packages/test/src/test/task/NotifyTask.test.ts` — **59 passed** (45 before this PR, 14 added).
- Same file with `packages/tasks/src/util/WebhookPost.ts` stashed back to the base version — **7 failed | 52 passed**, so the new assertions fail without the fix rather than passing vacuously: the `redirect: "error"` contract for all three tasks, the permanent/redacted/single-call redirect refusal for webhook and Discord, the withheld private failure body for Slack and Discord, and both request-construction cases.
- `bun scripts/test.ts task vitest` (73 files) — **1190 passed | 1 failed | 24 skipped**. The one failure is `OwnTask.test.ts > owns and disowns a pipe function` (`Class extends value undefined is not a constructor`, in `Conversions.ts`), which reproduces identically on the base branch with these changes stashed — pre-existing, unrelated.
- `npx turbo run build-types --filter=@workglow/tasks... --filter=@workglow/test` — **37/37 successful** (`tsgo`), after fixing one `httpStatus` typing in the new test.
- `npx eslint` on the four changed source files — clean; `npx prettier --write` on all six — no source-file changes.

All new tests stay at the `registerSafeFetch` seam; no real network.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz)_