### PR TITLE
usage: route a checkpoint's storage charge into the run total

### DIFF
--- a/examples/web/src/App.tsx
+++ b/examples/web/src/App.tsx
@@ -171,8 +171,9 @@ const setupWorkflow = async () => {
       console.error("Task graph error:", error.message, error.errors, error);
       throw error;
     } finally {
-      // Awaited so the last rows — including a checkpoint's storage charge,
-      // written during run-end scope disposal — are not lost to teardown.
+      // Awaited after run() resolves: run() owns the ResourceScope, so it has
+      // already disposed the run's checkpoints and their storage charges have
+      // been recorded by the time we detach.
       await detachUsage();
     }
   };

--- a/packages/ai/src/provider/CheckpointRegistry.ts
+++ b/packages/ai/src/provider/CheckpointRegistry.ts
@@ -40,6 +40,11 @@ export interface CheckpointEntry {
  * a chained emit supersedes its parent inline, and the run's `ResourceScope`
  * disposes whatever is left at run end. Keying the sink to the checkpoint id
  * makes the charge reach the minter from any of those sites.
+ *
+ * Every implementation routes through the minting task's `chargeLateUsage`,
+ * which folds the charge into that task's total and into the run total. Run-end
+ * disposal happens after the run's usage has settled, so the charge is the one
+ * kind of spend that arrives late and still has to be counted.
  */
 export type CheckpointUsageSink = (usage: Usage, modelId: string | undefined) => void;
 

--- a/packages/ai/src/task/AiChatTask.ts
+++ b/packages/ai/src/task/AiChatTask.ts
@@ -13,7 +13,7 @@ import type {
 } from "@workglow/task-graph";
 import { mergeUsage, TaskConfigSchema, USAGE_OUTPUT_KEY } from "@workglow/task-graph";
 import type { IHumanRequest } from "@workglow/util";
-import { DEFAULT_LIMITS, getLogger, resolveHumanConnector } from "@workglow/util";
+import { DEFAULT_LIMITS, resolveHumanConnector } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 import { recordUsageTelemetry } from "../capability/UsageTelemetry";
@@ -351,13 +351,7 @@ export class AiChatTask extends StreamingAiTask<AiChatTaskInput, AiChatTaskOutpu
 
     if (context.resourceScope && this._sessionId) {
       const sessionId = this._sessionId;
-      setCheckpointUsageSink(sessionId, (usage, modelId) => {
-        try {
-          this.emit("usage", usage, modelId);
-        } catch (err) {
-          getLogger().error("usage listener threw", { taskId: this.id, error: err });
-        }
-      });
+      setCheckpointUsageSink(sessionId, (usage, modelId) => this.chargeLateUsage(usage, modelId));
       context.resourceScope.register(`ai:session:${sessionId}`, async () => {
         await disposeCheckpoint(sessionId, model.provider);
       });

--- a/packages/ai/src/task/AiChatWithKbTask.ts
+++ b/packages/ai/src/task/AiChatWithKbTask.ts
@@ -15,7 +15,7 @@ import type {
 } from "@workglow/task-graph";
 import { mergeUsage, TaskConfigSchema, USAGE_OUTPUT_KEY } from "@workglow/task-graph";
 import type { IHumanRequest } from "@workglow/util";
-import { DEFAULT_LIMITS, getLogger, resolveHumanConnector } from "@workglow/util";
+import { DEFAULT_LIMITS, resolveHumanConnector } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 import { recordUsageTelemetry } from "../capability/UsageTelemetry";
@@ -422,13 +422,7 @@ export class AiChatWithKbTask extends StreamingAiTask<
 
     if (context.resourceScope && this._sessionId) {
       const sessionId = this._sessionId;
-      setCheckpointUsageSink(sessionId, (usage, modelId) => {
-        try {
-          this.emit("usage", usage, modelId);
-        } catch (err) {
-          getLogger().error("usage listener threw", { taskId: this.id, error: err });
-        }
-      });
+      setCheckpointUsageSink(sessionId, (usage, modelId) => this.chargeLateUsage(usage, modelId));
       context.resourceScope.register(`ai:session:${sessionId}`, async () => {
         await disposeCheckpoint(sessionId, model.provider);
       });

--- a/packages/ai/src/task/CacheCheckpointTask.ts
+++ b/packages/ai/src/task/CacheCheckpointTask.ts
@@ -6,7 +6,6 @@
 
 import type { CachePolicy, IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, TaskConfigurationError, Workflow } from "@workglow/task-graph";
-import { getLogger } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 import type { AiJobInput } from "../job/AiJob";
@@ -167,16 +166,10 @@ export class CacheCheckpointTask extends AiTask<
       ...(input.checkpoint ? { parentId: input.checkpoint } : {}),
     });
 
-    // Attribute this checkpoint's eventual storage charge to this task, whoever
-    // ends up disposing it — a chained emit supersedes and disposes it inline,
-    // which is not this disposer.
-    setCheckpointUsageSink(id, (usage, modelId) => {
-      try {
-        this.emit("usage", usage, modelId);
-      } catch (err) {
-        getLogger().error("usage listener threw", { taskId: this.id, error: err });
-      }
-    });
+    // Attribute this checkpoint's eventual storage charge to this task — and
+    // through it to the run total — whoever ends up disposing it: a chained
+    // emit supersedes and disposes it inline, which is not this disposer.
+    setCheckpointUsageSink(id, (usage, modelId) => this.chargeLateUsage(usage, modelId));
 
     if (context.resourceScope) {
       context.resourceScope.register(`ai:session:${id}`, async () => {

--- a/packages/ai/src/task/TextGenerationTask.ts
+++ b/packages/ai/src/task/TextGenerationTask.ts
@@ -12,7 +12,6 @@ import type {
   TaskConfig,
 } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
-import { getLogger } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 import type { AiJobInput } from "../job/AiJob";
@@ -190,15 +189,12 @@ export class TextGenerationTask extends StreamingAiTask<
     });
   }
 
-  /** Reports an emitted checkpoint's disposal-time storage charge as this task's usage. */
+  /**
+   * Reports an emitted checkpoint's disposal-time storage charge as this
+   * task's usage, and through it into the run total.
+   */
   private storageChargeSink(): CheckpointUsageSink {
-    return (usage, modelId) => {
-      try {
-        this.emit("usage", usage, modelId);
-      } catch (err) {
-        getLogger().error("usage listener threw", { taskId: this.id, error: err });
-      }
-    };
+    return (usage, modelId) => this.chargeLateUsage(usage, modelId);
   }
 
   private async finalizeCheckpoint(input: TextGenerationTaskInput, text: string): Promise<void> {

--- a/packages/ai/src/task/ToolCallingTask.ts
+++ b/packages/ai/src/task/ToolCallingTask.ts
@@ -14,7 +14,7 @@ import type {
   TaskConfig,
 } from "@workglow/task-graph";
 import type { ServiceRegistry } from "@workglow/util";
-import { getLogger, makeFingerprint } from "@workglow/util";
+import { makeFingerprint } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 import type { AiJobInput } from "../job/AiJob";
@@ -434,15 +434,12 @@ export class ToolCallingTask extends StreamingAiTask<
     }
   }
 
-  /** Reports an emitted checkpoint's disposal-time storage charge as this task's usage. */
+  /**
+   * Reports an emitted checkpoint's disposal-time storage charge as this
+   * task's usage, and through it into the run total.
+   */
   private storageChargeSink(): CheckpointUsageSink {
-    return (usage, modelId) => {
-      try {
-        this.emit("usage", usage, modelId);
-      } catch (err) {
-        getLogger().error("usage listener threw", { taskId: this.id, error: err });
-      }
-    };
+    return (usage, modelId) => this.chargeLateUsage(usage, modelId);
   }
 
   private async finalizeCheckpoint(

--- a/packages/ai/src/task/__tests__/CacheCheckpoint.test.ts
+++ b/packages/ai/src/task/__tests__/CacheCheckpoint.test.ts
@@ -32,6 +32,7 @@ import {
 } from "@workglow/ai";
 import { clearCheckpoints as clearCheckpointsForTesting } from "@workglow/ai/test";
 import type { IExecuteContext, StreamEvent, TaskOutput, Usage } from "@workglow/task-graph";
+import { TaskGraph, TaskGraphRunner } from "@workglow/task-graph";
 import { Container, HUMAN_CONNECTOR, ResourceScope, ServiceRegistry } from "@workglow/util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -455,6 +456,61 @@ describe("CacheCheckpointTask storage-cost emission at disposal", () => {
     // Three checkpoints, three charges — one each, none double-counted.
     expect(charges.map((c) => c.length)).toEqual([1, 1, 1]);
     for (const seen of charges) expect(seen[0]).toBeCloseTo(500_000, 6);
+  });
+});
+
+describe("CacheCheckpointTask storage cost inside a graph", () => {
+  // Same shape as the standalone suite above: disposal reports what a billed
+  // server-side cache released.
+  class BillingCheckpointProvider extends CheckpointTestProvider {
+    override async disposeSession(_sessionId: string): Promise<{
+      tokens: number | undefined;
+      lifetimeMs: number;
+    }> {
+      return { tokens: 500_000, lifetimeMs: 3_600_000 };
+    }
+  }
+
+  const billingWarmupFn: AiProviderRunFn = async (
+    _input,
+    _model,
+    _signal,
+    emit,
+    _schema,
+    session
+  ) => {
+    emit({
+      type: "finish",
+      data: { checkpoint: session?.sessionId ?? "" },
+    } as unknown as StreamEvent<TaskOutput>);
+  };
+
+  afterEach(() => {
+    setAiProviderRegistry(new AiProviderRegistry());
+  });
+
+  it("charges the run total for a checkpoint disposed at run end", async () => {
+    setAiProviderRegistry(new AiProviderRegistry());
+    const provider = new BillingCheckpointProvider([
+      { serves: CACHE_CHECKPOINT as Capability[], runFn: billingWarmupFn },
+    ]);
+    await provider.register({ queue: { autoCreate: false } });
+
+    const graph = new TaskGraph();
+    graph.addTask(
+      new CacheCheckpointTask({
+        id: "warm",
+        defaults: { model: checkpointModel(), systemPrompt: "sys" },
+      })
+    );
+
+    // runGraph owns the ResourceScope, so it disposes the checkpoint — and
+    // therefore learns its storage charge — after the run's usage has settled.
+    await new TaskGraphRunner(graph).runGraph();
+
+    expect(graph.runUsage?.extra?.[CACHE_STORAGE_TOKEN_HOURS_KEY]).toBeCloseTo(500_000, 6);
+    const byModel = graph.usageAggregator.byModel().get(checkpointModel().model_id!);
+    expect(byModel?.extra?.[CACHE_STORAGE_TOKEN_HOURS_KEY]).toBeCloseTo(500_000, 6);
   });
 });
 

--- a/packages/task-graph/src/storage/attachUsageRecorder.ts
+++ b/packages/task-graph/src/storage/attachUsageRecorder.ts
@@ -25,9 +25,11 @@ type RunUsageStorage = ITabularStorage<typeof RunUsageSchema, typeof RunUsagePri
  * snapshots still writes once. Nothing is recorded unless a caller attaches
  * this; the graph itself only emits.
  *
- * The returned detach awaits writes still in flight, so a caller that tears down
- * at run end does not lose the last rows. Attach it to the run's ResourceScope
- * ordering *after* checkpoint disposal, whose own late row is written then.
+ * The returned detach awaits writes still in flight, so a caller that tears
+ * down at run end does not lose the last rows. A checkpoint's storage charge is
+ * only known when the run's ResourceScope disposes it, so detach AFTER that
+ * disposal: `runGraph` awaits it before resolving when it owns the scope, but a
+ * caller-owned scope must be disposed by the caller first or its row is lost.
  */
 export function attachUsageRecorder(
   aggregator: GraphUsageAggregator,

--- a/packages/task-graph/src/task-graph/GraphUsageAggregator.ts
+++ b/packages/task-graph/src/task-graph/GraphUsageAggregator.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getLogger } from "@workglow/util";
 import type { Usage } from "../task/StreamTypes";
 import { mergeUsage } from "../task/StreamTypes";
 
@@ -144,6 +145,20 @@ export class GraphUsageAggregator {
     for (const taskId of [...this.live.keys()]) this.retire(taskId);
   }
 
+  /**
+   * Add a charge that settles after its execution finished — provider cache
+   * storage, billed at disposal. Merged into the retired totals rather than
+   * replacing a bucket: unlike a `usage` snapshot this is a delta, and the
+   * execution it belongs to was retired long before it arrived.
+   */
+  chargeLate(taskId: string, usage: Usage, modelId: string | undefined): void {
+    const key = modelKey(modelId);
+    this.retired = mergeUsage(this.retired, usage);
+    this.retiredByTask.set(taskId, mergeUsage(this.retiredByTask.get(taskId), usage) ?? usage);
+    this.retiredByModel.set(key, mergeUsage(this.retiredByModel.get(key), usage) ?? usage);
+    this.notifyRetire({ taskId, modelId, usage });
+  }
+
   private retireBucket(taskId: string, key: ModelKey): void {
     const models = this.live.get(taskId);
     const row = models?.get(key);
@@ -156,7 +171,21 @@ export class GraphUsageAggregator {
       mergeUsage(this.retiredByTask.get(taskId), row.usage) ?? row.usage
     );
     this.retiredByModel.set(key, mergeUsage(this.retiredByModel.get(key), row.usage) ?? row.usage);
-    for (const cb of this.retireListeners) cb(row);
+    this.notifyRetire(row);
+  }
+
+  /**
+   * A telemetry subscriber that throws must not take down the run that
+   * produced the numbers, nor starve the subscribers registered after it.
+   */
+  private notifyRetire(row: RetiredUsage): void {
+    for (const cb of this.retireListeners) {
+      try {
+        cb(row);
+      } catch (err) {
+        getLogger().error("usage retire listener threw", { taskId: row.taskId, error: err });
+      }
+    }
   }
 }
 

--- a/packages/task-graph/src/task-graph/StreamPump.ts
+++ b/packages/task-graph/src/task-graph/StreamPump.ts
@@ -9,7 +9,7 @@ import { getLogger } from "@workglow/util";
 import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import { BackpressureGate } from "../task/BackpressureGate";
 import type { ITask } from "../task/ITask";
-import type { StreamEvent, StreamMode } from "../task/StreamTypes";
+import type { StreamEvent, StreamMode, Usage } from "../task/StreamTypes";
 import {
   DEFAULT_BINARY_HIGH_WATER_BYTES,
   DEFAULT_STREAM_GATE_WATCHDOG_MS,
@@ -46,6 +46,8 @@ export interface StreamingRunOptions {
   readonly registry: ServiceRegistry;
   readonly outputCache: TaskOutputRepository | undefined;
   readonly resourceScope: ResourceScope | undefined;
+  /** Where a charge that settles after a task finished lands. */
+  readonly lateUsageSink?: (taskId: string, usage: Usage, modelId: string | undefined) => void;
   readonly accumulateLeafOutputs: boolean;
   /**
    * Opt-in to the no-accumulation passthrough path for this run. Off ⇒ every
@@ -334,6 +336,7 @@ export class StreamPump {
         updateProgress: options.updateProgress,
         registry: options.registry,
         resourceScope: options.resourceScope,
+        lateUsageSink: options.lateUsageSink,
         runId: options.runId,
         noAccumulation: options.noAccumulation,
         streamHighWaterBytes: options.streamHighWaterBytes,

--- a/packages/task-graph/src/task-graph/TaskGraph.ts
+++ b/packages/task-graph/src/task-graph/TaskGraph.ts
@@ -8,7 +8,7 @@ import type { IDisposeStrategy, ResourceScope, ServiceRegistry } from "@workglow
 import { EventEmitter, uuid4 } from "@workglow/util";
 import { DirectedAcyclicGraph } from "@workglow/util/graph";
 import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
-import type { ITask } from "../task/ITask";
+import type { IRunConfig, ITask } from "../task/ITask";
 import type { StreamEvent, Usage } from "../task/StreamTypes";
 import type { TaskEntitlements } from "../task/TaskEntitlements";
 import type { JsonTaskItem, TaskGraphJson, TaskGraphJsonOptions } from "../task/TaskJSON";
@@ -104,6 +104,9 @@ export interface TaskGraphRunConfig {
 
   /** Same semantics as on {@link IRunConfig}. */
   disposeStrategy?: IDisposeStrategy;
+
+  /** Same semantics as on {@link IRunConfig}. */
+  lateUsageSink?: IRunConfig["lateUsageSink"];
 
   /**
    * Stable identifier for this logical run. When provided, the graph runner

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -21,6 +21,7 @@ import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import { TASK_OUTPUT_REPOSITORY } from "../storage/TaskOutputRepository";
 import { ENTITLEMENT_ENFORCER, formatEntitlementDenial } from "../task/EntitlementEnforcer";
 import type { ITask } from "../task/ITask";
+import type { Usage } from "../task/StreamTypes";
 import { isTaskStreamable } from "../task/StreamTypes";
 import { Task } from "../task/Task";
 import type { TaskError } from "../task/TaskError";
@@ -138,6 +139,12 @@ export class TaskGraphRunner {
   protected resourceScope?: ResourceScope;
 
   /**
+   * Where a late charge from a task in this run lands. Installed by
+   * handleStart, inheriting an outer run's sink when this is a subgraph run.
+   */
+  protected lateUsageSink?: (taskId: string, usage: Usage, modelId: string | undefined) => void;
+
+  /**
    * Per-run state. Set by handleStart, cleared by handleComplete/Error/Abort.
    * The only mutable per-run state on the facade — exists so the public abort()
    * and disable() methods (which take no arguments) have something to act on.
@@ -160,13 +167,27 @@ export class TaskGraphRunner {
   protected baseRegistryForRun?: ServiceRegistry;
 
   /**
-   * Unsubscribes the current run's graph-level `task_usage` / `task_complete`
-   * listeners feeding {@link TaskGraph.usageAggregator}. The graph's event
-   * emitter outlives a single run, so handleStart tears down the previous
-   * run's pair before installing a fresh one — otherwise re-running the same
-   * graph instance would accumulate one duplicate listener pair per run.
+   * Unsubscribes everything the current run installed to feed
+   * {@link TaskGraph.usageAggregator}. The graph's event emitter outlives a
+   * single run, so handleStart tears down the previous run's set before
+   * installing a fresh one — otherwise re-running the same graph instance
+   * would accumulate one duplicate set per run.
+   *
+   * Wider than {@link offLiveUsageSubscriptions}: the aggregator's retire
+   * listener deliberately outlives the settle, so only the next run's start
+   * can detach it.
    */
   protected offGraphUsageSubscriptions?: () => void;
+
+  /**
+   * Unsubscribes just the `task_usage` / `task_complete` pair — the listeners
+   * that must not survive {@link settleRunUsage}, since a cumulative snapshot
+   * folding in after the freeze would contradict `graph.runUsage`.
+   */
+  protected offLiveUsageSubscriptions?: () => void;
+
+  /** True once {@link settleRunUsage} has frozen `graph.runUsage` for this run. */
+  protected runUsageSettled = false;
 
   /**
    * Registry to restore after a preview run completes. Captured in
@@ -536,6 +557,7 @@ export class TaskGraphRunner {
         registry: this.registry,
         outputCache: this.outputCache,
         resourceScope: this.resourceScope,
+        lateUsageSink: this.lateUsageSink,
         accumulateLeafOutputs: this.accumulateLeafOutputs,
         noAccumulation: this.noAccumulation,
         streamHighWaterBytes: this.streamHighWaterBytes,
@@ -568,6 +590,7 @@ export class TaskGraphRunner {
         await this.runScheduler.handleProgress(this.currentCtx!, task, progress, message, ...args),
       registry: this.registry,
       resourceScope: this.resourceScope,
+      lateUsageSink: this.lateUsageSink,
       runId: this.runId,
     });
 
@@ -644,6 +667,12 @@ export class TaskGraphRunner {
     if (config?.resourceScope !== undefined) {
       this.resourceScope = config.resourceScope;
     }
+    // Inherit the outer run's sink when one was passed (a subgraph run), so a
+    // nested task's late charge reaches the root run's aggregator rather than
+    // an inner aggregator whose run is already over.
+    this.lateUsageSink =
+      config?.lateUsageSink ??
+      ((taskId, usage, modelId) => this.graph.usageAggregator.chargeLate(taskId, usage, modelId));
     this.baseRegistryForRun = this.registry;
 
     // Store run identifier for per-task propagation.
@@ -784,11 +813,18 @@ export class TaskGraphRunner {
     // Tear down the previous run's graph-level usage subscriptions (if this
     // graph instance is being re-run) before installing a fresh aggregator.
     this.offGraphUsageSubscriptions?.();
+    this.offLiveUsageSubscriptions = undefined;
+    this.runUsageSettled = false;
     this.graph.usageAggregator.reset();
     this.graph.runUsage = undefined;
     const offRetire = this.graph.usageAggregator.onRetire(() => {
       const total = this.graph.usageAggregator.total;
-      if (total) this.graph.emit("graph_usage", total);
+      if (!total) return;
+      // A charge settled after the run (checkpoint storage, billed at
+      // disposal) still belongs to this run's total, so re-freeze rather than
+      // emit a `graph_usage` contradicting `graph.runUsage`.
+      if (this.runUsageSettled) this.graph.runUsage = total;
+      this.graph.emit("graph_usage", total);
     });
 
     const offTaskUsage = this.graph.subscribe("task_usage", (taskId, usage, modelId) => {
@@ -799,9 +835,13 @@ export class TaskGraphRunner {
     const offTaskComplete = this.graph.subscribe("task_complete", (taskId) => {
       this.graph.usageAggregator.retire(String(taskId));
     });
-    this.offGraphUsageSubscriptions = () => {
+    this.offLiveUsageSubscriptions = () => {
       offTaskUsage();
       offTaskComplete();
+    };
+    this.offGraphUsageSubscriptions = () => {
+      this.offLiveUsageSubscriptions?.();
+      this.offLiveUsageSubscriptions = undefined;
       offRetire();
     };
 
@@ -896,19 +936,22 @@ export class TaskGraphRunner {
 
   /**
    * Retire what is still live, freeze the run total, and detach this run's
-   * listeners.
+   * live listeners.
    *
-   * Detaching here rather than at the next run's start matters because the
-   * aggregator now outlives a run: a `task_usage` arriving after the total is
-   * frozen would otherwise still fold in and emit a `graph_usage` contradicting
-   * `graph.runUsage`. Order is load-bearing — the sweep's retirements must fire
-   * the listener before it goes.
+   * Only the `task_usage` / `task_complete` pair goes: a cumulative snapshot
+   * arriving after the freeze would fold in and emit a `graph_usage`
+   * contradicting `graph.runUsage`. The aggregator's retire listener stays,
+   * because a checkpoint's storage charge is only known when the run's
+   * ResourceScope disposes it — after this point — and it re-freezes
+   * `graph.runUsage` when it lands. Order is load-bearing: the sweep's
+   * retirements must fire the listener before the live pair goes.
    */
   protected settleRunUsage(): void {
     this.graph.usageAggregator.sweep();
     this.graph.runUsage = this.graph.usageAggregator.total;
-    this.offGraphUsageSubscriptions?.();
-    this.offGraphUsageSubscriptions = undefined;
+    this.offLiveUsageSubscriptions?.();
+    this.offLiveUsageSubscriptions = undefined;
+    this.runUsageSettled = true;
   }
 
   protected async handleComplete(): Promise<void> {

--- a/packages/task-graph/src/task-graph/__tests__/GraphUsageAggregator.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/GraphUsageAggregator.test.ts
@@ -170,3 +170,90 @@ describe("GraphUsageAggregator", () => {
     expect(rows).toContainEqual({ taskId: "foo", modelId: "bar baz", usage: usage(100, 20) });
   });
 });
+
+/** A provider cache-storage charge: no counters, one `extra` figure. */
+const storageCharge = (tokenHours: number): Usage => ({
+  input: undefined,
+  output: undefined,
+  cached: undefined,
+  cacheWrite: undefined,
+  reasoning: undefined,
+  total: undefined,
+  extra: { cacheStorageTokenHours: tokenHours },
+});
+
+describe("chargeLate", () => {
+  it("adds a late charge to the run total instead of replacing a bucket", () => {
+    const agg = new GraphUsageAggregator();
+    agg.observe("t1", usage(100, 20), "m");
+    agg.retire("t1");
+
+    agg.chargeLate("t1", storageCharge(500_000), "m");
+
+    // A late charge is a delta against an execution that is already over, so
+    // it merges. Routing it through `observe` would replace the retired
+    // execution's real counters with a bucket that has none.
+    expect(agg.total?.input).toBe(100);
+    expect(agg.total?.output).toBe(20);
+    expect(agg.total?.extra?.cacheStorageTokenHours).toBe(500_000);
+  });
+
+  it("files a late charge under the same task and model buckets", () => {
+    const agg = new GraphUsageAggregator();
+    agg.observe("t1", usage(100, 20), "m");
+    agg.retire("t1");
+
+    agg.chargeLate("t1", storageCharge(500_000), "m");
+
+    const byTask = agg.byTask().get("t1");
+    expect(byTask?.input).toBe(100);
+    expect(byTask?.extra?.cacheStorageTokenHours).toBe(500_000);
+    const byModel = agg.byModel().get("m");
+    expect(byModel?.input).toBe(100);
+    expect(byModel?.extra?.cacheStorageTokenHours).toBe(500_000);
+  });
+
+  it("notifies retire subscribers so a recorder writes a row for it", () => {
+    const agg = new GraphUsageAggregator();
+    const rows: RetiredUsage[] = [];
+    agg.onRetire((row) => rows.push(row));
+
+    agg.chargeLate("t1", storageCharge(500_000), "m");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.taskId).toBe("t1");
+    expect(rows[0]!.modelId).toBe("m");
+    expect(rows[0]!.usage.extra?.cacheStorageTokenHours).toBe(500_000);
+  });
+});
+
+describe("a throwing retire subscriber", () => {
+  it("does not fail the sweep when a listener throws", () => {
+    const agg = new GraphUsageAggregator();
+    const seen: RetiredUsage[] = [];
+    agg.onRetire(() => {
+      throw new Error("recorder blew up");
+    });
+    agg.onRetire((row) => seen.push(row));
+
+    agg.observe("t1", usage(10, 1), "m");
+
+    // One misbehaving telemetry subscriber must not take down the run that
+    // produced the numbers, nor starve the subscribers registered after it.
+    expect(() => agg.sweep()).not.toThrow();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.taskId).toBe("t1");
+  });
+
+  it("does not fail a late charge when a listener throws", () => {
+    const agg = new GraphUsageAggregator();
+    const seen: RetiredUsage[] = [];
+    agg.onRetire(() => {
+      throw new Error("recorder blew up");
+    });
+    agg.onRetire((row) => seen.push(row));
+
+    expect(() => agg.chargeLate("t1", storageCharge(1), "m")).not.toThrow();
+    expect(seen).toHaveLength(1);
+  });
+});

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -284,6 +284,14 @@ export interface IRunConfig {
   disposeStrategy?: IDisposeStrategy;
 
   /**
+   * Where a charge that settles after a task finished (provider cache storage,
+   * billed at disposal) is added to the run total. Threaded like
+   * `resourceScope`: a nested run inherits the outer run's sink, so a charge
+   * from a subgraph task reaches the root run's aggregator.
+   */
+  lateUsageSink?: (taskId: string, usage: Usage, modelId: string | undefined) => void;
+
+  /**
    * When true, check entitlements via the registered IEntitlementEnforcer
    * before graph execution begins. Throws TaskEntitlementError if denied.
    * Default: false (entitlements are declarative only, not enforced by the engine).
@@ -355,6 +363,12 @@ export interface ITaskLifecycle<
   get runner(): TaskRunner<Input, Output, Config>;
   abort(): void;
   disable(): Promise<void>;
+
+  /**
+   * Report a charge that settles after this task finished. Folded into the
+   * task total and the run total; see {@link IRunConfig.lateUsageSink}.
+   */
+  chargeLateUsage(usage: Usage, modelId: string | undefined): void;
 }
 
 export interface ITaskIO<Input extends TaskInput> {

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -13,6 +13,7 @@ import { DATAFLOW_ALL_PORTS } from "../task-graph/Dataflow";
 import { TaskGraph } from "../task-graph/TaskGraph";
 import type { IExecuteContext, IExecutePreviewContext, IRunConfig, ITask } from "./ITask";
 import type { Usage } from "./StreamTypes";
+import { mergeUsage } from "./StreamTypes";
 import { collectCacheVersion, isDeterministicId, resolveCachePolicy } from "./TaskCacheOps";
 import { smartClone, stripSymbols } from "./TaskCloneOps";
 import { EMPTY_ENTITLEMENTS, type TaskEntitlements } from "./TaskEntitlements";
@@ -228,6 +229,33 @@ export class Task<
 
   public async disable(): Promise<void> {
     await this.runner.disable();
+  }
+
+  /**
+   * Report a charge that settles after this execution finished — provider
+   * cache storage, billed when the checkpoint is disposed. Folded into this
+   * task's total and forwarded to the run's sink.
+   */
+  public chargeLateUsage(usage: Usage, modelId: string | undefined): void {
+    // While this task is executing again, StreamProcessor owns runUsage and the
+    // graph is still observing this task's cumulative `usage` events; folding
+    // the charge in there as well as into the run total would count it twice.
+    const live = this.status === TaskStatus.PROCESSING || this.status === TaskStatus.STREAMING;
+    if (!live) {
+      const total = mergeUsage(this.runUsage, usage);
+      this.runUsage = total;
+      if (total) {
+        try {
+          // The merged cumulative total, not the bare charge: the `usage`
+          // contract is replace-not-accumulate, so a delta blanks every
+          // consumer's display.
+          this.emit("usage", total, modelId ?? this.runUsageModelId);
+        } catch (err) {
+          getLogger().error("usage listener threw", { taskId: this.id, error: err });
+        }
+      }
+    }
+    this.runner.reportLateUsage(usage, modelId);
   }
 
   // ========================================================================

--- a/packages/task-graph/src/task/TaskEvents.ts
+++ b/packages/task-graph/src/task/TaskEvents.ts
@@ -43,6 +43,10 @@ export type TaskEventListeners = {
    * the per-model-call stream event it is derived from — so consumers replace
    * rather than accumulate. `modelId` is the model that produced this update, or
    * `undefined` when the provider did not name one.
+   *
+   * A charge that settles after the task finished (provider cache storage,
+   * billed at disposal) re-emits the new cumulative total, so replace still
+   * holds.
    */
   usage: (usage: Usage, modelId: string | undefined) => void;
 

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -27,7 +27,7 @@ import type { IRunConfig, ITask } from "./ITask";
 import type { ITaskRunner } from "./ITaskRunner";
 import type { BinaryRefSink, StreamSink } from "./StreamProcessor";
 import { StreamProcessor } from "./StreamProcessor";
-import type { StreamEvent } from "./StreamTypes";
+import type { StreamEvent, Usage } from "./StreamTypes";
 import {
   getBinaryPortFormat,
   getOutputStreamMode,
@@ -141,6 +141,13 @@ export class TaskRunner<
   protected registry: ServiceRegistry = globalServiceRegistry;
 
   protected resourceScope?: ResourceScope;
+
+  /**
+   * Where a charge that settles after this run finished is reported. Not
+   * cleared in `run()`'s `finally` — the whole point is that it fires after
+   * the run; the next `handleStart` overwrites it.
+   */
+  protected lateUsageSink?: (taskId: string, usage: Usage, modelId: string | undefined) => void;
 
   /**
    * True when `this.resourceScope` was auto-created by `run()` (caller did not
@@ -798,21 +805,37 @@ export class TaskRunner<
     this.currentCtx?.abortController.abort();
   }
 
+  /** @internal Forwards a post-completion charge to the run's usage sink. */
+  public reportLateUsage(usage: Usage, modelId: string | undefined): void {
+    try {
+      this.lateUsageSink?.(String(this.task.id), usage, modelId);
+    } catch (err) {
+      getLogger().error("late usage sink threw", { taskId: this.task.id, error: err });
+    }
+  }
+
   /**
-   * Stream-pacing options retained from the current run's config (resolved in
+   * Run options retained from the current run's config (resolved in
    * handleStart), in the shape both `TaskGraphRunConfig` and {@link IRunConfig}
    * accept. Compound tasks spread this into their subgraph runs so nested
-   * graphs inherit the caller's passthrough opt-in, high-water mark, and
-   * watchdog.
+   * graphs inherit the caller's passthrough opt-in, high-water mark, watchdog,
+   * and late-usage sink.
+   *
+   * `lateUsageSink` rides here rather than being threaded per call site
+   * because every nested-run site already spreads this — including
+   * `GraphAsTask.executeStream`, which threads neither `registry` nor
+   * `resourceScope` and would otherwise leave a streaming subgraph's late
+   * charge in an inner aggregator the root run never reads.
    */
   public get streamRunOptions(): Pick<
     IRunConfig,
-    "noAccumulation" | "streamHighWaterBytes" | "streamGateWatchdogMs"
+    "noAccumulation" | "streamHighWaterBytes" | "streamGateWatchdogMs" | "lateUsageSink"
   > {
     return {
       noAccumulation: this.noAccumulation,
       streamHighWaterBytes: this.streamHighWaterBytes,
       streamGateWatchdogMs: this.streamGateWatchdogMs,
+      lateUsageSink: this.lateUsageSink,
     };
   }
 
@@ -884,6 +907,10 @@ export class TaskRunner<
       const stamp: Partial<IRunConfig> = {
         registry: this.registry,
         signal: this.currentCtx?.abortController.signal,
+        // Unconditional, unlike `resourceScope`: a sink has no disposal
+        // lifetime to leak, and an owned child's own `task.run()` needs it to
+        // reach the run total.
+        lateUsageSink: this.lateUsageSink,
       };
       if (!this.ownsResourceScope) {
         stamp.resourceScope = this.resourceScope;
@@ -1084,6 +1111,10 @@ export class TaskRunner<
 
     if (config.resourceScope) {
       this.resourceScope = config.resourceScope;
+    }
+
+    if (config.lateUsageSink) {
+      this.lateUsageSink = config.lateUsageSink;
     }
 
     // Notify the disposal strategy that a new run is starting. Inactivity

--- a/packages/task-graph/src/task/__tests__/TaskUsageEvent.test.ts
+++ b/packages/task-graph/src/task/__tests__/TaskUsageEvent.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import type { IExecuteContext } from "../ITask";
 import type { StreamEvent, Usage } from "../StreamTypes";
 import { Task } from "../Task";
+import { TaskStatus } from "../TaskTypes";
 
 const usage = (input: number, output: number): Usage => ({
   input,
@@ -85,5 +86,53 @@ describe("the task-level usage event", () => {
 
     // Not zero: nothing reported is a different fact from nothing spent.
     expect(task.runUsage).toBe(undefined);
+  });
+});
+
+/** A provider cache-storage charge: no counters, one `extra` figure. */
+const storageCharge: Usage = {
+  input: undefined,
+  output: undefined,
+  cached: undefined,
+  cacheWrite: undefined,
+  reasoning: undefined,
+  total: undefined,
+  extra: { cacheStorageTokenHours: 500_000 },
+};
+
+describe("a charge that settles after the task finished", () => {
+  it("emits the merged cumulative total for a late charge, not the bare delta", () => {
+    const task = new UsageStreamTask({});
+    task.runUsage = usage(100, 20);
+    const seen: Usage[] = [];
+    task.subscribe("usage", (u) => seen.push(u));
+
+    task.chargeLateUsage(storageCharge, "m");
+
+    // The `usage` contract is "cumulative, replace not accumulate". Emitting
+    // the bare delta makes every consumer that replaces (useTaskUsage) blank
+    // its display at exactly the moment the run ends.
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.input).toBe(100);
+    expect(seen[0]!.output).toBe(20);
+    expect(seen[0]!.extra?.cacheStorageTokenHours).toBe(500_000);
+    expect(task.runUsage?.extra?.cacheStorageTokenHours).toBe(500_000);
+  });
+
+  it("skips the task-level emit while the task is executing again", () => {
+    const task = new UsageStreamTask({});
+    task.runUsage = usage(100, 20);
+    const seen: Usage[] = [];
+    task.subscribe("usage", (u) => seen.push(u));
+    task.status = TaskStatus.PROCESSING;
+
+    task.chargeLateUsage(storageCharge, "m");
+
+    // A loop that mints a checkpoint on iteration N and supersedes it on N+1
+    // disposes the parent mid-execution. StreamProcessor owns runUsage then,
+    // and the graph is still observing this task's cumulative snapshots, so
+    // folding the charge in here as well as into the run total counts twice.
+    expect(seen).toHaveLength(0);
+    expect(task.runUsage?.extra).toBe(undefined);
   });
 });

--- a/packages/test/src/test/task-graph/GraphUsageWiring.test.ts
+++ b/packages/test/src/test/task-graph/GraphUsageWiring.test.ts
@@ -5,7 +5,7 @@
  */
 
 import type { IExecuteContext, StreamEvent, Usage } from "@workglow/task-graph";
-import { Task, TaskGraph, TaskGraphRunner } from "@workglow/task-graph";
+import { GraphAsTask, Task, TaskGraph, TaskGraphRunner } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { describe, expect, it } from "vitest";
 
@@ -91,5 +91,101 @@ describe("graph-level usage wiring", () => {
     // listener reading graph.runUsage from inside its `complete` handler sees
     // the settled total rather than undefined.
     expect(runUsageAtComplete).toEqual(usage(10, 5));
+  });
+});
+
+/** A provider cache-storage charge: no counters, one `extra` figure. */
+const storageCharge: Usage = {
+  input: undefined,
+  output: undefined,
+  cached: undefined,
+  cacheWrite: undefined,
+  reasoning: undefined,
+  total: undefined,
+  extra: { cacheStorageTokenHours: 500_000 },
+};
+
+/**
+ * Stands in for a task that mints a provider cache checkpoint: it reports its
+ * generation spend during the run, and the charge for holding the cache is
+ * only known when the run's ResourceScope disposes the session at run end —
+ * long after this task's own `usage` subscription was torn down.
+ */
+class LateChargingTask extends Task<Record<string, never>, { text: string }> {
+  static override readonly type = "LateChargingTask";
+  static override readonly category = "Test";
+  static override readonly title = "Late charging task";
+  static override readonly description = "Reports a storage charge at scope disposal.";
+  static override readonly cacheable = false;
+
+  static override inputSchema(): DataPortSchema {
+    return { type: "object", properties: {}, additionalProperties: false } as const;
+  }
+
+  static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+      required: ["text"],
+      additionalProperties: false,
+    } as const;
+  }
+
+  override async execute(): Promise<{ text: string }> {
+    return { text: "" };
+  }
+
+  async *executeStream(
+    _input: Record<string, never>,
+    context: IExecuteContext
+  ): AsyncGenerator<StreamEvent> {
+    context.resourceScope!.register(`late:${String(this.id)}`, async () => {
+      this.chargeLateUsage(storageCharge, "m");
+    });
+    yield { type: "finish", data: {} as Record<string, never>, usage: usage(10, 5) };
+  }
+}
+
+describe("a charge that settles after the run", () => {
+  it("adds a disposal-time charge to graph.runUsage and graph_usage", async () => {
+    const graph = new TaskGraph();
+    graph.addTask(new LateChargingTask({ id: "t1" }));
+    const graphUsageEvents: Usage[] = [];
+    graph.subscribe("graph_usage", (total) => graphUsageEvents.push(total));
+
+    // runGraph owns the ResourceScope here, so it disposes the checkpoint and
+    // awaits that disposal before resolving.
+    await new TaskGraphRunner(graph).runGraph();
+
+    expect(graph.runUsage?.input).toBe(10);
+    expect(graph.runUsage?.output).toBe(5);
+    expect(graph.runUsage?.extra?.cacheStorageTokenHours).toBe(500_000);
+    expect(graphUsageEvents.at(-1)?.extra?.cacheStorageTokenHours).toBe(500_000);
+  });
+
+  it("counts a late charge once, not once per usage event", async () => {
+    const graph = new TaskGraph();
+    graph.addTask(new LateChargingTask({ id: "t1" }));
+
+    await new TaskGraphRunner(graph).runGraph();
+
+    // The charge is a delta merged into the retired bucket. Re-emitting it as
+    // a cumulative task snapshot as well would fold it in a second time.
+    expect(graph.usageAggregator.byTask().get("t1")?.extra?.cacheStorageTokenHours).toBe(500_000);
+  });
+
+  it("rolls a nested task's late charge up to the root run total", async () => {
+    const inner = new TaskGraph();
+    inner.addTask(new LateChargingTask({ id: "inner-1" }));
+    const outer = new TaskGraph();
+    outer.addTask(new GraphAsTask({ id: "compound", subGraph: inner }));
+
+    await new TaskGraphRunner(outer).runGraph();
+
+    // The subgraph's own aggregator settled when the compound task finished,
+    // so a charge arriving after that has to reach the ROOT run's aggregator.
+    // Only an inherited sink can do it — the subgraph event bridge is already
+    // torn down by then.
+    expect(outer.runUsage?.extra?.cacheStorageTokenHours).toBe(500_000);
   });
 });


### PR DESCRIPTION
**Stacked on #737** (`claude/optimistic-goldberg-gzrguj-usage-cleanup`), which is itself stacked on #735. Review/merge in that order — the diff below is only this PR's commit.

## The defect

A provider cache checkpoint is billed for **how long it is held**. Gemini's `CachedContent` is priced per **token-hour**: a 500,000-token prefix held for the duration of a one-hour run is 500,000 token-hours of storage, on top of the input/output tokens the generation itself spent. `disposeCheckpoint` already computes exactly that figure (`cacheStorageUsage(tokens, lifetimeMs)`) from what the provider reports at disposal.

**That charge is currently dropped entirely.** It never reaches `graph.runUsage`, never reaches the `graph_usage` event the `UsageStatus` display and the CLI progress UI render, and never reaches a `run_usage` row. Every one of them understates the run by the whole storage cost of every checkpoint it held — and understates it *silently*, because a checkpoint that is never disposed mid-run produces no row and no warning, just a smaller number.

Three independent reasons, each sufficient on its own:

1. **`RunScheduler`** unsubscribes its per-task `usage` → graph `task_usage` forwarder in the task's own `finally` (`RunScheduler.ts:337`), long before any disposal.
2. **`settleRunUsage()`** froze `graph.runUsage` and detached *every* graph-level usage subscription, called from `handleComplete` — which runs before `runGraph`'s `finally` awaits `resourceScope.runComplete()`, the moment every surviving checkpoint is disposed.
3. Even had the event arrived, **`GraphUsageAggregator.observe` replaces** the live bucket, and a storage charge carries only `extra.cacheStorageTokenHours` with every counter `undefined`. It would have wiped the task's real `input`/`output`, and `formatUsage` returns `""` for a usage with no counter set — which is why the CLI usage row goes blank at run end.

## The fix

### A late-charge channel that outlives the task subscription

`GraphUsageAggregator.chargeLate(taskId, usage, modelId)` **merges** into the retired totals and notifies retire listeners.

Deliberately a separate method from `observe`, not a second use of it: `observe` is documented and implemented as replace-because-cumulative. Feeding a delta through it either corrupts the task's real counters (reason 3 above) or forces `observe` to become mode-dependent, at which point every caller has to know which mode it is in.

A third graph event (`storage_charge`) was considered and rejected: `attachUsageRecorder` and the `graph_usage` bridge both subscribe to `onRetire`, and a late charge *is* "one more finished, chargeable unit of spend" with the same `RetiredUsage` row shape. A separate event would need both consumers duplicated.

Delivery from `@workglow/ai` is a **run-scoped sink threaded through `IRunConfig`**, mirroring `resourceScope`. That is the only route correct for all three shapes: a top-level task reaches the graph's own aggregator; a task nested in a `GraphAsTask`/`While`/`Iterator` subgraph inherits the outer sink so the charge lands in the **root** aggregator (the `SubGraphEventBridge` forwarding is torn down when the compound task finishes, so an event-based route structurally cannot reach it); a standalone `task.run()` has no graph sink and folds the charge into `task.runUsage` only.

The sink rides on `TaskRunner.streamRunOptions`, which **all six** nested-run sites already spread. That covers `GraphAsTask.executeStream` — the streaming compound path, which threads neither `registry` nor `resourceScope` and so would have been missed by a per-call-site threading of the two non-streaming runners. A test pinning the nested rollup caught this.

### A split settle, not a moved one

`settleRunUsage()` still runs exactly where it did, so `graph.runUsage` is correct when `complete` fires (pinned by an existing test that is untouched). What changed is *which* subscriptions it detaches:

- the **live** pair (`task_usage`, `task_complete`) is detached at settle, as before — a stray cumulative snapshot after the freeze must not fold in;
- the aggregator's **retire → `graph_usage`** listener survives until the next run's `handleStart` (which already tears down the previous run's subscriptions first thing), and once the run has settled it also re-freezes `graph.runUsage`.

**New behaviour worth knowing: a `graph_usage` event can now fire *after* `complete`, carrying a larger total.** This is the whole point — the run's real cost is not knowable until its checkpoints are released. Every consumer in the repo (`WorkflowRunApp`, `TaskRunApp`, `UsageStatus`, `RunGraphFlow`) just stores the event in state, so none needed a change; a consumer that snapshots at `complete` and stops listening will see the pre-disposal total.

Note the recorder-ordering consequence, now documented on `attachUsageRecorder`: detach it **after** checkpoint disposal. `runGraph` awaits that before resolving when it owns the scope, but a caller-owned scope must be disposed by the caller first or the row is lost.

### Also: guard the retire dispatch

`retireBucket` iterated `retireListeners` in a bare `for` loop. A throwing telemetry subscriber propagated out of `sweep()` and failed the run that produced the numbers, and starved every subscriber registered after it. Extracted to `notifyRetire`, which logs and continues — and which the new `chargeLate` shares.

### Comments corrected

Three comments asserted the behaviour that does not work, which is how this survived review: `attachUsageRecorder`'s detach-ordering note, `examples/web/src/App.tsx`'s claim that the charge is written during teardown, and `TaskEvents.usage`'s replace-not-accumulate contract (a late charge re-emits the merged **cumulative** total, so replace still holds).

## Testing

Regression tests written first; each confirmed failing on the parent branch.

- `GraphUsageAggregator.test.ts` — `chargeLate` merges rather than replaces, files under the same task/model buckets, notifies retire subscribers; plus a throwing-subscriber test that fails before the guard (`'Error: recorder blew up'` escapes `sweep()`).
- `GraphUsageWiring.test.ts` — a synthetic task registering a `resourceScope` disposer that calls `chargeLateUsage`: the charge reaches `graph.runUsage` and the last `graph_usage`, is counted exactly once, and rolls up from a `GraphAsTask` subgraph to the root run. All three failed before (`expected undefined to be 500000`).
- `CacheCheckpoint.test.ts` — the real path: a `CacheCheckpointTask` in a graph, a provider reporting 500,000 tokens × 1h at disposal. Failed before (`graph.runUsage` undefined).
- `TaskUsageEvent.test.ts` — `chargeLateUsage` emits the merged cumulative total, not the bare delta; and skips the task-level emit while the task is executing again (the loop case where iteration N+1 supersedes N's checkpoint mid-execution, which would otherwise double-count).

The two tests flagged as must-not-change both still pass unedited: `GraphUsageWiring.test.ts` "has a settled `graph.runUsage` by the time `complete` fires", and the whole existing `describe("CacheCheckpointTask storage-cost emission at disposal")` suite.

Sections run (all pass):

- `bun scripts/test.ts task-graph vitest` — 98 files, 897 tests
- `bun scripts/test.ts graph vitest` — 48 files, 478 tests
- `bun scripts/test.ts ai vitest` — 46 files, 366 tests
- `bun scripts/test.ts provider vitest` — 28 files, 406 passed / 1 skipped

Plus `bun run build:types` (repo-wide tsgo), `bun run typecheck:budget` (38 packages within budget), and `bun run format`.

## Known limitation

With a **caller-owned** `ResourceScope`, if the graph is re-run before the caller disposes, the aggregator has been `reset()` and the late charge lands in the second run's totals. Same class as `attachUsageRecorder` pinning `runId` at attach time; not addressed here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDvMMv78PuEw4T5atLeJeS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDvMMv78PuEw4T5atLeJeS)_