### PR TITLE
docs: note that TypeScript applies the browser condition only on opt-in

### DIFF
--- a/docs/technical/18-multi-runtime-abstraction.md
+++ b/docs/technical/18-multi-runtime-abstraction.md
@@ -125,7 +125,10 @@ Resolution rules:
 Each condition block includes a `"types"` field so that TypeScript resolves the correct `.d.ts`
 file for the platform. This is critical because the type declarations differ per platform — for
 example, the browser entry exports `Worker` as `globalThis.Worker` while the Node entry exports
-a `WorkerPolyfill` that wraps `worker_threads`.
+a `WorkerPolyfill` that wraps `worker_threads`. That resolution is not automatic for `tsc`:
+`"browser"` is not one of TypeScript's built-in conditions, so a browser consumer must set
+`"customConditions": ["browser"]` in its tsconfig or it type-checks the browser bundle against
+the node declarations. See [Conditional Exports](./19-build-system.md#conditional-exports).
 
 ### Sub-path exports
 

--- a/docs/technical/19-build-system.md
+++ b/docs/technical/19-build-system.md
@@ -430,6 +430,26 @@ successful compiles for symbols that are `undefined` at runtime, because the bro
 never exported them. `packages/test/src/test/util/ExportTypesPairing.test.ts` walks every
 condition branch of every workspace manifest and fails on any pair that has drifted apart.
 
+**TypeScript applies the `"browser"` condition only when the consumer asks for it.** Its condition
+set is `["import", "types"]` under `moduleResolution: "bundler"` and `["node", "import", "types"]`
+under `node16`/`nodenext` — `"browser"` is in neither. A Vite or webpack app therefore _bundles_
+`dist/browser.js` while `tsc` resolves the outer `"types"` and type-checks it against the node
+declaration. Correct manifests do not fix that on their own; they move the drift from the manifest
+to the consumer's tsconfig. Browser consumers must opt in:
+
+```json
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "customConditions": ["browser"]
+  }
+}
+```
+
+`examples/web/tsconfig.json` is the in-repo example. Downstream apps that bundle for the browser
+need the same line — without it, `import { _testOnly } from "@workglow/openai/ai"` compiles with
+full autocomplete and is `undefined` at runtime.
+
 ---
 
 ## Developer Workflow

--- a/packages/test/src/test/util/ExportTypesPairing.test.ts
+++ b/packages/test/src/test/util/ExportTypesPairing.test.ts
@@ -254,6 +254,65 @@ describe("workspace exports maps", () => {
 });
 
 /**
+ * A correct manifest is only half of it: TypeScript's condition set is
+ * `["import", "types"]` under `moduleResolution: "bundler"`, so `"browser"` is
+ * never applied unless the consumer names it in `customConditions`. Without that
+ * line a browser project bundles `dist/browser.js` while `tsc` type-checks it
+ * against the node declarations — no error anywhere, and the symbols the browser
+ * bundle omits still autocomplete.
+ */
+/** `tsconfig.json` is JSONC, so its comments have to go before `JSON.parse`. */
+function stripJsonComments(text: string): string {
+  let out = "";
+  let inString = false;
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!;
+    if (inString) {
+      out += char;
+      if (char === "\\") {
+        out += text[i + 1] ?? "";
+        i++;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      out += char;
+      continue;
+    }
+    if (char === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i++;
+      out += "\n";
+      continue;
+    }
+    if (char === "/" && text[i + 1] === "*") {
+      const end = text.indexOf("*/", i + 2);
+      i = end === -1 ? text.length : end + 1;
+      continue;
+    }
+    out += char;
+  }
+  return out;
+}
+
+describe("browser consumers opt into the browser condition", () => {
+  it("examples/web sets customConditions", () => {
+    // examples/web is the repo's only browser-bundled TypeScript project, and it
+    // imports packages that carry `browser` conditions (`@workglow/util`,
+    // `@workglow/indexeddb/storage`, `@workglow/tf-mediapipe/ai`). If that project
+    // is renamed or moved, repoint this path at its replacement rather than
+    // deleting the check.
+    const root = workspaceRoot();
+    const tsconfig = JSON.parse(
+      stripJsonComments(readFileSync(join(root.dir, "examples/web/tsconfig.json"), "utf8"))
+    ) as { compilerOptions?: { customConditions?: readonly string[] } };
+    expect(tsconfig.compilerOptions?.customConditions).toContain("browser");
+  });
+});
+
+/**
  * No manifest violates these rules today, so the code paths that catch them would
  * ship untested. These fixtures exercise them directly.
  */


### PR DESCRIPTION
The manifest fix in #717 is complete and uniform — every condition branch now pairs its `types` target with the implementation beside it, and `ExportTypesPairing.test.ts` enforces that across all 163 branches. But a correct manifest is only half of the story.

TypeScript's condition set is `["import", "types"]` under `moduleResolution: "bundler"` and `["node", "import", "types"]` under `node16`/`nodenext`. `"browser"` is in neither, and TypeScript only applies it when the consumer names it in `customConditions`. So a plain bundler-mode consumer still *bundles* `dist/browser.js` while `tsc` resolves the outer `"types"` and type-checks it against the **node** declarations — no error anywhere, and symbols the browser bundle genuinely omits (`_testOnly`, `OpenAI_ImageValidation`, `OpenAI_ModelSearch` in `@workglow/openai/ai`) still autocomplete and compile, then read `undefined` at runtime.

The correct manifests do not fix that on their own; they move the drift from the manifest to the consumer's tsconfig. This PR says so where the rule is stated.

## Changes

- `docs/technical/19-build-system.md` — a paragraph in **Conditional Exports** stating the opt-in, with the tsconfig snippet and `examples/web/tsconfig.json` as the in-repo example.
- `docs/technical/18-multi-runtime-abstraction.md` — one sentence on the same claim in the resolution-rules paragraph, linking to the section above.
- `packages/test/src/test/util/ExportTypesPairing.test.ts` — one assertion that `examples/web` sets `customConditions: ["browser"]`. It is the repo's only browser-bundled TypeScript project and it imports packages carrying `browser` conditions (`@workglow/util`, `@workglow/indexeddb/storage`, `@workglow/tf-mediapipe/ai`); deleting that one line silently reverts it to node declarations with nothing failing. Verified by mutation — removing the line fails the test.

Deliberately **not** added: a test that string-matches the doc prose. Nothing under `packages/test` reads `docs/`, and such a test breaks on rewording without catching any real defect.

## Known follow-up (separate repo)

`/home/user/builder`'s `packages/app` is exactly the consumer described above: `tsconfig.app.json` is `moduleResolution: "bundler"` with no `customConditions`, and it imports `@workglow/anthropic/ai`, `@workglow/deepseek/ai`, `@workglow/openai/ai` and `@workglow/tf-mediapipe/ai`. It (and the six other bundler-mode tsconfigs there) should gain `"customConditions": ["browser"]` — a separate PR in a separate repo.

Also out of scope: converging the node and browser barrels (dropping `_testOnly` from node barrels, exporting browser-safe modules from browser barrels). That is a public-API change across at least 8 provider packages and would obscure the manifest-correctness verification this branch already carries.

## Verification

| command | result |
| --- | --- |
| `bun scripts/test.ts util vitest` | 50 files passed, 731 passed / 10 skipped |
| `bunx prettier --check` (18, test file) | clean |
| `bunx prettier --check docs/technical/19-build-system.md` | fails — **pre-existing**, verified unclean on the base commit with the change stashed; the added paragraph itself is prettier-stable |
| `bunx eslint …/ExportTypesPairing.test.ts --max-warnings 0` | clean |
| `bunx tsc --showConfig -p examples/web/tsconfig.json` | `customConditions` present |

One deviation from the plan: `tsconfig.json` is JSONC (`examples/web/tsconfig.json` carries `/* Bundler mode */` comments), so a bare `JSON.parse` throws. The test strips comments first via a small local helper.


---
_Generated by [Claude Code](https://claude.ai/code/session_013oVdDSRMJeALBPLDQf3DgH)_