### PR TITLE
fix(triggers): stop-event, change-baseline, hung-poll and skip-log defects

### DIFF
--- a/packages/test/src/test/trigger/IntervalTrigger.test.ts
+++ b/packages/test/src/test/trigger/IntervalTrigger.test.ts
@@ -6,6 +6,8 @@
 
 import type { ITriggerFireContext } from "@workglow/triggers";
 import { IntervalTrigger, TriggerConfigurationError } from "@workglow/triggers";
+import type { ILogger } from "@workglow/util";
+import { getLogger, setLogger } from "@workglow/util";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { advanceFakeTimers, flushAsyncWork } from "../helpers/advanceFakeTimers";
@@ -24,6 +26,38 @@ function createGate(): Gate {
     open = resolve;
   });
   return { promise, open };
+}
+
+interface WarnRecord {
+  readonly message: string;
+  readonly meta: Record<string, unknown> | undefined;
+}
+
+/**
+ * Installs a logger that records `warn` calls; returns the sink and a restore fn.
+ * Built from scratch rather than spread from the installed logger, whose methods
+ * live on a class prototype and would be lost.
+ */
+function captureWarnings(): { warnings: WarnRecord[]; restore: () => void } {
+  const warnings: WarnRecord[] = [];
+  const previous = getLogger();
+  const noop = (): void => {};
+  const logger: ILogger = {
+    debug: noop,
+    info: noop,
+    warn: (message: string, meta?: Record<string, unknown>) => {
+      warnings.push({ message, meta });
+    },
+    error: noop,
+    fatal: noop,
+    child: () => logger,
+    time: noop,
+    timeEnd: noop,
+    group: noop,
+    groupEnd: noop,
+  };
+  setLogger(logger);
+  return { warnings, restore: () => setLogger(previous) };
 }
 
 describe("IntervalTrigger", () => {
@@ -283,6 +317,93 @@ describe("IntervalTrigger", () => {
       expect(
         () => new IntervalTrigger({ intervalMs: PERIOD, overlap: "queue", maxQueuedFires: 0 })
       ).toThrow(TriggerConfigurationError);
+    });
+  });
+
+  describe("skip logging", () => {
+    test("a contiguous run of skips logs once, then a count when it ends", async () => {
+      // A wedged handler at a 1s period would otherwise write 3,600 identical
+      // warnings an hour, forever.
+      const { warnings, restore } = captureWarnings();
+      try {
+        const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+        const gate = createGate();
+        const skips: number[] = [];
+        trigger.on("skip", (scheduledAt) => skips.push(scheduledAt));
+        trigger.start(async () => {
+          await gate.promise;
+        });
+
+        await advanceFakeTimers(PERIOD);
+        await advanceFakeTimers(PERIOD * 4);
+
+        // The EVENT still fires per dropped tick; only the log is collapsed.
+        expect(skips).toHaveLength(4);
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]?.message).toContain("skipped");
+
+        gate.open();
+        await flushAsyncWork();
+        await advanceFakeTimers(PERIOD);
+
+        expect(warnings).toHaveLength(2);
+        expect(warnings[1]?.meta?.skipped).toBe(4);
+
+        await trigger.stop();
+      } finally {
+        restore();
+      }
+    });
+
+    test("an isolated skip logs once and adds no summary", async () => {
+      // The ordinary intermittent case must not have its log volume doubled.
+      const { warnings, restore } = captureWarnings();
+      try {
+        const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+        const gate = createGate();
+        const skips: number[] = [];
+        trigger.on("skip", (scheduledAt) => skips.push(scheduledAt));
+        trigger.start(async () => {
+          await gate.promise;
+        });
+
+        await advanceFakeTimers(PERIOD * 2);
+        expect(skips).toHaveLength(1);
+
+        gate.open();
+        await flushAsyncWork();
+        await advanceFakeTimers(PERIOD);
+
+        expect(warnings).toHaveLength(1);
+
+        await trigger.stop();
+      } finally {
+        restore();
+      }
+    });
+
+    test("stopping mid-skip still reports the skip count", async () => {
+      const { warnings, restore } = captureWarnings();
+      try {
+        const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+        const gate = createGate();
+        const skips: number[] = [];
+        trigger.on("skip", (scheduledAt) => skips.push(scheduledAt));
+        trigger.start(async () => {
+          await gate.promise;
+        });
+
+        await advanceFakeTimers(PERIOD * 4);
+        expect(skips).toHaveLength(3);
+
+        const stopping = trigger.stop();
+        expect(warnings.map((warning) => warning.meta?.skipped)).toContain(3);
+
+        gate.open();
+        await stopping;
+      } finally {
+        restore();
+      }
     });
   });
 

--- a/packages/test/src/test/trigger/IntervalTrigger.test.ts
+++ b/packages/test/src/test/trigger/IntervalTrigger.test.ts
@@ -515,6 +515,35 @@ describe("IntervalTrigger", () => {
       await trigger.stop();
     });
 
+    test("a restart during stop() does not emit stop while the trigger is running", async () => {
+      // An observer that sees `stop` while `running` is true concludes the
+      // trigger is dead and stops watching it — while it is actively firing.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const runningAtStop: boolean[] = [];
+      trigger.on("stop", () => runningAtStop.push(trigger.running));
+
+      trigger.start(async () => {
+        await gate.promise;
+      });
+      await advanceFakeTimers(PERIOD);
+
+      // NOT awaited: the gated gen-1 handler keeps the old run draining.
+      const stopping = trigger.stop();
+      trigger.start(() => {});
+
+      gate.open();
+      await stopping;
+
+      // Gen 1 drained, but gen 2 owns the trigger.
+      expect(runningAtStop).toEqual([]);
+      expect(trigger.running).toBe(true);
+
+      // ...and the real stop still reports itself.
+      await trigger.stop();
+      expect(runningAtStop).toEqual([false]);
+    });
+
     test("a restart during stop() does not emit spurious skips (skip policy)", async () => {
       // The first generation's handler is still gated when the second starts.
       // Overlap state belongs to a RUN, not to the trigger: if the new

--- a/packages/test/src/test/trigger/PollingTrigger.test.ts
+++ b/packages/test/src/test/trigger/PollingTrigger.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@workglow/triggers";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { advanceFakeTimers } from "../helpers/advanceFakeTimers";
+import { advanceFakeTimers, flushAsyncWork } from "../helpers/advanceFakeTimers";
 
 const START = Date.UTC(2026, 0, 1, 0, 0, 0);
 const PERIOD = 100;
@@ -210,6 +210,77 @@ describe("PollingTrigger", () => {
     // Poll 3 returns the same value poll 1 did, so change detection stays quiet.
     expect(payloads).toEqual(["steady"]);
     expect(trigger.lastResult).toBe("steady");
+
+    await trigger.stop();
+  });
+
+  test("a failed handler does not consume the change", async () => {
+    // At-most-once here is silent data loss: the update the handler failed on is
+    // never offered again, because the baseline already moved past it.
+    const results = ["a", "b", "b", "b"];
+    let polls = 0;
+    let failNext = true;
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      poll: () => results[polls++]!,
+      shouldFire: firesOnChange,
+    });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+
+    const payloads: string[] = [];
+    trigger.start((context) => {
+      payloads.push(context.payload as string);
+      if (context.payload === "b" && failNext) {
+        failNext = false;
+        throw new Error("sink down");
+      }
+    });
+
+    await advanceFakeTimers(PERIOD * 4);
+
+    // "b" is re-delivered on the next poll that still observes it, then settles.
+    expect(payloads).toEqual(["a", "b", "b"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toBe("sink down");
+    expect(trigger.lastResult).toBe("b");
+
+    await trigger.stop();
+  });
+
+  test("a failed handler does not resurrect a value a later tick already delivered", async () => {
+    // Under `concurrent`, a slow failing tick settles AFTER a newer one advanced
+    // the baseline. Restoring unconditionally would re-deliver a value that has
+    // already been handled successfully.
+    const results = ["a", "b", "c", "c"];
+    let polls = 0;
+    const gate = createGate();
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      overlap: "concurrent",
+      poll: () => results[polls++]!,
+      shouldFire: firesOnChange,
+    });
+    trigger.on("error", () => {});
+
+    const payloads: string[] = [];
+    trigger.start(async (context) => {
+      payloads.push(context.payload as string);
+      if (context.payload === "b") {
+        await gate.promise;
+        throw new Error("sink down");
+      }
+    });
+
+    await advanceFakeTimers(PERIOD * 3);
+    expect(payloads).toEqual(["a", "b", "c"]);
+
+    gate.open();
+    await flushAsyncWork();
+    await advanceFakeTimers(PERIOD);
+
+    expect(payloads).toEqual(["a", "b", "c"]);
+    expect(trigger.lastResult).toBe("c");
 
     await trigger.stop();
   });

--- a/packages/test/src/test/trigger/PollingTrigger.test.ts
+++ b/packages/test/src/test/trigger/PollingTrigger.test.ts
@@ -9,6 +9,7 @@ import {
   isNonEmptyPollResult,
   PollingTrigger,
   TriggerConfigurationError,
+  TriggerPollTimeoutError,
 } from "@workglow/triggers";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -481,6 +482,175 @@ describe("PollingTrigger", () => {
       expect(skips).toBe(0);
 
       await trigger.stop();
+    });
+  });
+
+  describe("pollTimeoutMs", () => {
+    // Deliberately not a multiple of PERIOD, so a deadline lands between ticks
+    // and the assertions do not depend on same-instant timer ordering.
+    const POLL_TIMEOUT = 250;
+
+    test("rejects an invalid pollTimeoutMs", () => {
+      expect(
+        () => new PollingTrigger({ intervalMs: PERIOD, poll: () => 1, pollTimeoutMs: 0 })
+      ).toThrow(TriggerConfigurationError);
+      expect(
+        () => new PollingTrigger({ intervalMs: PERIOD, poll: () => 1, pollTimeoutMs: 1.5 })
+      ).toThrow(TriggerConfigurationError);
+    });
+
+    test("a hung poll wedges the trigger when no timeout is configured", async () => {
+      // The default is unchanged, deliberately: a deadline nobody asked for
+      // would break a legitimately slow poll on upgrade. A hang is not a throw,
+      // so nothing reaches `error` and every later tick is dropped instead.
+      const trigger = new PollingTrigger<string>({
+        intervalMs: PERIOD,
+        poll: () => new Promise<string>(() => {}),
+      });
+      const errors: Error[] = [];
+      const payloads: unknown[] = [];
+      let skips = 0;
+      trigger.on("error", (error) => errors.push(error));
+      trigger.on("skip", () => {
+        skips += 1;
+      });
+      trigger.start((context) => {
+        payloads.push(context.payload);
+      });
+
+      await advanceFakeTimers(PERIOD * 5);
+
+      expect(errors).toEqual([]);
+      expect(skips).toBe(4);
+      expect(payloads).toEqual([]);
+      expect(trigger.running).toBe(true);
+
+      // Not stopped: `stop()` awaits the in-flight tick, and that tick is the
+      // pending poll — the same wedge, seen from the other side.
+    });
+
+    test("pollTimeoutMs fails a hung poll and the loop keeps going", async () => {
+      let polls = 0;
+      const trigger = new PollingTrigger<string>({
+        intervalMs: PERIOD,
+        pollTimeoutMs: POLL_TIMEOUT,
+        poll: () => {
+          polls += 1;
+          if (polls === 1) return new Promise<string>(() => {});
+          return "ok";
+        },
+      });
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      const payloads: unknown[] = [];
+      trigger.start((context) => {
+        payloads.push(context.payload);
+      });
+
+      // Poll 1 starts at START + PERIOD; its deadline is START + 350.
+      await advanceFakeTimers(PERIOD * 3);
+      expect(errors).toEqual([]);
+      expect(payloads).toEqual([]);
+
+      // 350 -> the deadline fires; 400 -> the next tick polls a healthy source.
+      await advanceFakeTimers(PERIOD);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(TriggerPollTimeoutError);
+      expect(payloads).toEqual(["ok"]);
+      expect(trigger.running).toBe(true);
+
+      await trigger.stop();
+    });
+
+    test("the deadline aborts the signal handed to the poll", async () => {
+      let observed: AbortSignal | undefined;
+      const trigger = new PollingTrigger<string>({
+        intervalMs: PERIOD,
+        pollTimeoutMs: POLL_TIMEOUT,
+        poll: (signal) => {
+          observed ??= signal;
+          return new Promise<string>((_resolve, reject) => {
+            signal.addEventListener("abort", () => reject(new Error("poll aborted")), {
+              once: true,
+            });
+          });
+        },
+      });
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      trigger.start(() => {});
+
+      await advanceFakeTimers(PERIOD * 4);
+
+      expect(observed?.aborted).toBe(true);
+      expect(observed?.reason).toBeInstanceOf(TriggerPollTimeoutError);
+      // The tick fails with the TIMEOUT, not with the poll's own abort error:
+      // a cooperative poll rejects synchronously on abort and would otherwise
+      // win the race with its own error, hiding why the tick failed.
+      expect(errors[0]).toBeInstanceOf(TriggerPollTimeoutError);
+
+      await trigger.stop();
+    });
+
+    test("stop() aborts an in-flight poll's signal when a timeout is configured", async () => {
+      let observed: AbortSignal | undefined;
+      const trigger = new PollingTrigger<string>({
+        intervalMs: PERIOD,
+        pollTimeoutMs: PERIOD * 10,
+        poll: (signal) => {
+          observed ??= signal;
+          return new Promise<string>((_resolve, reject) => {
+            signal.addEventListener("abort", () => reject(new Error("poll aborted")), {
+              once: true,
+            });
+          });
+        },
+      });
+      trigger.on("error", () => {});
+      trigger.start(() => {});
+
+      await advanceFakeTimers(PERIOD);
+      expect(observed?.aborted).toBe(false);
+
+      const stopping = trigger.stop();
+      // Synchronous, through the run controller the per-poll controller follows.
+      expect(observed?.aborted).toBe(true);
+
+      await stopping;
+      expect(trigger.running).toBe(false);
+      // The deadline timer was cleared rather than left to fire on a dead run.
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    test("a timed-out poll drives errorBackoff", async () => {
+      let polls = 0;
+      const trigger = new PollingTrigger<string>({
+        intervalMs: PERIOD,
+        pollTimeoutMs: POLL_TIMEOUT,
+        errorBackoff: { initialMs: PERIOD * 4, maxMs: PERIOD * 4 },
+        poll: () => {
+          polls += 1;
+          return new Promise<string>(() => {});
+        },
+      });
+      trigger.on("error", () => {});
+      trigger.start(() => {});
+
+      // The first deadline fires at START + 350: a timeout is a POLL failure.
+      await advanceFakeTimers(PERIOD * 4);
+      expect(trigger.consecutiveFailures).toBeGreaterThanOrEqual(1);
+
+      const polled = polls;
+      await advanceFakeTimers(PERIOD * 20);
+      // At the full rate that window is 20 polls; backed off it is a handful.
+      expect(polls - polled).toBeLessThan(10);
+
+      // This poll ignores its signal, so its DEADLINE is what releases the
+      // drain — which is also how a timeout bounds `stop()` on a hung poll.
+      const stopping = trigger.stop();
+      await advanceFakeTimers(POLL_TIMEOUT);
+      await stopping;
+      expect(trigger.running).toBe(false);
     });
   });
 

--- a/packages/triggers/README.md
+++ b/packages/triggers/README.md
@@ -72,7 +72,11 @@ scope exit.
   A fire past that bound is dropped and reported on `error`. When queueing is
   what you want, ask for it: `overlap: "queue"` with `maxQueuedFires`.
 - **Errors** — a handler rejection never stops the loop. It is emitted on
-  `error` as the real `Error` and logged through `getLogger()`.
+  `error` as the real `Error` and logged through `getLogger()`. A polling
+  handler that throws does not consume the change: the baseline is restored and
+  the value is offered again on the next poll that still observes it
+  (at-least-once, always with the freshest result — retries are paced by the
+  poll period, not by `errorBackoff`, which counts POLL failures only).
 - **Drift** — each tick is scheduled from the previous tick's scheduled instant,
   not from when its handler finished, so handler duration never accumulates.
   Waits longer than a timer's ~24.8-day ceiling are chunked.

--- a/packages/triggers/README.md
+++ b/packages/triggers/README.md
@@ -32,7 +32,7 @@ await trigger.stop();
 ## Driving a workflow
 
 ```ts
-import "@workglow/triggers"; // patches Workflow.prototype
+import { IntervalTrigger, PollingTrigger } from "@workglow/triggers"; // also patches Workflow.prototype
 import { Workflow } from "@workglow/task-graph";
 
 const workflow = new Workflow().addTask(MyTask);

--- a/packages/triggers/README.md
+++ b/packages/triggers/README.md
@@ -70,7 +70,9 @@ scope exit.
   cannot run re-entrantly — so `"concurrent"` plus a workflow binding degrades
   to queue semantics, bounded by the binding's `maxPendingFires` (default `1`).
   A fire past that bound is dropped and reported on `error`. When queueing is
-  what you want, ask for it: `overlap: "queue"` with `maxQueuedFires`.
+  what you want, ask for it: `overlap: "queue"` with `maxQueuedFires`. A dropped
+  tick emits `skip` every time; the accompanying log is collapsed to the first
+  skip of a contiguous run plus a count when the run ends.
 - **Errors** — a handler rejection never stops the loop. It is emitted on
   `error` as the real `Error` and logged through `getLogger()`. A polling
   handler that throws does not consume the change: the baseline is restored and

--- a/packages/triggers/README.md
+++ b/packages/triggers/README.md
@@ -77,6 +77,13 @@ scope exit.
   the value is offered again on the next poll that still observes it
   (at-least-once, always with the freshest result — retries are paced by the
   poll period, not by `errorBackoff`, which counts POLL failures only).
+- **Hung polls** — `poll` gets no deadline by default. Pass `pollTimeoutMs` to
+  bound one poll: exceeding it aborts the signal handed to `poll` and fails the
+  tick with a `TriggerPollTimeoutError`, which counts as a poll failure
+  (reported on `error`, and it drives `errorBackoff`). Without it, a `fetch`
+  against a black-holed host keeps the tick in flight forever, and under the
+  default `"skip"` policy every later tick is dropped — the trigger goes quiet
+  with nothing on `error`, because a hang is not a throw.
 - **Drift** — each tick is scheduled from the previous tick's scheduled instant,
   not from when its handler finished, so handler duration never accumulates.
   Waits longer than a timer's ~24.8-day ceiling are chunked.

--- a/packages/triggers/package.json
+++ b/packages/triggers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workglow/triggers",
   "type": "module",
-  "version": "0.3.37",
+  "version": "0.3.38",
   "repository": {
     "type": "git",
     "url": "https://github.com/workglow-dev/libs.git",

--- a/packages/triggers/src/trigger/BaseTrigger.ts
+++ b/packages/triggers/src/trigger/BaseTrigger.ts
@@ -292,9 +292,11 @@ export abstract class BaseTrigger implements ITrigger {
       await Promise.allSettled([...run.pending]);
     }
 
-    // A `start()` during the drain installed a newer run; clearing `_run` here
-    // would strand it.
-    if (this._run === run) this._run = undefined;
+    // A `start()` during the drain installed a newer run. Clearing `_run` here
+    // would strand it, and emitting `stop` would report a trigger that is
+    // actively firing as stopped.
+    if (this._run !== run) return;
+    this._run = undefined;
     this.safeEmit("stop");
   }
 

--- a/packages/triggers/src/trigger/BaseTrigger.ts
+++ b/packages/triggers/src/trigger/BaseTrigger.ts
@@ -75,6 +75,8 @@ export interface TriggerRun {
   timer: ReturnType<typeof setTimeout> | undefined;
   /** Handler invocations currently in flight. */
   inFlight: number;
+  /** Length of the current contiguous run of skipped ticks; 0 when not skipping. */
+  skipStreak: number;
   /** False from the moment `stop()` is entered; nothing new is scheduled after. */
   active: boolean;
   /** Detaches the caller-signal abort listener, when one was registered. */
@@ -187,6 +189,7 @@ export abstract class BaseTrigger implements ITrigger {
       pending: new Set(),
       timer: undefined,
       inFlight: 0,
+      skipStreak: 0,
       active: true,
       removeExternalAbort: undefined,
       stopping: undefined,
@@ -229,6 +232,7 @@ export abstract class BaseTrigger implements ITrigger {
     if (run.stopping) return run.stopping;
 
     run.active = false;
+    this.flushSkipStreak(run);
     if (run.timer !== undefined) {
       clearTimeout(run.timer);
       run.timer = undefined;
@@ -349,18 +353,15 @@ export abstract class BaseTrigger implements ITrigger {
   private dispatch(run: TriggerRun, scheduledAt: number): void {
     if (this.overlap !== "concurrent" && (run.inFlight > 0 || run.queued.length > 0)) {
       if (this.overlap === "queue" && run.queued.length < this.maxQueuedFires) {
+        this.flushSkipStreak(run);
         run.queued.push(scheduledAt);
         return;
       }
       this.safeEmit("skip", scheduledAt);
-      getLogger().warn("Trigger fire skipped; previous handler still running", {
-        triggerId: this.id,
-        kind: this.kind,
-        scheduledAt,
-        overlap: this.overlap,
-      });
+      this.noteSkip(run, scheduledAt);
       return;
     }
+    this.flushSkipStreak(run);
 
     // The microtask hop is load-bearing, not ceremony. Called directly,
     // `runTickChain` runs its whole synchronous prefix — the `fire` emit and the
@@ -378,6 +379,35 @@ export abstract class BaseTrigger implements ITrigger {
     // crashing a Node host whose only fault was a noisy listener. `stop()`
     // still awaits `chain` itself through `allSettled`.
     void chain.catch(() => {}).finally(() => run.pending.delete(chain));
+  }
+
+  /**
+   * Logs the FIRST skip of a contiguous run only. A handler wedged against a
+   * 1s period otherwise writes 3,600 identical warnings an hour, indefinitely;
+   * the count is reported once by {@link flushSkipStreak} when the run ends.
+   */
+  private noteSkip(run: TriggerRun, scheduledAt: number): void {
+    run.skipStreak += 1;
+    if (run.skipStreak > 1) return;
+    getLogger().warn("Trigger fire skipped; previous handler still running", {
+      triggerId: this.id,
+      kind: this.kind,
+      scheduledAt,
+      overlap: this.overlap,
+    });
+  }
+
+  /** Reports how long a contiguous run of skips lasted, once it ends. */
+  private flushSkipStreak(run: TriggerRun): void {
+    const skipped = run.skipStreak;
+    run.skipStreak = 0;
+    // A lone skip already logged everything there is to say.
+    if (skipped < 2) return;
+    getLogger().warn("Trigger fire skips ended", {
+      triggerId: this.id,
+      kind: this.kind,
+      skipped,
+    });
   }
 
   /**

--- a/packages/triggers/src/trigger/ITrigger.ts
+++ b/packages/triggers/src/trigger/ITrigger.ts
@@ -67,7 +67,11 @@ export type TriggerHandler = (context: ITriggerFireContext) => void | Promise<vo
 export type TriggerEventListeners = {
   /** The trigger began scheduling. */
   start: () => void;
-  /** The trigger stopped and any in-flight handler has settled. */
+  /**
+   * The trigger stopped and any in-flight handler has settled. Not emitted for a
+   * generation superseded by a `start()` during an un-awaited `stop()` drain —
+   * the trigger is running again, and the newer generation reports its own stop.
+   */
   stop: () => void;
   /** A handler invocation is about to begin. */
   fire: (context: ITriggerFireContext) => void;

--- a/packages/triggers/src/trigger/PollingTrigger.ts
+++ b/packages/triggers/src/trigger/PollingTrigger.ts
@@ -33,6 +33,8 @@ export function isNonEmptyPollResult(result: unknown): boolean {
  * Ready-made {@link PollResultPredicate} for change detection: fires when the
  * result differs from the previously polled one by `Object.is`. Reference
  * equality, so supply your own predicate when polling freshly-built objects.
+ * A change whose handler throws is offered again on the next poll that still
+ * observes it.
  */
 export function firesOnChange<Result>(result: Result, previous: Result | undefined): boolean {
   return !Object.is(result, previous);
@@ -92,6 +94,11 @@ export interface PollingTriggerOptions<Result> extends TriggerOptions {
  * previous result is left unchanged so the next comparison is against the last
  * value actually observed. Pass `errorBackoff` to slow the loop down while a
  * dependency stays down instead of polling it at full rate.
+ *
+ * A handler that throws does not consume the change: the comparison baseline is
+ * restored, so the next poll observing the same value fires again. Delivery is
+ * therefore at-least-once and always carries the freshest poll result — nothing
+ * is queued.
  */
 export class PollingTrigger<Result = unknown> extends BaseTrigger {
   public readonly kind = TRIGGER_KINDS.polling;
@@ -116,8 +123,9 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
   }
 
   /**
-   * Most recent result successfully polled by the CURRENT run, or `undefined`
-   * before its first poll and while the trigger is stopped.
+   * Change-detection baseline of the CURRENT run — the most recent successfully
+   * polled result whose delivery did not fail. `undefined` before the first poll
+   * and while the trigger is stopped.
    */
   public get lastResult(): Result | undefined {
     const run = this.currentRun;
@@ -161,12 +169,21 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
     const previous = state.previous;
     state.previous = result;
     if (!this._shouldFire(result, previous)) return;
-    await this.invokeHandler(run, {
-      triggerId: this.id,
-      scheduledAt,
-      signal,
-      payload: result,
-    });
+    try {
+      await this.invokeHandler(run, {
+        triggerId: this.id,
+        scheduledAt,
+        signal,
+        payload: result,
+      });
+    } catch (error) {
+      // A failed delivery must not consume the change: restore the baseline so
+      // the next poll of the same value still counts as one. Skipped when a
+      // later tick already advanced it (`overlap: "concurrent"`), which would
+      // otherwise resurrect a value that has since been delivered.
+      if (Object.is(state.previous, result)) state.previous = previous;
+      throw error;
+    }
   }
 
   private stateFor(run: TriggerRun): PollRunState<Result> {

--- a/packages/triggers/src/trigger/PollingTrigger.ts
+++ b/packages/triggers/src/trigger/PollingTrigger.ts
@@ -12,7 +12,7 @@ import {
   nextFixedIntervalFireTime,
 } from "./fixedInterval";
 import { TRIGGER_KINDS } from "./ITrigger";
-import { TriggerConfigurationError } from "./TriggerError";
+import { TriggerConfigurationError, TriggerPollTimeoutError } from "./TriggerError";
 
 /** Decides whether a poll result should fire the handler. */
 export type PollResultPredicate<Result> = (result: Result, previous: Result | undefined) => boolean;
@@ -82,6 +82,20 @@ export interface PollingTriggerOptions<Result> extends TriggerOptions {
    * fares. The counter resets on the first poll that does not throw.
    */
   readonly errorBackoff?: PollErrorBackoff | undefined;
+  /**
+   * Deadline for one poll, in milliseconds. A positive integer.
+   *
+   * Omitted (the default) means NO deadline: a poll that hangs — a `fetch`
+   * against a black-holed host is the usual way — keeps the tick in flight
+   * forever, so under `overlap: "skip"` every later tick is dropped and the
+   * trigger goes quiet with no `error` to show for it. A hang is not a throw,
+   * so `errorBackoff` never engages either.
+   *
+   * When set, exceeding it aborts the signal handed to `poll` and fails the
+   * tick with a {@link TriggerPollTimeoutError}, which counts as a poll failure
+   * — it is reported on `error` and drives `errorBackoff` like any other.
+   */
+  readonly pollTimeoutMs?: number | undefined;
 }
 
 /**
@@ -107,6 +121,7 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
   private readonly _poll: (signal: AbortSignal) => Result | Promise<Result>;
   private readonly _shouldFire: PollResultPredicate<Result>;
   private readonly _errorBackoff: PollErrorBackoff | undefined;
+  private readonly _pollTimeoutMs: number | undefined;
   private readonly _runState = new WeakMap<TriggerRun, PollRunState<Result>>();
 
   constructor(options: PollingTriggerOptions<Result>) {
@@ -120,6 +135,10 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
     this._errorBackoff = options.errorBackoff
       ? assertValidErrorBackoff(options.errorBackoff)
       : undefined;
+    this._pollTimeoutMs =
+      options.pollTimeoutMs === undefined
+        ? undefined
+        : assertValidPollTimeoutMs(options.pollTimeoutMs);
   }
 
   /**
@@ -156,7 +175,7 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
     const state = this.stateFor(run);
     let result: Result;
     try {
-      result = await this._poll(signal);
+      result = await this.pollOnce(run);
     } catch (error) {
       state.failures += 1;
       throw error;
@@ -186,6 +205,46 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
     }
   }
 
+  /**
+   * Races `poll` against its deadline. The race is what makes the timeout
+   * effective: a poll that ignores its signal never settles, so aborting alone
+   * would leave the tick in flight forever.
+   */
+  private async pollOnce(run: TriggerRun): Promise<Result> {
+    const timeoutMs = this._pollTimeoutMs;
+    if (timeoutMs === undefined) return await this._poll(run.signal);
+
+    const controller = new AbortController();
+    const onRunAbort = (): void => controller.abort(run.signal.reason);
+    if (run.signal.aborted) controller.abort(run.signal.reason);
+    else run.signal.addEventListener("abort", onRunAbort, { once: true });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const polled = Promise.resolve(this._poll(controller.signal));
+      // A poll that outlives the race still settles somewhere; without this the
+      // late rejection is an unhandledRejection that takes a Node host down.
+      polled.catch(() => {});
+      const deadline = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          const error = new TriggerPollTimeoutError(`Poll did not settle within ${timeoutMs}ms.`);
+          // Reject BEFORE aborting: a cooperative poll rejects synchronously on
+          // abort and would otherwise win the race with its own error, hiding
+          // the reason the tick failed.
+          reject(error);
+          controller.abort(error);
+        }, timeoutMs);
+        if (this.unrefTimer) {
+          (timer as unknown as { unref?: () => void }).unref?.();
+        }
+      });
+      return await Promise.race([polled, deadline]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+      run.signal.removeEventListener("abort", onRunAbort);
+    }
+  }
+
   private stateFor(run: TriggerRun): PollRunState<Result> {
     const existing = this._runState.get(run);
     if (existing) return existing;
@@ -193,6 +252,15 @@ export class PollingTrigger<Result = unknown> extends BaseTrigger {
     this._runState.set(run, created);
     return created;
   }
+}
+
+function assertValidPollTimeoutMs(pollTimeoutMs: number): number {
+  if (!Number.isInteger(pollTimeoutMs) || pollTimeoutMs <= 0) {
+    throw new TriggerConfigurationError(
+      `pollTimeoutMs must be a positive integer, received ${String(pollTimeoutMs)}.`
+    );
+  }
+  return pollTimeoutMs;
 }
 
 function assertValidErrorBackoff(backoff: PollErrorBackoff): PollErrorBackoff {

--- a/packages/triggers/src/trigger/TriggerError.ts
+++ b/packages/triggers/src/trigger/TriggerError.ts
@@ -16,6 +16,11 @@ export class TriggerConfigurationError extends TriggerError {
   public static override type = "TriggerConfigurationError";
 }
 
+/** Raised when a {@link PollingTrigger}'s poll exceeds `pollTimeoutMs`. */
+export class TriggerPollTimeoutError extends TriggerError {
+  public static override type = "TriggerPollTimeoutError";
+}
+
 /** Raised when a cron expression cannot be parsed. */
 export class CronExpressionError extends TriggerError {
   public static override type = "CronExpressionError";


### PR DESCRIPTION
Stacks onto **#679** (`claude/libs-issues-triage-prs-mh6x2o-237`), which introduces `@workglow/triggers`. This targets that feature branch, not `main`, so it can be merged into #679 before it lands.

Three MEDIUM defects found reviewing #679, plus two LOW chores. Because the package has not shipped, the API/semantics changes here land alongside its first published version — no consumer can observe the intermediate state, and no deprecation is ever needed.

## The defects

### 1. `stop` emitted for a generation superseded by a restart

`BaseTrigger.releaseWhenIdle` guarded the `_run` clear with an identity check but emitted `stop` unconditionally on the next line.

**Failure scenario.** A caller does `trigger.stop()` without awaiting it (or aborts a caller signal) and then `trigger.start(...)` — the ordinary "reconfigure and restart" shape. The old generation's handler is still in flight, so the drain completes later; when it does, it emits `stop` even though the new generation owns the trigger and is actively firing. An observer latched on `stop` concludes the trigger is dead and stops watching a live trigger; `trigger.running` reads `true` inside its own `stop` listener.

The emit now sits inside the same identity guard, after the clear, so a real stop still reports `running === false`. A superseded generation stays silent and the newer one reports its own stop. Every path reaching `releaseWhenIdle` was traced: the only behaviour change is the restart-mid-drain case.

### 2. `firesOnChange` loses a change when the handler throws

`PollingTrigger.runTick` assigned `state.previous = result` *before* awaiting the handler. A handler rejection propagates up to `runTickChain`, which reports it — leaving the advanced baseline in place.

**Failure scenario.** A change feed polls a source, sees `a -> b`, and the handler's sink is down for one call. `b` is never offered again: the next poll observes `b`, compares against a baseline that already reads `b`, and stays quiet. The update is lost silently, with nothing distinguishing "handled" from "dropped", and it is unrecoverable — `errorBackoff` counts *poll* failures only and never sees a handler rejection.

The baseline is now restored when delivery throws, making delivery at-least-once. Retries are paced by the poll period (no extra ticks, and the overlap policy still gates them) and always carry the *freshest* result — the restored baseline is the last value the handler accepted, so if the source moves `b -> c` while the sink is down, the next fire delivers `c`, not a queue of `b`s. The restore is skipped when a later tick already advanced the baseline (reachable under `overlap: "concurrent"`), which would otherwise resurrect a value that has since been delivered successfully.

### 3. A hung poll wedges the trigger, and every dropped tick warns

Two halves of the same incident.

**Failure scenario.** `poll` does a `fetch` against a black-holed host. It never settles and never throws, so: the tick stays in flight forever; under the default `overlap: "skip"` every later tick is dropped; `errorBackoff` never engages (a hang is not a throw); and nothing at all reaches the `error` event. The trigger simply goes quiet. Meanwhile each dropped tick writes its own identical warning — at a 1s period that is 3,600 lines an hour, indefinitely, burying whatever else the process had to say. `stop()` never resolves either, because it awaits the pending tick.

- **`pollTimeoutMs`** (new option) bounds one poll. Exceeding it aborts the signal handed to `poll` and fails the tick with a new `TriggerPollTimeoutError`, which counts as a poll failure — reported on `error`, and it drives `errorBackoff` like any other. The deadline is *raced* against the poll rather than merely signalled: a poll that ignores its signal never settles, so aborting alone would leave the tick in flight. Releasing the tick is also what un-wedges the skip branch and bounds `stop()`. The default stays `undefined` (no deadline), so a legitimately slow poll is not broken on upgrade — pinned by a characterization test.
- **Skip logging** is collapsed to the first skip of a contiguous run, plus one summary carrying the count when the run ends (or when the trigger is stopped mid-run). Net volume: one warning for an isolated skip, unchanged from before; two for a run of any length. The `skip` **event** still fires once per dropped tick — it is a programmatic signal with existing coverage, and collapsing it would be a semantic change.

## Chores

- `packages/triggers` was left at `0.3.37` while every other workspace is `0.3.38`. Dependents use `workspace:*`, so no lockfile change.
- The README "Driving a workflow" example imported the package for its side effect only and then used `IntervalTrigger` / `PollingTrigger` — copying it produced two `ReferenceError`s. Named imports patch `Workflow.prototype` just the same.

## Testing

Every regression test was written first and confirmed failing against the unfixed code:

| Test | Symptom before the fix |
| --- | --- |
| `a restart during stop() does not emit stop while the trigger is running` | `runningAtStop` is `[true]` |
| `a failed handler does not consume the change` | `payloads` is `["a", "b"]`, missing the redelivery |
| `rejects an invalid pollTimeoutMs` | no validation, nothing thrown |
| `pollTimeoutMs fails a hung poll and the loop keeps going` | zero errors, zero payloads — wedged |
| `the deadline aborts the signal handed to the poll` | signal never aborted |
| `a timed-out poll drives errorBackoff` | `consecutiveFailures` stays `0` |
| `a contiguous run of skips logs once, then a count when it ends` | 4 warnings instead of 1 |
| `stopping mid-skip still reports the skip count` | no summary warning |

Three further tests are guards that pass before **and** after, and would fail against a naive version of each fix: `a failed handler does not resurrect a value a later tick already delivered` (the `concurrent` baseline guard), `a hung poll wedges the trigger when no timeout is configured` (pins the opt-in default), and `an isolated skip logs once and adds no summary` (pins that the ordinary intermittent case does not double its log volume).

No existing test body was modified.

- `bun scripts/test.ts trigger vitest` — 5 files, **147 passed** (up from 135), run against a real `build:packages` output rather than source stubs
- `bun run test:vitest:unit` (full sweep) — 438 files passed / 2 skipped, **5194 passed / 47 skipped, 0 failed**
- `bun run build:types`, `bun run --filter @workglow/triggers lint`, `bun run format` — all clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDvMMv78PuEw4T5atLeJeS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDvMMv78PuEw4T5atLeJeS)_