### PR TITLE
fix(tasks): handle the SafeFetch body-pipe rejection instead of crashing the process

### DIFF
--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -187,7 +187,10 @@ async function fetchWithProgress(
           while (true) {
             if (options.signal?.aborted) {
               controller.error(createFetchUrlAbortedError());
-              reader.cancel();
+              // Cancelling rejects when the source stream is already errored;
+              // the consumer sees the abort through `controller.error` above,
+              // so an unhandled rejection here would only crash the process.
+              void reader.cancel().catch(() => {});
               return;
             }
 
@@ -209,7 +212,7 @@ async function fetchWithProgress(
       push();
     },
     cancel() {
-      reader.cancel();
+      void reader.cancel().catch(() => {});
     },
   });
 

--- a/packages/tasks/src/util/SafeFetch.server.ts
+++ b/packages/tasks/src/util/SafeFetch.server.ts
@@ -209,9 +209,19 @@ export const serverSafeFetch: SafeFetchFn = async (url, options) => {
       const body = response.body;
       if (body !== null) {
         const { readable, writable } = new TransformStream();
-        body.pipeTo(writable).finally(() => {
-          closeAgent(dispatcher);
-        });
+        // `.catch` after `.finally` so the dispatcher closes on both paths.
+        // Cancelling the returned readable errors the writable, so `pipeTo`
+        // rejects with the cancel reason — `undefined` for a bare `cancel()` —
+        // and an unhandled rejection exits the process under Node's default
+        // `--unhandled-rejections=throw`. Nothing is lost by swallowing it:
+        // the consumer observes any real pipe error through the readable it
+        // holds.
+        void body
+          .pipeTo(writable)
+          .finally(() => {
+            closeAgent(dispatcher);
+          })
+          .catch(() => {});
         return new Response(readable, {
           status: response.status,
           statusText: response.statusText,

--- a/packages/test/src/test/task/SafeFetchServerTransport.test.ts
+++ b/packages/test/src/test/task/SafeFetchServerTransport.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Real-transport tests for the server SafeFetch implementation.
+ *
+ * Every other SafeFetch test installs a mock through `registerSafeFetch`, so
+ * none of them exercise the undici request, the passthrough TransformStream, or
+ * the dispatcher lifecycle — the code that actually runs in production. This
+ * file talks to a throwaway `node:http` server over loopback and never mocks
+ * the transport, which is why it can see a body-pipe rejection that a mocked
+ * suite cannot: an unhandled rejection under Node's default
+ * `--unhandled-rejections=throw` terminates the process.
+ */
+
+import { FetchUrlTask, getSafeFetchImpl, safeFetch } from "@workglow/tasks";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+interface TestServer {
+  readonly origin: string;
+  readonly server: http.Server;
+}
+
+const servers: http.Server[] = [];
+const timers: NodeJS.Timeout[] = [];
+
+/**
+ * Start a loopback HTTP server on an ephemeral port. Registered for teardown in
+ * `afterEach`.
+ */
+async function withServer(handler: http.RequestListener): Promise<TestServer> {
+  const server = http.createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return { origin: `http://127.0.0.1:${port}`, server };
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  // undici keeps sockets alive; without closeAllConnections() the close()
+  // callback never fires and the hook times out.
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+/** Timer that is cleared on teardown, so a stalling handler cannot leak one. */
+function trackedTimeout(fn: () => void, ms: number): void {
+  timers.push(setTimeout(fn, ms));
+}
+
+/**
+ * An unhandled rejection is reported after the microtask queue drains, on a
+ * later macrotask turn — two `setImmediate` turns is enough for Node to have
+ * decided a rejection had no handler.
+ */
+async function drainRejections(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function waitForNoConnections(server: http.Server, timeoutMs: number): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  let count = await new Promise<number>((resolve) =>
+    server.getConnections((_err, n) => resolve(n ?? 0))
+  );
+  while (count > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    count = await new Promise<number>((resolve) =>
+      server.getConnections((_err, n) => resolve(n ?? 0))
+    );
+  }
+  return count;
+}
+
+describe("SafeFetch server transport (real node:http, no mocks)", () => {
+  let unhandled: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown): void => {
+    unhandled.push(reason);
+  };
+
+  beforeEach(() => {
+    unhandled = [];
+    process.on("unhandledRejection", onUnhandledRejection);
+  });
+
+  afterEach(async () => {
+    process.off("unhandledRejection", onUnhandledRejection);
+    for (const timer of timers.splice(0)) clearTimeout(timer);
+    for (const server of servers.splice(0)) await closeServer(server);
+  });
+
+  // Tripwire: the whole file is vacuous if a mock is installed, so assert the
+  // registered implementation is the one from SafeFetch.server.ts. It is not
+  // exported from the package root, so identify it by function name.
+  test("the registered implementation is the real server transport", () => {
+    expect(getSafeFetchImpl().name).toBe("serverSafeFetch");
+  });
+
+  test("cancelling an unread 200 body raises no unhandled rejection", async () => {
+    const { origin } = await withServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+
+    const response = await safeFetch(`${origin}/`, { allowPrivate: true });
+    expect(response.status).toBe(200);
+    expect(response.body).not.toBeNull();
+
+    await response.body!.cancel();
+    await drainRejections();
+
+    expect(unhandled).toEqual([]);
+  });
+
+  test("a cancelled body still frees the connection for the next request", async () => {
+    const { origin, server } = await withServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+
+    const first = await safeFetch(`${origin}/`, { allowPrivate: true });
+    await first.body!.cancel();
+
+    // The dispatcher must still be closed on the cancel path, otherwise its
+    // keep-alive socket stays open forever.
+    expect(await waitForNoConnections(server, 5000)).toBe(0);
+
+    const second = await safeFetch(`${origin}/`, { allowPrivate: true });
+    expect(second.status).toBe(200);
+    expect(await second.text()).toBe("ok");
+
+    await drainRejections();
+    expect(unhandled).toEqual([]);
+  });
+
+  test("a fully read body returns the complete text and raises no unhandled rejection", async () => {
+    const { origin } = await withServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.write("chunk-1;");
+      trackedTimeout(() => {
+        res.write("chunk-2;");
+        trackedTimeout(() => res.end("chunk-3"), 10);
+      }, 10);
+    });
+
+    const response = await safeFetch(`${origin}/`, { allowPrivate: true });
+    expect(await response.text()).toBe("chunk-1;chunk-2;chunk-3");
+
+    await drainRejections();
+    expect(unhandled).toEqual([]);
+  });
+
+  test("abandoning a body midway raises no unhandled rejection", async () => {
+    const { origin } = await withServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.write("first;");
+      // Keep the response open so the cancel lands mid-body.
+      trackedTimeout(() => res.write("second;"), 500);
+    });
+
+    const response = await safeFetch(`${origin}/`, { allowPrivate: true });
+    const reader = response.body!.getReader();
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    expect(new TextDecoder().decode(first.value)).toContain("first;");
+
+    await reader.cancel();
+    await drainRejections();
+
+    expect(unhandled).toEqual([]);
+  });
+
+  test("a connection reset mid-body surfaces on the read, not as an unhandled rejection", async () => {
+    const { origin } = await withServer((req, res) => {
+      res.writeHead(200, { "content-type": "text/plain", "content-length": "1024" });
+      res.write("partial");
+      trackedTimeout(() => req.socket.destroy(), 10);
+    });
+
+    const response = await safeFetch(`${origin}/`, { allowPrivate: true });
+    await expect(response.text()).rejects.toThrow();
+
+    await drainRejections();
+    expect(unhandled).toEqual([]);
+  });
+
+  test("aborting FetchUrlTask mid-body raises no unhandled rejection", async () => {
+    const { origin } = await withServer((_req, res) => {
+      // A stated content-length makes FetchUrlTask report progress per chunk,
+      // which is where the abort lands; the body is never completed.
+      res.writeHead(200, { "content-type": "text/plain", "content-length": "4096" });
+      res.write("first-chunk;");
+      trackedTimeout(() => res.write("second-chunk;"), 1000);
+    });
+
+    const task = new FetchUrlTask();
+    task.on("progress", () => task.abort());
+    trackedTimeout(() => task.abort(), 1500);
+
+    await expect(task.run({ url: `${origin}/`, response_type: "text" })).rejects.toThrow();
+
+    await drainRejections();
+    expect(unhandled).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The crash

`serverSafeFetch` (`packages/tasks/src/util/SafeFetch.server.ts`) returns a `Response` wrapping a `TransformStream` fed by:

```ts
body.pipeTo(writable).finally(() => { closeAgent(dispatcher); });
```

There is no `.catch()`. When a consumer cancels the returned readable (`response.body.cancel()`), the writable errors, `pipeTo` rejects with the cancel reason — `undefined` for a bare `cancel()` — and nothing handles it. Under Node's default `--unhandled-rejections=throw` that terminates the process.

This is reachable on `main` today from `FetchUrlTask`: a `200` with body `ok` fetched through `serverSafeFetch` and then cancelled produces exactly one `unhandledRejection`; under plain `node` the process exits 1 with `ERR_UNHANDLED_REJECTION ... rejected with the reason "undefined"`.

The block is unchanged from `main` and **predates PR #678** (notification tasks), which merely surfaced it — `git log -L 210,225 -- packages/tasks/src/util/SafeFetch.server.ts` traces it to the 0.3.34 release. Hence a separate PR against `main`; **#678 should rebase on this.**

## The fix

1. `SafeFetch.server.ts` — `void body.pipeTo(writable).finally(() => closeAgent(dispatcher)).catch(() => {})`. The `.catch` goes **after** `.finally` so the dispatcher still closes on both the success and the cancel path. Nothing is lost by swallowing: the consumer already observes any real pipe error through the readable it holds.
2. `FetchUrlTask.ts` — both floating `reader.cancel()` calls (the abort branch inside `push()`, and the wrapper `ReadableStream`'s `cancel()` hook) become `void reader.cancel().catch(() => {})`. Both cancel a reader over that same `TransformStream` readable, so each is an independent second rejection source.

## The test

`packages/test/src/test/task/SafeFetchServerTransport.test.ts` — the root-cause fix. **No test anywhere under `packages/` used `node:http`** before this one; every existing SafeFetch test installs a mock via `registerSafeFetch`, so none of them exercise the undici request, the passthrough `TransformStream`, or the dispatcher lifecycle. That is why 89 notification tests could pass while every successful call crashed the process.

The file drives the real transport over a loopback `node:http` server, never calls `registerSafeFetch`, and carries a tripwire asserting the registered impl is `serverSafeFetch` (the file is vacuous under a mock). Unhandled rejections are captured deterministically by a per-test `process.on("unhandledRejection", …)` listener, drained over two `setImmediate` turns and asserted empty — vitest's own reporting fails the run but does not attribute the failure to a test. `close()` calls `server.closeAllConnections()` first, otherwise undici's keep-alive sockets hang the `afterEach` hook.

Cases: cancel an unread 200 body; a cancelled body still frees the connection (second request succeeds, and the server's connection count returns to 0 — proving `.catch` did not skip `closeAgent`); a fully read multi-chunk body; abandoning a body midway; a mid-body connection reset surfacing on the read rather than as an unhandled rejection; and aborting `FetchUrlTask` mid-body (covers change 2).

### Before / after

Before the fix (`vitest run … src/test/task/SafeFetchServerTransport.test.ts`):

```
 ❯ src/test/task/SafeFetchServerTransport.test.ts (7 tests | 5 failed) 236ms
     × cancelling an unread 200 body raises no unhandled rejection 53ms (retry x1)
     × a cancelled body still frees the connection for the next request 70ms (retry x1)
     × abandoning a body midway raises no unhandled rejection 17ms (retry x1)
     × a connection reset mid-body surfaces on the read, not as an unhandled rejection 32ms (retry x1)
     × aborting FetchUrlTask mid-body raises no unhandled rejection 37ms (retry x1)

AssertionError: expected [ undefined ] to deeply equal []
- []
+ [ undefined ]
```

(the reset case reports `TypeError: terminated`, the abort case two `AbortError`s.)

After:

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Full section — `bun scripts/test.ts task vitest`:

```
 Test Files  65 passed (65)
      Tests  942 passed | 24 skipped (966)
   Duration  63.43s
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfGrjKns4esniEmXs52Wfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfGrjKns4esniEmXs52Wfd)_