### PR TITLE
Add decode heartbeat for streaming HFT models

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -235,6 +235,20 @@ Shared cloud-provider helpers (base classes, registration, model search, OpenAI-
 
 **Streaming convention:** Provider stream functions (`AiProviderStreamFn`) must **not** accumulate output. They yield incremental `text-delta` / `object-delta` events and a final `finish` event with `{} as Output`. The consumer (`StreamingAiTask` / `TaskRunner`) is responsible for accumulating deltas into the final output. This separation keeps providers stateless and avoids double-buffering. Do **not** change finish events to include accumulated data.
 
+**Streaming convention (decode feedback):** deltas do not drive progress —
+`StreamProcessor` translates only `phase` events into `updateProgress`, and
+`StreamingAiTask` emits exactly one `Generating` phase, latched on the first
+delta. A slow model therefore renders as a single static line for its entire
+run unless the run-fn says otherwise. Local providers must emit a periodic
+`phase` heartbeat while decoding; the HFT provider gets this from
+`createDecodeHeartbeat` (`HFT_Streaming.ts`), wired inside
+`createStreamingTextStreamer` so a new streaming run-fn cannot ship without it.
+Put the token count in the phase **message**, not in `progress`: a consumer that
+owns its own percentage (a sweep reporting `done/total`) discards a subtask's
+number and keeps only the text. Report a count rather than a percentage —
+generation stops at an end token, not at `max_new_tokens`, so any fraction of
+the cap stalls near an arbitrary value and then jumps, which reads as a hang.
+
 **Streaming convention exception (one-shot run-fns):** Run-fns that do not stream incremental deltas — typically meta-ops (`provider.model-info`, `provider.model-search`, `model.count-tokens`, `model.unload`, `model.download`), embeddings (`text.embedding`, `image.embedding`), and one-shot vision/classification (`image.classification`, `image.segmentation`, etc.) — MUST emit a single `finish` event whose `data` is the full `Output`. The `collectStream(...)` consumer in `@workglow/ai/capability` returns `finish.data` directly in this mode, so the payload is the result. Do not also yield deltas in this pattern — `collectStream` rejects streams mixing deltas with a one-shot finish.
 
 **Streaming convention exception (structured generation):** Run-fns serving

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@workglow-dev/libs",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001807",
+        "caniuse-lite": "^1.0.30001809",
       },
       "devDependencies": {
         "@sqliteai/sqlite-vector": "catalog:",
@@ -18,7 +18,7 @@
         "@vitest/ui": "4.1.10",
         "bunset": "^1.0.13",
         "concurrently": "^10.0.4",
-        "eslint": "^10.8.0",
+        "eslint": "^10.8.1",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -30,9 +30,9 @@
         "pkg-pr-new": "^0.0.87",
         "prettier": "^3.9.6",
         "prettier-plugin-organize-imports": "^4.3.0",
-        "turbo": "^2.10.8",
+        "turbo": "^2.10.9",
         "typescript": "6.0.3",
-        "vitest": "^4.1.10",
+        "vitest": "catalog:",
       },
       "optionalDependencies": {
         "@sqliteai/sqlite-vector-darwin-arm64": "^1.0.0",
@@ -74,17 +74,17 @@
         "@workglow/util": "workspace:*",
         "@workglow/xai": "workspace:*",
         "chalk": "^6.0.0",
-        "commander": "^15.0.0",
+        "commander": "catalog:",
         "ink": "^7.1.1",
         "node-llama-cpp": "catalog:",
         "ollama": "catalog:",
         "openai": "catalog:",
-        "react": "^19.2.8",
+        "react": "catalog:",
         "smol-toml": "^1.7.1",
         "tiktoken": "catalog:",
       },
       "devDependencies": {
-        "@types/react": "^19.2.18",
+        "@types/react": "catalog:",
       },
     },
     "examples/eval": {
@@ -107,8 +107,8 @@
         "@workglow/task-graph": "workspace:*",
         "@workglow/util": "workspace:*",
         "@workglow/xai": "workspace:*",
-        "commander": "^15.0.0",
-        "hyparquet": "^1.27.1",
+        "commander": "catalog:",
+        "hyparquet": "^1.28.1",
         "hyparquet-compressors": "^1.1.1",
       },
     },
@@ -137,7 +137,7 @@
         "@workglow/util": "workspace:*",
         "@xyflow/react": "^12.11.2",
         "clsx": "^2.1.1",
-        "react": "^19.2.8",
+        "react": "catalog:",
         "react-dom": "^19.2.8",
         "react-icons": "^5.7.0",
         "react-resizable-panels": "^4.12.2",
@@ -145,7 +145,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.3",
-        "@types/react": "^19.2.18",
+        "@types/react": "catalog:",
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.0.5",
         "rollup-plugin-visualizer": "^7.0.1",
@@ -191,7 +191,7 @@
         "@workglow/job-queue": "workspace:*",
         "@workglow/storage": "workspace:*",
         "@workglow/util": "workspace:*",
-        "fake-indexeddb": "^6.2.4",
+        "fake-indexeddb": "catalog:",
       },
       "peerDependencies": {
         "@workglow/job-queue": "workspace:*",
@@ -274,7 +274,11 @@
         "@workglow/job-queue": "workspace:*",
         "@workglow/storage": "workspace:*",
         "@workglow/util": "workspace:*",
+        "vitest": "catalog:",
       },
+      "optionalPeers": [
+        "vitest",
+      ],
     },
     "packages/tasks": {
       "name": "@workglow/tasks",
@@ -304,16 +308,16 @@
       "name": "@workglow/test",
       "version": "0.3.38",
       "devDependencies": {
-        "@aws-sdk/client-sqs": "^3.1105.0",
-        "@cloudflare/workers-types": "^5.20260804.1",
+        "@aws-sdk/client-sqs": "catalog:",
+        "@cloudflare/workers-types": "catalog:",
         "@duckdb/node-api": "catalog:",
         "@electric-sql/pglite": "catalog:",
         "@electric-sql/pglite-pgvector": "catalog:",
         "@modelcontextprotocol/sdk": "catalog:",
         "@sqliteai/sqlite-vector": "catalog:",
         "@supabase/supabase-js": "catalog:",
-        "@types/dom-chromium-ai": "^0.0.17",
-        "@types/pg": "^8.20.4",
+        "@types/dom-chromium-ai": "catalog:",
+        "@types/pg": "catalog:",
         "@workglow/ai": "workspace:*",
         "@workglow/anthropic": "workspace:*",
         "@workglow/aws": "workspace:*",
@@ -350,13 +354,13 @@
         "@workglow/tf-mediapipe": "workspace:*",
         "@workglow/util": "workspace:*",
         "@workglow/xai": "workspace:*",
-        "aws-sdk-client-mock": "^4.0.0",
-        "fake-indexeddb": "^6.2.4",
-        "miniflare": "^5.20260801.0-alpha",
+        "aws-sdk-client-mock": "catalog:",
+        "fake-indexeddb": "catalog:",
+        "miniflare": "^5.20260801.1-alpha",
         "node-llama-cpp": "catalog:",
         "pg": "catalog:",
         "playwright": "catalog:",
-        "vitest": "^4.1.10",
+        "vitest": "catalog:",
       },
     },
     "packages/util": {
@@ -427,13 +431,13 @@
       "name": "@workglow/aws",
       "version": "0.3.38",
       "devDependencies": {
-        "@aws-sdk/client-sqs": "^3.1105.0",
+        "@aws-sdk/client-sqs": "catalog:",
         "@workglow/job-queue": "workspace:*",
         "@workglow/util": "workspace:*",
-        "aws-sdk-client-mock": "^4.0.0",
+        "aws-sdk-client-mock": "catalog:",
       },
       "peerDependencies": {
-        "@aws-sdk/client-sqs": "^3.1105.0",
+        "@aws-sdk/client-sqs": "catalog:",
         "@workglow/job-queue": "workspace:*",
         "@workglow/util": "workspace:*",
       },
@@ -475,7 +479,7 @@
       "name": "@workglow/chrome-ai",
       "version": "0.3.38",
       "devDependencies": {
-        "@types/dom-chromium-ai": "^0.0.17",
+        "@types/dom-chromium-ai": "catalog:",
         "@workglow/ai": "workspace:*",
         "@workglow/job-queue": "workspace:*",
         "@workglow/storage": "workspace:*",
@@ -494,12 +498,12 @@
       "name": "@workglow/cloudflare",
       "version": "0.3.38",
       "devDependencies": {
-        "@cloudflare/workers-types": "^5.20260804.1",
+        "@cloudflare/workers-types": "catalog:",
         "@workglow/job-queue": "workspace:*",
         "@workglow/util": "workspace:*",
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260804.1",
+        "@cloudflare/workers-types": "catalog:",
         "@workglow/job-queue": "workspace:*",
         "@workglow/util": "workspace:*",
       },
@@ -604,10 +608,8 @@
     "providers/huggingface-transformers": {
       "name": "@workglow/huggingface-transformers",
       "version": "0.3.38",
-      "dependencies": {
-        "@huggingface/transformers": "catalog:",
-      },
       "devDependencies": {
+        "@huggingface/transformers": "catalog:",
         "@workglow/ai": "workspace:*",
         "@workglow/job-queue": "workspace:*",
         "@workglow/storage": "workspace:*",
@@ -615,6 +617,7 @@
         "@workglow/util": "workspace:*",
       },
       "peerDependencies": {
+        "@huggingface/transformers": "catalog:",
         "@workglow/ai": "workspace:*",
         "@workglow/job-queue": "workspace:*",
         "@workglow/storage": "workspace:*",
@@ -755,7 +758,7 @@
       "name": "@workglow/postgres",
       "version": "0.3.38",
       "devDependencies": {
-        "@types/pg": "^8.20.4",
+        "@types/pg": "catalog:",
         "@workglow/job-queue": "workspace:*",
         "@workglow/storage": "workspace:*",
         "@workglow/util": "workspace:*",
@@ -894,11 +897,14 @@
     "ip-address": "^10.2.0",
     "protobufjs": "^7.6.4",
     "qs": "^6.15.2",
+    "sharp": "0.35.3",
     "shell-quote": "^1.10.0",
     "uuid": "^11.1.1",
   },
   "catalog": {
-    "@anthropic-ai/sdk": "^0.115.0",
+    "@anthropic-ai/sdk": "^0.116.0",
+    "@aws-sdk/client-sqs": "^3.1106.0",
+    "@cloudflare/workers-types": "^5.20260809.1",
     "@duckdb/node-api": "^1.5.5-r.3",
     "@electric-sql/pglite": "^0.5.4",
     "@electric-sql/pglite-pgvector": "^0.0.5",
@@ -913,23 +919,31 @@
     "@sqlite.org/sqlite-wasm": "^3.53.0-build1",
     "@sqliteai/sqlite-vector": "^1.0.0",
     "@supabase/supabase-js": "^2.112.2",
+    "@types/dom-chromium-ai": "^0.0.17",
+    "@types/pg": "^8.21.0",
+    "@types/react": "^19.2.18",
+    "aws-sdk-client-mock": "^4.0.0",
     "better-sqlite3": "^13.0.3",
+    "commander": "^15.0.0",
     "electron": "^43.3.0",
+    "fake-indexeddb": "^6.2.4",
     "js-tiktoken": "^1.0.16",
     "needle-rs": "^0.1.0",
     "node-llama-cpp": "^3.19.1",
     "ollama": "^0.6.3",
     "openai": "^7.4.0",
-    "pg": "^8.22.0",
+    "pg": "^8.23.0",
     "playwright": "^1.62.1",
+    "react": "^19.2.8",
     "tiktoken": "^1.0.22",
+    "vitest": "^4.1.10",
   },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.115.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.116.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww=="],
 
-    "@aws-sdk/client-sqs": ["@aws-sdk/client-sqs@3.1105.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/credential-provider-node": "^3.972.78", "@aws-sdk/middleware-sdk-sqs": "^3.972.39", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3VfR9ceXpDZwZ8oQWPbP7IUfWBfeoWDwvC5OEtrD0P2A0AW9i1dyZIZVTYli+xl8puECtPqt0C4VIAU1CwDESQ=="],
+    "@aws-sdk/client-sqs": ["@aws-sdk/client-sqs@3.1106.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/credential-provider-node": "^3.972.78", "@aws-sdk/middleware-sdk-sqs": "^3.972.39", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-U+QW8p+T/4zG11UvsWU/EfNeq/ShiLtv1S+0TFyKxj49fNKBa88ifT/cWbRHr5Mfm/FDmXKwc7YZUZ9+IHBFTg=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.977.6", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.37", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw=="],
 
@@ -1009,7 +1023,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260804.1", "", {}, "sha512-B1dwxpN6e5RZXZkE5zpZj+ooNeNZ1mwavLIyHDYe10ojhlGTwDfe8sAl7R1mMXc1cyIsbr+jKVdvmMEyVcdTdg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260809.1", "", {}, "sha512-sBM+0I5lCY9LgTnorn/N2UyrA6KVbUzj9tncxwH8v6sH8tVeAyJj+i0z3xXWY4l4fd1oDcwt8CGf50vGwVISYQ=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 
@@ -1151,7 +1165,7 @@
 
     "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
     "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
 
@@ -1441,17 +1455,17 @@
 
     "@tinyhttp/content-disposition": ["@tinyhttp/content-disposition@2.2.4", "", {}, "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-po+7rfJfUnFXjWlcoN2RwhErgzCdRtBc1T26vYPcywHlggmCQiQe1uWaE4j+BibI2uY9/2pDoFzMN0rmSaPFOw=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-Jh+pTGXLNz8+1tkUU13TI/f+ZOI+OvC4YbHi1H+57iSpLt5DR3xgptd+4sA07RdjdRR/RX/01uQQu2OkbzIefA=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+zB2btDJ00lnPRuqOvpVvgl4x34k/djZQGZTTCfjn7JgNCl8QFY5Njo5+dqkY1g/+9gbbsnAvWm9CmJg9ebcXA=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aqtpPkiIC4IUas8Vv27oJ3aDfTuP1d5wofd01dZ7gfhHRrIKuFdqQb4imvNnVFahcOViF9Jh8Oi7feDoz8/ciA=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.10.8", "", { "os": [ "linux", "android", ], "cpu": "x64" }, "sha512-K1dxqiVisyN7cViVsfQLs6xscQbYuI8aO2nbUhFURDACgEDfZRdP/b4CCxeosBJpcMfhYyiibWqJorCnvz9kKg=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.9", "", { "os": [ "linux", "android", ], "cpu": "x64" }, "sha512-XyAneUBsS5uNOUOjBSs81zyigMVwwhVUd3u7F2JFMKGQk6F7eNAiOEBASJ+aHLldjYsOEjhfW+5gWIqwziyFFw=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.8", "", { "os": [ "linux", "android", ], "cpu": "arm64" }, "sha512-Gi77ibVnrE1fEmvr+/wBD/yvRqhwp/RQuCp2+//lv1U1wNFFyVg0V7Wj8FG9FXPFAw5QHReo8rxc9+wBSDZjzA=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.9", "", { "os": [ "linux", "android", ], "cpu": "arm64" }, "sha512-5jAcldLnkuWIjujGhCn2MGIeUwW8IVNOq9Sce4EEzzgLcxmhTasbV0RiW6ZkaRdOjmOCGzeNXPLkDJEOIucOLw=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.10.8", "", { "os": "win32", "cpu": "x64" }, "sha512-znnLO1haJPYTHoKMKwlAvlkjRiYbbhBzME6wIGaMd+fwir23U6jVd1ecaTWWi1fbnRVqxMfgDBKseQ/hLKb83g=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.9", "", { "os": "win32", "cpu": "x64" }, "sha512-u1xGpGlefzuhBedbt/VR2nWdftfFVZwPeDg9e5uZl68sV1fL3HNYTNr5VyHkzgtPK2VTYg1x4OKZuGrh1Gvhtg=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-VN30vh3b3Czh2WzYHNTfF1FE0YMZ5aHsLO8dBMGHJewA6792wX6iJR8ZxlzFW6WdOu0gEAKIvlYhfyT81Wkm4Q=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-W2Ub165Qv0iMFljbYKxxbZN+2dVSngnzEjQNEFXtnz5oJVx9XSypmNmUvMtuYMeZ3kdVC1zI7yd/rtuX+SDnbg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -1487,7 +1501,7 @@
 
     "@types/papaparse": ["@types/papaparse@5.5.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA=="],
 
-    "@types/pg": ["@types/pg@8.20.4", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-Jz7UDOlIiFJuacC0TlBoLyNtmwlA/wpIyPDd3tvUqlRM+HzkWy2xUgpFpaXtbfTAFF6sIGq5lsCDBdJnhky1Xg=="],
+    "@types/pg": ["@types/pg@8.21.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
@@ -1751,7 +1765,7 @@
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001807", "", {}, "sha512-daRXJ9EB/rdRgu7kV+TTl1YUKtlsMWblPl2sLnpg9DZae16QCegol6A1SmCE31Lm9mXC1sRWGt/krouH+/dl7Q=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001809", "", {}, "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -1931,7 +1945,7 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@10.8.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.7.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ=="],
+    "eslint": ["eslint@10.8.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.7.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ=="],
 
     "eslint-plugin-jsx-a11y": ["eslint-plugin-jsx-a11y@6.10.2", "", { "dependencies": { "aria-query": "^5.3.2", "array-includes": "^3.1.8", "array.prototype.flatmap": "^1.3.2", "ast-types-flow": "^0.0.8", "axe-core": "^4.10.0", "axobject-query": "^4.1.0", "damerau-levenshtein": "^1.0.8", "emoji-regex": "^9.2.2", "hasown": "^2.0.2", "jsx-ast-utils": "^3.3.5", "language-tags": "^1.0.9", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "safe-regex-test": "^1.0.3", "string.prototype.includes": "^2.0.1" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9" } }, "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q=="],
 
@@ -2109,7 +2123,7 @@
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
-    "hyparquet": ["hyparquet@1.27.1", "", {}, "sha512-kvMGVKlB/xa9UHxWLJkySJYGC436nPeBWC9Fzo/BZtMEzFUjmzD1KuLz67EOpA3Ci6V7yF/yTG7QRSDSx5EDSg=="],
+    "hyparquet": ["hyparquet@1.28.1", "", {}, "sha512-04PlyhYZpNDVaOjJNX4SP00beWf9Y9vXEOEQXSMFqVQNzxGxTmsJOQgBjar8VzLpT6E2kxNiWKL539e1dHcOVA=="],
 
     "hyparquet-compressors": ["hyparquet-compressors@1.1.1", "", { "dependencies": { "fzstd": "0.1.1", "hysnappy": "1.0.0" } }, "sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A=="],
 
@@ -2351,7 +2365,7 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "miniflare": ["miniflare@5.20260801.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.28.0", "workerd": "1.20260801.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-AfMrnQbJg81ESsGkGhOkHBtwTqCG+mosR+3GE+qDrhF1I/ieIvgg3ICxNyBvgHBZ3iapy6cysBQHNPykkzrfgw=="],
+    "miniflare": ["miniflare@5.20260801.1-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260801.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA=="],
 
     "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
@@ -2467,7 +2481,7 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
+    "pg": ["pg@8.23.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.16.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg=="],
 
     "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
 
@@ -2477,7 +2491,7 @@
 
     "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
 
-    "pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
+    "pg-protocol": ["pg-protocol@1.16.0", "", {}, "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg=="],
 
     "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
@@ -2757,7 +2771,7 @@
 
     "tslog": ["tslog@5.1.0", "", { "bin": { "tslog": "esm/subpaths/cli.js" } }, "sha512-g77ALovust2HNBX/63ePEJwetIeX0Vi/dlzqBO+ZAg+aERB54KMmaz/khNPxhFpaxKQ6RQj65sK6vIhj1SJgjQ=="],
 
-    "turbo": ["turbo@2.10.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.8", "@turbo/darwin-arm64": "2.10.8", "@turbo/linux-64": "2.10.8", "@turbo/linux-arm64": "2.10.8", "@turbo/windows-64": "2.10.8", "@turbo/windows-arm64": "2.10.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-9+8YX5QOkGXzZxcIykTHgaooRHGMWO+jfdyRK0o+rN0U7hBIig2MrJ8r/aNzIPDPhdA73SGb0O+tIztaModTMg=="],
+    "turbo": ["turbo@2.10.9", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.9", "@turbo/darwin-arm64": "2.10.9", "@turbo/linux-64": "2.10.9", "@turbo/linux-arm64": "2.10.9", "@turbo/windows-64": "2.10.9", "@turbo/windows-arm64": "2.10.9" }, "bin": { "turbo": "bin/turbo" } }, "sha512-Yl9+ukxH+UmPtKidpDkjn82tvPoEvFNb9UACd9vUomN1Ft0cwl3rx0P8yC1D93W9EOsWRMjllvIDG8y25sFOog=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -2889,12 +2903,6 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@huggingface/transformers/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
-
-    "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
-
-    "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
-
     "@inkjs/ui/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@istanbuljs/load-nyc-config/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
@@ -2981,9 +2989,7 @@
 
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "miniflare/sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
-
-    "miniflare/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "miniflare/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "miniflare/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
@@ -3045,54 +3051,6 @@
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
-    "@huggingface/transformers/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
-
-    "@huggingface/transformers/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
-
-    "@huggingface/transformers/sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
-
     "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -3135,58 +3093,6 @@
 
     "istanbul-lib-report/make-dir/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
-    "miniflare/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
-
-    "miniflare/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.1" }, "os": "darwin", "cpu": "x64" }, "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw=="],
-
-    "miniflare/sharp/@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "os": "freebsd" }, "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw=="],
-
-    "miniflare/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g=="],
-
-    "miniflare/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ=="],
-
-    "miniflare/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg=="],
-
-    "miniflare/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw=="],
-
-    "miniflare/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng=="],
-
-    "miniflare/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.1", "", { "os": "linux", "cpu": "none" }, "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw=="],
-
-    "miniflare/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew=="],
-
-    "miniflare/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A=="],
-
-    "miniflare/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw=="],
-
-    "miniflare/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg=="],
-
-    "miniflare/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.1" }, "os": "linux", "cpu": "arm" }, "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A=="],
-
-    "miniflare/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA=="],
-
-    "miniflare/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.1" }, "os": "linux", "cpu": "ppc64" }, "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg=="],
-
-    "miniflare/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.1" }, "os": "linux", "cpu": "none" }, "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA=="],
-
-    "miniflare/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.1" }, "os": "linux", "cpu": "s390x" }, "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA=="],
-
-    "miniflare/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA=="],
-
-    "miniflare/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg=="],
-
-    "miniflare/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
-
-    "miniflare/sharp/@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "cpu": "none" }, "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g=="],
-
-    "miniflare/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ=="],
-
-    "miniflare/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
-
-    "miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
-
-    "miniflare/sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
-
     "node-llama-cpp/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "node-llama-cpp/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -3226,10 +3132,6 @@
     "cmake-js/yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "cmake-js/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "miniflare/sharp/@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
-
-    "miniflare/sharp/@img/sharp-webcontainers-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
 
     "node-llama-cpp/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -67,13 +67,13 @@
     "@napi-rs/keyring": "^1.3.0",
     "@inkjs/ui": "^2.0.0",
     "chalk": "^6.0.0",
-    "commander": "^15.0.0",
+    "commander": "catalog:",
     "ink": "^7.1.1",
-    "react": "^19.2.8",
+    "react": "catalog:",
     "smol-toml": "^1.7.1"
   },
   "devDependencies": {
-    "@types/react": "^19.2.18"
+    "@types/react": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/examples/eval/package.json
+++ b/examples/eval/package.json
@@ -46,8 +46,8 @@
     "@workglow/util": "workspace:*",
     "@workglow/xai": "workspace:*",
     "@huggingface/transformers": "catalog:",
-    "commander": "^15.0.0",
-    "hyparquet": "^1.27.1",
+    "commander": "catalog:",
+    "hyparquet": "^1.28.1",
     "hyparquet-compressors": "^1.1.1"
   },
   "publishConfig": {

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -39,14 +39,14 @@
     "@uiw/react-codemirror": "^4.25.11",
     "@xyflow/react": "^12.11.2",
     "clsx": "^2.1.1",
-    "react": "^19.2.8",
+    "react": "catalog:",
     "react-dom": "^19.2.8",
     "react-icons": "^5.7.0",
     "react-resizable-panels": "^4.12.2",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
-    "@types/react": "^19.2.18",
+    "@types/react": "catalog:",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
     "@tailwindcss/vite": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "dev-link": "bun ./scripts/dev-link-workglow.ts"
   },
   "dependencies": {
-    "caniuse-lite": "^1.0.30001807"
+    "caniuse-lite": "^1.0.30001809"
   },
   "catalog": {
     "@huggingface/transformers": "^4.2.0",
@@ -70,7 +70,7 @@
     "@mediapipe/tasks-vision": "^1.0.1",
     "@mediapipe/tasks-audio": "^1.0.1",
     "@mediapipe/tasks-genai": "^0.10.29",
-    "@anthropic-ai/sdk": "^0.115.0",
+    "@anthropic-ai/sdk": "^0.116.0",
     "electron": "^43.3.0",
     "@google/genai": "^2.16.0",
     "node-llama-cpp": "^3.19.1",
@@ -81,7 +81,7 @@
     "tiktoken": "^1.0.22",
     "js-tiktoken": "^1.0.16",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "pg": "^8.22.0",
+    "pg": "^8.23.0",
     "playwright": "^1.62.1",
     "@electric-sql/pglite": "^0.5.4",
     "@electric-sql/pglite-pgvector": "^0.0.5",
@@ -89,7 +89,17 @@
     "@duckdb/node-api": "^1.5.5-r.3",
     "@sqlite.org/sqlite-wasm": "^3.53.0-build1",
     "@sqliteai/sqlite-vector": "^1.0.0",
-    "better-sqlite3": "^13.0.3"
+    "better-sqlite3": "^13.0.3",
+    "@aws-sdk/client-sqs": "^3.1106.0",
+    "@cloudflare/workers-types": "^5.20260809.1",
+    "fake-indexeddb": "^6.2.4",
+    "@types/dom-chromium-ai": "^0.0.17",
+    "@types/pg": "^8.21.0",
+    "aws-sdk-client-mock": "^4.0.0",
+    "vitest": "^4.1.10",
+    "react": "^19.2.8",
+    "@types/react": "^19.2.18",
+    "commander": "^15.0.0"
   },
   "optionalDependencies": {
     "@sqliteai/sqlite-vector-darwin-arm64": "^1.0.0",
@@ -111,7 +121,7 @@
     "@vitest/ui": "4.1.10",
     "bunset": "^1.0.13",
     "concurrently": "^10.0.4",
-    "eslint": "^10.8.0",
+    "eslint": "^10.8.1",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
@@ -123,9 +133,9 @@
     "pkg-pr-new": "^0.0.87",
     "prettier": "^3.9.6",
     "prettier-plugin-organize-imports": "^4.3.0",
-    "turbo": "^2.10.8",
+    "turbo": "^2.10.9",
     "typescript": "6.0.3",
-    "vitest": "^4.1.10"
+    "vitest": "catalog:"
   },
   "engines": {
     "bun": "^1.3.11"
@@ -155,6 +165,7 @@
     "uuid": "^11.1.1",
     "@hono/node-server": "^2.0.11",
     "adm-zip": "^0.6.0",
-    "shell-quote": "^1.10.0"
+    "shell-quote": "^1.10.0",
+    "sharp": "0.35.3"
   }
 }

--- a/packages/indexeddb/package.json
+++ b/packages/indexeddb/package.json
@@ -66,7 +66,7 @@
     }
   },
   "devDependencies": {
-    "fake-indexeddb": "^6.2.4",
+    "fake-indexeddb": "catalog:",
     "@workglow/job-queue": "workspace:*",
     "@workglow/storage": "workspace:*",
     "@workglow/util": "workspace:*"

--- a/packages/task-graph/package.json
+++ b/packages/task-graph/package.json
@@ -59,7 +59,7 @@
     "@workglow/job-queue": "workspace:*",
     "@workglow/storage": "workspace:*",
     "@workglow/util": "workspace:*",
-    "vitest": "^4.1.10"
+    "vitest": "catalog:"
   },
   "peerDependenciesMeta": {
     "@workglow/job-queue": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -26,16 +26,16 @@
     "test-concurrently": "bash -c 'cmds=(); for d in ./src/test/*/; do cmds+=(\"cd $d && bun test\"); done; concurrently \"${cmds[@]}\"'"
   },
   "devDependencies": {
-    "@aws-sdk/client-sqs": "^3.1105.0",
-    "@cloudflare/workers-types": "^5.20260804.1",
+    "@aws-sdk/client-sqs": "catalog:",
+    "@cloudflare/workers-types": "catalog:",
     "@duckdb/node-api": "catalog:",
     "@electric-sql/pglite": "catalog:",
     "@electric-sql/pglite-pgvector": "catalog:",
     "@modelcontextprotocol/sdk": "catalog:",
     "@sqliteai/sqlite-vector": "catalog:",
     "@supabase/supabase-js": "catalog:",
-    "@types/dom-chromium-ai": "^0.0.17",
-    "@types/pg": "^8.20.4",
+    "@types/dom-chromium-ai": "catalog:",
+    "@types/pg": "catalog:",
     "@workglow/ai": "workspace:*",
     "@workglow/anthropic": "workspace:*",
     "@workglow/aws": "workspace:*",
@@ -72,12 +72,12 @@
     "@workglow/tf-mediapipe": "workspace:*",
     "@workglow/util": "workspace:*",
     "@workglow/xai": "workspace:*",
-    "aws-sdk-client-mock": "^4.0.0",
-    "fake-indexeddb": "^6.2.4",
-    "miniflare": "^5.20260801.0-alpha",
+    "aws-sdk-client-mock": "catalog:",
+    "fake-indexeddb": "catalog:",
+    "miniflare": "^5.20260801.1-alpha",
     "node-llama-cpp": "catalog:",
     "pg": "catalog:",
     "playwright": "catalog:",
-    "vitest": "^4.1.10"
+    "vitest": "catalog:"
   }
 }

--- a/packages/test/src/test/ai-provider-hft/HFT_DecodeHeartbeat.test.ts
+++ b/packages/test/src/test/ai-provider-hft/HFT_DecodeHeartbeat.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createDecodeHeartbeat } from "@workglow/huggingface-transformers/ai-runtime";
+import type { StreamPhase } from "@workglow/task-graph";
+import { describe, expect, it } from "vitest";
+
+/** Drives the heartbeat with a clock the test advances by hand. */
+function harness(intervalMs = 250) {
+  const events: StreamPhase[] = [];
+  let clock = 1_000;
+  const tick = createDecodeHeartbeat((event) => events.push(event), {
+    intervalMs,
+    now: () => clock,
+  });
+  return {
+    events,
+    /** Decode `count` token pieces, advancing the clock `ms` between each. */
+    decode(count: number, ms: number) {
+      for (let i = 0; i < count; i++) {
+        clock += ms;
+        tick();
+      }
+    },
+  };
+}
+
+describe("createDecodeHeartbeat", () => {
+  it("stays silent on the first token so it does not race the task's own Generating phase", () => {
+    const h = harness();
+    h.decode(1, 10_000);
+    expect(h.events).toEqual([]);
+  });
+
+  it("emits at most once per interval and reports the running token count", () => {
+    const h = harness(250);
+    // 20 tokens at 100ms apart = 2s of decode, so ~8 heartbeats, not 20.
+    h.decode(20, 100);
+
+    expect(h.events.length).toBeGreaterThan(0);
+    expect(h.events.length).toBeLessThan(20);
+    for (const event of h.events) {
+      expect(event.type).toBe("phase");
+      expect(event.message).toMatch(/^Generating \d+ tok$/);
+    }
+  });
+
+  it("reports a count, never a percentage — generation ends at an end token", () => {
+    const h = harness(250);
+    h.decode(10, 300);
+
+    // `progress` left undefined: any fraction of `max_new_tokens` would stall
+    // near an arbitrary value and then jump when the model stops early.
+    for (const event of h.events) {
+      expect(event.progress).toBeUndefined();
+    }
+    // The counts are strictly increasing and count every decoded piece.
+    const counts = h.events.map((e) => Number(e.message.match(/(\d+) tok$/)![1]));
+    expect(counts).toEqual([...counts].sort((a, b) => a - b));
+    expect(new Set(counts).size).toBe(counts.length);
+    expect(counts.at(-1)).toBeLessThanOrEqual(10);
+  });
+
+  it("does not fire while the model is slower than the interval, then resumes", () => {
+    const h = harness(250);
+    h.decode(1, 0); // anchor
+    h.decode(1, 10); // too soon
+    expect(h.events).toEqual([]);
+
+    h.decode(1, 500); // interval elapsed
+    expect(h.events).toHaveLength(1);
+    expect(h.events[0]!.message).toBe("Generating 3 tok");
+  });
+
+  it("honors a custom label", () => {
+    const events: StreamPhase[] = [];
+    let clock = 0;
+    const tick = createDecodeHeartbeat((e) => events.push(e), {
+      label: "Replying",
+      intervalMs: 10,
+      now: () => clock,
+    });
+    tick();
+    clock += 100;
+    tick();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.message).toBe("Replying 2 tok");
+  });
+});

--- a/packages/test/src/test/ai-provider-hft/HFT_DecodeHeartbeat.test.ts
+++ b/packages/test/src/test/ai-provider-hft/HFT_DecodeHeartbeat.test.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { createDecodeHeartbeat } from "@workglow/huggingface-transformers/ai-runtime";
+import {
+  createDecodeHeartbeat,
+  createStreamingTextStreamer,
+  createTextStreamer,
+} from "@workglow/huggingface-transformers/ai-runtime";
 import type { StreamPhase } from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
 
@@ -89,5 +93,56 @@ describe("createDecodeHeartbeat", () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]!.message).toBe("Replying 2 tok");
+  });
+});
+
+class FakeTextStreamer {
+  readonly puts: bigint[][][] = [];
+
+  constructor(
+    _tokenizer: unknown,
+    readonly options: {
+      callback_function?: ((text: string) => void) | undefined;
+    }
+  ) {}
+
+  put(value: bigint[][]): void {
+    this.puts.push(value);
+  }
+
+  end(): void {}
+}
+
+describe("HFT streamer prefill phase", () => {
+  it("emits Prefilling exactly when the prompt reaches the streaming streamer", () => {
+    const events: StreamPhase[] = [];
+    const streamer = createStreamingTextStreamer(
+      {},
+      () => {},
+      FakeTextStreamer as any,
+      (event) => events.push(event)
+    ) as unknown as FakeTextStreamer;
+
+    expect(events).toEqual([]);
+    streamer.put([[1n, 2n]]);
+    expect(events).toEqual([{ type: "phase", message: "Prefilling", progress: undefined }]);
+
+    streamer.put([[3n]]);
+    expect(events).toHaveLength(1);
+    expect(streamer.puts).toEqual([[[1n, 2n]], [[3n]]]);
+  });
+
+  it("also emits Prefilling for the non-streaming progress streamer", () => {
+    const updates: Array<{ progress: number | undefined; message: string | undefined }> = [];
+    const streamer = createTextStreamer(
+      {},
+      (progress, message) => updates.push({ progress, message }),
+      FakeTextStreamer as any
+    ) as unknown as FakeTextStreamer;
+
+    streamer.put([[1n, 2n]]);
+    streamer.put([[3n]]);
+
+    expect(updates).toEqual([{ progress: undefined, message: "Prefilling" }]);
   });
 });

--- a/packages/test/src/test/ai-provider-hft/HFT_Device.test.ts
+++ b/packages/test/src/test/ai-provider-hft/HFT_Device.test.ts
@@ -25,9 +25,12 @@ describe("resolveHftPipelineDevice", () => {
     expect(resolveHftPipelineDevice(undefined)).toBeUndefined();
   });
 
-  it("strips browser-only devices on the server", () => {
-    expect(resolveHftPipelineDevice("webgpu")).toBeUndefined();
+  it("strips wasm on the server but passes webgpu through", () => {
+    // `wasm` has no server-side execution provider at all, so it is stripped to
+    // the CPU default. `webgpu` is forwarded: onnxruntime-node can serve it, and
+    // a local model run on a GPU box is the reason to ask for it.
     expect(resolveHftPipelineDevice("wasm")).toBeUndefined();
+    expect(resolveHftPipelineDevice("webgpu")).toBe("webgpu");
   });
 
   it("defaults auto to WebGPU in the browser", () => {

--- a/providers/aws/package.json
+++ b/providers/aws/package.json
@@ -38,7 +38,7 @@
     }
   },
   "peerDependencies": {
-    "@aws-sdk/client-sqs": "^3.1105.0",
+    "@aws-sdk/client-sqs": "catalog:",
     "@workglow/job-queue": "workspace:*",
     "@workglow/util": "workspace:*"
   },
@@ -54,8 +54,8 @@
     }
   },
   "devDependencies": {
-    "@aws-sdk/client-sqs": "^3.1105.0",
-    "aws-sdk-client-mock": "^4.0.0",
+    "@aws-sdk/client-sqs": "catalog:",
+    "aws-sdk-client-mock": "catalog:",
     "@workglow/job-queue": "workspace:*",
     "@workglow/util": "workspace:*"
   },

--- a/providers/chrome-ai/package.json
+++ b/providers/chrome-ai/package.json
@@ -68,7 +68,7 @@
     }
   },
   "devDependencies": {
-    "@types/dom-chromium-ai": "^0.0.17",
+    "@types/dom-chromium-ai": "catalog:",
     "@workglow/ai": "workspace:*",
     "@workglow/job-queue": "workspace:*",
     "@workglow/storage": "workspace:*",

--- a/providers/cloudflare/package.json
+++ b/providers/cloudflare/package.json
@@ -34,7 +34,7 @@
     }
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^5.20260804.1",
+    "@cloudflare/workers-types": "catalog:",
     "@workglow/job-queue": "workspace:*",
     "@workglow/util": "workspace:*"
   },
@@ -47,7 +47,7 @@
     }
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^5.20260804.1",
+    "@cloudflare/workers-types": "catalog:",
     "@workglow/job-queue": "workspace:*",
     "@workglow/util": "workspace:*"
   },

--- a/providers/huggingface-transformers/package.json
+++ b/providers/huggingface-transformers/package.json
@@ -35,10 +35,8 @@
       "import": "./dist/ai-runtime.js"
     }
   },
-  "dependencies": {
-    "@huggingface/transformers": "catalog:"
-  },
   "peerDependencies": {
+    "@huggingface/transformers": "^catalog:",
     "@workglow/ai": "workspace:*",
     "@workglow/job-queue": "workspace:*",
     "@workglow/storage": "workspace:*",
@@ -46,6 +44,9 @@
     "@workglow/util": "workspace:*"
   },
   "peerDependenciesMeta": {
+    "@huggingface/transformers": {
+      "optional": false
+    },
     "@workglow/ai": {
       "optional": false
     },
@@ -63,6 +64,7 @@
     }
   },
   "devDependencies": {
+    "@huggingface/transformers": "catalog:",
     "@workglow/ai": "workspace:*",
     "@workglow/job-queue": "workspace:*",
     "@workglow/storage": "workspace:*",

--- a/providers/huggingface-transformers/package.json
+++ b/providers/huggingface-transformers/package.json
@@ -36,7 +36,7 @@
     }
   },
   "peerDependencies": {
-    "@huggingface/transformers": "^catalog:",
+    "@huggingface/transformers": "catalog:",
     "@workglow/ai": "workspace:*",
     "@workglow/job-queue": "workspace:*",
     "@workglow/storage": "workspace:*",

--- a/providers/huggingface-transformers/src/ai/common/HFT_Chat.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Chat.ts
@@ -225,7 +225,8 @@ async function generateTurn(
         accumulated += text;
         onDelta(text);
       },
-      TextStreamer
+      TextStreamer,
+      emit
     );
   } else {
     // Non-streaming path: use progress-reporting text streamer and accumulate

--- a/providers/huggingface-transformers/src/ai/common/HFT_Device.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Device.ts
@@ -31,6 +31,6 @@ export function resolveHftPipelineDevice(raw: string | undefined): string | unde
   // execution provider instead of probing CUDA (which throws when the CUDA
   // shared libraries are absent, e.g. CPU-only CI runners). "wasm"/"webgpu" are
   // browser-only and stripped here as well.
-  if (!raw || raw === "auto" || raw === "wasm" || raw === "webgpu") return undefined;
+  if (!raw || raw === "auto" || raw === "wasm" ) return undefined;
   return raw;
 }

--- a/providers/huggingface-transformers/src/ai/common/HFT_Device.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Device.ts
@@ -29,8 +29,13 @@ export function resolveHftPipelineDevice(raw: string | undefined): string | unde
 
   // On the server, resolve to undefined so onnxruntime-node defaults to the CPU
   // execution provider instead of probing CUDA (which throws when the CUDA
-  // shared libraries are absent, e.g. CPU-only CI runners). "wasm"/"webgpu" are
-  // browser-only and stripped here as well.
-  if (!raw || raw === "auto" || raw === "wasm" ) return undefined;
+  // shared libraries are absent, e.g. CPU-only CI runners). "wasm" has no
+  // server-side execution provider and is stripped here as well.
+  //
+  // "webgpu" is deliberately NOT stripped: onnxruntime-node can serve it, and a
+  // local model on a GPU box is the reason to ask for it. It is passed through
+  // unconditionally, so a host without a usable WebGPU adapter fails at pipeline
+  // creation rather than degrading to CPU.
+  if (!raw || raw === "auto" || raw === "wasm") return undefined;
   return raw;
 }

--- a/providers/huggingface-transformers/src/ai/common/HFT_Pipeline.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Pipeline.ts
@@ -38,10 +38,16 @@ export async function loadTransformersSDK(): Promise<TransformersSDKModule> {
       _transformersSdk = mod;
       return mod;
     })
-    .catch(() => {
+    .catch((err: unknown) => {
       _loadPromise = undefined;
+      // Preserve the underlying failure — a missing package is only one cause.
+      // Linked `bun link` setups often fail here on a sharp/libvips mismatch
+      // (e.g. format.jp2k) which this wrapper used to hide.
+      const detail = err instanceof Error ? err.message : String(err);
       throw new Error(
-        "@huggingface/transformers is required for HuggingFace Transformers tasks. Install it with: bun add @huggingface/transformers"
+        `@huggingface/transformers failed to load (${detail}). ` +
+          `Install it in the app package (bun add @huggingface/transformers). ` +
+          `If it is already installed, check for conflicting sharp / @img/sharp-* versions after bun link.`
       );
     });
   return _loadPromise;

--- a/providers/huggingface-transformers/src/ai/common/HFT_Streaming.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Streaming.ts
@@ -5,22 +5,94 @@
  */
 
 import type { TextStreamer } from "@huggingface/transformers";
+import type { StreamPhase } from "@workglow/task-graph";
+
+/** How often {@link createDecodeHeartbeat} may emit, in milliseconds. */
+const HEARTBEAT_INTERVAL_MS = 250;
+
+/**
+ * Decode heartbeat: a `phase` event carrying the running token count, emitted
+ * at most every {@link HEARTBEAT_INTERVAL_MS} while the model generates.
+ *
+ * Deltas do not drive progress. `StreamProcessor` translates only `phase`
+ * events into `updateProgress`, and `StreamingAiTask` emits exactly one
+ * `Generating` phase, latched on the first delta — so a local model decoding
+ * for minutes renders as one static line for the whole run even though a token
+ * is arriving every few hundred milliseconds.
+ *
+ * The count rides in the **message**, not in `progress`: a consumer that owns
+ * its own percentage discards a subtask's number, so a numeric-only heartbeat
+ * would be invisible in exactly the sweeps where the wait is longest. It is
+ * also a count rather than a percentage because generation stops at an end
+ * token, not at `max_new_tokens` — any fraction of the token cap would stall
+ * near an arbitrary value and then jump, which reads as a hang.
+ *
+ * The returned function is called once per decoded token piece, including
+ * pieces a caller filters out of its own output (a `<think>` block, tool
+ * markup): those are decode work too, and a count that froze while the model
+ * chewed through reasoning tokens would report a hang that is not happening.
+ */
+export function createDecodeHeartbeat(
+  emit: (event: StreamPhase) => void,
+  options: {
+    label?: string;
+    intervalMs?: number;
+    now?: () => number;
+  } = {}
+): () => void {
+  const label = options.label ?? "Generating";
+  const intervalMs = options.intervalMs ?? HEARTBEAT_INTERVAL_MS;
+  const now = options.now ?? Date.now;
+  let count = 0;
+  // Anchored at the first token rather than at construction: the streamer is
+  // built before prompt formatting and pipeline warm-up, so anchoring here
+  // would spend the whole first interval before a token ever arrived and fire
+  // a heartbeat immediately on token one.
+  let lastEmit: number | undefined;
+  return () => {
+    count++;
+    const at = now();
+    if (lastEmit === undefined) {
+      // Leading edge suppressed: `StreamingAiTask` emits its own `Generating`
+      // on this same first delta, so a heartbeat racing it would either be
+      // overwritten or relabel the row twice at t=0.
+      lastEmit = at;
+      return;
+    }
+    if (at - lastEmit < intervalMs) return;
+    lastEmit = at;
+    emit({ type: "phase", message: `${label} ${count} tok`, progress: undefined });
+  };
+}
 
 /**
  * Creates a TextStreamer that invokes `onText` for each decoded token piece.
  * The pipeline yields tokens synchronously through the callback during
  * `model.generate(...)`, so `onText` can call `emit` directly — no queue
  * is needed between the SDK and the consumer.
+ *
+ * `emit` is taken (and the heartbeat wired) here rather than left to each
+ * run-fn so that no streaming run-fn can ship without decode feedback: the
+ * silence is invisible in tests and only shows up as a minutes-long static
+ * line against a slow local model.
  */
 export function createStreamingTextStreamer(
   tokenizer: any,
   onText: (text: string) => void,
-  textStreamer: typeof TextStreamer
+  textStreamer: typeof TextStreamer,
+  emit: (event: StreamPhase) => void
 ) {
+  const heartbeat = createDecodeHeartbeat(emit);
   return new textStreamer(tokenizer, {
     skip_prompt: true,
     decode_kwargs: { skip_special_tokens: true },
-    callback_function: onText,
+    callback_function: (text: string) => {
+      // Counted before the caller's own handling so a piece the caller drops
+      // still advances the count, and so a throw in `onText` cannot silently
+      // stop the heartbeat while generation continues.
+      heartbeat();
+      onText(text);
+    },
   });
 }
 

--- a/providers/huggingface-transformers/src/ai/common/HFT_Streaming.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Streaming.ts
@@ -11,6 +11,28 @@ import type { StreamPhase } from "@workglow/task-graph";
 const HEARTBEAT_INTERVAL_MS = 250;
 
 /**
+ * Emit the prefill phase when Transformers.js hands the prompt to its
+ * streamer. For decoder-only generation, `generate()` does this immediately
+ * before the first model forward, so it excludes provider/model preparation
+ * while still covering the complete prompt evaluation wait. Encoder-decoder
+ * models may run their separate encoder before this callback.
+ */
+function emitPrefillOnFirstPut(
+  streamer: { put(value: bigint[][]): void },
+  emit: (event: StreamPhase) => void
+): void {
+  const put = streamer.put.bind(streamer);
+  let promptPending = true;
+  streamer.put = (value: bigint[][]): void => {
+    if (promptPending) {
+      promptPending = false;
+      emit({ type: "phase", message: "Prefilling", progress: undefined });
+    }
+    put(value);
+  };
+}
+
+/**
  * Decode heartbeat: a `phase` event carrying the running token count, emitted
  * at most every {@link HEARTBEAT_INTERVAL_MS} while the model generates.
  *
@@ -83,7 +105,7 @@ export function createStreamingTextStreamer(
   emit: (event: StreamPhase) => void
 ) {
   const heartbeat = createDecodeHeartbeat(emit);
-  return new textStreamer(tokenizer, {
+  const streamer = new textStreamer(tokenizer, {
     skip_prompt: true,
     decode_kwargs: { skip_special_tokens: true },
     callback_function: (text: string) => {
@@ -94,15 +116,17 @@ export function createStreamingTextStreamer(
       onText(text);
     },
   });
+  emitPrefillOnFirstPut(streamer, emit);
+  return streamer;
 }
 
 export function createTextStreamer(
   tokenizer: any,
-  updateProgress: (progress: number, message?: string, details?: any) => void,
+  updateProgress: (progress: number | undefined, message?: string, details?: any) => void,
   textStreamer: typeof TextStreamer
 ) {
   let count = 0;
-  return new textStreamer(tokenizer, {
+  const streamer = new textStreamer(tokenizer, {
     skip_prompt: true,
     decode_kwargs: { skip_special_tokens: true },
     callback_function: (text: string) => {
@@ -112,4 +136,6 @@ export function createTextStreamer(
       updateProgress(progress, "Generating", { text, progress });
     },
   });
+  emitPrefillOnFirstPut(streamer, (event) => updateProgress(event.progress, event.message));
+  return streamer;
 }

--- a/providers/huggingface-transformers/src/ai/common/HFT_StructuredGeneration.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_StructuredGeneration.ts
@@ -87,7 +87,8 @@ export const HFT_StructuredGeneration: AiProviderRunFn<
         }
         emit({ type: "text-delta", port: "text", textDelta: delta });
       },
-      TextStreamer
+      TextStreamer,
+      emit
     );
     const stopping_criteria = new InterruptableStoppingCriteria();
     if (signal) {

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextGeneration.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextGeneration.ts
@@ -48,7 +48,8 @@ export const HFT_TextGeneration: AiProviderRunFn<
         accumulated += text;
         emit({ type: "text-delta", port: "text", textDelta: text });
       },
-      TextStreamer
+      TextStreamer,
+      emit
     );
     const stopping_criteria = new InterruptableStoppingCriteria();
     if (signal) {

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextQuestionAnswer.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextQuestionAnswer.ts
@@ -38,7 +38,8 @@ export const HFT_TextQuestionAnswer: AiProviderRunFn<
     const streamer = createStreamingTextStreamer(
       generateAnswer.tokenizer,
       (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
-      TextStreamer
+      TextStreamer,
+      emit
     );
     const stopping_criteria = new InterruptableStoppingCriteria();
     if (signal) {

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextRewriter.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextRewriter.ts
@@ -26,7 +26,8 @@ export const HFT_TextRewriter: AiProviderRunFn<
     const streamer = createStreamingTextStreamer(
       generateText.tokenizer,
       (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
-      TextStreamer
+      TextStreamer,
+      emit
     );
     const stopping_criteria = new InterruptableStoppingCriteria();
     if (signal) {

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextSummary.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextSummary.ts
@@ -26,7 +26,8 @@ export const HFT_TextSummary: AiProviderRunFn<
     const streamer = createStreamingTextStreamer(
       generateSummary.tokenizer,
       (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
-      TextStreamer
+      TextStreamer,
+      emit
     );
     const stopping_criteria = new InterruptableStoppingCriteria();
     if (signal) {

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextTranslation.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextTranslation.ts
@@ -30,7 +30,8 @@ export const HFT_TextTranslation: AiProviderRunFn<
     const streamer = createStreamingTextStreamer(
       translate.tokenizer,
       (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
-      TextStreamer
+      TextStreamer,
+      emit
     );
     const stopping_criteria = new InterruptableStoppingCriteria();
     if (signal) {

--- a/providers/huggingface-transformers/src/ai/common/HFT_ToolCalling.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_ToolCalling.ts
@@ -436,7 +436,8 @@ export const HFT_ToolCalling: AiProviderRunFn<
         fullText += text;
         filter.feed(text);
       },
-      TextStreamer
+      TextStreamer,
+      emit
     );
     const stopping_criteria = new InterruptableStoppingCriteria();
     if (signal) {

--- a/providers/huggingface-transformers/src/ai/runtime.ts
+++ b/providers/huggingface-transformers/src/ai/runtime.ts
@@ -19,6 +19,7 @@ export * from "./common/HFT_Device";
 export * from "./common/HFT_ModelSchema";
 export * from "./common/HFT_OnnxDtypes";
 export * from "./common/HFT_Pipeline";
+export * from "./common/HFT_Streaming";
 export * from "./common/HFT_TextReranker";
 export * from "./common/HFT_ToolMarkup";
 export * from "./registerHuggingFaceTransformersInline";

--- a/providers/postgres/package.json
+++ b/providers/postgres/package.json
@@ -86,7 +86,7 @@
     }
   },
   "devDependencies": {
-    "@types/pg": "^8.20.4",
+    "@types/pg": "catalog:",
     "@workglow/job-queue": "workspace:*",
     "@workglow/storage": "workspace:*",
     "@workglow/util": "workspace:*"


### PR DESCRIPTION
## Summary

Adds a periodic heartbeat mechanism to provide progress feedback while the Hugging Face Transformers provider decodes tokens. This addresses the issue where slow local models render as a single static line for their entire run without any indication of ongoing work.

## Changes

- **New `createDecodeHeartbeat` function** (`HFT_Streaming.ts`): Emits a `phase` event with the running token count at most every 250ms while the model generates. The heartbeat:
  - Suppresses the first token to avoid racing with `StreamingAiTask`'s own `Generating` phase
  - Reports token count in the message (not progress percentage) since generation stops at an end token, not at `max_new_tokens`
  - Counts all decoded pieces, including those filtered out by the caller (e.g., `<think>` blocks)
  - Accepts customizable label, interval, and clock for testing

- **Updated `createStreamingTextStreamer`** to wire the heartbeat: now accepts an `emit` callback and calls the heartbeat on every decoded token before invoking the caller's `onText` handler

- **Updated all HFT run-fns** to pass `emit` to `createStreamingTextStreamer`:
  - `HFT_Chat.ts`
  - `HFT_StructuredGeneration.ts`
  - `HFT_TextGeneration.ts`
  - `HFT_TextQuestionAnswer.ts`
  - `HFT_TextRewriter.ts`
  - `HFT_TextSummary.ts`
  - `HFT_TextTranslation.ts`
  - `HFT_ToolCalling.ts`

- **Exported `createDecodeHeartbeat`** from `ai/runtime.ts` for use by other providers

- **Updated CLAUDE.md** with streaming decode feedback convention: explains why heartbeats use message-based counts rather than progress percentages, and documents that local providers must emit periodic phase events during decoding

- **Added comprehensive test suite** (`HFT_DecodeHeartbeat.test.ts`): validates suppression of the first token, throttling to the interval, strict token counting, resumption after slow decodes, and custom labels

## Implementation Details

The heartbeat is wired inside `createStreamingTextStreamer` rather than left to individual run-fns to ensure no streaming run-fn can ship without decode feedback. The token count rides in the phase message (not `progress`) because a consumer that owns its own percentage (e.g., a sweep reporting `done/total`) discards a subtask's number and keeps only the text. Reporting a count rather than a percentage prevents the stall-and-jump behavior that would occur if generation stops early at an end token before reaching `max_new_tokens`.

https://claude.ai/code/session_01X7FvvzGidgdeuQhNCRDzVH