### PR TITLE
fix(anthropic): build a legal request under legacy extended thinking

### DIFF
--- a/packages/test/src/test/ai-provider-api/Anthropic_SamplingParams.test.ts
+++ b/packages/test/src/test/ai-provider-api/Anthropic_SamplingParams.test.ts
@@ -139,6 +139,36 @@ describe("applyAnthropicSamplingParams", () => {
     expect(warn).toHaveBeenCalledTimes(1);
   });
 
+  // Thinking bounds `top_p` rather than forbidding it: the API accepts
+  // `>= 0.95`. Dropping such a value would discard a setting the request was
+  // entitled to send, and with nothing dropped there is nothing to warn about.
+  it("keeps an in-range top_p when extended thinking is enabled", () => {
+    const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+    const params: Record<string, unknown> = {
+      thinking: { type: "enabled", budget_tokens: 1024 },
+    };
+    applyAnthropicSamplingParams(params, { topP: 0.98 }, model("claude-haiku-4-5"));
+    expect(params.top_p).toBe(0.98);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // `temperature` goes even when in range. Its only legal value under thinking
+  // is the default, so dropping it cannot change the result — and keeping it
+  // beside a surviving `top_p` would trip the separate rule that the two may
+  // not both be specified, turning a legal request into a 400.
+  it("drops temperature but keeps an in-range top_p under extended thinking", () => {
+    const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+    const params: Record<string, unknown> = {
+      thinking: { type: "enabled", budget_tokens: 1024 },
+    };
+    applyAnthropicSamplingParams(params, { temperature: 1, topP: 0.98 }, model("claude-haiku-4-5"));
+    expect("temperature" in params).toBe(false);
+    expect(params.top_p).toBe(0.98);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const meta = warn.mock.calls[0]![1] as { dropped: string[] };
+    expect(meta.dropped).toEqual(["temperature"]);
+  });
+
   // Scope guard: adaptive thinking on 4.6+ is the recommended configuration and
   // does accept sampling, so the suppression must key on "enabled" alone.
   it("keeps sampling parameters under adaptive thinking", () => {

--- a/packages/test/src/test/ai-provider-api/Anthropic_SamplingParams.test.ts
+++ b/packages/test/src/test/ai-provider-api/Anthropic_SamplingParams.test.ts
@@ -123,6 +123,29 @@ describe("applyAnthropicSamplingParams", () => {
     expect(meta.model).toBe("claude-opus-5");
     expect(meta.dropped).toEqual(["temperature", "top_p"]);
   });
+
+  // A model can accept sampling parameters in general and still reject them on
+  // a request carrying legacy extended thinking. `claude-haiku-4-5` is exactly
+  // that case: it is on the accepting list, so before this guard a
+  // thinking-configured run with a pinned temperature sent both and got a 400.
+  it("drops sampling parameters when extended thinking is enabled", () => {
+    const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+    const params: Record<string, unknown> = {
+      thinking: { type: "enabled", budget_tokens: 1024 },
+    };
+    applyAnthropicSamplingParams(params, { temperature: 0, topP: 0.9 }, model("claude-haiku-4-5"));
+    expect("temperature" in params).toBe(false);
+    expect("top_p" in params).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  // Scope guard: adaptive thinking on 4.6+ is the recommended configuration and
+  // does accept sampling, so the suppression must key on "enabled" alone.
+  it("keeps sampling parameters under adaptive thinking", () => {
+    const params: Record<string, unknown> = { thinking: { type: "adaptive" } };
+    applyAnthropicSamplingParams(params, { temperature: 0.4 }, model("claude-haiku-4-5"));
+    expect(params.temperature).toBe(0.4);
+  });
 });
 
 /**

--- a/packages/test/src/test/ai-provider/Anthropic_Thinking.test.ts
+++ b/packages/test/src/test/ai-provider/Anthropic_Thinking.test.ts
@@ -5,9 +5,14 @@
  */
 
 import { _testOnly } from "@workglow/anthropic/ai";
-import { describe, expect, it } from "vitest";
+import { getLogger } from "@workglow/util";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { buildAnthropicThinkingParams, anthropicSupportsAdaptiveThinking } = _testOnly;
+const {
+  buildAnthropicThinkingParams,
+  applyAnthropicThinkingParams,
+  anthropicSupportsAdaptiveThinking,
+} = _testOnly;
 
 function model(opts: {
   model_name: string;
@@ -112,5 +117,112 @@ describe("buildAnthropicThinkingParams", () => {
       output_config: { effort: "max" },
       max_tokens: 1000,
     });
+  });
+
+  // Anthropic rejects a legacy budget below 1024 with a 400, and `low` maps to
+  // 512. Before the clamp, `{model_name: "claude-haiku-4-5", effort: "low"}` —
+  // an ordinary configuration — built a request the API always refused.
+  it("clamps the legacy budget up to the 1024 minimum", () => {
+    expect(
+      buildAnthropicThinkingParams(model({ model_name: "claude-haiku-4-5", effort: "low" }), 1000)
+    ).toEqual({
+      thinking: { type: "enabled", budget_tokens: 1024 },
+      max_tokens: 1000 + 1024,
+    });
+  });
+
+  // Scope guard: on the adaptive path the same 512 is `max_tokens` headroom,
+  // not a budget, so the minimum does not apply and must not be applied.
+  it("does not clamp adaptive headroom", () => {
+    expect(
+      buildAnthropicThinkingParams(model({ model_name: "claude-sonnet-5", effort: "low" }), 1000)
+    ).toEqual({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "low" },
+      max_tokens: 1000 + 512,
+    });
+  });
+
+  // Carve-out guard: a native `provider_config.thinking.budget_tokens` is an
+  // explicit provider-level opt-in. Silently rewriting it would hide the
+  // config error rather than surfacing it as the 400 it is.
+  it("leaves a native sub-minimum budget alone", () => {
+    expect(
+      buildAnthropicThinkingParams(
+        model({
+          model_name: "claude-haiku-4-5",
+          thinking: { type: "enabled", budget_tokens: 100 },
+        }),
+        1000
+      )
+    ).toEqual({
+      thinking: { type: "enabled", budget_tokens: 100 },
+      max_tokens: 1100,
+    });
+  });
+});
+
+describe("applyAnthropicThinkingParams — forced tool choice", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function baseParams(toolChoice?: Record<string, unknown>): Record<string, unknown> {
+    return { max_tokens: 1000, ...(toolChoice ? { tool_choice: toolChoice } : {}) };
+  }
+
+  it("merges thinking when no tool_choice is present", () => {
+    const params = baseParams();
+    applyAnthropicThinkingParams(params, model({ model_name: "claude-haiku-4-5", effort: "high" }));
+    expect(params.thinking).toEqual({ type: "enabled", budget_tokens: 2048 });
+    expect(params.max_tokens).toBe(1000 + 2048);
+  });
+
+  // A forced tool choice cannot carry legacy extended thinking. Before the
+  // guard, a structured-generation request (which always forces
+  // `{type:"tool"}`) on a thinking-configured legacy model sent both.
+  it.each([[{ type: "tool", name: "structured_output" }], [{ type: "any" }]])(
+    "omits legacy thinking under tool_choice %o",
+    (toolChoice) => {
+      vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+      const params = baseParams(toolChoice);
+      applyAnthropicThinkingParams(
+        params,
+        model({ model_name: "claude-haiku-4-5", effort: "high" })
+      );
+      expect("thinking" in params).toBe(false);
+      // max_tokens is left unpadded — there is no thinking budget to pad for.
+      expect(params.max_tokens).toBe(1000);
+    }
+  );
+
+  // `{type:"auto"}` is what mapAnthropicToolChoice produces by default, so a
+  // naive "tool_choice is present" check would suppress thinking on nearly
+  // every tool-calling request.
+  it("does not treat tool_choice auto as forced", () => {
+    const params = baseParams({ type: "auto" });
+    applyAnthropicThinkingParams(params, model({ model_name: "claude-haiku-4-5", effort: "high" }));
+    expect(params.thinking).toEqual({ type: "enabled", budget_tokens: 2048 });
+  });
+
+  // Over-suppression guard: the constraint is on legacy `enabled` thinking.
+  // Adaptive thinking on 4.6+ is unaffected and must survive a forced choice.
+  it("keeps adaptive thinking under a forced tool choice", () => {
+    const params = baseParams({ type: "tool", name: "structured_output" });
+    applyAnthropicThinkingParams(params, model({ model_name: "claude-sonnet-5", effort: "high" }));
+    expect(params.thinking).toEqual({ type: "adaptive" });
+    expect(params.output_config).toEqual({ effort: "high" });
+  });
+
+  // The guard reads the built result, not the model version, so a native
+  // provider_config.thinking on a modern id is covered too.
+  it("omits a native enabled thinking under a forced tool choice", () => {
+    vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+    const params = baseParams({ type: "any" });
+    applyAnthropicThinkingParams(
+      params,
+      model({ model_name: "claude-sonnet-5", thinking: { type: "enabled", budget_tokens: 2048 } })
+    );
+    expect("thinking" in params).toBe(false);
   });
 });

--- a/packages/test/src/test/ai-provider/Anthropic_ThinkingRequestShape.test.ts
+++ b/packages/test/src/test/ai-provider/Anthropic_ThinkingRequestShape.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn } from "@workglow/ai";
+import { ANTHROPIC, _testOnly } from "@workglow/anthropic/ai";
+import { _testOnly as runtimeTestOnly } from "@workglow/anthropic/ai-runtime";
+import { getLogger } from "@workglow/util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { ANTHROPIC_RUN_FNS, setAnthropicClientForTests } = _testOnly;
+
+/**
+ * The three legacy-thinking constraints are enforced across two helpers and the
+ * order in which each run-fn calls them, so unit-testing the helpers alone
+ * cannot prove the request that actually goes on the wire is well formed. This
+ * suite captures the params object handed to the SDK client.
+ */
+function findRunFn(serves: readonly string[]): AiProviderRunFn {
+  const registration = ANTHROPIC_RUN_FNS.find(
+    ({ serves: candidate }) =>
+      (candidate as readonly string[]).length === serves.length &&
+      serves.every((capability) => (candidate as readonly string[]).includes(capability))
+  );
+  expect(registration).toBeDefined();
+  return registration!.runFn as AiProviderRunFn;
+}
+
+/** `claude-haiku-4-5` is on the legacy thinking path AND accepts sampling. */
+const modelConfig = (effort: string, modelName = "claude-haiku-4-5") =>
+  ({
+    model_id: modelName,
+    title: modelName,
+    description: "",
+    provider: ANTHROPIC,
+    effort,
+    provider_config: { model_name: modelName, api_key: "test-key" },
+    capabilities: ["text.generation"],
+    metadata: {},
+  }) as never;
+
+describe("Anthropic legacy thinking request shape", () => {
+  let captured: Record<string, unknown>[];
+
+  beforeEach(() => {
+    captured = [];
+    vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+    const fakeClient = {
+      messages: {
+        stream: (params: Record<string, unknown>) => {
+          captured.push(params);
+          return {
+            async *[Symbol.asyncIterator]() {
+              // No events: every run-fn tolerates an empty stream and finishes.
+            },
+          };
+        },
+      },
+    };
+    setAnthropicClientForTests(fakeClient);
+    runtimeTestOnly.setAnthropicClientForTests?.(fakeClient);
+  });
+
+  afterEach(() => {
+    setAnthropicClientForTests(undefined);
+    runtimeTestOnly.setAnthropicClientForTests?.(undefined);
+    vi.restoreAllMocks();
+  });
+
+  it("sends a legal budget and no temperature for effort low with temperature pinned", async () => {
+    const runFn = findRunFn(["text.generation"]);
+    const model = modelConfig("low");
+    await runFn(
+      { model, prompt: "hi", temperature: 0 } as never,
+      model,
+      undefined as never,
+      (() => {}) as never
+    );
+
+    expect(captured).toHaveLength(1);
+    const params = captured[0]!;
+    // 512 (the `low` budget) is below Anthropic's 1024 minimum and is a 400.
+    expect(params.thinking).toEqual({ type: "enabled", budget_tokens: 1024 });
+    // Extended thinking rejects sampling parameters even on a model that
+    // otherwise accepts them.
+    expect("temperature" in params).toBe(false);
+    expect("top_p" in params).toBe(false);
+  });
+
+  it("omits thinking entirely on the structured-generation path", async () => {
+    const runFn = findRunFn(["text.generation", "json-mode"]);
+    const model = modelConfig("high");
+    await runFn(
+      { model, prompt: "hi" } as never,
+      model,
+      undefined as never,
+      (() => {}) as never,
+      { type: "object", properties: { a: { type: "string" } } } as never
+    );
+
+    expect(captured).toHaveLength(1);
+    const params = captured[0]!;
+    // Structured generation always forces `tool_choice: {type: "tool"}`, which
+    // cannot carry legacy extended thinking.
+    expect(params.tool_choice).toEqual({ type: "tool", name: "structured_output" });
+    expect("thinking" in params).toBe(false);
+  });
+
+  it("omits thinking on a tool-calling run that forces a tool", async () => {
+    const runFn = findRunFn(["text.generation", "tool-use"]);
+    const model = modelConfig("high");
+    const tools = [{ name: "lookup", description: "Look up", inputSchema: { type: "object" } }];
+    await runFn(
+      { model, prompt: "hi", tools, toolChoice: "required", temperature: 0 } as never,
+      model,
+      undefined as never,
+      (() => {}) as never
+    );
+
+    expect(captured).toHaveLength(1);
+    const params = captured[0]!;
+    expect(params.tool_choice).toEqual({ type: "any" });
+    expect("thinking" in params).toBe(false);
+    // No thinking on the request, so sampling is legal again on this model.
+    expect(params.temperature).toBe(0);
+  });
+
+  it("keeps thinking and drops sampling on an auto tool-calling run", async () => {
+    const runFn = findRunFn(["text.generation", "tool-use"]);
+    const model = modelConfig("high");
+    const tools = [{ name: "lookup", description: "Look up", inputSchema: { type: "object" } }];
+    await runFn(
+      { model, prompt: "hi", tools, toolChoice: "auto", temperature: 0 } as never,
+      model,
+      undefined as never,
+      (() => {}) as never
+    );
+
+    const params = captured[0]!;
+    // `auto` is not a forced choice, so thinking survives — and suppresses
+    // sampling in turn.
+    expect(params.tool_choice).toEqual({ type: "auto" });
+    expect(params.thinking).toEqual({ type: "enabled", budget_tokens: 2048 });
+    expect("temperature" in params).toBe(false);
+  });
+
+  it("leaves an adaptive-thinking model's sampling parameters alone", async () => {
+    const runFn = findRunFn(["text.generation"]);
+    // `claude-sonnet-4-6` is on the adaptive path and still accepts sampling.
+    const model = modelConfig("high", "claude-sonnet-4-6");
+    await runFn(
+      { model, prompt: "hi", temperature: 0.5 } as never,
+      model,
+      undefined as never,
+      (() => {}) as never
+    );
+
+    const params = captured[0]!;
+    expect(params.thinking).toEqual({ type: "adaptive" });
+    expect(params.temperature).toBe(0.5);
+  });
+});

--- a/providers/anthropic/src/ai/common/Anthropic_RequestParams.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_RequestParams.ts
@@ -137,6 +137,9 @@ interface AnthropicSamplingInput {
  * model accepts them. On a rejecting model the keys are left absent (rather
  * than set to `undefined`) and a single warning names everything dropped, so
  * the user's setting becoming a no-op is visible without failing the request.
+ *
+ * Call this after {@link applyAnthropicThinkingParams}: whether the request
+ * carries extended thinking decides whether sampling is legal at all.
  */
 export function applyAnthropicSamplingParams(
   params: Record<string, unknown>,
@@ -147,6 +150,19 @@ export function applyAnthropicSamplingParams(
   if (input.temperature !== undefined) supplied.push(["temperature", input.temperature]);
   if (input.topP !== undefined) supplied.push(["top_p", input.topP]);
   if (supplied.length === 0) return;
+
+  // Extended thinking (`thinking.type = "enabled"`) rejects sampling parameters.
+  // Scoped to "enabled" on purpose: `{type:"adaptive"}` on 4.6+ is the
+  // recommended configuration and does accept them. Requires that thinking has
+  // already been merged onto `params`.
+  const thinking = params.thinking as { type?: string } | undefined;
+  if (thinking?.type === "enabled") {
+    getLogger().warn("Anthropic extended thinking is on; dropping sampling parameters.", {
+      model: model?.provider_config?.model_name ?? "",
+      dropped: supplied.map(([wireName]) => wireName),
+    });
+    return;
+  }
 
   if (anthropicAcceptsSamplingParams(model)) {
     for (const [wireName, value] of supplied) params[wireName] = value;

--- a/providers/anthropic/src/ai/common/Anthropic_RequestParams.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_RequestParams.ts
@@ -133,6 +133,13 @@ interface AnthropicSamplingInput {
 }
 
 /**
+ * Extended thinking bounds `top_p` rather than forbidding it: the API rejects
+ * anything below this with a 400 and accepts everything at or above it, so a
+ * value in range is worth passing through instead of discarding.
+ */
+const THINKING_MIN_TOP_P = 0.95;
+
+/**
  * Copies the caller's sampling fields onto an Anthropic request body when the
  * model accepts them. On a rejecting model the keys are left absent (rather
  * than set to `undefined`) and a single warning names everything dropped, so
@@ -151,26 +158,43 @@ export function applyAnthropicSamplingParams(
   if (input.topP !== undefined) supplied.push(["top_p", input.topP]);
   if (supplied.length === 0) return;
 
-  // Extended thinking (`thinking.type = "enabled"`) rejects sampling parameters.
-  // Scoped to "enabled" on purpose: `{type:"adaptive"}` on 4.6+ is the
-  // recommended configuration and does accept them. Requires that thinking has
-  // already been merged onto `params`.
+  // Extended thinking (`thinking.type = "enabled"`) narrows sampling rather
+  // than forbidding it, so an in-range `top_p` is passed through instead of
+  // discarded. `temperature` is always dropped: its only legal value under
+  // thinking is the default `1`, so sending it can never change the result,
+  // and omitting it also keeps the request clear of the separate rule that
+  // `temperature` and `top_p` may not both be specified. Scoped to "enabled"
+  // on purpose: `{type:"adaptive"}` on 4.6+ is the recommended configuration
+  // and accepts the full range. Requires that thinking has already been merged
+  // onto `params`.
   const thinking = params.thinking as { type?: string } | undefined;
+  let permitted = supplied;
   if (thinking?.type === "enabled") {
-    getLogger().warn("Anthropic extended thinking is on; dropping sampling parameters.", {
-      model: model?.provider_config?.model_name ?? "",
-      dropped: supplied.map(([wireName]) => wireName),
+    const dropped: string[] = [];
+    permitted = supplied.filter(([wireName, value]) => {
+      if (wireName === "top_p" && value >= THINKING_MIN_TOP_P) return true;
+      dropped.push(wireName);
+      return false;
     });
-    return;
+    if (dropped.length > 0) {
+      getLogger().warn(
+        "Anthropic extended thinking constrains sampling; dropping unsupported parameters.",
+        {
+          model: model?.provider_config?.model_name ?? "",
+          dropped,
+        }
+      );
+    }
+    if (permitted.length === 0) return;
   }
 
   if (anthropicAcceptsSamplingParams(model)) {
-    for (const [wireName, value] of supplied) params[wireName] = value;
+    for (const [wireName, value] of permitted) params[wireName] = value;
     return;
   }
 
   getLogger().warn("Anthropic model rejects sampling parameters; dropping them.", {
     model: model?.provider_config?.model_name ?? "",
-    dropped: supplied.map(([wireName]) => wireName),
+    dropped: permitted.map(([wireName]) => wireName),
   });
 }

--- a/providers/anthropic/src/ai/common/Anthropic_TextGeneration.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_TextGeneration.ts
@@ -74,8 +74,8 @@ export const Anthropic_TextGeneration_Stream: AiProviderRunFn<
       messages,
       max_tokens: getMaxTokens(input, model),
     };
-    applyAnthropicSamplingParams(params, input, model);
     applyAnthropicThinkingParams(params, model);
+    applyAnthropicSamplingParams(params, input, model);
 
     // Emit-only run (emitCheckpoint with no parent checkpoint): this request
     // is the cache write the emitted checkpoint's first consumer reads, so it

--- a/providers/anthropic/src/ai/common/Anthropic_Thinking.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Thinking.ts
@@ -5,6 +5,7 @@
  */
 
 import { isModelEffort, type ModelEffort } from "@workglow/ai";
+import { getLogger } from "@workglow/util/worker";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 import { parseAnthropicModelId } from "./Anthropic_RequestParams";
 
@@ -17,6 +18,13 @@ const EFFORT_TO_BUDGET: Record<ModelEffort, number> = {
   extra: 4096,
   ultra: 8192,
 };
+
+/**
+ * Anthropic rejects `thinking.budget_tokens` below 1024 with a 400. The coarse
+ * `low` effort maps to 512, which is legal headroom on the adaptive path but
+ * not a legal legacy budget.
+ */
+const MIN_LEGACY_THINKING_BUDGET = 1024;
 
 /** Maps coarse effort onto Anthropic adaptive `output_config.effort`. */
 const EFFORT_TO_ADAPTIVE: Record<Exclude<ModelEffort, "none">, string> = {
@@ -102,14 +110,17 @@ export function buildAnthropicThinkingParams(
     };
   }
 
+  const legacyBudget = Math.max(budget, MIN_LEGACY_THINKING_BUDGET);
   return {
-    thinking: { type: "enabled", budget_tokens: budget },
-    max_tokens: padMaxTokens(maxTokens, budget),
+    thinking: { type: "enabled", budget_tokens: legacyBudget },
+    max_tokens: padMaxTokens(maxTokens, legacyBudget),
   };
 }
 
 /**
- * Merges thinking / output_config / padded max_tokens onto an Anthropic request body.
+ * Merges thinking / output_config / padded max_tokens onto an Anthropic request
+ * body. Call this after `tool_choice` is on `params` and before sampling params
+ * — both of the guards below read what has already been built.
  */
 export function applyAnthropicThinkingParams(
   params: Record<string, unknown>,
@@ -117,6 +128,21 @@ export function applyAnthropicThinkingParams(
 ): void {
   if (typeof params.max_tokens !== "number") return;
   const built = buildAnthropicThinkingParams(model, params.max_tokens);
+
+  // Legacy `thinking.type = "enabled"` cannot be combined with a forced tool
+  // choice. `{type:"auto"}` is not forced, and the adaptive path is unaffected.
+  // Testing the built result rather than the model version also covers a
+  // native `provider_config.thinking`.
+  const choice = params.tool_choice as { type?: string } | undefined;
+  const forcedTool = choice?.type === "tool" || choice?.type === "any";
+  if (forcedTool && (built.thinking as { type?: string } | undefined)?.type === "enabled") {
+    getLogger().warn("Anthropic forced tool choice cannot carry extended thinking; skipping it.", {
+      model: (model?.provider_config as AnthropicThinkingProviderConfig | undefined)?.model_name,
+      tool_choice: choice?.type,
+    });
+    return;
+  }
+
   params.max_tokens = built.max_tokens;
   if (built.thinking !== undefined) params.thinking = built.thinking;
   if (built.output_config !== undefined) params.output_config = built.output_config;

--- a/providers/anthropic/src/ai/common/Anthropic_ToolCalling.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_ToolCalling.ts
@@ -145,16 +145,18 @@ export const Anthropic_ToolCalling_Stream: AiProviderRunFn<
     max_tokens: getMaxTokens(input, model),
   };
 
-  applyAnthropicSamplingParams(params, input, model);
-  applyAnthropicThinkingParams(params, model);
-
-  if (input.systemPrompt) {
-    params.system = input.systemPrompt;
-  }
-
+  // tool_choice first: a forced choice suppresses legacy extended thinking,
+  // which in turn decides whether sampling parameters are legal.
   if (toolChoice !== undefined) {
     params.tools = tools;
     params.tool_choice = toolChoice;
+  }
+
+  applyAnthropicThinkingParams(params, model);
+  applyAnthropicSamplingParams(params, input, model);
+
+  if (input.systemPrompt) {
+    params.system = input.systemPrompt;
   }
 
   // Emit-only run (emitCheckpoint with no parent checkpoint): this request is

--- a/providers/anthropic/src/ai/index.ts
+++ b/providers/anthropic/src/ai/index.ts
@@ -23,6 +23,7 @@ import {
 } from "./common/Anthropic_RequestParams";
 import {
   anthropicSupportsAdaptiveThinking,
+  applyAnthropicThinkingParams,
   buildAnthropicThinkingParams,
 } from "./common/Anthropic_Thinking";
 import { createAnthropicUsageCollector, mapAnthropicUsage } from "./common/Anthropic_Usage";
@@ -38,6 +39,7 @@ export const _testOnly = {
   anthropicAcceptsSamplingParams,
   applyAnthropicSamplingParams,
   anthropicSupportsAdaptiveThinking,
+  applyAnthropicThinkingParams,
   buildAnthropicThinkingParams,
   setAnthropicClientForTests: clientTestOnly.setAnthropicClientForTests,
   createAnthropicUsageCollector,


### PR DESCRIPTION
## What

`model.effort` on a pre-4.6 Claude id takes the legacy thinking path and builds `thinking: {type: "enabled", budget_tokens: N}`. Three constraints on that shape were unenforced, and each turns an ordinary configuration into an HTTP 400 — which `@workglow/job-queue` maps to a non-retryable `PermanentJobError`:

1. **Sub-minimum budget.** `effort: "low"` maps to `budget_tokens: 512`. Anthropic's documented minimum is 1024, so `{model_name: "claude-haiku-4-5", effort: "low"}` built a request the API always refused.
2. **Sampling with thinking.** Extended thinking rejects `temperature` / `top_p`. `claude-haiku-4-5` is on `anthropicAcceptsSamplingParams`'s accepting list, so a thinking-configured run that also pinned `temperature: 0` sent both.
3. **Forced tool choice with thinking.** `Anthropic_StructuredGeneration` always forces `tool_choice: {type: "tool", name: "structured_output"}`, and `Anthropic_ToolCalling`'s `mapAnthropicToolChoice` produces `{type: "any"}` for `toolChoice: "required"`. Either combined with legacy thinking.

**Which of these is confirmed, and which is defensive** — stated plainly because the distinction matters for review:

| | status |
|---|---|
| `budget_tokens >= 1024` | **Confirmed** against Anthropic's documented contract. |
| no sampling with `thinking.type = "enabled"` | **Documented contract only** — not reproduced. |
| no legacy thinking with a forced `tool_choice` | **Documented contract only** — not reproduced. |

There is no Anthropic SDK installed in this checkout (`catalog:`, no `node_modules` on the base) and no API key, so none of the three was verified live. All three changes are clamps or suppressions: none can turn a request the API previously accepted into one it rejects, which is why the two inferred constraints are still worth applying. A single live request would settle each — see **Unverified**.

## Why this fix

The guards read **what has already been built** rather than re-deriving it from the model id. That is what makes them correct for a user's native `provider_config.thinking` as well as for the derived `model.effort` path, and it establishes one ordering invariant every Anthropic run-fn now follows:

> assign `tool_choice` → apply thinking → apply sampling

- `Anthropic_ToolCalling` assigned `tools`/`tool_choice` *after* thinking and sampling, and called sampling first. Both moved. The cache-annotation block (`annotateLastTool`) still runs after the tools assignment, so the move is safe — verified by reading the whole function.
- `Anthropic_TextGeneration` had sampling before thinking; swapped.
- `Anthropic_StructuredGeneration` already assigned `tool_choice` before calling thinking — no edit needed.

Deliberate carve-outs, each pinned by a test:

- **The adaptive path is untouched.** `{type: "adaptive"}` on 4.6+ is the recommended configuration, its 512 is `max_tokens` headroom rather than a budget, and it accepts sampling. Suppressing there would be a regression, so every guard keys on `"enabled"` specifically.
- **A native `provider_config.thinking.budget_tokens` below 1024 is left alone.** It is an explicit provider-level opt-in; silently rewriting it hides a config error rather than surfacing it.
- **`{type: "auto"}` is not a forced choice.** It is what `mapAnthropicToolChoice` returns by default, so a naive "is `tool_choice` present?" check would suppress thinking on nearly every tool-calling request.

## Tests

`applyAnthropicThinkingParams` was added to the `_testOnly` barrel (the forced-choice guard lives there, not in `buildAnthropicThinkingParams`).

- `Anthropic_Thinking.test.ts` — budget clamped 512→1024; adaptive headroom **not** clamped; native sub-minimum budget left alone; `{type:"tool"}` and `{type:"any"}` omit thinking and leave `max_tokens` unpadded; `{type:"auto"}` not treated as forced; adaptive survives a forced choice; a native `enabled` thinking is suppressed under a forced choice.
- `Anthropic_SamplingParams.test.ts` — drops `temperature`/`top_p` under `thinking.type === "enabled"` on an otherwise-accepting model; keeps them under `"adaptive"`.
- **New** `Anthropic_ThinkingRequestShape.test.ts` — the three constraints are enforced across two helpers *plus the order each run-fn calls them in*, so unit tests of the helpers cannot prove the wire request is well formed. This one captures the params object handed to the SDK via `_testOnly.setAnthropicClientForTests` and asserts the real built request for each run-fn.

**Executed.** After `bun install` + `bun run use-source`, with `npx vitest run --project test`:

- against pre-fix source (test-only `_testOnly` export kept so the suite can load): **9 failed, 48 passed** — every new behavioural assertion fails, every scope-guard assertion passes both before and after, as intended.
- after the fix, the whole `ai-provider/` directory plus `Anthropic_SamplingParams` and `AnthropicProvider`: **38 files, 493 passed, 1 skipped**.

Not executed: the full repo suite. Typecheck (`tsgo --noEmit` on `providers/anthropic`) was compared before vs. after — the diff is a single entry, `Anthropic_Thinking.ts` importing `getLogger` from `@workglow/util/worker`, which is the same source-mode `.d.ts`-stub artifact already reported for the identical existing import in `Anthropic_RequestParams.ts` (143 → 144 pre-existing errors of that class). No genuine type error introduced.

## Risk / blast radius

Anthropic only, and all three changes are suppressions or clamps — none can invalidate a request the API previously accepted.

Behaviour changes a reviewer must accept:

- A run configured with **both** a legacy-thinking effort and a temperature now silently drops the temperature (with a `logger.warn`). If the API in fact accepts that combination, this is a behaviour regression for those callers rather than a fix — see **Unverified**. Escape hatch: `provider_config.sampling_params: "send"` does **not** override this guard; drop the effort or use a 4.6+ id to keep sampling.
- Structured generation on a pre-4.6 id configured with an effort now sends **no** thinking at all. It previously sent thinking that (per the documented contract) the API rejected.
- The `Anthropic_ToolCalling` statement reorder is the only structural change; `params.tools` is now assigned earlier in a function that later mutates it for cache annotation.

## Unverified

- **Not reproduced against the live API.** No SDK, no key. Each constraint is one request away from being settled:
  - `{model: "claude-haiku-4-5", thinking: {type: "enabled", budget_tokens: 1024}, temperature: 0}` settles the sampling constraint.
  - adding `tool_choice: {type: "tool", name: "..."}` to the above settles the forced-choice constraint.
  - A 200 on either means that half of this PR is over-suppression and should be reverted independently; they are separate guards in separate functions.
- The exact minimum (1024) is taken from Anthropic's documented contract, not measured.
- Whether `{type: "any"}` and `{type: "tool"}` are *both* rejected, or only `{type: "tool"}`, is not distinguished — both are treated as forced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H797qbH356jjznKgUax63o)_