### PR TITLE
docs(bootstrap): correct the self-registration invariant and the isolated-context example

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -298,7 +298,7 @@ Pre-built tasks: `InputTask`, `OutputTask`, `LambdaTask`, `DelayTask`, `FetchUrl
 
 ### `@workglow/bootstrap` — default registration
 
-Nothing self-registers at import time, so a runtime has to install the defaults before any task runs. This package is that seam, and **the implementation lives here** — `packages/workglow/src/bootstrap.ts` is now a pure `export * from "@workglow/bootstrap"` re-export shim. Add a new default registration in `packages/bootstrap/src/bootstrap/registerAllDefaults.ts`; editing the shim does nothing.
+Each registrar self-registers on the **global** registry when its module happens to be imported — `registerModelDefaults()`, `registerTabularStorageDefaults()` and the twelve others run at module scope, and default their `registry` parameter to the global one. What is populated therefore depends on which modules your import graph has pulled in, which is import-order dependent and easy to mis-diagnose. `bootstrapWorkglow()` is the guarantee: it installs the full set in dependency order, idempotently. An isolated registry gets **nothing** until `registerAllDefaults(registry)` (or `createOrchestrationContext()`) is called explicitly. This package is that seam, and **the implementation lives here** — `packages/workglow/src/bootstrap.ts` is now a pure `export * from "@workglow/bootstrap"` re-export shim. Add a new default registration in `packages/bootstrap/src/bootstrap/registerAllDefaults.ts`; editing the shim does nothing.
 
 - `bootstrapWorkglow(opts?)` — installs defaults onto the global registry, idempotent. The normal application entry point.
 - `createOrchestrationContext(opts?)` — a fresh, disposable registry backed by its own container (tests, multi-tenant servers, embedded use).

--- a/bun.lock
+++ b/bun.lock
@@ -174,7 +174,7 @@
     },
     "packages/bootstrap": {
       "name": "@workglow/bootstrap",
-      "version": "0.3.37",
+      "version": "0.3.38",
       "devDependencies": {
         "@workglow/ai": "workspace:*",
         "@workglow/knowledge-base": "workspace:*",
@@ -337,6 +337,7 @@
         "@workglow/ai": "workspace:*",
         "@workglow/anthropic": "workspace:*",
         "@workglow/aws": "workspace:*",
+        "@workglow/bootstrap": "workspace:*",
         "@workglow/browser-control": "workspace:*",
         "@workglow/bun-webview": "workspace:*",
         "@workglow/cactus": "workspace:*",

--- a/packages/bootstrap/README.md
+++ b/packages/bootstrap/README.md
@@ -2,11 +2,19 @@
 
 Runtime bootstrap for Workglow: registers every built-in default onto a service registry.
 
-Workglow does not self-register defaults at import time. Something has to install
-the logger, telemetry, worker-manager, credential, model, provider, knowledge-base,
-MCP, storage, task, and transform factories before any task runs — this package is
-that something, sitting below both the `workglow` meta-package and the test harness
-so neither has to own its own copy.
+Each registrar self-registers on the **global** registry when its module happens to
+be imported — `registerModelDefaults()`, `registerTabularStorageDefaults()` and the
+twelve others run at module scope, and default their `registry` parameter to the
+global one. What is populated therefore depends on which modules your import graph
+has pulled in, which is import-order dependent and easy to mis-diagnose.
+`bootstrapWorkglow()` is the guarantee: it installs the full set — logger,
+telemetry, worker-manager, credential, model, provider, knowledge-base, MCP,
+storage, task, and transform factories — in dependency order, idempotently. An
+isolated registry gets **nothing** until `registerAllDefaults(registry)` (or
+`createOrchestrationContext()`) is called explicitly.
+
+This package is that seam, sitting below both the `workglow` meta-package and the
+test harness so neither has to own its own copy.
 
 ## Installation
 
@@ -51,11 +59,16 @@ import { createOrchestrationContext } from "@workglow/bootstrap";
 
 const ctx = createOrchestrationContext();
 try {
-  await task.run({ context: ctx });
+  await task.run({}, { registry: ctx.registry });
 } finally {
   await ctx.dispose();
 }
 ```
+
+The registry travels in the **run config** — `run()`'s second argument. The first
+argument is input overrides, so passing a context there silently becomes an input
+named `context`, the run uses the global registry, and `ctx.dispose()` tears down a
+registry nothing ever touched.
 
 ### Registering onto a registry you already have
 

--- a/packages/bootstrap/src/bootstrap/bootstrapWorkglow.ts
+++ b/packages/bootstrap/src/bootstrap/bootstrapWorkglow.ts
@@ -72,7 +72,10 @@ export function bootstrapWorkglow(opts: BootstrapOptions = {}): WorkglowContext 
  * ```ts
  * const ctx = createOrchestrationContext({ logger: new MyLogger() });
  * try {
- *   await task.run({ ..., context: ctx });
+ *   // The registry travels in the run config — `run()`'s FIRST argument is
+ *   // input overrides, so a context passed there is just an input named
+ *   // `context` and the run still uses the global registry.
+ *   await task.run({}, { registry: ctx.registry });
  * } finally {
  *   await ctx.dispose();
  * }

--- a/packages/bootstrap/src/bootstrap/registerAllDefaults.ts
+++ b/packages/bootstrap/src/bootstrap/registerAllDefaults.ts
@@ -9,13 +9,13 @@ import { registerKnowledgeBaseDefaults } from "@workglow/knowledge-base";
 import { registerMcpServerDefaults } from "@workglow/mcp/util";
 import { registerTabularStorageDefaults } from "@workglow/storage";
 import { registerTaskDefaults, registerTransformDefaults } from "@workglow/task-graph";
+import type { ServiceRegistry } from "@workglow/util";
 import {
   registerCredentialDefaults,
   registerInputCompactorDefaults,
   registerInputResolverDefaults,
   registerLoggerDefaults,
   registerTelemetryDefaults,
-  ServiceRegistry,
 } from "@workglow/util";
 import { registerImageDefaults } from "@workglow/util/media";
 import { registerWorkerManagerDefaults } from "@workglow/util/worker";

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -39,6 +39,7 @@
     "@workglow/ai": "workspace:*",
     "@workglow/anthropic": "workspace:*",
     "@workglow/aws": "workspace:*",
+    "@workglow/bootstrap": "workspace:*",
     "@workglow/browser-control": "workspace:*",
     "@workglow/bun-webview": "workspace:*",
     "@workglow/cactus": "workspace:*",

--- a/packages/test/src/test/util/BootstrapReadme.test.ts
+++ b/packages/test/src/test/util/BootstrapReadme.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Executable transcription of the "Isolated context" example in
+ * `packages/bootstrap/README.md` (and the matching `createOrchestrationContext`
+ * JSDoc example).
+ *
+ * The README used to show `await task.run({ context: ctx })`. `Task.run` takes
+ * input overrides first and a run config second, and neither `IRunConfig` nor
+ * `TaskGraphRunConfig` has a `context` key — so with a loosely typed `Input`
+ * that object is an input override named `context`, the run keeps the global
+ * registry, and `ctx.dispose()` tears down a registry the task never touched.
+ * Both halves are pinned below so the snippet cannot silently rot back.
+ */
+
+import { createOrchestrationContext } from "@workglow/bootstrap";
+import type { IExecuteContext, TaskInput, TaskOutput } from "@workglow/task-graph";
+import { Task } from "@workglow/task-graph";
+import type { ServiceRegistry } from "@workglow/util";
+import { globalServiceRegistry } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+
+interface RegistryProbeOutput extends TaskOutput {
+  isGlobal: boolean;
+}
+
+/** Reports whether the run resolved against the process-wide registry. */
+class RegistryProbeTask extends Task<TaskInput, RegistryProbeOutput> {
+  public static override readonly type = "RegistryProbeTask";
+  public static override readonly category = "Test";
+  public static override readonly title = "Registry probe";
+  public static override readonly description = "Reports which service registry the run used.";
+  public static override readonly cacheable = false;
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {},
+      additionalProperties: true,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { isGlobal: { type: "boolean" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public seenRegistry: ServiceRegistry | undefined;
+
+  public override async execute(
+    _input: TaskInput,
+    context: IExecuteContext
+  ): Promise<RegistryProbeOutput> {
+    this.seenRegistry = context.registry;
+    return { isGlobal: context.registry === globalServiceRegistry };
+  }
+}
+
+describe("the @workglow/bootstrap README isolated-context example", () => {
+  it("routes the run to the isolated registry when the context is passed in the run config", async () => {
+    const ctx = createOrchestrationContext();
+    const task = new RegistryProbeTask();
+    try {
+      const output = await task.run({}, { registry: ctx.registry });
+
+      expect(output.isGlobal).toBe(false);
+      expect(task.seenRegistry).toBe(ctx.registry);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  it("keeps the global registry when a context is passed as an input override instead", async () => {
+    const ctx = createOrchestrationContext();
+    const task = new RegistryProbeTask();
+    try {
+      // The shape the README used to document. It type-checks only because this
+      // task's input schema is open; the run silently ignores it.
+      const output = await task.run({ context: ctx });
+
+      expect(output.isGlobal).toBe(true);
+      expect(task.seenRegistry).not.toBe(ctx.registry);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "../indexeddb" },
     { "path": "../mcp" },
     { "path": "../browser-control" },
+    { "path": "../bootstrap" },
     { "path": "../../providers/anthropic" },
     { "path": "../../providers/bun-webview" },
     { "path": "../../providers/deepseek" },


### PR DESCRIPTION
Stacked on #720 — base is `claude/wonderful-turing-rjtcnx-bootstrap-polish`, not `main`.

#720's mechanical work was reviewed and is correct: the version bump, the `exports`/`files` shape, and making `registerAllDefaults`'s `registry` parameter required all hold up. **This PR is documentation corrections only**, plus one import-style fix and a test that pins the corrected snippet.

## 1. "Nothing self-registers at import time" is false

`packages/bootstrap/README.md:5` and `.claude/CLAUDE.md:236` stated the package's raison d'être as *"Workglow does not self-register defaults at import time"* / *"Nothing self-registers at import time, so a runtime has to install the defaults before any task runs"*.

All 14 `register*Defaults` functions **do** self-register on `globalServiceRegistry` at module scope, and each also defaults its `registry` parameter to it. Verified individually (line numbers as of `dd97b0d`):

| module | module-scope call |
| --- | --- |
| `packages/util/src/logging/LoggerRegistry.ts` | `:59` |
| `packages/util/src/di/InputResolverRegistry.ts` | `:43` |
| `packages/util/src/di/InputCompactorRegistry.ts` | `:42` |
| `packages/util/src/telemetry/TelemetryRegistry.ts` | `:46` |
| `packages/util/src/worker/WorkerManager.ts` | `:616` |
| `packages/util/src/media/imageHydrationResolver.ts` | `:42` |
| `packages/util/src/credentials/CredentialStoreRegistry.ts` | `:96` |
| `packages/ai/src/model/ModelRegistry.ts` | `:94` |
| `packages/ai/src/provider/AiProviderRegistry.ts` | `:400` |
| `packages/knowledge-base/src/knowledge-base/KnowledgeBaseRegistry.ts` | `:177` |
| `packages/mcp/src/util/_server-registry/McpServerRegistry.ts` | `:124` |
| `packages/storage/src/tabular/TabularStorageRegistry.ts` | `:96` |
| `packages/task-graph/src/task/TaskRegistry.ts` | `:216` |
| `packages/task-graph/src/task-graph/TransformRegistry.ts` | `:38` |

(Two entries differ from the numbers a reader might expect: `WorkerManager.ts` is `:616` and `AiProviderRegistry.ts` is `:400` on this branch.)

Why it matters: a reader who trusts the old text concludes the global registry is empty until `bootstrapWorkglow()` runs, and will mis-diagnose ordering bugs. `getLogger()` (`LoggerRegistry.ts:66-71`) additionally self-registers lazily when the registry lacks `LOGGER`, so "it worked without calling bootstrap" looks impossible under the old doc.

Replaced with the real invariant in both files: registrars self-register on the **global** registry when their module happens to be imported, so what is populated depends on the import graph and is import-order dependent; `bootstrapWorkglow()` is the guarantee that installs the full set in dependency order, idempotently; an isolated registry gets **nothing** until `registerAllDefaults(registry)` (or `createOrchestrationContext()`) is called explicitly. The `.claude/CLAUDE.md` edit is confined to that one inverted sentence — the "implementation lives here / shim" sentences are untouched.

## 2. The isolated-context example passed an option no run API accepts

`README.md:52-56` (and the `createOrchestrationContext` JSDoc at `bootstrapWorkglow.ts:73`, inherited from main) showed:

```ts
await task.run({ context: ctx });
```

`Task.run(overrides, runConfig)` takes **input overrides first** (`packages/task-graph/src/task/Task.ts:222`), and neither `IRunConfig` (`ITask.ts:120`) nor `TaskGraphRunConfig` (`TaskGraph.ts:39`) has a `context` key — `IRunConfig` carries `registry?: ServiceRegistry` (`ITask.ts:252`).

Failure mode, confirmed by running it: with a loosely typed `Input` the object is accepted as an input override named `context`; `TaskRunner` keeps its `globalServiceRegistry` default (`TaskRunner.ts:140`) because it only overrides when `config.registry` is set (`TaskRunner.ts:1012`); the run therefore mutates and reads **process-wide** state, and `ctx.dispose()` tears down a registry nothing ever touched — the exact hazard the rest of the README argues against. With a strictly typed `Input` it is a compile error instead.

Corrected in both places to `await task.run({}, { registry: ctx.registry })`, with a sentence explaining that the registry travels in the run config (second argument).

### Pinned by a doc-conformance test

The repo already has the "transcribe the doc example into a test" pattern (`packages/test/src/test/util/readme.test.ts`), so the corrected snippet is now executable: `packages/test/src/test/util/BootstrapReadme.test.ts` asserts both halves — that `run({}, { registry: ctx.registry })` reaches the isolated registry, and that the old `run({ context: ctx })` shape silently falls back to the global one. Mutation-checked: reverting the first test to the old snippet fails it with `expected true to be false`.

This required adding `@workglow/bootstrap` to `packages/test`'s devDependencies and tsconfig references (one line each). It is the only structural change in the PR — happy to drop the test and both lines if you'd rather keep this strictly docs-only.

## 3. Import-style fix

`registerAllDefaults.ts` kept `ServiceRegistry` in the value-import list after `globalServiceRegistry` was removed, though it is used solely as a parameter type. Split into a top-level `import type`, per CLAUDE.md's convention.

## 4. Lockfile sync (incidental)

`bun.lock` still recorded `packages/bootstrap` at `0.3.37` while #720 bumped `package.json` to `0.3.38`. A plain `bun install` corrects it; included here so the next contributor's install doesn't produce unrelated churn. CI runs `bun i` (not `--frozen-lockfile`), so this was not breaking anything.

## Two suggested LOW fixes I did **not** apply

Both were requested, but the stated premises do not survive checking, so applying them would have traded one wrong doc for another. Flagging rather than silently skipping.

**`packages/bootstrap/CHANGELOG.md` heading.** The premise was that every sibling opens with its package name and that leaving `# Changelog` would make the next release run produce a two-headed file. Neither holds:

- Five packages open with `# Changelog`, not one: `bootstrap`, `browser-control`, `indexeddb`, `javascript`, `mcp`. All are public and released (all at 0.3.38).
- `bunset`'s `writeChangelog` (`node_modules/bunset/src/changelog.ts:98-122`) writes `# Changelog` only when the file **does not exist**; for an existing file it preserves the first line verbatim and inserts the new entry after it. `browser-control` has carried `# Changelog` across six releases with no second heading. So `# Changelog` is exactly what the tool generated for this new package, and renaming it would fight the generator rather than align with it.

**The `↓` separator in the `.claude/CLAUDE.md` dependency graph.** The parenthetical reason given was that `providers/*` does not depend on `bootstrap` — which is true (verified: nothing under `providers/` lists `@workglow/bootstrap`; the only dependent in the repo is `packages/workglow`), but it argues *against* the change. In that graph `↓` means "tier below"; inserting one between `bootstrap` and `providers/*` would assert that providers depend on bootstrap. They are genuine siblings: both sit below `ai`, neither depends on the other. Consecutive un-arrowed lines are already the graph's sibling notation — the bottom tier lists `test` / `workglow` / `debug` the same way. The current rendering is correct as-is.

## Verification

```
$ bunx tsc -b packages/bootstrap
(exit 0, no output)

$ bunx tsc --noEmit -p packages/bootstrap
(exit 0, no output)

$ bunx tsc -b --force packages/test
65 errors — identical file set to the pre-change baseline (also 65);
zero in any file this PR touches. All pre-existing, all TS2307/TS7006 from
optional providers not built in this environment (cactus, chrome-ai, mlx,
llamacpp-server, openrouter, stable-diffusion-server).

$ bun scripts/test.ts util vitest
Test Files  50 passed (50)
     Tests  685 passed | 10 skipped (695)
(49 files / 683 tests before this PR's new file)

$ bunx eslint packages/test/src/test/util/BootstrapReadme.test.ts
(exit 0)

$ bunx prettier --check <every changed file>
All matched files use Prettier code style!
```

The `util` section is where `BootstrapPackageExports.test.ts` and the new `BootstrapReadme.test.ts` live. Vitest runs were done in `use-source` mode; the tree was returned to dist mode before committing, so no `package.json` export churn is in the diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz)_