### PR TITLE
fix(triggers): make the scheduler survive wall-clock steps

### DIFF
--- a/packages/test/src/test/trigger/CronTrigger.test.ts
+++ b/packages/test/src/test/trigger/CronTrigger.test.ts
@@ -153,6 +153,32 @@ describe("CronTrigger", () => {
     await trigger.stop();
   });
 
+  test("a backward clock step delays a cron fire rather than misfiring it", async () => {
+    // A cron expression names a calendar instant, so a clock corrected backwards
+    // means the appointment has NOT arrived yet and the trigger must wait the
+    // correction out. This is the guard that the interval triggers' "an expiry
+    // is a fire whatever the clock reads" rule is never applied here too.
+    useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
+    const trigger = new CronTrigger({ expression: "*/5 * * * *" });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(2 * MINUTE);
+    // Clock steps back 10 minutes; 3 minutes of monotonic delay remain.
+    vi.setSystemTime(Date.now() - 10 * MINUTE);
+    await advanceFakeTimers(3 * MINUTE);
+    await advanceFakeTimers(0);
+    expect(fires).toBe(0);
+
+    // The clock reaches 12:05 for real.
+    await advanceFakeTimers(10 * MINUTE);
+    expect(fires).toBe(1);
+
+    await trigger.stop();
+  });
+
   test("stop() halts further fires", async () => {
     useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
     const trigger = new CronTrigger({ expression: "* * * * *" });

--- a/packages/test/src/test/trigger/IntervalTrigger.test.ts
+++ b/packages/test/src/test/trigger/IntervalTrigger.test.ts
@@ -306,6 +306,52 @@ describe("IntervalTrigger", () => {
     await trigger.stop();
   });
 
+  test("a backward clock step does not stall the loop", async () => {
+    // A fixed-interval period is measured by the host timer, not by the wall
+    // clock, so an NTP correction backwards must not turn one 60s period into a
+    // 31-minute silence. Both assertions are load-bearing: re-arming the pending
+    // tick alone would fire once and then go quiet for the size of the step,
+    // because the next target is still computed off the pre-step anchor.
+    const trigger = new IntervalTrigger({ intervalMs: 60_000 });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(30_000);
+    // Sinon shifts every pending callAt by the same delta, so 30s of monotonic
+    // delay remains on a timer whose target is now 30 minutes in the future.
+    vi.setSystemTime(Date.now() - 1_800_000);
+    await advanceFakeTimers(30_000);
+    await advanceFakeTimers(0);
+    expect(fires).toBe(1);
+
+    await advanceFakeTimers(60_000);
+    expect(fires).toBe(2);
+
+    await trigger.stop();
+  });
+
+  test("a host timer that fires a hair early still waits for its instant", async () => {
+    // Hosts do fire a timer a millisecond early. That shortfall is jitter, not a
+    // clock step, so the tick is re-armed for the remainder rather than fired.
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(PERIOD - 1);
+    vi.setSystemTime(Date.now() - 1);
+    await advanceFakeTimers(1);
+    expect(fires).toBe(0);
+
+    await advanceFakeTimers(1);
+    expect(fires).toBe(1);
+
+    await trigger.stop();
+  });
+
   test("unrefTimer unrefs the scheduled timer without changing the schedule", async () => {
     // A running trigger otherwise keeps a Node process alive; the opt-out must
     // not change when it fires.

--- a/packages/test/src/test/trigger/PollingTrigger.test.ts
+++ b/packages/test/src/test/trigger/PollingTrigger.test.ts
@@ -370,6 +370,47 @@ describe("PollingTrigger", () => {
 
       await trigger.stop();
     });
+
+    test("a host that slept through a backed-off gap does not replay the backlog", async () => {
+      // The backed-off target is measured from the previous tick's instant, so a
+      // host suspended across several gaps leaves it far in the past. Unclamped,
+      // every one of those stale targets is already due and the loop replays the
+      // whole backlog as a burst of setTimeout(0) ticks.
+      let polls = 0;
+      const trigger = new PollingTrigger<number>({
+        intervalMs: PERIOD,
+        poll: () => {
+          polls += 1;
+          throw new Error("dependency down");
+        },
+        errorBackoff: { initialMs: PERIOD * 2, maxMs: PERIOD * 2 },
+      });
+      trigger.on("error", () => {});
+      let skips = 0;
+      trigger.on("skip", () => {
+        skips += 1;
+      });
+      trigger.start(() => {});
+
+      // Ticks at P and 2P; the tick after those is armed for START + 4P.
+      await advanceFakeTimers(PERIOD * 2);
+      expect(polls).toBe(2);
+
+      // The host freezes for 10s. Sinon shifts every pending callAt by the same
+      // delta, so the timer keeps its 200ms of MONOTONIC delay while the wall
+      // clock jumps 10s past the target it was armed for.
+      vi.setSystemTime(START + PERIOD * 2 + 10_000);
+      await advanceFakeTimers(PERIOD * 2);
+      // A replayed backlog arrives as zero-delay ticks, which fake timers space a
+      // millisecond apart, so give it a whole period to show itself. The clamped
+      // loop has nothing due until START + 10_600.
+      await advanceFakeTimers(PERIOD);
+
+      expect(polls).toBe(3);
+      expect(skips).toBe(0);
+
+      await trigger.stop();
+    });
   });
 
   test("stop() halts polling", async () => {

--- a/packages/triggers/package.json
+++ b/packages/triggers/package.json
@@ -24,8 +24,7 @@
     "build-browser": "bun build --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/browser.ts",
     "build-node": "bun build --target=node --sourcemap=external --packages=external --outdir ./dist ./src/node.ts",
     "build-types": "rm -f tsconfig.tsbuildinfo && tsgo",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "test": "bun test"
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "exports": {
     ".": {

--- a/packages/triggers/src/trigger/BaseTrigger.ts
+++ b/packages/triggers/src/trigger/BaseTrigger.ts
@@ -25,6 +25,13 @@ import { TriggerConfigurationError } from "./TriggerError";
  */
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
+/**
+ * Largest shortfall at timer expiry still attributable to a host firing a timer a
+ * hair early. Anything larger, on a wait we did not truncate, means the wall clock
+ * moved backwards under a monotonic timer.
+ */
+const EARLY_TIMER_TOLERANCE_MS = 50;
+
 /** Options common to every built-in trigger. */
 export interface TriggerOptions {
   /** Stable id; a UUID is generated when omitted. */
@@ -95,6 +102,21 @@ export abstract class BaseTrigger implements ITrigger {
   protected readonly overlap: OverlapPolicy;
   protected readonly maxQueuedFires: number;
   protected readonly unrefTimer: boolean;
+
+  /**
+   * How the instants from {@link computeNextFireTime} are meant to be read.
+   *
+   * `"wall"` — a calendar appointment (`CronTrigger`). A timer that expires before
+   * the clock reaches it has not reached the appointment: re-arm for the
+   * remainder, which is what makes a backward NTP correction DELAY the fire rather
+   * than misfire it.
+   *
+   * `"period"` — a bookkeeping anchor for "every N ms" (`IntervalTrigger`,
+   * `PollingTrigger`). The timer, not the clock, measures the period, so an expiry
+   * is a fire whatever the clock reads; re-arming on a backward step would stall
+   * the trigger for the size of the step.
+   */
+  protected readonly clockDomain: "wall" | "period" = "period";
 
   /** The current run, or `undefined` when the trigger is stopped and drained. */
   private _run: TriggerRun | undefined;
@@ -278,12 +300,20 @@ export abstract class BaseTrigger implements ITrigger {
 
   private scheduleAt(run: TriggerRun, targetMs: number): void {
     const remaining = Math.max(0, targetMs - Date.now());
+    // Decided HERE, while the wall clock is still trustworthy. Re-deciding it at
+    // expiry from `Date.now() < targetMs` cannot tell a chunk apart from a
+    // backward clock step, and serves the step as a wait of the same size.
+    const truncated = remaining > MAX_TIMER_DELAY_MS;
     const timer = setTimeout(
       () => {
         run.timer = undefined;
         if (!run.active) return;
         // A chunked wait (or an early host timer) lands before the target.
-        if (Date.now() < targetMs) {
+        const shortfall = targetMs - Date.now();
+        if (
+          shortfall > 0 &&
+          (truncated || this.clockDomain === "wall" || shortfall <= EARLY_TIMER_TOLERANCE_MS)
+        ) {
           this.scheduleAt(run, targetMs);
           return;
         }

--- a/packages/triggers/src/trigger/CronTrigger.ts
+++ b/packages/triggers/src/trigger/CronTrigger.ts
@@ -35,6 +35,10 @@ export class CronTrigger extends BaseTrigger {
   public readonly kind = TRIGGER_KINDS.cron;
   public readonly schedule: CronSchedule;
 
+  // A cron instant is an appointment on the wall clock, not a period: a clock
+  // corrected backwards means it has not arrived yet.
+  protected override readonly clockDomain = "wall" as const;
+
   constructor(options: CronTriggerOptions) {
     super(options);
     this.schedule = parseCronExpression(options.expression);

--- a/packages/triggers/src/trigger/PollingTrigger.ts
+++ b/packages/triggers/src/trigger/PollingTrigger.ts
@@ -6,7 +6,11 @@
 
 import type { TriggerOptions, TriggerRun } from "./BaseTrigger";
 import { BaseTrigger } from "./BaseTrigger";
-import { assertValidIntervalMs, nextFixedIntervalFireTime } from "./fixedInterval";
+import {
+  assertValidIntervalMs,
+  nextBackoffFireTime,
+  nextFixedIntervalFireTime,
+} from "./fixedInterval";
 import { TRIGGER_KINDS } from "./ITrigger";
 import { TriggerConfigurationError } from "./TriggerError";
 
@@ -134,7 +138,7 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
       // backoff takes effect from the tick AFTER the first failure.
       const exponent = Math.min(failures - 1, 31);
       const delay = Math.min(backoff.maxMs, backoff.initialMs * 2 ** exponent);
-      return fromMs + delay;
+      return nextBackoffFireTime(fromMs, delay);
     }
     return nextFixedIntervalFireTime(fromMs, this.intervalMs);
   }

--- a/packages/triggers/src/trigger/fixedInterval.ts
+++ b/packages/triggers/src/trigger/fixedInterval.ts
@@ -17,7 +17,10 @@ import { TriggerConfigurationError } from "./TriggerError";
 export function nextFixedIntervalFireTime(fromMs: number, intervalMs: number): number {
   const next = fromMs + intervalMs;
   const now = Date.now();
-  if (next > now) return next;
+  // A backward clock step leaves the phase anchor arbitrarily far in the future. A
+  // period trigger must still fire every `intervalMs`, so re-anchor instead of
+  // waiting the jump out; the phase it loses was a wall-clock artifact anyway.
+  if (next > now) return Math.min(next, now + intervalMs);
   const missedPeriods = Math.floor((now - next) / intervalMs) + 1;
   return next + missedPeriods * intervalMs;
 }

--- a/packages/triggers/src/trigger/fixedInterval.ts
+++ b/packages/triggers/src/trigger/fixedInterval.ts
@@ -22,6 +22,21 @@ export function nextFixedIntervalFireTime(fromMs: number, intervalMs: number): n
   return next + missedPeriods * intervalMs;
 }
 
+/**
+ * The next fire time after a backoff `delayMs`, measured from the PREVIOUS tick's
+ * scheduled instant, clamped to `(now, now + delayMs]` exactly as
+ * {@link nextFixedIntervalFireTime} clamps to `(now, now + intervalMs]`.
+ *
+ * An anchor the host slept past would otherwise land in the past and be replayed
+ * as a burst of `setTimeout(0)` ticks; one left in the FUTURE by a backward clock
+ * step would stall the loop for the size of the step.
+ */
+export function nextBackoffFireTime(fromMs: number, delayMs: number): number {
+  const target = fromMs + delayMs;
+  const now = Date.now();
+  return target > now ? Math.min(target, now + delayMs) : now + delayMs;
+}
+
 /** Validates a period shared by the fixed-interval triggers. */
 export function assertValidIntervalMs(intervalMs: number): number {
   if (!Number.isInteger(intervalMs) || intervalMs <= 0) {


### PR DESCRIPTION
Follow-up on #679. Two clock hazards in the trigger scheduler, plus one packaging cleanup.

Both hazards come from the same mismatch: a host timer measures its delay **monotonically**, but the scheduler decides everything by comparing absolute `Date.now()` values. A wall clock that moves independently of the timer — a suspend/resume, an NTP correction — makes those comparisons lie in both directions.

## 1. A slept-through backoff replays its backlog as a `setTimeout(0)` burst

`PollingTrigger`'s error backoff returned `fromMs + delay` with no clamp — the previous tick's scheduled instant plus the delay. Suspend the host for 10s during a 200ms backed-off gap and every anchor from that point on is already in the past when it wakes: `scheduleAt` computes `remaining === 0` for each one and re-fires immediately, so the loop replays ~50 catch-up ticks back to back. It hammers the very dependency the backoff exists to spare, at exactly the moment that dependency is down. In the other direction, a backward clock step leaves the anchor far in the future and stalls the loop for the size of the step.

`nextBackoffFireTime` (new, beside `nextFixedIntervalFireTime` so the two clamps are read together) establishes the same `(now, now + delay]` invariant with `delay` in place of `intervalMs`. It is bit-for-bit a no-op on the ordinary path: `computeNextFireTime` runs synchronously at timer expiry, so `fromMs + delay` already equals `now + delay`.

New test polls 3 times over the sleep; before the fix it polls **53** times.

## 2. A backward NTP step stalls every fixed-interval trigger for the size of the jump

`scheduleAt` re-armed whenever `Date.now() < targetMs` at expiry. That guard exists for chunked long waits (past the ~24.8-day `setTimeout` ceiling), but it cannot tell a chunk apart from a clock step — and it serves the step as a wait of the same size. A 30-minute correction backwards turns a 60-second `IntervalTrigger` into 31 minutes of silence.

The re-arm decision now keys off a fact known at **arm** time, while the wall clock is still trustworthy: was this wait truncated by the timer ceiling? Plus a 50 ms tolerance for a host firing a hair early (above real jitter, below the smallest step a clock daemon takes rather than slews).

It is gated per **clock domain**, because the right answer depends on what the instant means:

- `CronTrigger` names a calendar appointment. A clock corrected backwards means it has **not** arrived; firing at the old instant would be a misfire. It declares `clockDomain = "wall"` and keeps the re-arm — waiting the correction out is the correct behaviour, which is also why a `performance.now()` deadline would be wrong here.
- `IntervalTrigger` / `PollingTrigger` mean "every N ms", a period the timer already measures. An expiry is a fire whatever the clock reads.

Firing the pending tick is only half the fix. The **next** target was still computed off the pre-step anchor — `nextFixedIntervalFireTime(START + 60_000, 60_000)` returns `START + 120_000`, ~31 minutes out by the corrected clock — so the trigger would fire once and then go quiet anyway. The clamp is now symmetric: an anchor left in the future is re-anchored to `now + intervalMs`, giving the same `(now, now + intervalMs]` guarantee it already gave for a stale one. The phase it drops was a wall-clock artifact.

> ⚠️ **Behaviour change on public API.** `nextFixedIntervalFireTime` now returns `Math.min(fromMs + intervalMs, Date.now() + intervalMs)` rather than `fromMs + intervalMs` when `fromMs` is in the **future**. The in-repo callers are `IntervalTrigger` and `PollingTrigger`, both of which call it synchronously at tick time where `fromMs <= Date.now()`, so nothing in-tree changes; the no-drift-over-100-periods guard is untouched. `clockDomain` is a new protected member on the exported abstract `BaseTrigger`: an external subclass inherits `"period"`, right for anything that is not a calendar schedule, but a third-party cron-like subclass wants the override.

Three tests: the `IntervalTrigger` backward-step case (both assertions load-bearing — the first alone passes with the re-arm fix while the trigger stays silently quiet for 31 minutes; the second pins the anchor clamp), an early-timer-jitter case pinning the tolerance, and a `CronTrigger` case that passes before and after — it exists to fail if `clockDomain` is ever collapsed into a uniform period-domain re-arm.

## 3. `packages/triggers` declared a test script it cannot satisfy

The package ships no co-located test files — they live in `packages/test/src/test/trigger/` — so `bun test` there exits 1 with `0 test files matching`. Dropped, mirroring `packages/ai`, `packages/task-graph` and `packages/util`, which are wired the same way. `packages/test` depends on `@workglow/triggers` and has its own script, so the trigger tests keep running.

## Verification

- `bun scripts/test.ts vitest trigger` — 5 files, 135 tests, all passing
- `packages/triggers`: `bun run lint` clean; `build-types` produces the same 23 pre-existing source-mode errors as the base commit, none new
- `prettier --check` clean on every changed file


---
_Generated by [Claude Code](https://claude.ai/code/session_013oVdDSRMJeALBPLDQf3DgH)_