### PR TITLE
fix(tasks): enforce the network:private grant at execute time for webhook notify tasks

### DIFF
--- a/packages/tasks/README.md
+++ b/packages/tasks/README.md
@@ -189,7 +189,7 @@ const workflow = new Workflow()
 
 - Runs inline through the SSRF-aware `safeFetch` wrapper
 - **Redirects are refused** — a webhook that answers `3xx` fails rather than re-sending the payload and headers to the new origin. Point `url` at the final endpoint
-- **A private/internal destination is refused unless `allow_private_destination` is set** — which also declares the `network:private` entitlement, scoped to `url` when no credential key is configured. Without the flag the post fails with `PRIVATE_DENIED` before any request is made
+- **A private/internal destination is refused unless `allow_private_destination` is set** — which also declares the `network:private` entitlement, scoped to `url` when no credential key is configured. Without the flag the post fails with `PRIVATE_DENIED` before any request is made, and, when an entitlement enforcer is registered, the `network:private` grant is re-checked at execute time against the URL actually resolved — so a run-input or credential-supplied private destination cannot slip past the declaration the enforcer graded
 - A permitted private/internal destination is reachable but its response body is **never echoed** — `response` is always `""`. Notification needs no reply body, and returning one would make this task an SSRF read primitive (e.g. POSTing to a cloud metadata endpoint and reading the answer back into the graph)
 - 429/503 and 5xx raise `RetryableJobError`; retries require a `@workglow/job-queue` consumer, which these inline tasks do not have
 - Response bodies are read as a stream and abandoned past 1MB, so an endpoint answering with an unbounded body cannot exhaust runner memory — on the failure path too
@@ -247,7 +247,7 @@ const workflow = new Workflow().slackNotify({
 
 - Absent optional fields are omitted from the payload rather than sent as `null`
 - **Redirects are refused** — a webhook that answers `3xx` fails rather than re-sending the payload and headers to the new origin. Point `url` at the final endpoint
-- **A private/internal destination is refused unless `allow_private_destination` is set**, which also declares the `network:private` entitlement
+- **A private/internal destination is refused unless `allow_private_destination` is set**, which also declares the `network:private` entitlement, and, when an entitlement enforcer is registered, the `network:private` grant is re-checked at execute time against the URL actually resolved — so a run-input or credential-supplied private destination cannot slip past the declaration the enforcer graded
 - Slack answers `200` with the body `ok`; failure bodies (`invalid_payload`, `no_service`) are surfaced in the error message — but **only for a public destination**. A private/internal endpoint's reply body is never spliced into the error, which would otherwise make the task an SSRF read primitive; its status is still reported
 - **Channel-wide broadcasts in `text` and `blocks` are neutralized by default.** Slack has no `allowed_mentions`; its documented control is HTML-entity escaping, so the literal `<!` is escaped to `&lt;!`. That defuses `<!channel>`, `<!here>`, `<!everyone>` and `<!subteam^ID>` while leaving `<https://…|label>` links and single-user `<@U123>` mentions intact, and `link_names: false` is sent explicitly. `blocks` is walked to every string leaf, so a broadcast written inside a section, a `fields[]` entry or an `elements[]` entry is defused too. Set `allow_mentions: true` to send both verbatim
 - Requests time out after 30s by default (`timeout`)
@@ -304,7 +304,7 @@ const workflow = new Workflow().discordNotify({
 
 - A successful post answers `204 No Content`, so no response body is read or parsed
 - **Redirects are refused** — a webhook that answers `3xx` fails rather than re-sending the payload and headers to the new origin. Point `url` at the final endpoint
-- **A private/internal destination is refused unless `allow_private_destination` is set**, which also declares the `network:private` entitlement
+- **A private/internal destination is refused unless `allow_private_destination` is set**, which also declares the `network:private` entitlement, and, when an entitlement enforcer is registered, the `network:private` grant is re-checked at execute time against the URL actually resolved — so a run-input or credential-supplied private destination cannot slip past the declaration the enforcer graded
 - A failure body is surfaced in the error message **only for a public destination**; a private/internal endpoint's reply body is never spliced in, which would otherwise make the task an SSRF read primitive
 - Rate limits arrive as `429` and may carry the delay as `{"retry_after": <seconds>}` in the body instead of a `Retry-After` header; both are parsed onto the raised `RetryableJobError`. Nothing acts on the value — retries require a `@workglow/job-queue` consumer, which these inline tasks do not have
 - **Mass mentions are suppressed by default** — `allowed_mentions: { parse: [] }` is sent, so `@everyone`/`@here`, role and user pings in `content` do nothing even when the content was piped in from a fetch or a model. Set `allow_mentions: true` to let the message ping

--- a/packages/tasks/src/task/DiscordNotifyTask.ts
+++ b/packages/tasks/src/task/DiscordNotifyTask.ts
@@ -172,6 +172,7 @@ export class DiscordNotifyTask<
       headers: undefined,
       timeout: input.timeout,
       signal: context.signal,
+      registry: context.registry,
       readSuccessBody: false,
       includeBodyInError: true,
       retryAfterFromJsonBody: true,

--- a/packages/tasks/src/task/SlackNotifyTask.ts
+++ b/packages/tasks/src/task/SlackNotifyTask.ts
@@ -228,6 +228,7 @@ export class SlackNotifyTask<
       headers: undefined,
       timeout: input.timeout,
       signal: context.signal,
+      registry: context.registry,
       readSuccessBody: false,
       includeBodyInError: true,
       retryAfterFromJsonBody: false,

--- a/packages/tasks/src/task/WebhookNotifyTask.ts
+++ b/packages/tasks/src/task/WebhookNotifyTask.ts
@@ -156,6 +156,7 @@ export class WebhookNotifyTask<
       headers: input.headers,
       timeout: input.timeout,
       signal: context.signal,
+      registry: context.registry,
       readSuccessBody: !isPrivate,
       includeBodyInError: false,
       retryAfterFromJsonBody: false,

--- a/packages/tasks/src/util/WebhookPost.ts
+++ b/packages/tasks/src/util/WebhookPost.ts
@@ -22,7 +22,8 @@
 
 import { AbortSignalJobError } from "@workglow/job-queue";
 import type { TaskEntitlements } from "@workglow/task-graph";
-import { Entitlements, mergeEntitlements } from "@workglow/task-graph";
+import { ENTITLEMENT_ENFORCER, Entitlements, mergeEntitlements } from "@workglow/task-graph";
+import type { ServiceRegistry } from "@workglow/util";
 import { SECURITY_LIMITS } from "@workglow/util";
 import type { FetchUrlJobErrorInstance } from "../task/FetchUrlJobError";
 import {
@@ -236,11 +237,19 @@ export interface WebhookPostRequest {
   /**
    * The caller declared a private/internal destination is intended.
    *
-   * Without it a private destination is refused outright, so the
-   * `allowPrivate` flag handed to {@link safeFetch} is never self-derived from
-   * whatever the URL happened to resolve to.
+   * A declaration, not the authorization: it is what keeps the `allowPrivate`
+   * flag handed to {@link safeFetch} from being self-derived from whatever the
+   * URL happened to resolve to. The `network:private` grant is what authorizes
+   * the post, and it is re-checked against the resolved URL via
+   * {@link assertPrivateDestinationGranted}.
    */
   readonly allowPrivateDestination: boolean;
+  /**
+   * Registry the task is executing under. When it carries an
+   * {@link ENTITLEMENT_ENFORCER}, a private destination must hold a
+   * `network:private` grant for the URL actually resolved.
+   */
+  readonly registry: ServiceRegistry | undefined;
   /** Human-readable subject used in error messages, e.g. "Slack webhook". */
   readonly label: string;
 }
@@ -420,11 +429,53 @@ async function readBodyText(
 }
 
 /**
+ * Re-checks the `network:private` grant against the URL actually resolved.
+ *
+ * `allow_private_destination` is an input, and a graph root task's inputs are
+ * applied AFTER the runner evaluates entitlements — so the declaration the
+ * enforcer graded need not be the one `execute()` receives, and a
+ * credential-backed URL does not exist yet at that point either. The
+ * declaration is therefore advisory; this is the check that binds.
+ *
+ * No enforcer registered means no policy to satisfy, and the post proceeds.
+ */
+export async function assertPrivateDestinationGranted(
+  registry: ServiceRegistry | undefined,
+  url: string,
+  label: string
+): Promise<void> {
+  if (registry === undefined || !registry.has(ENTITLEMENT_ENFORCER)) {
+    return;
+  }
+  const denied = await registry.get(ENTITLEMENT_ENFORCER).checkAll({
+    entitlements: [
+      {
+        id: Entitlements.NETWORK_PRIVATE,
+        reason: `Posts ${label} to a private/internal destination`,
+        resources: [urlResourcePattern(url)],
+      },
+    ],
+  });
+  if (denied.length > 0) {
+    throw createFetchUrlJobError(
+      FetchUrlErrorCode.PRIVATE_DENIED,
+      `Refusing to post ${label} to a private/internal destination: the 'network:private' ` +
+        `entitlement is not granted for it.`,
+      { url: redactWebhookUrl(url) }
+    );
+  }
+}
+
+/**
  * POSTs `payload` as JSON to a webhook endpoint through {@link safeFetch}.
  *
  * Private/loopback destinations are refused unless the caller declared
  * `allowPrivateDestination`, which is what the `network:private` entitlement is
- * granted against. A permitted private destination additionally overrides
+ * granted against — and, when an enforcer is registered, that grant is
+ * re-checked here against the URL actually resolved
+ * ({@link assertPrivateDestinationGranted}), because the declaration graded at
+ * entitlement-evaluation time need not be the one `execute()` receives. A
+ * permitted private destination additionally overrides
  * `readSuccessBody` and `includeBodyInError` to `false`: those flags
  * are a ceiling set by the calling task, and no reply from an internal host is
  * ever surfaced — otherwise a notification task doubles as an SSRF read
@@ -455,6 +506,9 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
         `Set 'allow_private_destination' and grant the 'network:private' entitlement.`,
       { url: redactWebhookUrl(url) }
     );
+  }
+  if (isPrivate) {
+    await assertPrivateDestinationGranted(request.registry, url, label);
   }
   const timeoutSignal =
     request.timeout !== undefined && request.timeout > 0
@@ -579,6 +633,10 @@ export function webhookBaseEntitlements(reason: string): TaskEntitlements {
  * declaration is scoped to the `url` port when that port is the destination;
  * with a credential key the URL is unknown here, so the grant is unscoped and
  * says why.
+ *
+ * Only an explicit `false` opts out: a root task's run-input is applied after
+ * entitlements are evaluated, so an unset flag is "not yet knowable" and fails
+ * closed.
  */
 export function webhookPrivateEntitlements(
   base: TaskEntitlements,
@@ -600,7 +658,7 @@ export function webhookPrivateEntitlements(
         ],
       })
     : base;
-  if (allowPrivate !== true) {
+  if (allowPrivate === false) {
     return withCredential;
   }
   const scoped = !credentialWins && typeof url === "string" && url.length > 0;

--- a/packages/test/src/test/task/NotifyTask.test.ts
+++ b/packages/test/src/test/task/NotifyTask.test.ts
@@ -10,7 +10,16 @@ import {
   PermanentJobError,
   RetryableJobError,
 } from "@workglow/job-queue";
-import { TaskRegistry, Workflow } from "@workglow/task-graph";
+import {
+  createPolicyEnforcer,
+  createProfilePolicy,
+  ENTITLEMENT_ENFORCER,
+  Entitlements,
+  TaskGraph,
+  TaskGraphRunner,
+  TaskRegistry,
+  Workflow,
+} from "@workglow/task-graph";
 import {
   createFetchUrlJobError,
   createSafeFetchRedirectError,
@@ -26,7 +35,12 @@ import {
   type SafeFetchFn,
   type SafeFetchOptions,
 } from "@workglow/tasks";
-import { getGlobalCredentialStore, SECURITY_LIMITS } from "@workglow/util";
+import {
+  Container,
+  getGlobalCredentialStore,
+  SECURITY_LIMITS,
+  ServiceRegistry,
+} from "@workglow/util";
 import { validateSchema } from "@workglow/util/schema";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -545,7 +559,11 @@ describe("Webhook notification tasks", () => {
 
     test("a public URL needs no network:private entitlement", () => {
       const task = new WebhookNotifyTask();
-      task.runInputData = { url: WEBHOOK_URL, payload: {} } as any;
+      task.runInputData = {
+        url: WEBHOOK_URL,
+        payload: {},
+        allow_private_destination: false,
+      } as any;
       expect(requiresPrivate(task)).toBe(false);
     });
 
@@ -554,7 +572,11 @@ describe("Webhook notification tasks", () => {
     // driven by the DECLARATION, not by grading a URL that may be a decoy.
     test("a private URL alone declares no network:private", () => {
       const task = new WebhookNotifyTask();
-      task.runInputData = { url: "http://127.0.0.1:9200/ingest", payload: {} } as any;
+      task.runInputData = {
+        url: "http://127.0.0.1:9200/ingest",
+        payload: {},
+        allow_private_destination: false,
+      } as any;
       expect(requiresPrivate(task)).toBe(false);
     });
 
@@ -577,13 +599,30 @@ describe("Webhook notification tasks", () => {
         url: WEBHOOK_URL,
         payload: {},
         url_credential_key: "internal-hook",
+        allow_private_destination: false,
       } as any;
       expect(requiresPrivate(task)).toBe(false);
     });
 
     test("an absent url alone requires no network:private", () => {
       const task = new WebhookNotifyTask();
-      task.runInputData = { payload: {} } as any;
+      task.runInputData = { payload: {}, allow_private_destination: false } as any;
+      expect(requiresPrivate(task)).toBe(false);
+    });
+
+    // An unset flag means "not yet knowable" — a root task's run-input lands
+    // after entitlements are evaluated — so the declaration fails closed.
+    test("an unset allow_private_destination declares network:private", () => {
+      const task = new WebhookNotifyTask();
+      task.runInputData = { url: WEBHOOK_URL, payload: {} } as any;
+      expect(requiresPrivate(task)).toBe(true);
+    });
+
+    // The UX guarantee: an ordinary instance carries the schema default, so a
+    // public Slack/Discord/webhook post never demands network:private. Deleting
+    // `default: false` from the schema would break this.
+    test("the schema default keeps an ordinary instance off network:private", () => {
+      const task = new WebhookNotifyTask({ defaults: { url: WEBHOOK_URL, payload: {} } });
       expect(requiresPrivate(task)).toBe(false);
     });
 
@@ -1304,6 +1343,136 @@ describe("Webhook notification tasks", () => {
       expect(() => new SlackNotifyTask({ url: SLACK_URL, text: "hi" } as never)).toThrow();
       expect(() => new DiscordNotifyTask({ url: DISCORD_URL, content: "hi" } as never)).toThrow();
       expect(mockFetch.mock.calls.length).toBe(0);
+    });
+  });
+
+  describe("graph-root entitlement enforcement", () => {
+    const METADATA_URL = "http://169.254.169.254/latest/meta-data/";
+
+    /** Grants network:http and credential, but deliberately NOT network:private. */
+    function browserRegistry(): ServiceRegistry {
+      const registry = new ServiceRegistry(new Container());
+      registry.register(ENTITLEMENT_ENFORCER, () =>
+        createPolicyEnforcer(createProfilePolicy("browser"))
+      );
+      return registry;
+    }
+
+    beforeEach(() => {
+      registerCommonTasks();
+    });
+
+    // A root task's entitlements are graded BEFORE the graph run-input reaches
+    // it, so `allow_private_destination` supplied here was invisible to the
+    // enforcer. The grant, not the declaration, has to be what gates the post.
+    test("graph run-input cannot smuggle allow_private_destination past a denied network:private", async () => {
+      const graph = new TaskGraph();
+      graph.addTask(new WebhookNotifyTask({ id: "notify", defaults: { payload: { ping: true } } }));
+      const runner = new TaskGraphRunner(graph);
+
+      const error = await runner
+        .runGraph(
+          { url: METADATA_URL, allow_private_destination: true },
+          { registry: browserRegistry(), enforceEntitlements: true }
+        )
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(String((error as Error).message)).toContain("network:private");
+      expect(String((error as Error).message)).not.toContain("/latest/meta-data");
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    // The fix is a gate, not a blanket refusal: the same run succeeds once the
+    // destination is actually granted.
+    test("a granted network:private scope permits the same run", async () => {
+      const browserPolicy = createProfilePolicy("browser");
+      const registry = new ServiceRegistry(new Container());
+      registry.register(ENTITLEMENT_ENFORCER, () =>
+        createPolicyEnforcer({
+          deny: browserPolicy.deny,
+          grant: [
+            ...browserPolicy.grant,
+            { id: Entitlements.NETWORK_PRIVATE, resources: ["http://169.254.169.254/*"] },
+          ],
+          ask: browserPolicy.ask,
+        })
+      );
+
+      const graph = new TaskGraph();
+      graph.addTask(new WebhookNotifyTask({ id: "notify", defaults: { payload: { ping: true } } }));
+      const runner = new TaskGraphRunner(graph);
+
+      await expect(
+        runner.runGraph(
+          { url: METADATA_URL, allow_private_destination: true },
+          { registry, enforceEntitlements: true }
+        )
+      ).resolves.toBeDefined();
+      expect(lastCall().url).toBe(METADATA_URL);
+    });
+
+    test("a grant scoped elsewhere does not cover the resolved destination", async () => {
+      const browserPolicy = createProfilePolicy("browser");
+      const registry = new ServiceRegistry(new Container());
+      registry.register(ENTITLEMENT_ENFORCER, () =>
+        createPolicyEnforcer({
+          deny: browserPolicy.deny,
+          grant: [
+            ...browserPolicy.grant,
+            { id: Entitlements.NETWORK_PRIVATE, resources: ["http://localhost:*"] },
+          ],
+          ask: browserPolicy.ask,
+        })
+      );
+
+      const graph = new TaskGraph();
+      graph.addTask(new WebhookNotifyTask({ id: "notify", defaults: { payload: {} } }));
+      const runner = new TaskGraphRunner(graph);
+
+      const error = await runner
+        .runGraph(
+          { url: "http://127.0.0.1:9200/ingest", allow_private_destination: true },
+          { registry, enforceEntitlements: true }
+        )
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    // Declaration-time enforcement can never reach this case: the entitlement
+    // enforcer runs before the credential resolver, so the URL does not exist
+    // yet when the declaration is graded.
+    test("a credential-resolved private URL is checked against the grant", async () => {
+      const registry = browserRegistry();
+      // The store is per-registry, so seed the one this run will resolve from.
+      const store = getGlobalCredentialStore(registry);
+      await store.put("internal-hook", "http://127.0.0.1:9200/x");
+
+      const error = (await new WebhookNotifyTask()
+        .run(
+          { payload: {}, url_credential_key: "internal-hook", allow_private_destination: true },
+          { registry }
+        )
+        .catch((e: unknown) => e)
+        .finally(() => store.delete("internal-hook"))) as PermanentJobError;
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error.code).toBe(FetchUrlErrorCode.PRIVATE_DENIED);
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    // The contract is opt-in: with no enforcer registered there is no policy to
+    // satisfy, so behaviour is unchanged.
+    test("no registered enforcer leaves a declared private post working", async () => {
+      const result = await new WebhookNotifyTask().run(
+        { url: "http://127.0.0.1:9200/ingest", payload: {}, allow_private_destination: true },
+        { registry: new ServiceRegistry(new Container()) }
+      );
+
+      expect(result.status).toBe(200);
+      expect(lastCall().url).toBe("http://127.0.0.1:9200/ingest");
     });
   });
 });

--- a/packages/test/src/test/task/NotifyTask.test.ts
+++ b/packages/test/src/test/task/NotifyTask.test.ts
@@ -988,6 +988,66 @@ describe("Webhook notification tasks", () => {
     });
   });
 
+  // `allowPrivate` and `privateResourceScopes` are what the transport itself
+  // enforces against, so the arguments each task hands it are pinned here
+  // rather than being left implied by the outcome assertions above.
+  describe("safeFetch private-destination arguments", () => {
+    const PRIVATE_URL = "http://127.0.0.1:9200/ingest";
+
+    test("a public destination is fetched with allowPrivate false and no scopes", async () => {
+      await webhookNotify({ url: WEBHOOK_URL, payload: {} });
+
+      expect(lastCall().options.allowPrivate).toBe(false);
+      expect(lastCall().options.privateResourceScopes).toBeUndefined();
+    });
+
+    test("a declared private destination is scoped to its own origin", async () => {
+      await webhookNotify({
+        url: PRIVATE_URL,
+        payload: {},
+        allow_private_destination: true,
+      });
+
+      expect(lastCall().options.allowPrivate).toBe(true);
+      expect(lastCall().options.privateResourceScopes).toEqual(["http://127.0.0.1:9200/*"]);
+    });
+
+    // The DNS-rebinding invariant: the flag is a declaration about the
+    // destination, never a licence to widen the transport for a public
+    // hostname. A name that resolves into private space at connect time must
+    // still be refused there.
+    test("a public URL keeps allowPrivate false even when allow_private_destination is set", async () => {
+      await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: {},
+        allow_private_destination: true,
+      });
+
+      expect(lastCall().options.allowPrivate).toBe(false);
+      expect(lastCall().options.privateResourceScopes).toBeUndefined();
+    });
+
+    test("Slack and Discord share the same transport arguments", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+
+      await slackNotify({ url: PRIVATE_URL, text: "hi", allow_private_destination: true });
+      expect(lastCall().options.allowPrivate).toBe(true);
+      expect(lastCall().options.privateResourceScopes).toEqual(["http://127.0.0.1:9200/*"]);
+
+      await discordNotify({ url: PRIVATE_URL, content: "hi", allow_private_destination: true });
+      expect(lastCall().options.allowPrivate).toBe(true);
+      expect(lastCall().options.privateResourceScopes).toEqual(["http://127.0.0.1:9200/*"]);
+
+      await slackNotify({ url: SLACK_URL, text: "hi" });
+      expect(lastCall().options.allowPrivate).toBe(false);
+      expect(lastCall().options.privateResourceScopes).toBeUndefined();
+
+      await discordNotify({ url: DISCORD_URL, content: "hi" });
+      expect(lastCall().options.allowPrivate).toBe(false);
+      expect(lastCall().options.privateResourceScopes).toBeUndefined();
+    });
+  });
+
   describe("credential misconfiguration", () => {
     // Wiring a bearer token into `url_credential_key` is the likely mistake:
     // for these tasks the credential must BE the whole webhook URL.


### PR DESCRIPTION
**Stacks onto #678** — base is `claude/libs-issues-triage-prs-mh6x2o-241`, not `main`. Review after that PR.

## The SSRF

`allow_private_destination` is an **input**, and a graph **root** task's run-input is applied by `TaskRunner.run()` — strictly *after* `TaskGraphRunner` has already called `activeEnforcer.checkTask(task)` on `task.entitlements()`. The declaration the enforcer graded is therefore not necessarily the one `execute()` receives.

Concretely, under an enforcer that **denies** `network:private` (the `browser` profile grants `network:http`, `credential` and friends but deliberately not `network:private`):

```ts
const graph = new TaskGraph();
graph.addTask(new WebhookNotifyTask({ id: "notify", defaults: { payload: { ping: true } } }));

await new TaskGraphRunner(graph).runGraph(
  { url: "http://169.254.169.254/latest/meta-data/", allow_private_destination: true },
  { registry, enforceEntitlements: true }
);
```

...resolved successfully and posted to the cloud metadata endpoint. The task instance's `allow_private_destination` was still the schema default `false` when the enforcer graded it, so no `network:private` requirement was ever declared, and by the time `execute()` ran the flag was `true` and `postWebhookJson` had nothing left to consult. The same window is what makes a **credential-resolved** URL ungradeable at declaration time — the enforcer runs before the credential resolver, so the URL does not exist yet.

Reproduced first as a failing test: before the source change the metadata endpoint **was** posted to (`mockFetch` called once) and the run resolved.

## The fix

`postWebhookJson` now re-checks the `network:private` grant at execute time, against the URL **actually resolved**, using the registry the task is executing under (`context.registry`, threaded through by all three notify tasks). New exported helper `assertPrivateDestinationGranted` in `packages/tasks/src/util/WebhookPost.ts`; it throws `PRIVATE_DENIED` with the origin only (never the path — the webhook URL is the credential).

- No enforcer registered → no policy to satisfy → behaviour unchanged.
- Public destination → never checked.
- Private destination → must hold the grant, scoped to the destination's own origin (a broad grant still covers it via `grantCoversResources`).

Secondary, defence in depth: `webhookPrivateEntitlements` now opts out of declaring `network:private` only on an explicit `false` (was: only declared on an explicit `true`). The branch is unreachable while the three input schemas keep `default: false` — which is **retained deliberately**, since removing it would make every ordinary Slack/Discord/webhook post demand `network:private` — but it means a later removal of that default fails closed rather than open. The four existing `private-destination entitlements` tests that assign `runInputData` wholesale now pass `allow_private_destination: false` explicitly; their assertions are unchanged, and a new test pins that an ordinary instance carrying the schema default still needs no grant.

Also, the MEDIUM follow-up (test-only): the `allowPrivate` / `privateResourceScopes` arguments handed to `safeFetch` are now pinned directly, including the DNS-rebinding invariant that `allow_private_destination` never widens the transport for a public hostname.

## Behavioural caveats worth flagging

1. **A registered-but-unused enforcer now gates private posts.** An application that registers `ENTITLEMENT_ENFORCER` but runs with `enforceEntitlements: false` will see its private webhook posts checked where previously nothing was checked. `IExecuteContext` exposes no "enforcement is active this run" signal, so registry presence is the only available seam; adding such a field is deliberately out of scope here.
2. **An `ask` policy may be consulted twice.** The declaration-time check and this execute-time check are two `checkAll`/`checkTask` calls. `createPolicyEnforcer` consults `resolver.lookup` before prompting and saves the answer, so the second one is answered from cache rather than re-prompting — but implementations of `IEntitlementResolver` that do not cache would prompt again.

## Files

- `packages/tasks/src/util/WebhookPost.ts` — new `assertPrivateDestinationGranted`, `WebhookPostRequest.registry`, `!== false` tightening, doc updates
- `packages/tasks/src/task/{Webhook,Slack,Discord}NotifyTask.ts` — one line each, passing `context.registry`
- `packages/tasks/README.md` — three private-destination bullets updated
- `packages/test/src/test/task/NotifyTask.test.ts` — regression + companion tests

## Tests

- `bun scripts/test.ts task vitest` — 73 files, **1235 passed**, 24 skipped
- `bun scripts/test.ts graph vitest` — 126 files, **1088 passed**
- `bun run format`, `bun run build:types` clean

`NotifyTask.test.ts` goes from 79 to 89 tests. New coverage: run-input smuggling is refused with zero fetches; a granted scope permits the identical run (a gate, not a blanket refusal); a grant scoped elsewhere does not cover the destination; a credential-resolved private URL is checked (the case declaration-time enforcement can never reach); and no registered enforcer leaves a declared private post working.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDvMMv78PuEw4T5atLeJeS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDvMMv78PuEw4T5atLeJeS)_