### PR TITLE
fix(util,ai): correct TurboQuant quantization grid and harden its decode path (follow-up to #354)

### DIFF
--- a/packages/ai/src/task/VectorQuantizeTask.ts
+++ b/packages/ai/src/task/VectorQuantizeTask.ts
@@ -61,7 +61,7 @@ const inputSchema = {
       enum: Object.values(QuantizationMethod),
       title: "Method",
       description:
-        "Quantization method: 'linear' for simple min-max scaling, 'turbo' for TurboQuant (randomized rotation + optimal scalar quantization, better distortion than linear at the same bit width). Turbo requires a signed integer targetType (int8 or int16). Turbo rotates in nextPowerOf2(d) dimensions but keeps only the first d coordinates, so for a non-power-of-2 dimensionality it is a random projection and cosine similarity is preserved only approximately (measured int8 RMSE: d=1024 -> 0.001, d=1536 -> 0.013, d=768 -> 0.019); zero-pad to a power of 2 when fidelity matters.",
+        "Quantization method: 'linear' for simple min-max scaling, 'turbo' for TurboQuant (randomized Hadamard rotation + uniform scalar quantization at the MSE-optimal Gaussian clipping range). Turbo requires a signed integer targetType (int8 or int16) AND a power-of-2 vector dimensionality: it rotates in nextPowerOf2(d) dimensions, so a non-power-of-2 input is rejected rather than silently degraded. At equal byte width linear is measurably more accurate at the common embedding sizes — measured int8 cosine RMSE, turbo vs linear: 0.0164 vs 0.0027 at d=768, 0.0126 vs 0.0033 at d=1536, 0.0094 vs 0.0026 at d=3072. Turbo wins only at d=1024 (0.0008 vs 0.0033).",
       default: QuantizationMethod.LINEAR,
     },
     turboSeed: {
@@ -144,6 +144,13 @@ export type VectorQuantizeTaskOutput = {
 };
 export type VectorQuantizeTaskConfig = TaskConfig<VectorQuantizeTaskInput>;
 
+/** Smallest power of 2 that is >= n. Doubles rather than shifts to stay 32-bit safe. */
+function nextPowerOf2(n: number): number {
+  let p = 1;
+  while (p < n) p *= 2;
+  return p;
+}
+
 /**
  * Task for quantizing vectors to reduce storage and improve performance.
  * Supports various quantization types including binary, int8, uint8, int16, uint16.
@@ -195,6 +202,19 @@ export class VectorQuantizeTask extends Task<
       if (targetType !== TensorType.INT8 && targetType !== TensorType.INT16) {
         throw new Error(
           `VectorQuantizeTask: method "turbo" supports signed integer target types only (int8, int16), got "${targetType}"`
+        );
+      }
+      // Checked here rather than left to turboQuantizeToTypedArray so the message names
+      // the task's own remedies. Turbo rotates in nextPowerOf2(d) dimensions and cannot
+      // return a d-length result without discarding coordinates, which measures worse
+      // than linear at exactly the dimensionalities embedding models use.
+      const unpadded = vectors.find((v) => v.length !== nextPowerOf2(v.length));
+      if (unpadded !== undefined) {
+        throw new Error(
+          `VectorQuantizeTask: method "turbo" requires a power of 2 vector dimensionality, got ${unpadded.length}. ` +
+            `Either use method: "linear" at this dimensionality (it is measurably more accurate here — ` +
+            `int8 cosine RMSE at d=768: linear 0.0027 vs turbo 0.0164), or zero-pad the vectors to ` +
+            `${nextPowerOf2(unpadded.length)} before quantizing and size the storage column to match.`
         );
       }
       quantized = vectors.map((v) => turboQuantizeToTypedArray(v, targetType, turboSeed));

--- a/packages/test/src/test/rag/VectorQuantizeTask.test.ts
+++ b/packages/test/src/test/rag/VectorQuantizeTask.test.ts
@@ -310,6 +310,36 @@ describe("VectorQuantizeTask", () => {
       }
     });
 
+    test("should reject a non-power-of-2 dimensionality with an actionable message", async () => {
+      // 768 is MiniLM's dimensionality, so this is the common case rather than an edge
+      // one. Turbo would have to discard 256 of 1024 rotated coordinates to return a
+      // 768-length vector, which measures worse than linear at that size — so the task
+      // refuses and names both remedies instead of silently returning worse vectors.
+      const vector = new Float32Array(768);
+      for (let i = 0; i < 768; i++) vector[i] = Math.sin(i * 0.1);
+
+      await expect(
+        vectorQuantize({ vector, targetType: TensorType.INT8, method: "turbo", turboSeed: 42 })
+      ).rejects.toThrow(/power of 2/);
+
+      await expect(
+        vectorQuantize({ vector, targetType: TensorType.INT8, method: "turbo", turboSeed: 42 })
+      ).rejects.toThrow(/768/);
+
+      // Both remedies are named: switch method, or pad to the next power of 2.
+      await expect(
+        vectorQuantize({ vector, targetType: TensorType.INT8, method: "turbo", turboSeed: 42 })
+      ).rejects.toThrow(/linear/);
+
+      await expect(
+        vectorQuantize({ vector, targetType: TensorType.INT8, method: "turbo", turboSeed: 42 })
+      ).rejects.toThrow(/1024/);
+
+      // The same vector is fine under linear quantization.
+      const linear = await vectorQuantize({ vector, targetType: TensorType.INT8 });
+      expect((linear.vector as Int8Array).length).toBe(768);
+    });
+
     test("should report method and turboSeed on the output", async () => {
       const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
 

--- a/packages/test/src/test/util/TurboQuantize.test.ts
+++ b/packages/test/src/test/util/TurboQuantize.test.ts
@@ -5,8 +5,10 @@
  */
 
 import { setLogger } from "@workglow/util";
+import type { TurboQuantizeResult } from "@workglow/util/schema";
 import {
   TensorType,
+  clearSignTableCache,
   cosineSimilarity,
   inner,
   magnitude,
@@ -124,7 +126,7 @@ describe("TurboQuantize", () => {
       const codes = Array.from(
         turboQuantize(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]), { bits: 4, seed: 42 }).codes
       );
-      expect(codes).toEqual([117, 165, 180, 133]);
+      expect(codes).toEqual([117, 180, 195, 133]);
 
       const v64 = new Float32Array(64);
       for (let i = 0; i < 64; i++) v64[i] = Math.sin(i * 0.7) * ((i % 5) + 1);
@@ -132,8 +134,74 @@ describe("TurboQuantize", () => {
         turboQuantizeToTypedArray(v64, TensorType.INT8, 42).slice(0, 16) as Int8Array
       );
       expect(first16).toEqual([
-        21, -29, -20, -39, -22, -22, 45, 10, -44, -17, -41, -93, 10, 35, -14, -17,
+        16, -22, -15, -30, -17, -17, 35, 8, -34, -13, -31, -71, 8, 27, -10, -13,
       ]);
+    });
+
+    test("should reject a decode whose codes are not a Uint8Array", () => {
+      // TurboQuantizeResult is a plain serializable record, so the obvious way to persist
+      // one is JSON. That turns `codes` into a plain object with no usable `length`, and
+      // `undefined < expectedBytes` is false — so a size-only guard waves it through and
+      // every byte reads back as NaN -> code 0, decoding to a confident vector of garbage.
+      const quantized = turboQuantize(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]), {
+        bits: 4,
+        seed: 42,
+      });
+
+      const shapes: readonly TurboQuantizeResult[] = [
+        JSON.parse(JSON.stringify(quantized)) as TurboQuantizeResult,
+        { ...quantized, codes: { "0": 1, "1": 2 } as unknown as Uint8Array },
+        { ...quantized, codes: Array.from(quantized.codes) as unknown as Uint8Array },
+      ];
+
+      for (const broken of shapes) {
+        expect(() => turboDequantize(broken)).toThrow(/Uint8Array/);
+        expect(() => turboQuantizedInnerProduct(broken, quantized)).toThrow(/Uint8Array/);
+        expect(() => turboQuantizedCosineSimilarity(broken, quantized)).toThrow(/Uint8Array/);
+      }
+    });
+
+    test("should accept a JSON-restored record once its codes are rebuilt", () => {
+      // The counterpart to the guard above: rebuilding the Uint8Array is all that is
+      // needed, so the guard rejects a broken carrier rather than a legitimate record.
+      const quantized = turboQuantize(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]), {
+        bits: 8,
+        seed: 42,
+      });
+      const restored = JSON.parse(JSON.stringify(quantized)) as TurboQuantizeResult;
+      const repaired: TurboQuantizeResult = {
+        ...restored,
+        codes: Uint8Array.from(Object.values(restored.codes as unknown as Record<string, number>)),
+      };
+
+      expect(turboQuantizedCosineSimilarity(repaired, quantized)).toBeCloseTo(1, 6);
+    });
+
+    test("should reject a record whose version this build does not support", () => {
+      const quantized = turboQuantize(new Float32Array([1, 2, 3, 4]), { bits: 4, seed: 42 });
+      expect(quantized.version).toBe(1);
+
+      const future = { ...quantized, version: 2 };
+      expect(() => turboDequantize(future)).toThrow(/version 2 is not supported/);
+      expect(() => turboQuantizedInnerProduct(future, quantized)).toThrow(
+        /version 2 is not supported/
+      );
+    });
+
+    test("should reject a non-integer or out-of-int32-range seed at encode time", () => {
+      // Encode-side validation matters more than decode-side: a record written with a
+      // seed this module cannot reproduce is data that can never be read back.
+      const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
+
+      expect(() => turboQuantize(vector, { bits: 4, seed: 1.5 })).toThrow(/seed/);
+      expect(() => turboQuantize(vector, { bits: 4, seed: 2 ** 32 + 1 })).toThrow(/seed/);
+      expect(() => turboQuantize(vector, { bits: 4, seed: NaN })).toThrow(/seed/);
+      expect(() => turboQuantizeToTypedArray(vector, TensorType.INT8, 1.5)).toThrow(/seed/);
+      expect(() => turboQuantizeToTypedArray(vector, TensorType.INT8, 2 ** 32 + 1)).toThrow(/seed/);
+
+      // The int32 window itself stays usable at both ends.
+      expect(() => turboQuantize(vector, { bits: 4, seed: -(2 ** 31) })).not.toThrow();
+      expect(() => turboQuantize(vector, { bits: 4, seed: 2 ** 31 - 1 })).not.toThrow();
     });
 
     test("should support different TypedArray inputs", () => {
@@ -231,6 +299,73 @@ describe("TurboQuantize", () => {
       expect(() => turboQuantizedInnerProduct(quantized, tampered)).toThrow("paddedDimensions");
     });
 
+    test("should preserve magnitude at every bit width", () => {
+      // A fixed 3-sigma clipping range put the two 1-bit reconstruction points at +/-3
+      // standard deviations, so a 1-bit reconstruction came back exactly 3x too long.
+      // Reconstruction is renormalized to the recorded norm, so magnitude is now carried
+      // by the one quantity the encoder stored exactly.
+      const d = 1024;
+      const rnd = makeRandom(42);
+      const original = new Float32Array(d);
+      for (let i = 0; i < d; i++) original[i] = rnd() - 0.5;
+
+      for (let bits = 1; bits <= 8; bits++) {
+        const reconstructed = turboDequantize(turboQuantize(original, { bits, seed: 42 }));
+        const ratio = magnitude(reconstructed) / magnitude(original);
+        expect(ratio).toBeGreaterThan(0.98);
+        expect(ratio).toBeLessThan(1.02);
+      }
+    });
+
+    test("should preserve magnitude at a cropped (non-power-of-2) dimensionality", () => {
+      const d = 768;
+      const rnd = makeRandom(7);
+      const original = new Float32Array(d);
+      for (let i = 0; i < d; i++) original[i] = rnd() - 0.5;
+
+      for (let bits = 1; bits <= 8; bits++) {
+        const ratio =
+          magnitude(turboDequantize(turboQuantize(original, { bits, seed: 42 }))) /
+          magnitude(original);
+        expect(ratio).toBeGreaterThan(0.9);
+        expect(ratio).toBeLessThan(1.02);
+      }
+    });
+
+    test("should reduce relative L2 error monotonically with bit width", () => {
+      // The monotonicity assertion is the point of this test. With a bits-independent
+      // 3-sigma clipping range, clipping error dominated everything the extra levels
+      // bought and relative L2 flattened out: 6, 7 and 8 bits all landed at ~0.035, so
+      // four times the levels bought nothing. Per-bit ceilings alone would not catch a
+      // regression back to a flat tail; requiring each step to be a real improvement does.
+      const d = 1024;
+      const rnd = makeRandom(42);
+      const original = new Float32Array(d);
+      for (let i = 0; i < d; i++) original[i] = rnd() - 0.5;
+
+      let originalEnergy = 0;
+      for (let i = 0; i < d; i++) originalEnergy += original[i] * original[i];
+
+      const ceilings = [0.75, 0.45, 0.26, 0.15, 0.09, 0.05, 0.028, 0.016];
+      const relativeL2: number[] = [];
+      for (let bits = 1; bits <= 8; bits++) {
+        const reconstructed = turboDequantize(turboQuantize(original, { bits, seed: 42 }));
+        let errorEnergy = 0;
+        for (let i = 0; i < d; i++) {
+          const delta = reconstructed[i] - original[i];
+          errorEnergy += delta * delta;
+        }
+        relativeL2.push(Math.sqrt(errorEnergy / originalEnergy));
+      }
+
+      relativeL2.forEach((value, index) => {
+        expect(value).toBeLessThan(ceilings[index]);
+      });
+      for (let i = 0; i + 1 < relativeL2.length; i++) {
+        expect(relativeL2[i + 1]).toBeLessThan(relativeL2[i] * 0.85);
+      }
+    });
+
     test("should improve quality with higher dimensions", () => {
       // TurboQuant relies on concentration of measure, which improves with dimension
       const d64 = 64;
@@ -269,6 +404,32 @@ describe("TurboQuantize", () => {
 
       // At 8 bits, should be reasonably close
       expect(estimatedIP).toBeCloseTo(trueIP, -1); // within order of magnitude
+    });
+
+    test("should estimate inner products accurately at embedding scale", () => {
+      // The 8-dim case above is dominated by how poorly a Gaussian-derived clipping range
+      // fits 8 bounded coordinates. At a realistic dimensionality the concentration the
+      // rotation relies on actually holds, and this is where the loading-factor fix pays:
+      // mean absolute error over these pairs measured 0.0566 at a fixed 3-sigma range and
+      // 0.0252 at the MSE-optimal one.
+      const d = 1024;
+      const pairs = 20;
+      const rnd = makeRandom(1024);
+      let totalError = 0;
+      for (let p = 0; p < pairs; p++) {
+        const a = new Float32Array(d);
+        const b = new Float32Array(d);
+        for (let i = 0; i < d; i++) {
+          a[i] = rnd() - 0.5;
+          b[i] = rnd() - 0.5;
+        }
+        const estimated = turboQuantizedInnerProduct(
+          turboQuantize(a, { bits: 8, seed: 42 }),
+          turboQuantize(b, { bits: 8, seed: 42 })
+        );
+        totalError += Math.abs(estimated - inner(a, b));
+      }
+      expect(totalError / pairs).toBeLessThan(0.04);
     });
 
     test("should reject vectors with different dimensions", () => {
@@ -332,6 +493,72 @@ describe("TurboQuantize", () => {
       const qb = turboQuantize(v, { bits: 8, seed: 42 });
 
       expect(turboQuantizedCosineSimilarity(qa, qb)).toBeGreaterThan(0.95);
+    });
+
+    test("should score a record against itself at exactly 1 for every bit width", () => {
+      // Treating the codes as if they were already unit vectors made self-similarity a
+      // function of how far the reconstruction's magnitude drifted from 1: at 1 bit the
+      // reconstruction was 3x too long and a record scored 9.0 against itself, on a
+      // function documented to return [-1, 1]. Dividing by each reconstruction's own norm
+      // makes this an actual cosine, so the identity holds by construction.
+      const d = 1024;
+      const rnd = makeRandom(42);
+      const v = new Float32Array(d);
+      for (let i = 0; i < d; i++) v[i] = rnd() - 0.5;
+
+      for (let bits = 1; bits <= 8; bits++) {
+        const q = turboQuantize(v, { bits, seed: 42 });
+        const self = turboQuantizedCosineSimilarity(q, q);
+        expect(self).toBeGreaterThan(0.999);
+        expect(self).toBeLessThanOrEqual(1.0);
+      }
+    });
+
+    test("should stay within [-1, 1] across many pairs at every bit width", () => {
+      const d = 1024;
+      const pairs = 40;
+      for (let bits = 1; bits <= 8; bits++) {
+        const rnd = makeRandom(1000 + bits);
+        for (let p = 0; p < pairs; p++) {
+          const a = new Float32Array(d);
+          const b = new Float32Array(d);
+          for (let i = 0; i < d; i++) {
+            a[i] = rnd() - 0.5;
+            b[i] = rnd() - 0.5;
+          }
+          const sim = turboQuantizedCosineSimilarity(
+            turboQuantize(a, { bits, seed: 42 }),
+            turboQuantize(b, { bits, seed: 42 })
+          );
+          expect(sim).toBeGreaterThanOrEqual(-1);
+          expect(sim).toBeLessThanOrEqual(1);
+        }
+      }
+    });
+  });
+
+  describe("sign table cache", () => {
+    test("should stay bounded and still reproduce an evicted table exactly", () => {
+      // The cache is process-global and keyed by (seed, paddedLen). Eviction has to be
+      // transparent: a table is a pure function of its key, so a recomputed one must give
+      // byte-identical codes. Twenty distinct seeds overflow the 16-entry bound, so the
+      // first seed's table is gone by the end of the loop.
+      const d = 4096;
+      const vector = new Float32Array(d);
+      for (let i = 0; i < d; i++) vector[i] = Math.sin(i * 0.01);
+
+      const first = turboQuantize(vector, { bits: 4, seed: 1 });
+      for (let seed = 2; seed <= 20; seed++) {
+        expect(() => turboQuantize(vector, { bits: 4, seed })).not.toThrow();
+      }
+
+      const afterEviction = turboQuantize(vector, { bits: 4, seed: 1 });
+      expect(Array.from(afterEviction.codes)).toEqual(Array.from(first.codes));
+
+      // An explicit clear is likewise result-preserving.
+      clearSignTableCache();
+      const afterClear = turboQuantize(vector, { bits: 4, seed: 1 });
+      expect(Array.from(afterClear.codes)).toEqual(Array.from(first.codes));
     });
   });
 
@@ -463,15 +690,13 @@ describe("TurboQuantize", () => {
       expect(negatives / result.length).toBeGreaterThanOrEqual(0.3);
     });
 
-    test("should preserve cosine similarity across common embedding dimensions", () => {
-      // The rotation runs in nextPowerOf2(d) dimensions but only the first d
-      // coordinates are kept, so a non-power-of-2 d is a random projection.
-      // Bounds mirror the RMSE documented on turboQuantizeToTypedArray (x1.5).
+    test("should preserve cosine similarity across power-of-2 dimensions", () => {
+      // At a power-of-2 dimensionality the rotation is orthogonal and nothing is
+      // discarded, so cosine similarity survives int8 quantization almost exactly.
       const cases: readonly { readonly d: number; readonly rmse: number }[] = [
-        { d: 768, rmse: 0.019 },
-        { d: 1000, rmse: 0.006 },
-        { d: 1024, rmse: 0.001 },
-        { d: 1536, rmse: 0.013 },
+        { d: 512, rmse: 0.00056 },
+        { d: 1024, rmse: 0.00044 },
+        { d: 2048, rmse: 0.00026 },
       ];
 
       for (const { d, rmse } of cases) {
@@ -494,8 +719,57 @@ describe("TurboQuantize", () => {
           if (error > maxError) maxError = error;
         }
         expect(Math.sqrt(squaredError / pairs)).toBeLessThan(rmse * 1.5);
-        expect(maxError).toBeLessThan(0.08);
+        expect(maxError).toBeLessThan(0.005);
       }
+    });
+
+    test("should reject a non-power-of-2 dimensionality", () => {
+      // Keeping the first d of nextPowerOf2(d) rotated coordinates is a lossy random
+      // projection that measures WORSE than linear quantization at exactly the sizes
+      // real embedding models use, so it is refused rather than silently degraded.
+      for (const d of [768, 1000, 1536, 3072]) {
+        expect(() => turboQuantizeToTypedArray(new Float32Array(d), TensorType.INT8)).toThrow(
+          /power of 2/
+        );
+      }
+    });
+
+    test("should widen to the next power of 2 when padToPowerOf2 is set", () => {
+      const padded = turboQuantizeToTypedArray(new Float32Array(768), TensorType.INT8, {
+        seed: 42,
+        padToPowerOf2: true,
+      });
+      expect(padded.length).toBe(1024);
+      expect(padded).toBeInstanceOf(Int8Array);
+
+      // Already a power of 2: the option is a no-op on length.
+      const exact = turboQuantizeToTypedArray(new Float32Array(1024), TensorType.INT8, {
+        seed: 42,
+        padToPowerOf2: true,
+      });
+      expect(exact.length).toBe(1024);
+    });
+
+    test("should preserve cosine similarity for padded non-power-of-2 vectors", () => {
+      // Padding keeps the rotation orthogonal, which is the whole point of preferring it
+      // over cropping: at d=768 cropping measured 0.0164 RMSE, padding measures ~0.0003.
+      const d = 768;
+      const rnd = makeRandom(768);
+      let squaredError = 0;
+      const pairs = 40;
+      for (let p = 0; p < pairs; p++) {
+        const a = new Float32Array(d);
+        const b = new Float32Array(d);
+        for (let i = 0; i < d; i++) {
+          a[i] = rnd() - 0.5;
+          b[i] = rnd() - 0.5;
+        }
+        const qa = turboQuantizeToTypedArray(a, TensorType.INT8, { seed: 42, padToPowerOf2: true });
+        const qb = turboQuantizeToTypedArray(b, TensorType.INT8, { seed: 42, padToPowerOf2: true });
+        const error = Math.abs(cosineSimilarity(qa, qb) - cosineSimilarity(a, b));
+        squaredError += error * error;
+      }
+      expect(Math.sqrt(squaredError / pairs)).toBeLessThan(0.002);
     });
 
     test("should reject empty vectors", () => {
@@ -612,7 +886,7 @@ describe("TurboQuantize", () => {
     const original = new Float32Array(d);
     for (let i = 0; i < d; i++) original[i] = Math.sin(i * 0.1) * (1 + Math.cos(i * 0.05));
 
-    for (const bits of [2, 3, 4, 6, 8]) {
+    for (const bits of [1, 2, 3, 4, 5, 6, 7, 8]) {
       test(`should maintain reasonable quality at ${bits} bits`, () => {
         const quantized = turboQuantize(original, { bits, seed: 42 });
         const reconstructed = turboDequantize(quantized);
@@ -623,8 +897,10 @@ describe("TurboQuantize", () => {
           expect(sim).toBeGreaterThan(0.95);
         } else if (bits >= 4) {
           expect(sim).toBeGreaterThan(0.85);
-        } else {
+        } else if (bits >= 2) {
           expect(sim).toBeGreaterThan(0.5); // Even 2-bit should preserve direction
+        } else {
+          expect(sim).toBeGreaterThan(0.6); // 1-bit keeps direction via sign information
         }
       });
     }

--- a/packages/util/src/vector/TurboQuantize.ts
+++ b/packages/util/src/vector/TurboQuantize.ts
@@ -5,21 +5,29 @@
  */
 
 /**
- * TurboQuant: Near-optimal vector quantization using randomized rotation
- * and optimal per-coordinate scalar quantization.
+ * Vector quantization by randomized rotation plus uniform scalar quantization.
  *
- * Based on "TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate"
+ * Inspired by "TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate"
  * by Zandieh, Daliri, Hadian, and Mirrokni (2025).
  *
- * The key insight: applying a random orthogonal rotation to a unit vector causes its
- * coordinates to concentrate around a known Beta distribution. This enables near-optimal
- * scalar quantization per coordinate without needing to observe the data distribution first.
+ * Why rotate: a random orthogonal rotation spreads a vector's energy evenly over its
+ * coordinates, so no coordinate dominates and every coordinate ends up with the same
+ * approximately Gaussian marginal. One fixed quantization grid then fits every
+ * coordinate of every vector, with no training pass and no per-dataset codebook.
+ *
+ * What this module implements: the randomized Hadamard rotation, plus a UNIFORM scalar
+ * quantizer whose clipping range is the MSE-optimal loading factor for a unit-variance
+ * Gaussian at the given bit width. Reconstruction is renormalized back to the recorded
+ * L2 norm, which keeps reconstructed magnitude and the similarity estimates unbiased.
+ *
+ * What it does NOT implement: the paper's non-uniform, distribution-fitted (Beta) level
+ * placement. Distortion here is that of an optimal *uniform* quantizer, which is coarser
+ * than the paper's near-optimal one.
  *
  * Properties:
  * - Data-oblivious: no training or codebook construction needed
  * - Per-vector: each vector quantized independently (streaming-friendly)
- * - Near-optimal: within ~2.7x of theoretical distortion limit at all bit-widths
- * - Preserves inner products for accurate similarity search
+ * - Preserves inner products and cosine similarity for similarity search
  */
 
 import { TensorType } from "./Tensor";
@@ -37,8 +45,20 @@ export interface TurboQuantizeOptions {
 
 /**
  * Result of TurboQuant quantization, containing everything needed for dequantization.
+ *
+ * Two records are comparable only when their `(version, bits, seed, dimensions)` tuple
+ * matches. `seed` selects the rotation basis, `bits` and `version` together fix the
+ * reconstruction grid, and `dimensions` fixes the padding — mixing any of them yields
+ * meaningless similarities. The pairwise helpers here enforce the last three; `version`
+ * is enforced on every decode.
  */
 export interface TurboQuantizeResult {
+  /**
+   * Encoding version. Bumped whenever the encoded codes to reconstructed values mapping
+   * changes, so an older record fails loudly on decode instead of being silently
+   * mis-scaled by a newer grid.
+   */
+  readonly version: number;
   /** Quantized codes packed into a Uint8Array */
   readonly codes: Uint8Array;
   /** Number of bits per dimension used */
@@ -60,15 +80,31 @@ export interface TurboQuantizeResult {
 const DEFAULT_SEED = 42;
 
 /**
+ * Current {@link TurboQuantizeResult.version}. Bump whenever the mapping between stored
+ * codes and reconstructed values changes (grid, loading factor, rotation, packing).
+ */
+const TURBO_QUANTIZE_VERSION = 1;
+
+/**
  * Upper bound on the dimensionality this module will accept.
  *
- * Every entry point pads the input to `nextPowerOf2(dimensions)` and allocates a
- * `Float64Array` of that length as the transform's working buffer. At 2^24 that
- * buffer is 128 MB (2^24 * 8 bytes), which is already far beyond any real
- * embedding. Rejecting anything larger keeps a bogus or hostile `dimensions`
- * value from either exhausting memory or spinning inside the padding loop.
+ * Every entry point pads the input to `nextPowerOf2(dimensions)` and allocates several
+ * `Float64Array`s of that length as working buffers, so peak cost is a multiple of the
+ * padded length rather than the single buffer a naive estimate assumes: measured peak RSS
+ * growth is 32 MB at d = 2^20, about 32 bytes per padded coordinate. 2^20 is already ~340x
+ * the largest real embedding (3072-dim). Rejecting anything larger keeps a bogus or
+ * hostile `dimensions` value from exhausting memory or spinning in the padding loop.
  */
-const MAX_TURBO_DIMENSIONS = 2 ** 24;
+const MAX_TURBO_DIMENSIONS = 2 ** 20;
+
+/**
+ * Inclusive bounds on a rotation seed: the int32 window {@link createPrng} actually
+ * distinguishes. It coerces with `>>> 0` after an XOR, so anything outside this window
+ * silently aliases onto another seed (`2**32 + 1` becomes `1`) and would decode against
+ * a different rotation basis than it was encoded with.
+ */
+const MIN_SEED = -(2 ** 31);
+const MAX_SEED = 2 ** 31 - 1;
 
 /** Number of (sign-flip + Walsh-Hadamard) rounds applied by the randomized rotation. */
 const SIGN_ROUNDS = 3;
@@ -83,7 +119,7 @@ function assertDimensions(n: number): void {
   }
   if (n > MAX_TURBO_DIMENSIONS) {
     throw new Error(
-      `TurboQuant dimensions must be at most ${MAX_TURBO_DIMENSIONS}, got ${n} (the padded working buffer would exceed 128 MB)`
+      `TurboQuant dimensions must be at most ${MAX_TURBO_DIMENSIONS}, got ${n} (the padded working buffers would exceed ~32 MB)`
     );
   }
 }
@@ -95,6 +131,24 @@ function assertDimensions(n: number): void {
 function assertBits(bits: number): void {
   if (!Number.isInteger(bits) || bits < 1 || bits > 8) {
     throw new Error(`TurboQuant bits must be an integer between 1 and 8, got ${bits}`);
+  }
+}
+
+/**
+ * Validates a rotation seed before it reaches the PRNG.
+ *
+ * Checked on encode as well as decode: a record written with a seed this module cannot
+ * reproduce (a fraction, or a value outside the int32 window) is data that can never be
+ * read back, and failing at write time is the only point where nothing has been lost yet.
+ *
+ * @param seed - Candidate rotation seed
+ */
+function assertSeed(seed: number): void {
+  if (!Number.isInteger(seed) || seed < MIN_SEED || seed > MAX_SEED) {
+    throw new Error(
+      `TurboQuant seed must be an integer in the int32 range [${MIN_SEED}, ${MAX_SEED}], got ${seed}. ` +
+        `Values outside that window alias onto a different seed once truncated to 32 bits.`
+    );
   }
 }
 
@@ -120,11 +174,45 @@ function createPrng(seed: number): () => number {
   };
 }
 
-/** Maximum number of memoized sign tables. Bounded so a hostile seed stream cannot grow it. */
-const SIGN_TABLE_CACHE_LIMIT = 16;
+/**
+ * Memory budget for memoized sign tables.
+ *
+ * An entry costs `SIGN_ROUNDS * paddedLen` bytes, so a count-only cap says nothing about
+ * memory: 16 entries at the maximum dimensionality would retain hundreds of megabytes.
+ * The byte total is the real bound; the count cap stays as a secondary limit so a stream
+ * of tiny distinct seeds cannot accumulate unbounded Map overhead.
+ */
+const SIGN_TABLE_CACHE_MAX_BYTES = 8 * 1024 * 1024;
+
+/** Secondary bound on memoized sign tables, in entries. */
+const SIGN_TABLE_CACHE_MAX_ENTRIES = 16;
 
 /** Memoized sign tables keyed by `${seed}:${paddedLen}` (insertion-ordered for eviction). */
 const signTableCache = new Map<string, readonly Uint8Array[]>();
+
+/** Running total of the bytes retained by {@link signTableCache}. */
+let signTableCacheBytes = 0;
+
+/** Total bytes held by one memoized sign table. */
+function signTableBytes(table: readonly Uint8Array[]): number {
+  let total = 0;
+  for (const mask of table) total += mask.length;
+  return total;
+}
+
+/**
+ * Drops every memoized sign table.
+ *
+ * The cache is process-global and keyed by `(seed, paddedLen)`, so a long-lived host that
+ * quantizes across many seeds or dimensionalities holds up to
+ * {@link SIGN_TABLE_CACHE_MAX_BYTES} indefinitely. This releases it. Purely a memory
+ * operation: tables are pure functions of their key, so clearing changes no result, only
+ * the cost of recomputing one.
+ */
+export function clearSignTableCache(): void {
+  signTableCache.clear();
+  signTableCacheBytes = 0;
+}
 
 /**
  * Returns the `SIGN_ROUNDS` Rademacher flip masks for a (seed, paddedLen) pair.
@@ -158,14 +246,25 @@ function getSignTable(seed: number, paddedLen: number): readonly Uint8Array[] {
     table.push(mask);
   }
 
-  if (signTableCache.size >= SIGN_TABLE_CACHE_LIMIT) {
-    // Map iteration is insertion-ordered, so this evicts the oldest entry.
+  // Evict oldest-first until the new entry fits both bounds. Map iteration is
+  // insertion-ordered, so `keys().next()` is the oldest entry. A single table can never
+  // exceed the byte budget on its own (SIGN_ROUNDS * MAX_TURBO_DIMENSIONS = 3 MB), so
+  // this always terminates with room to spare.
+  const entryBytes = signTableBytes(table);
+  while (
+    signTableCache.size > 0 &&
+    (signTableCache.size >= SIGN_TABLE_CACHE_MAX_ENTRIES ||
+      signTableCacheBytes + entryBytes > SIGN_TABLE_CACHE_MAX_BYTES)
+  ) {
     const oldest = signTableCache.keys().next();
-    if (oldest.done !== true) {
-      signTableCache.delete(oldest.value);
-    }
+    if (oldest.done === true) break;
+    const evicted = signTableCache.get(oldest.value);
+    if (evicted !== undefined) signTableCacheBytes -= signTableBytes(evicted);
+    signTableCache.delete(oldest.value);
   }
+
   signTableCache.set(key, table);
+  signTableCacheBytes += entryBytes;
   return table;
 }
 
@@ -282,25 +381,124 @@ function nextPowerOf2(n: number): number {
 }
 
 /**
+ * Outermost reconstruction level of the MSE-optimal uniform quantizer for a
+ * unit-variance Gaussian, indexed by `bits - 1` (so `levels = 2^bits`).
+ *
+ * Derived from Max (1960), whose optimum-uniform step sizes are
+ * `Δ = 1.596, 0.9957, 0.5860, 0.3352, 0.1881, 0.1041, 0.0568, 0.0308`; the outer level is
+ * `(levels - 1) * Δ / 2`. That is exactly this module's parameterization, because
+ * {@link dequantizeScalar} places `levels` equally spaced points spanning `[-scale, scale]`
+ * — so `scale` IS the outer level.
+ *
+ * The clipping range has to widen with bit width. A range fixed at 3σ leaves a
+ * bits-independent clipping error that dominates everything the extra levels buy: measured
+ * relative L2 at d=1024 was identical (~0.035) at 6 and 8 bits, and at 1 bit the two
+ * reconstruction points sat at ±3σ, inflating reconstructed magnitude 3x.
+ */
+const GAUSSIAN_LOADING_FACTORS = [
+  0.7979, 1.4937, 2.0517, 2.5138, 2.9156, 3.2792, 3.6068, 3.927,
+] as const;
+
+/** Standard normal density. */
+function gaussianPdf(x: number): number {
+  return Math.exp(-(x * x) / 2) / Math.sqrt(2 * Math.PI);
+}
+
+/**
+ * `∫₀^∞ u² · exp(-a·u - u²/2) du`, the clipping-error integral with the constant
+ * `φ(a)` factored out analytically.
+ *
+ * Written this way on purpose. The closed form `(1 + a²)Q(a) - a·φ(a)` cancels catastrophically
+ * once `a` reaches the far tail the 16-bit grid optimizes into (~6σ), where the two terms agree
+ * to three digits and a tail approximation's absolute error dwarfs their difference. Factoring
+ * `φ(a)` out leaves a smooth positive integrand that Simpson's rule resolves to full precision
+ * at any `a`, and needs no error-function approximation.
+ */
+function clippingErrorIntegral(a: number): number {
+  const upper = 12;
+  const steps = 1200;
+  const h = upper / steps;
+  const term = (u: number): number => u * u * Math.exp(-a * u - (u * u) / 2);
+  let sum = term(0) + term(upper);
+  for (let i = 1; i < steps; i++) {
+    sum += term(i * h) * (i % 2 === 1 ? 4 : 2);
+  }
+  return (sum * h) / 3;
+}
+
+/**
+ * Mean squared error of a uniform quantizer with `levels` points spanning `[-a, a]`,
+ * applied to a unit-variance Gaussian: uniform granular error plus clipping error.
+ */
+function quantizerDistortion(a: number, levels: number): number {
+  const step = (2 * a) / (levels - 1);
+  return (step * step) / 12 + 2 * gaussianPdf(a) * clippingErrorIntegral(a);
+}
+
+/** Memoized {@link optimalLoadingFactor} results for level counts outside the table. */
+const loadingFactorCache = new Map<number, number>();
+
+/**
+ * Outermost reconstruction level of the MSE-optimal uniform quantizer for a unit-variance
+ * Gaussian with `levels` levels.
+ *
+ * Power-of-two level counts up to 256 come from {@link GAUSSIAN_LOADING_FACTORS}. Anything
+ * else is solved numerically by minimizing {@link quantizerDistortion} — needed by
+ * {@link turboQuantizeToTypedArray}, whose effective level count is `2 * max + 1`
+ * (255 for int8, 65535 for int16) and so is never in the table. The numeric solution
+ * reproduces the tabulated values to within 0.35% (0.00% at 64 levels), which is what
+ * pins the two paths to the same curve.
+ */
+function optimalLoadingFactor(levels: number): number {
+  if (!Number.isInteger(levels) || levels < 2) {
+    throw new Error(`TurboQuant requires at least 2 quantization levels, got ${levels}`);
+  }
+  const bitsIndex = Math.log2(levels);
+  if (
+    Number.isInteger(bitsIndex) &&
+    bitsIndex >= 1 &&
+    bitsIndex <= GAUSSIAN_LOADING_FACTORS.length
+  ) {
+    return GAUSSIAN_LOADING_FACTORS[bitsIndex - 1];
+  }
+
+  const cached = loadingFactorCache.get(levels);
+  if (cached !== undefined) return cached;
+
+  // Ternary search: distortion is unimodal in `a` (granular error rises with it, clipping
+  // error falls). 80 iterations shrink the bracket well past double precision.
+  let low = 0.2;
+  let high = 20;
+  for (let i = 0; i < 80; i++) {
+    const leftThird = low + (high - low) / 3;
+    const rightThird = high - (high - low) / 3;
+    if (quantizerDistortion(leftThird, levels) < quantizerDistortion(rightThird, levels)) {
+      high = rightThird;
+    } else {
+      low = leftThird;
+    }
+  }
+  const solved = (low + high) / 2;
+  loadingFactorCache.set(levels, solved);
+  return solved;
+}
+
+/**
  * Returns quantization parameters for uniform scalar quantization over the range
  * [-scale, scale].
  *
  * After random rotation in paddedLen-dimensional space, each coordinate of a
- * d-dimensional unit vector (zero-padded to paddedLen) has variance 1/paddedLen.
- * We use a fixed range of ±3 standard deviations (coverage ≈ 99.7%) as the
- * clipping boundary for a uniform quantizer with `levels = 2^bits` levels.
- * This is a simple, practical uniform quantizer; no non-uniform or
- * distribution-fitted quantization is performed.
+ * d-dimensional unit vector (zero-padded to paddedLen) has variance 1/paddedLen, so the
+ * clipping boundary is the MSE-optimal loading factor for that bit width, in units of the
+ * per-coordinate standard deviation. No non-uniform or distribution-fitted quantization is
+ * performed — the levels are equally spaced.
  */
 function getQuantizationParams(
   bits: number,
   paddedLen: number
 ): { readonly levels: number; readonly scale: number } {
   const levels = 1 << bits; // 2^bits quantization levels
-  // After rotation, coordinates have std dev ≈ 1/sqrt(paddedLen).
-  // Cover ±3 standard deviations.
-  const coverage = 3.0;
-  const scale = coverage / Math.sqrt(paddedLen);
+  const scale = optimalLoadingFactor(levels) / Math.sqrt(paddedLen);
   return { levels, scale };
 }
 
@@ -394,10 +592,19 @@ function packCodes(codes: number[], bits: number): Uint8Array {
  * typed array keeps the per-comparison hot path free of boxed `number[]`
  * allocations.
  *
- * Throws if the buffer is too small for the requested count and bit width.
+ * Throws if the buffer is not a Uint8Array, or is too small for the requested count and
+ * bit width.
  */
 function unpackCodes(packed: Uint8Array, bits: number, count: number): Uint8Array {
   const expectedBytes = Math.ceil((count * bits) / 8);
+  // Checked before the length comparison: a non-array `packed` has an `undefined` length,
+  // and `undefined < N` is false, so a size check alone waves it through and every byte
+  // read yields `undefined -> NaN -> code 0`.
+  if (!(packed instanceof Uint8Array)) {
+    throw new Error(
+      `unpackCodes: codes must be a Uint8Array, got ${Object.prototype.toString.call(packed)}`
+    );
+  }
   if (packed.length < expectedBytes) {
     throw new Error(
       `unpackCodes: buffer too small - need ${expectedBytes} bytes for ${count} codes at ${bits} bits, got ${packed.length}`
@@ -432,7 +639,8 @@ function unpackCodes(packed: Uint8Array, bits: number, count: number): Uint8Arra
  * Steps:
  * 1. Normalize the vector and record its L2 norm
  * 2. Apply randomized rotation (sign flips + Walsh-Hadamard transform)
- * 3. Quantize each rotated coordinate using optimal scalar quantization
+ * 3. Quantize each rotated coordinate on a uniform grid whose clipping range is the
+ *    MSE-optimal loading factor for this bit width
  * 4. Pack the codes into a compact bit representation
  *
  * @param vector - Input vector (any TypedArray). Must not contain NaN or Infinity.
@@ -447,6 +655,7 @@ export function turboQuantize(
   const seed = options?.seed ?? DEFAULT_SEED;
 
   assertBits(bits);
+  assertSeed(seed);
 
   const d = vector.length;
   if (d === 0) {
@@ -472,6 +681,7 @@ export function turboQuantize(
   const packed = packCodes(codes, bits);
 
   return {
+    version: TURBO_QUANTIZE_VERSION,
     codes: packed,
     bits,
     dimensions: d,
@@ -490,12 +700,26 @@ export function turboQuantize(
  * the transform is therefore re-checked rather than trusted.
  */
 function assertQuantizeResultShape(quantized: TurboQuantizeResult): void {
-  const { bits, dimensions, paddedDimensions, seed, norm } = quantized;
+  const { version, codes, bits, dimensions, paddedDimensions, seed, norm } = quantized;
+  // First, before any length or range check: a record that has been through JSON (or any
+  // structured-clone-free channel) carries `codes` as a plain object — `{"type":"Buffer",
+  // "data":[...]}` from a Node Buffer, `{"0":..,"1":..}` from a Uint8Array. Neither has a
+  // usable `length`, so every downstream size guard passes and the decode silently yields
+  // a vector of zeroes instead of failing.
+  if (!(codes instanceof Uint8Array)) {
+    throw new Error(
+      `TurboQuant codes must be a Uint8Array, got ${Object.prototype.toString.call(codes)}. ` +
+        `A record restored from JSON must have its codes rebuilt (e.g. Uint8Array.from(...)) before decoding.`
+    );
+  }
+  if (version !== TURBO_QUANTIZE_VERSION) {
+    throw new Error(
+      `TurboQuant record version ${version} is not supported by this build (expected ${TURBO_QUANTIZE_VERSION})`
+    );
+  }
   assertBits(bits);
   assertDimensions(dimensions);
-  if (!Number.isInteger(seed)) {
-    throw new Error(`TurboQuant seed must be an integer, got ${seed}`);
-  }
+  assertSeed(seed);
   if (!Number.isFinite(norm)) {
     throw new Error(`TurboQuant norm must be a finite number, got ${norm}`);
   }
@@ -508,39 +732,74 @@ function assertQuantizeResultShape(quantized: TurboQuantizeResult): void {
 }
 
 /**
+ * Reconstructs the rotated-domain coordinates from a record's packed codes.
+ *
+ * Returns the L2 norm of those coordinates alongside them because every consumer needs it:
+ * clipping and rounding do not preserve magnitude, so the reconstruction has to be
+ * renormalized before it means anything. Shared by the decode and both similarity helpers
+ * so all three sit on one definition of "the vector these codes stand for".
+ *
+ * @param quantized - A record whose shape has already been validated
+ */
+function reconstructRotatedCodes(quantized: TurboQuantizeResult): {
+  readonly values: Float64Array;
+  readonly codeNorm: number;
+} {
+  const { codes, bits, paddedDimensions } = quantized;
+  const unpacked = unpackCodes(codes, bits, paddedDimensions);
+  const { levels, scale } = getQuantizationParams(bits, paddedDimensions);
+
+  const values = new Float64Array(paddedDimensions);
+  let sumSquares = 0;
+  for (let i = 0; i < paddedDimensions; i++) {
+    const value = dequantizeScalar(unpacked[i], scale, levels);
+    values[i] = value;
+    sumSquares += value * value;
+  }
+  return { values, codeNorm: Math.sqrt(sumSquares) };
+}
+
+/**
  * Dequantizes a TurboQuant result back to a Float32Array.
  *
  * Steps:
- * 1. Unpack the codes from the compact representation
- * 2. Reconstruct the rotated coordinates from quantization levels
- * 3. Apply inverse rotation
- * 4. Scale by the original norm
+ * 1. Unpack the codes and reconstruct the rotated coordinates
+ * 2. Apply inverse rotation
+ * 3. Crop to the original dimensions and renormalize to the recorded norm
+ *
+ * The final step is a rescale, not a multiply. Quantization does not preserve magnitude —
+ * at low bit widths the clipped grid inflates it badly — and `norm` is the one quantity the
+ * encoder stored exactly, so restoring it costs nothing and removes the bias.
  *
  * @param quantized - The TurboQuant quantization result
  * @returns Reconstructed vector as Float32Array
  */
 export function turboDequantize(quantized: TurboQuantizeResult): Float32Array {
-  const { codes, bits, dimensions, paddedDimensions, seed, norm } = quantized;
-
   assertQuantizeResultShape(quantized);
+  const { dimensions, seed, norm } = quantized;
 
-  // Step 1: Unpack all paddedDimensions codes
-  const unpacked = unpackCodes(codes, bits, paddedDimensions);
-
-  // Step 2: Reconstruct rotated coordinates (all paddedDimensions)
-  const { levels, scale } = getQuantizationParams(bits, paddedDimensions);
-  const rotated = new Float64Array(paddedDimensions);
-  for (let i = 0; i < paddedDimensions; i++) {
-    rotated[i] = dequantizeScalar(unpacked[i], scale, levels);
-  }
-
-  // Step 3: Inverse rotation (returns full paddedDimensions array)
-  const unrotated = inverseRandomRotate(rotated, seed);
-
-  // Step 4: Crop to original dimensions and scale by original norm
   const result = new Float32Array(dimensions);
+  // A zero vector has no direction to restore. The early return is also what keeps the
+  // rescale below safe: for an even `levels` count no reconstruction point sits at exactly
+  // zero, so a zero input decodes to a small non-zero vector that renormalizing would
+  // amplify to full length.
+  if (norm === 0) return result;
+
+  const { values } = reconstructRotatedCodes(quantized);
+  const unrotated = inverseRandomRotate(values, seed);
+
+  // Renormalize against the CROPPED coordinates: those are the output, and for a
+  // non-power-of-2 dimensionality their norm differs from the padded one.
+  let sumSquares = 0;
   for (let i = 0; i < dimensions; i++) {
-    result[i] = unrotated[i] * norm;
+    sumSquares += unrotated[i] * unrotated[i];
+  }
+  const croppedNorm = Math.sqrt(sumSquares);
+  if (croppedNorm === 0) return result;
+
+  const rescale = norm / croppedNorm;
+  for (let i = 0; i < dimensions; i++) {
+    result[i] = unrotated[i] * rescale;
   }
 
   return result;
@@ -557,6 +816,16 @@ export function turboDequantize(quantized: TurboQuantizeResult): Float32Array {
  * @returns Estimated inner product
  */
 export function turboQuantizedInnerProduct(a: TurboQuantizeResult, b: TurboQuantizeResult): number {
+  assertComparablePair(a, b);
+  return quantizedCosine(a, b) * a.norm * b.norm;
+}
+
+/**
+ * Validates that two records were produced by compatible encodings and are individually
+ * well-formed. The pairwise checks come first so a mismatch reports the mismatch rather
+ * than whichever record happens to be inspected first.
+ */
+function assertComparablePair(a: TurboQuantizeResult, b: TurboQuantizeResult): void {
   if (a.dimensions !== b.dimensions) {
     throw new Error("Vectors must have the same dimensions");
   }
@@ -568,26 +837,28 @@ export function turboQuantizedInnerProduct(a: TurboQuantizeResult, b: TurboQuant
   }
   assertQuantizeResultShape(a);
   assertQuantizeResultShape(b);
+}
 
-  const paddedLen = a.paddedDimensions;
-  const { levels, scale } = getQuantizationParams(a.bits, paddedLen);
+/**
+ * Cosine similarity between the two reconstructions, computed in the rotated domain.
+ *
+ * The rotation is orthogonal, so it preserves both inner products and norms and the
+ * rotated-domain cosine IS the original-domain cosine. Dividing by each reconstruction's
+ * own norm — rather than treating the codes as if they were already unit vectors — is what
+ * makes the result an actual cosine: Cauchy-Schwarz then bounds it to [-1, 1] by
+ * construction and a record compared with itself scores exactly 1. The clamp only absorbs
+ * floating-point rounding at the endpoints.
+ */
+function quantizedCosine(a: TurboQuantizeResult, b: TurboQuantizeResult): number {
+  const { values: valuesA, codeNorm: codeNormA } = reconstructRotatedCodes(a);
+  const { values: valuesB, codeNorm: codeNormB } = reconstructRotatedCodes(b);
+  if (codeNormA === 0 || codeNormB === 0) return 0;
 
-  // Unpack both code arrays (paddedLen codes each)
-  const codesA = unpackCodes(a.codes, a.bits, paddedLen);
-  const codesB = unpackCodes(b.codes, b.bits, paddedLen);
-
-  // Compute dot product in the rotated (quantized) domain.
-  // Since rotation is orthogonal, inner products are preserved:
-  // <Ra, Rb> = <a, b> (for orthogonal R)
   let dot = 0;
-  for (let i = 0; i < paddedLen; i++) {
-    const va = dequantizeScalar(codesA[i], scale, levels);
-    const vb = dequantizeScalar(codesB[i], scale, levels);
-    dot += va * vb;
+  for (let i = 0; i < valuesA.length; i++) {
+    dot += valuesA[i] * valuesB[i];
   }
-
-  // Scale by both norms
-  return dot * a.norm * b.norm;
+  return Math.max(-1, Math.min(1, dot / (codeNormA * codeNormB)));
 }
 
 /**
@@ -601,10 +872,9 @@ export function turboQuantizedCosineSimilarity(
   a: TurboQuantizeResult,
   b: TurboQuantizeResult
 ): number {
+  assertComparablePair(a, b);
   if (a.norm === 0 || b.norm === 0) return 0;
-  // Inner product of unit vectors = cosine similarity
-  // turboQuantizedInnerProduct includes norm scaling, so divide it out
-  return turboQuantizedInnerProduct(a, b) / (a.norm * b.norm);
+  return quantizedCosine(a, b);
 }
 
 /**
@@ -618,15 +888,25 @@ const SIGNED_TARGET_RANGES = {
 } as const;
 
 /**
+ * Options for {@link turboQuantizeToTypedArray}.
+ */
+export interface TurboQuantizeToTypedArrayOptions {
+  /** Seed for the random rotation. Defaults to the module default when undefined. */
+  readonly seed: number | undefined;
+  /**
+   * Accept a non-power-of-2 input length by returning `nextPowerOf2(length)` values
+   * instead of throwing. The result is LONGER than the input; a storage column sized to
+   * the input dimensionality will not hold it.
+   */
+  readonly padToPowerOf2: boolean | undefined;
+}
+
+/**
  * Quantizes a vector using TurboQuant rotation directly into a byte-aligned TypedArray.
  *
  * Unlike the packed `turboQuantize`, this outputs a standard TypedArray (Int8Array or
  * Int16Array) with the **same `.length`** as the input vector, so it drops into
  * storage backends that expect a fixed-width vector column.
- *
- * The rotation spreads information across all coordinates and concentrates their
- * distribution, yielding better distortion than naive linear quantization at the
- * same byte width.
  *
  * ## Signed targets only
  *
@@ -649,30 +929,35 @@ const SIGNED_TARGET_RANGES = {
  * a per-seed change of basis, so mixing them yields meaningless rankings with no
  * error raised anywhere.
  *
- * ## Fidelity and non-power-of-2 dimensions
+ * ## Power-of-2 dimensions required
  *
- * The rotation operates on `nextPowerOf2(d)` coordinates but only the first `d`
- * are kept (the output length must match the input length), so for a
- * non-power-of-2 `d` this is a random projection rather than an orthogonal
- * rotation, and cosine similarity is preserved only approximately. Measured
- * cosine RMSE against the exact similarity (int8, seed 42, 40 random pairs):
- * d=1024 -> 0.001, d=1000 -> 0.006, d=1536 -> 0.013, d=768 -> 0.019
- * (worst single pair 0.052). When fidelity matters, zero-pad the vectors to a
- * power of 2 at the call site.
+ * The rotation operates on `nextPowerOf2(d)` coordinates. Keeping only the first `d` of
+ * them would make this a lossy random projection rather than an orthogonal rotation, and
+ * it measures WORSE than plain linear quantization at exactly the dimensionalities real
+ * embedding models use — cosine RMSE against the exact similarity (int8, seed 42, 40
+ * random pairs), turbo vs linear: 0.0164 vs 0.0027 at d=768 (MiniLM), 0.0126 vs 0.0033 at
+ * d=1536, 0.0094 vs 0.0026 at d=3072; turbo wins only at d=1024 (0.0008 vs 0.0033).
+ *
+ * A non-power-of-2 `d` is therefore rejected rather than silently degraded. Pass
+ * `{ padToPowerOf2: true }` to opt into a `nextPowerOf2(d)`-length result instead — note
+ * this output is LONGER than the input, so a fixed-width storage column must be declared
+ * at the padded width. {@link turboQuantize} is unaffected either way: it keeps all
+ * `paddedLen` coordinates and stays fully invertible at any dimensionality.
  *
  * Note: The vector norm is not preserved (cosine similarity is scale-invariant,
  * so this is fine for similarity search).
  *
  * @param vector - Input vector (any TypedArray). Must not contain NaN or Infinity.
  * @param targetType - Target signed integer type (INT8 or INT16)
- * @param seed - Seed for the random rotation (default: 42). All vectors in the
- *   same collection must use the same seed for similarity search to work.
- * @returns TypedArray of the target type with `.length === vector.length`
+ * @param seedOrOptions - Rotation seed (default: 42), or an options object. All vectors in
+ *   the same collection must use the same seed for similarity search to work.
+ * @returns TypedArray of the target type, with `.length === vector.length` unless
+ *   `padToPowerOf2` widened it to `nextPowerOf2(vector.length)`
  */
 export function turboQuantizeToTypedArray(
   vector: TypedArray,
   targetType: TensorType,
-  seed: number = DEFAULT_SEED
+  seedOrOptions: number | TurboQuantizeToTypedArrayOptions = DEFAULT_SEED
 ): TypedArray {
   // `Object.hasOwn` before indexing: a plain `[targetType]` lookup would resolve
   // inherited Object.prototype keys, so a name like "constructor" would yield a
@@ -684,28 +969,47 @@ export function turboQuantizeToTypedArray(
   }
   const { max } = SIGNED_TARGET_RANGES[targetType as keyof typeof SIGNED_TARGET_RANGES];
 
+  const seed =
+    typeof seedOrOptions === "number" ? seedOrOptions : (seedOrOptions.seed ?? DEFAULT_SEED);
+  const padToPowerOf2 = typeof seedOrOptions === "number" ? false : seedOrOptions.padToPowerOf2;
+
   const d = vector.length;
   if (d === 0) {
     throw new Error("Cannot quantize an empty vector");
   }
   assertDimensions(d);
+  assertSeed(seed);
+
+  const paddedLen = nextPowerOf2(d);
+  if (paddedLen !== d && padToPowerOf2 !== true) {
+    throw new Error(
+      `turboQuantizeToTypedArray requires a power of 2 dimensionality, got ${d}. ` +
+        `Returning only the first ${d} of ${paddedLen} rotated coordinates is a lossy random ` +
+        `projection that measures worse than linear quantization at this size (int8 cosine RMSE ` +
+        `at d=768: turbo 0.0164 vs linear 0.0027). Pass { padToPowerOf2: true } to receive ` +
+        `${paddedLen} values instead, or quantize linearly.`
+    );
+  }
 
   // Step 1: Normalize to unit vector
   const { values } = normalizeToUnit(vector);
 
   // Step 2: Random rotation (spreads information, concentrates distribution)
-  // randomRotate returns all paddedLen coordinates; we only use the first d.
-  const paddedLen = nextPowerOf2(d);
   const rotated = randomRotate(values, seed);
 
-  // Step 3: Map rotated coordinates to the signed target range.
-  // After rotation in paddedLen-dimensional space, coordinates have std dev ≈ 1/sqrt(paddedLen).
-  const coverage = 3.0;
-  const scale = coverage / Math.sqrt(paddedLen);
+  // Step 3: Map rotated coordinates to the signed target range. After rotation in
+  // paddedLen-dimensional space coordinates have std dev ≈ 1/sqrt(paddedLen), and the
+  // clipping range is the MSE-optimal loading factor for this grid. The grid is the signed
+  // range INCLUDING zero, so it holds 2 * max + 1 levels — the same helper the packed path
+  // uses, solved numerically because that count is never a power of 2.
+  const levels = 2 * max + 1;
+  const scale = optimalLoadingFactor(levels) / Math.sqrt(paddedLen);
 
-  // Map [-scale, scale] → [-max, max]
-  const result = targetType === TensorType.INT8 ? new Int8Array(d) : new Int16Array(d);
-  for (let i = 0; i < d; i++) {
+  // Map [-scale, scale] → [-max, max]. Length is paddedLen, which equals d unless the
+  // caller opted into padding.
+  const result =
+    targetType === TensorType.INT8 ? new Int8Array(paddedLen) : new Int16Array(paddedLen);
+  for (let i = 0; i < paddedLen; i++) {
     const clamped = Math.max(-scale, Math.min(scale, rotated[i]));
     result[i] = Math.round((clamped / scale) * max);
   }


### PR DESCRIPTION
Follow-up to #354, stacked on it — this PR targets `claude/integrate-arxiv-paper-VF55c`, not `main`, and should merge after #354.

`packages/util/src/vector/TurboQuantize.ts` is new in #354: it does not exist on `origin/main` and `@workglow/util` has never shipped it. **There is no persisted encoded data anywhere**, so this PR is free to change the encoded format. The only backward-compat artifacts were two golden-byte fixtures, re-pinned here. `version: 1` is added now so the next grid change cannot be silent.

## The quantization grid was bit-width independent

`getQuantizationParams` hardcoded a clipping range of 3 standard deviations for every bit width. That is roughly right around 4 bits and wrong in both directions elsewhere.

**At the low end** the two 1-bit reconstruction points sat at ±3σ, so a 1-bit reconstruction came back exactly **3.0x too long**, and `turboQuantizedCosineSimilarity(q, q)` returned **9.0** — from a function whose JSDoc promises `[-1, 1]`.

**At the high end** the fixed clip is a bits-independent error floor that dominates everything the extra levels buy. Measured relative L2 at d=1024, seed 42:

| bits | before | after | | bits | before | after |
|---|---|---|---|---|---|---|
| 1 | 2.2825 | **0.6351** | | 5 | 0.0647 | 0.0648 |
| 2 | 0.5881 | **0.3474** | | 6 | 0.0429 | **0.0382** |
| 3 | 0.2496 | **0.1889** | | 7 | 0.0356 | **0.0213** |
| 4 | 0.1229 | **0.1099** | | 8 | 0.0336 | **0.0098** |

Before, 6/7/8 bits landed at 0.0429 / 0.0356 / 0.0336 — four times the levels for a 22% gain. After, every step improves by at least 15%, which is what the new strict-monotonicity assertion pins. Per-bit ceilings alone would not have caught the flat tail; the monotonicity check is the assertion that would have.

Mean absolute inner-product error at d=1024 improves **0.0566 → 0.0252**.

### Why these loading factors

`dequantizeScalar` places `levels` equally spaced points spanning `[-scale, +scale]`, so `scale` **is** the outermost reconstruction level. The MSE-optimal value of that level for a unit-variance Gaussian is a solved problem — Max (1960) tabulates the optimum-uniform step sizes `Δ = 1.596, 0.9957, 0.5860, 0.3352, 0.1881, 0.1041, 0.0568, 0.0308`, and the outer level is `(levels - 1)·Δ/2`. Those eight values are the table.

`turboQuantizeToTypedArray` needs level counts that are never powers of two (`2·max + 1` — 255 for int8, 65535 for int16), so those are solved numerically by minimizing granular + clipping error. Two notes on that solver:

- The usual closed form for the clipping term, `(1 + a²)Q(a) − a·φ(a)`, **cancels catastrophically** in the far tail the 16-bit grid optimizes into (~6σ), where the two terms agree to three digits. An Abramowitz–Stegun tail approximation has absolute error ~7.5e-8 there, roughly 75x the true tail value, and returns a badly wrong 6.13. The implementation instead factors `φ(a)` out analytically and integrates the remaining smooth positive integrand, which is accurate at any `a`.
- The solver is **validated against the table**: it reproduces the eight tabulated values to within 0.35% (0.00% at 64 levels, 0.12% at 256). That agreement is what pins the packed and typed-array paths to the same curve, and it is why the int8 value (3.921 at 255 levels) is continuous with the table's 256-level entry (3.927).

Both call sites now read the same helper — the typed-array path previously re-inlined its own copy of the constant, which is how the two drifted.

### Renormalized reconstruction

Quantization does not preserve magnitude, and `norm` is the one quantity the encoder stores exactly. `turboDequantize` now rescales the cropped output to the recorded norm, and the similarity helpers divide by each reconstruction's own norm. Cosine is therefore an actual cosine: Cauchy–Schwarz bounds it to `[-1, 1]` by construction, self-similarity is exactly 1, and the clamp only absorbs float rounding. The `norm === 0` early return is retained — for an even level count no reconstruction point sits at exactly zero, so a zero vector would otherwise be renormalized up to full length.

## `turboQuantizeToTypedArray` rejects non-power-of-2 dimensions

It kept only the first `d` of `nextPowerOf2(d)` rotated coordinates, making it a lossy random projection — and **measurably worse than the plain linear quantizer it was documented to beat**. Cosine RMSE (int8, seed 42, 40 pairs):

| d | turbo | linear | |
|---|---|---|---|
| 768 (MiniLM) | 0.01639 | 0.00269 | **6.1x worse** |
| 1536 (text-embedding-3-small) | 0.01259 | 0.00331 | 3.8x worse |
| 3072 (text-embedding-3-large) | 0.00938 | 0.00263 | 3.6x worse |
| 1024 | 0.00083 | 0.00330 | turbo wins |

Silently returning 1024 values for a 768-dim column would break the fixed-width storage contract; silently keeping 768 of 1024 is the 6x regression. So it now throws, with `{ padToPowerOf2: true }` as an explicit opt-in to the longer result — padding d=768 measures **0.00034** RMSE against 0.01639 for cropping, a 48x improvement. `VectorQuantizeTask` surfaces the rejection naming both remedies (`method: "linear"`, or pad), since from a task caller's seat the underlying throw reads as a bug. The `method` schema description drops the "better distortion than linear" claim and states the measured comparison.

`turboQuantize` (the packed path) is unaffected — it keeps all padded coordinates and stays invertible at any dimensionality.

## Decode-path hardening

- **`codes` must be a `Uint8Array`**, checked before anything else. `TurboQuantizeResult` is a plain serializable record, so the obvious way to persist one is JSON — which yields `{"type":"Buffer","data":[...]}` or `{"0":..}`, neither with a usable `length`. Since `undefined < expectedBytes` is `false`, the existing size guard waved both through and every byte decoded as `undefined → NaN → code 0`: a confident vector of garbage, no error anywhere. `unpackCodes` gets the same check as defence in depth.
- **Seeds are validated on encode**, not only on decode. `turboQuantize(v, { seed: 1.5 })` previously succeeded and wrote a record that `turboDequantize` then refused — data written and permanently unreadable. The bound is the int32 window `createPrng` actually distinguishes; outside it `2**32 + 1` silently aliased onto `1`.
- **`version: 1`** on every record, checked on every decode.

## Memory

`MAX_TURBO_DIMENSIONS` drops 2^24 → 2^20 (still ~340x the largest real embedding). Its comment justified the old cap as "a single 128 MB buffer", but the transform allocates several working buffers: measured peak RSS growth is **32 MB at d=2^20**, ~32 bytes per padded coordinate — so 2^24 permitted far more than advertised.

The module-global sign-table cache was bounded by entry count only (16), which says nothing about memory — 16 entries at the old maximum would retain hundreds of megabytes, never evicted, with no release path. It is now bounded by a running byte total (8 MB, oldest-first eviction; the count cap stays as a secondary bound), and `clearSignTableCache()` is exported. Verified: 12 distinct 3 MB tables retain **6.00 MB** against the budget where uncapped would be 36 MB, and eviction is transparent — a recomputed table reproduces codes byte-for-byte.

## Docs

The header claimed "optimal per-coordinate scalar quantization", coordinates concentrating around a Beta distribution, and "within ~2.7x of theoretical distortion limit at all bit-widths" — while `getQuantizationParams` conceded 280 lines away that no non-uniform or distribution-fitted quantization is performed. The header now states what the module does (randomized Hadamard rotation + uniform scalar quantizer at the MSE-optimal Gaussian loading factor) and what it does not (the paper's Beta-fitted levels), keeping the citation and the rotation rationale.

## Testing

```
npx vitest run packages/test/src/test/util/TurboQuantize.test.ts     ->  66 passed
npx vitest run packages/test/src/test/rag/VectorQuantizeTask.test.ts ->  19 passed
bun scripts/test.ts util vitest    ->  50 files, 788 passed | 10 skipped
bun scripts/test.ts rag vitest     ->  24 files, 231 passed
npx tsc --noEmit -p tsconfig.typecheck.json  ->  exit 0
npx eslint <changed files>                   ->  exit 0
```

New coverage: shape-guard rejection across all three entry points (JSON round-trip, `{"0":..}`, plain array) plus a positive case proving a rebuilt `Uint8Array` is accepted; encode-side seed validation including both int32 endpoints; version rejection; magnitude ratio at every bit width (power-of-2 and cropped); relative-L2 ceilings **plus strict monotonicity**; self-similarity exactly ≤ 1 and in `[0.999, 1]`; cosine within `[-1, 1]` over 320 pairs; the bit-width roundtrip loop extended from `[2,3,4,6,8]` to `1..8`; non-power-of-2 rejection and the padded path; cache eviction transparency.

Golden bytes were regenerated and independently reproduced under a second runtime (Bun as well as Node/vitest), which is the cross-process determinism that fixture exists to protect.

### One deliberate non-regression

The 8-dimensional `turboQuantizedInnerProduct` assertion gets *less* accurate (error 0.28 → 1.17, still well inside its `toBeCloseTo(-1)` tolerance). I chased this rather than loosening the bound, and it is not the renormalization. Isolating the two changes over 200 random pairs per dimension, mean absolute IP error:

| d | 3σ, no renorm | 3σ + renorm | optimal, no renorm | optimal + renorm |
|---|---|---|---|---|
| 8 | 0.00172 | 0.00157 | 0.00216 | 0.00217 |
| 64 | 0.00956 | 0.00866 | 0.00682 | 0.00673 |
| 1024 | 0.05663 | 0.05600 | 0.02535 | **0.02522** |

Renormalization is neutral-to-helpful at every dimension. The d=8 cost comes from the wider Gaussian-optimal grid, and the Gaussian assumption is genuinely weak at `paddedLen ≤ 16`, where the true marginal is Beta-like with bounded support and the tails the wider clip protects do not exist. That is a real tradeoff, taken deliberately: it buys a 2.2x improvement at d=1024 and larger, which is where embeddings actually live. The specific `[1..8]`/`[8..1]` pair is also an unlucky sample (0.98% relative error against a 0.33% typical), not a representative one.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz)_