### PR TITLE
fix(bootstrap): drop the redundant bun build target (unbreaks BunExportConditions)

### DIFF
--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -15,17 +15,15 @@
   "homepage": "https://workglow.dev",
   "scripts": {
     "watch": "concurrently -c 'auto' 'bun:watch-*'",
-    "watch-js": "concurrently -c 'auto' -n 'browser,node,bun' 'bun run watch-browser' 'bun run watch-node' 'bun run watch-bun'",
+    "watch-js": "concurrently -c 'auto' -n 'browser,node' 'bun run watch-browser' 'bun run watch-node'",
     "watch-browser": "bun build --watch --no-clear-screen --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/browser.ts",
     "watch-node": "bun build --watch --no-clear-screen --target=node --sourcemap=external --packages=external --outdir ./dist ./src/node.ts",
-    "watch-bun": "bun build --watch --no-clear-screen --target=bun --sourcemap=external --packages=external --outdir ./dist ./src/bun.ts",
     "watch-types": "tsc --watch --preserveWatchOutput",
-    "build-package": "concurrently -c 'auto' -n 'browser,node,bun,types' 'bun run build-browser' 'bun run build-node' 'bun run build-bun' 'bun run build-types'",
-    "build-js": "concurrently -m 12 --timings -c 'auto' -n 'browser,node,bun' 'bun run build-browser' 'bun run build-node' 'bun run build-bun'",
+    "build-package": "concurrently -c 'auto' -n 'browser,node,types' 'bun run build-browser' 'bun run build-node' 'bun run build-types'",
+    "build-js": "concurrently -m 12 --timings -c 'auto' -n 'browser,node' 'bun run build-browser' 'bun run build-node'",
     "build-clean": "rm -fr dist/* tsconfig.tsbuildinfo",
     "build-browser": "bun build --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/browser.ts",
     "build-node": "bun build --target=node --sourcemap=external --packages=external --outdir ./dist ./src/node.ts",
-    "build-bun": "bun build --target=bun --sourcemap=external --packages=external --outdir ./dist ./src/bun.ts",
     "build-types": "rm -f tsconfig.tsbuildinfo && tsgo",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "bun test"
@@ -75,10 +73,6 @@
       "browser": {
         "types": "./dist/browser.d.ts",
         "import": "./dist/browser.js"
-      },
-      "bun": {
-        "types": "./dist/bun.d.ts",
-        "import": "./dist/bun.js"
       },
       "types": "./dist/node.d.ts",
       "import": "./dist/node.js"

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -25,8 +25,7 @@
     "build-browser": "bun build --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/browser.ts",
     "build-node": "bun build --target=node --sourcemap=external --packages=external --outdir ./dist ./src/node.ts",
     "build-types": "rm -f tsconfig.tsbuildinfo && tsgo",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "test": "bun test"
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "peerDependencies": {
     "@workglow/ai": "workspace:*",

--- a/packages/bootstrap/src/bun.ts
+++ b/packages/bootstrap/src/bun.ts
@@ -1,9 +1,0 @@
-/**
- * @license
- * Copyright 2026 Steven Roussey <sroussey@gmail.com>
- * SPDX-License-Identifier: Apache-2.0
- */
-
-// organize-imports-ignore
-
-export * from "./common";

--- a/packages/bootstrap/tsconfig.json
+++ b/packages/bootstrap/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src/common.ts", "src/*/**/*"],
-  "files": ["./src/browser.ts", "./src/node.ts", "./src/bun.ts"],
+  "files": ["./src/browser.ts", "./src/node.ts"],
   "exclude": ["dist", "node_modules"],
   "compilerOptions": {
     "composite": true,

--- a/packages/test/src/test/util/BootstrapReadme.test.ts
+++ b/packages/test/src/test/util/BootstrapReadme.test.ts
@@ -14,7 +14,13 @@
  * `TaskGraphRunConfig` has a `context` key — so with a loosely typed `Input`
  * that object is an input override named `context`, the run keeps the global
  * registry, and `ctx.dispose()` tears down a registry the task never touched.
- * Both halves are pinned below so the snippet cannot silently rot back.
+ *
+ * Two halves are pinned below. The first `describe` exercises both shapes at
+ * runtime, proving the documented one works and the old one does not. The
+ * second reads the two documents themselves, so a snippet that rots back is a
+ * test failure rather than prose nobody re-checks. The document cases scan
+ * every fenced block for the wrong shape, so a deliberate counter-example in
+ * the README would trip them — write the counter-example as prose instead.
  */
 
 import { createOrchestrationContext } from "@workglow/bootstrap";
@@ -23,7 +29,29 @@ import { Task } from "@workglow/task-graph";
 import type { ServiceRegistry } from "@workglow/util";
 import { globalServiceRegistry } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+const README_PATH = join(REPO_ROOT, "packages/bootstrap/README.md");
+const SOURCE_PATH = join(REPO_ROOT, "packages/bootstrap/src/bootstrap/bootstrapWorkglow.ts");
+
+/** The registry travelling in the run config — `run()`'s second argument. */
+const REGISTRY_IN_RUN_CONFIG =
+  /\.run\(\s*\{\s*\}\s*,\s*\{\s*registry:\s*\w+\.registry[\s,]*\}\s*\)/;
+/** The shape that silently becomes an input override named `context`. */
+const CONTEXT_AS_INPUT = /\.run\(\s*\{\s*context\s*:/;
+
+/**
+ * Every fenced code block's body, whatever its info string. Selecting blocks by
+ * content rather than by the heading above them keeps a heading rename from
+ * making these cases pass vacuously.
+ */
+function fencedBlocks(markdown: string): string[] {
+  return [...markdown.matchAll(/^```[^\n]*\n([\s\S]*?)^```/gm)].map((match) => match[1]!);
+}
 
 interface RegistryProbeOutput extends TaskOutput {
   isGlobal: boolean;
@@ -91,5 +119,39 @@ describe("the @workglow/bootstrap README isolated-context example", () => {
     } finally {
       await ctx.dispose();
     }
+  });
+});
+
+describe("the documents the example is transcribed from", () => {
+  it("README documents the registry in the run config", () => {
+    const blocks = fencedBlocks(readFileSync(README_PATH, "utf8")).filter((block) =>
+      block.includes("createOrchestrationContext(")
+    );
+
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(blocks.some((block) => REGISTRY_IN_RUN_CONFIG.test(block))).toBe(true);
+  });
+
+  it("no README code block passes the context as an input override", () => {
+    // Code only: the surrounding prose deliberately discusses "an input named
+    // `context`" and has to stay legal.
+    const offenders = fencedBlocks(readFileSync(README_PATH, "utf8")).filter((block) =>
+      CONTEXT_AS_INPUT.test(block)
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("the createOrchestrationContext JSDoc shows the same shape", () => {
+    const source = readFileSync(SOURCE_PATH, "utf8");
+    const jsdoc = source.match(
+      /\/\*\*([\s\S]*?)\*\/\s*export function createOrchestrationContext\b/
+    );
+
+    expect(jsdoc).not.toBeNull();
+
+    const comment = jsdoc![1]!.replace(/^\s*\*/gm, "");
+    expect(REGISTRY_IN_RUN_CONFIG.test(comment)).toBe(true);
+    expect(CONTEXT_AS_INPUT.test(comment)).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to #672, targeting its head branch.

## What was broken

**1. `@workglow/bootstrap` declared a third `bun` build target — deterministic red CI.**

`packages/bootstrap/src/bun.ts` was byte-identical to `src/node.ts` (`export * from "./common";`), so the `"bun"` export condition bought a second bundle and a second `.d.ts` to keep in sync for zero behavior change — exactly what the repo's "No `bun` entry unless it differs" rule exists to prevent.

That rule is enforced by a fixture, and the fixture is red on the branch as it stands:

```
FAIL src/test/util/BunExportConditions.test.ts > bun export conditions
     > exist only where the Bun implementation genuinely differs

+   "@workglow/bootstrap .",
    "@workglow/sqlite ./storage",
    "@workglow/util .",
    "@workglow/util ./worker",
```

This is not flaky and not environment-dependent — it reads `package.json` files off disk, so it fails on every run, for everyone, the moment this branch merges. `EXPECTED_BUN_CONDITIONS`, `.claude/CLAUDE.md`, and `docs/technical/19-build-system.md` all already state the correct three-entry set; the package manifest was the thing that was wrong, so the fixture and the prose are untouched.

**2. `"test": "bun test"` in a package with no test files.**

`bun --cwd packages/bootstrap test` exits 1 with `error: 0 test files matching`. It is the only `bun test` script in the repo: the 8 workspaces that declare `test` all use `vitest run --config ../../vitest.config.ts --project <name>`, and the 31 that have no tests omit the key entirely.

**3. `BootstrapReadme.test.ts` claimed to pin documents it never read.**

Its header said "Both halves are pinned below", but the file only reproduced the shapes in TypeScript. Nothing read `packages/bootstrap/README.md` or the `createOrchestrationContext` JSDoc, so either could rot back to `await task.run({ context: ctx })` — the bug the test was written for — with the suite still green.

## What changed

- **`packages/bootstrap/package.json`** — dropped `watch-bun` / `build-bun`, removed `bun` from the `watch-js` / `build-package` / `build-js` fan-outs, and deleted the `"bun"` branch from `exports["."]`. The `scripts` block and the exports map now match `packages/knowledge-base` (the two-target reference sibling) exactly. Also removed the `test` script.
- **`packages/bootstrap/src/bun.ts`** — deleted. Bun now resolves the default `"import"` condition to `dist/node.js`, which is the same code it was already running.
- **`packages/bootstrap/tsconfig.json`** — dropped `./src/bun.ts` from `files`.
- **`packages/test/src/test/util/BootstrapReadme.test.ts`** — kept both runtime cases, added a second `describe` that reads the README and the JSDoc: the README shows the registry in the run config, no README fence passes the context as an input override, and the JSDoc example matches. Fenced blocks are selected by *content* (`createOrchestrationContext(`) rather than by the heading above them, so renaming `### Isolated context` cannot make the cases pass vacuously.

No `CHANGELOG` entry: `0.3.38` is this package's unreleased initial release in the same PR, so the removed bun target never shipped.

## How it was verified

Run in an isolated worktree off this PR's head, with `bun install` + `bun run use-source`.

- `bun scripts/test.ts util vitest` — **55 files / 765 passed, 10 skipped.** Covers `BunExportConditions`, `BootstrapReadme`, and `BootstrapPackageExports`.
- **The fixture failure was reproduced first.** Restoring only the base branch's `packages/bootstrap/package.json` and re-running `BunExportConditions.test.ts` fails with the diff quoted above; restoring the fix makes it pass. `collectBunConditions()` now returns exactly the three expected entries.
- **The new document cases were proven to bite.** Temporarily reverting the README snippet to `await task.run({ context: ctx })` fails cases 1 and 2; doing the same to the `createOrchestrationContext` JSDoc fails case 3. Both were restored.
- `bun run build-clean && bun run build-package` in `packages/bootstrap` — browser, node and types all exit 0; `dist/` contains `browser.*`, `node.*`, `common.d.ts` and **no `bun.*`**.
- `bunx turbo run test --filter=@workglow/bootstrap` — exits 0; the dry plan shows `@workglow/bootstrap#test` resolving to `<NONEXISTENT>` (no task), confirming the removed script breaks nothing.
- `bun scripts/test.ts --check-sections` — "Every test file is discovered and reachable by section+kind selection."
- `eslint` and `prettier --check` clean on the changed files. (The first draft of `REGISTRY_IN_RUN_CONFIG` tripped `regexp/no-super-linear-backtracking` on an ambiguous `\s*,?\s*`; it is now `[\s,]*`.)

### Known trade-off

The "no README code block passes the context as an input override" case scans **every** fence, so an author adding a deliberate counter-example snippet would trip it. That is intentional and noted in the file's header comment — the README's existing counter-example is prose, which stays legal.

### Not verified here

`bun run test:vitest:unit` (the full CI job) was launched but had not finished at the time this description was written; the `util` section it contains — the one holding every changed and affected fixture — passed in full. Nothing outside `packages/bootstrap` and that one test file is touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_013oVdDSRMJeALBPLDQf3DgH)_