### PR TITLE
fix(tasks): redact webhook query values and the reason phrase

### DIFF
--- a/packages/tasks/src/util/WebhookPost.ts
+++ b/packages/tasks/src/util/WebhookPost.ts
@@ -66,6 +66,14 @@ export function redactWebhookUrl(url: string): string {
 }
 
 /**
+ * Routing segments of the supported providers' webhook paths. Redacting these
+ * would mangle prose like `invalid webhooks payload` for no gain. Everything
+ * else long enough to be a token is redacted even when all-lowercase — a
+ * lowercase secret is still a secret.
+ */
+const STRUCTURAL_PATH_SEGMENTS: ReadonlySet<string> = new Set(["services", "webhooks"]);
+
+/**
  * Strips every trace of `url` out of `text`.
  *
  * Matching the literal full URL alone is not enough: an endpoint routinely
@@ -73,17 +81,32 @@ export function redactWebhookUrl(url: string): string {
  * `Cannot POST /services/T0.../SECRETTOKEN` — the path, never the origin — and
  * a validation error may quote the token on its own. So after the full URL
  * collapses to its origin (which stays the useful diagnostic), the path, the
- * query and each individual path segment are replaced too.
+ * query, each individual path segment AND each query VALUE are replaced too.
+ *
+ * Query values are a real carrier here, not a hypothetical one: plenty of
+ * webhook endpoints take their token as `?token=…` rather than as a path
+ * segment, and an echoing endpoint quotes back the value on its own.
  *
  * Candidates are applied LONGEST FIRST: replacing a short segment first would
  * break a longer candidate that contains it, leaving the rest of that longer
  * fragment behind.
  *
- * A candidate is admitted only when it is long enough to plausibly be a token
- * AND is not an all-lowercase word. Both clauses are load-bearing: `services`
- * and `webhooks` are real segments of the Slack and Discord webhook paths, and
- * redacting them would corrupt ordinary prose like `invalid webhooks payload`
- * for no security gain.
+ * Admission is by LENGTH only. A candidate shorter than
+ * `SECURITY_LIMITS.webhookMinRedactableSegmentChars` is far likelier to be an
+ * ordinary word than a token, and replacing it would mangle the diagnostic this
+ * redaction exists to preserve. That floor applies to query values too, so a
+ * short `?t=abc` still leaks — the same policy as segments, stated rather than
+ * silently special-cased.
+ *
+ * There is deliberately no "all-lowercase words are safe" exemption: a
+ * lowercase token is still a token, and the endpoint that echoes it does not
+ * care about its character class. The two lowercase strings actually worth
+ * keeping are the providers' own routing segments, which are named in
+ * {@link STRUCTURAL_PATH_SEGMENTS} instead.
+ *
+ * Cost, accepted: a generic webhook whose path carries a long lowercase WORD
+ * (`/notifications/deploy`) now has that word redacted out of echoed
+ * diagnostics.
  */
 export function redactWebhookUrlIn(text: string, url: string): string {
   if (url.length === 0) {
@@ -100,20 +123,40 @@ export function redactWebhookUrlIn(text: string, url: string): string {
 
   const candidates = new Set<string>();
   const admit = (candidate: string): void => {
-    if (
-      candidate.length >= SECURITY_LIMITS.webhookMinRedactableSegmentChars &&
-      !/^[a-z]+$/.test(candidate)
-    ) {
+    if (candidate.length >= SECURITY_LIMITS.webhookMinRedactableSegmentChars) {
       candidates.add(candidate);
     }
   };
+  const admitVariants = (candidate: string): void => {
+    admit(candidate);
+    const encoded = encodeURIComponent(candidate);
+    if (encoded !== candidate) {
+      admit(encoded);
+    }
+  };
+
   admit(`${parsed.pathname}${parsed.search}`);
   admit(parsed.search);
   for (const segment of parsed.pathname.split("/")) {
-    admit(segment);
-    const encoded = encodeURIComponent(segment);
-    if (encoded !== segment) {
-      admit(encoded);
+    if (STRUCTURAL_PATH_SEGMENTS.has(segment)) {
+      continue;
+    }
+    admitVariants(segment);
+  }
+  // Split the raw query rather than reading `searchParams`: the decoder turns
+  // `+` into a space, so the decoded value would not match the bytes an
+  // endpoint echoes back. Both forms are admitted.
+  for (const pair of parsed.search.replace(/^\?/, "").split("&")) {
+    const equals = pair.indexOf("=");
+    if (equals < 0) {
+      continue;
+    }
+    const raw = pair.slice(equals + 1);
+    admit(raw);
+    try {
+      admit(decodeURIComponent(raw));
+    } catch {
+      // Malformed escape: the raw form is what appears in an echo anyway.
     }
   }
 
@@ -582,14 +625,20 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
     request.includeBodyInError && !isPrivate && failureBody.length > 0
       ? `: ${truncate(redactWebhookUrlIn(failureBody, url), MAX_ERROR_BODY_CHARS)}`
       : "";
+  // The reason phrase is caller-controlled text like the body, so it gets the
+  // same two treatments: withheld entirely for a private destination, and
+  // redacted otherwise. A server is free to put anything in it, and the well
+  // known phrases ("Not Found", "Bad Request") survive redaction unchanged.
+  const statusText = isPrivate ? "" : redactWebhookUrlIn(response.statusText, url);
 
   throw createFetchUrlJobError(
     httpStatusToFetchUrlErrorCode(response.status),
-    `Failed to post ${label} to ${redacted}: ${response.status} ${response.statusText}${bodySuffix}`,
+    `Failed to post ${label} to ${redacted}: ${response.status}` +
+      `${statusText === "" ? "" : ` ${statusText}`}${bodySuffix}`,
     {
       url: redacted,
       httpStatus: response.status,
-      httpStatusText: response.statusText,
+      httpStatusText: statusText === "" ? undefined : statusText,
       retryDate,
     }
   );

--- a/packages/test/src/test/task/NotifyTask.test.ts
+++ b/packages/test/src/test/task/NotifyTask.test.ts
@@ -471,8 +471,9 @@ describe("Webhook notification tasks", () => {
 
     // The guard against over-redaction. `webhooks` is a real path segment of
     // every Discord webhook URL and is exactly 8 characters, so a length floor
-    // alone would delete the word from ordinary prose. All-lowercase-alphabetic
-    // runs are words, not tokens.
+    // alone would delete the word from ordinary prose. It is exempt because it
+    // is a named ROUTING segment of a supported provider, not because it is
+    // lowercase — this pins the replacement for the deleted lowercase rule.
     test("an ordinary word that happens to be a path segment survives", async () => {
       mockFetch.mockImplementation(() =>
         Promise.resolve(
@@ -486,6 +487,86 @@ describe("Webhook notification tasks", () => {
 
       expect(error.message).toContain("invalid webhooks payload");
       expect(error.message).not.toContain("SECRETTOKEN");
+    });
+
+    // A token in the query string is a real deployment shape — plenty of
+    // endpoints authenticate with `?token=…` rather than a path segment — and
+    // nothing admitted a query VALUE as a redaction candidate. The whole
+    // `?token=…` pair was a candidate, but an endpoint echoes the value alone,
+    // so the pair never matched and the secret went out verbatim.
+    test("a token carried in the query string is redacted from an echoed body", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response("bad token SUPERSECRET1", { status: 403, statusText: "Forbidden" })
+        )
+      );
+
+      const error = (await slackNotify({
+        url: "https://hooks.example.com/notify?token=SUPERSECRET1",
+        text: "hi",
+      }).catch((e: unknown) => e)) as PermanentJobError;
+
+      expect(error.message).not.toContain("SUPERSECRET1");
+      expect(String(error.stack)).not.toContain("SUPERSECRET1");
+      // The surrounding diagnostic survives; only the token is removed.
+      expect(error.message).toContain("bad token");
+    });
+
+    // An all-lowercase path segment was exempted outright, on the theory that
+    // such a run is a word rather than a token. A lowercase token is still a
+    // token, and the endpoint echoing it does not care about its character
+    // class.
+    test("an all-lowercase token in the path is redacted from an echoed body", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response("rejected: supersecrettoken", { status: 403, statusText: "Forbidden" })
+        )
+      );
+
+      const error = (await slackNotify({
+        url: "https://hooks.example.com/hooks/supersecrettoken",
+        text: "hi",
+      }).catch((e: unknown) => e)) as PermanentJobError;
+
+      expect(error.message).not.toContain("supersecrettoken");
+      expect(String(error.stack)).not.toContain("supersecrettoken");
+      expect(error.message).toContain("rejected");
+    });
+
+    // The stated cost of dropping the lowercase exemption, pinned rather than
+    // discovered later: a long lowercase word in a generic webhook's path is
+    // now redacted out of echoed diagnostics, because nothing distinguishes it
+    // from a lowercase token.
+    test("a long lowercase path word in a generic webhook is redacted, the accepted cost", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response("unknown notifications route", { status: 404, statusText: "Not Found" })
+        )
+      );
+
+      const error = (await slackNotify({
+        url: "https://hooks.example.com/notifications/deploy",
+        text: "hi",
+      }).catch((e: unknown) => e)) as PermanentJobError;
+
+      expect(error.message).not.toContain("notifications");
+      expect(error.message).toContain("unknown");
+    });
+
+    // `statusText` is caller-controlled text just like the body, and it was
+    // interpolated into the message and stored as `httpStatusText` with no
+    // redaction pass over it at all.
+    test("a reason phrase echoing the token is redacted", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response("nope", { status: 403, statusText: "token SECRETTOKEN bad" }))
+      );
+
+      const error = (await slackNotify({ url: SLACK_URL, text: "hi" }).catch(
+        (e: unknown) => e
+      )) as PermanentJobError & { httpStatusText?: string };
+
+      expect(error.message).not.toContain("SECRETTOKEN");
+      expect(String(error.httpStatusText)).not.toContain("SECRETTOKEN");
     });
 
     test("the webhook URL is absent from every output schema", () => {
@@ -1250,6 +1331,33 @@ describe("Webhook notification tasks", () => {
       // The status still reports; only the body is withheld.
       expect(error.message).toContain("400");
       expect(error.httpStatus).toBe(400);
+    });
+
+    // The body was withheld for a private destination but the reason phrase was
+    // not, and a server is free to put anything in it. That left the SSRF read
+    // open through a narrower channel: the internal service names its own index
+    // in the phrase, and it reached both the message and `httpStatusText`.
+    test("Slack does not echo a private endpoint's reason phrase", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(ES_BODY, { status: 400, statusText: "index=cluster-secrets shard=3" })
+        )
+      );
+
+      const error = (await slackNotify({
+        url: PRIVATE_URL,
+        text: "x",
+        allow_private_destination: true,
+      }).catch((e: unknown) => e)) as PermanentJobError & {
+        httpStatus?: number;
+        httpStatusText?: string;
+      };
+
+      expect(error.message).not.toContain("cluster-secrets");
+      // The status still reports; only the caller-controlled text is withheld.
+      expect(error.message).toContain("400");
+      expect(error.httpStatus).toBe(400);
+      expect(error.httpStatusText).toBeUndefined();
     });
 
     test("Discord does not echo a private endpoint's failure body", async () => {


### PR DESCRIPTION
Based on #744 (retarget to `main` once that merges). Independent of #745 — both touch `packages/tasks`, different files.

## What

For the notification tasks the webhook URL **is** the credential, and `redactWebhookUrlIn` is the control that keeps it out of a diagnostic quoting the endpoint's reply. It reaches the caller because `SlackNotifyTask` and `DiscordNotifyTask` both set `includeBodyInError: true`. Two shapes walked straight through it.

**Query values were never candidates.** Candidates came only from `pathname+search`, `search`, and the individual path segments. An endpoint authenticating with `?token=SUPERSECRET1` that answers `bad token SUPERSECRET1` matched nothing: the whole `?token=SUPERSECRET1` pair was admitted, but the echo quotes the value on its own. `?token=` auth is an ordinary deployment shape.

**All-lowercase candidates were exempted outright**, on the theory that an all-lowercase run is a word rather than a token. So `/hooks/supersecrettoken` echoed back as `rejected: supersecrettoken` went out verbatim, despite being 16 characters and clearly a secret.

**Rider, same function:** `response.statusText` was interpolated into the message unconditionally and stored as `httpStatusText`, with no redaction pass over it — and, unlike the failure body, it was **not** withheld for a private destination. A server puts whatever it likes in a reason phrase, so that left the SSRF read the body suppression exists to prevent open through a narrower channel.

## Why this fix

Admission is now by **length only**. The `services` / `webhooks` exemption the lowercase rule was really protecting is expressed directly, as a named set of the supported providers' routing segments — which is what it always meant, stated in terms that do not also exempt every lowercase secret.

Query values are admitted in both raw and decoded form, and the raw query is **split by hand rather than read from `searchParams`**: that decoder turns `+` into a space, so a decoded value would not match the bytes an endpoint echoes back. A malformed escape falls back to the raw form, which is what appears in an echo anyway.

The 8-char floor (`SECURITY_LIMITS.webhookMinRedactableSegmentChars`) is **unchanged** and now applies to query values too, so a short `?t=abc` still leaks. That is the same policy segments already had; the JSDoc now says so rather than leaving it to be rediscovered.

**Not folded in:** the `REDIRECT_NOT_FOLLOWED` diagnostic (same file, different function — it rebuilds the transport's refusal as `INVALID_URL`). It requires flipping three baked-in assertions and is a diagnostics-quality issue, not a leak. Deliberately deferred.

## Tests

Six cases, all through the tasks — `redactWebhookUrlIn` is not on the public surface (`WebhookPost.ts` is not re-exported from `common.ts`), and `WebhookNotifyTask` sets `includeBodyInError: false`, so Slack/Discord are the drivers.

| case | pre-fix |
|---|---|
| `?token=SUPERSECRET1` + 403 body `bad token SUPERSECRET1` → absent from `.message` and `.stack` | **fails** |
| `/hooks/supersecrettoken` + 403 body `rejected: supersecrettoken` → absent | **fails** |
| `/notifications/deploy` + `unknown notifications route` → `notifications` **is** redacted (the accepted cost, pinned) | **fails** |
| public 403 with reason phrase `token SECRETTOKEN bad` → absent from message and `httpStatusText` | **fails** |
| private 400 with reason phrase `index=cluster-secrets shard=3` → message has `400`, not `cluster-secrets`; `httpStatusText` undefined | **fails** |
| structural guard: Discord 400 body `invalid webhooks payload` → `webhooks` survives | passes both sides |

The last is the pre-existing over-redaction guard; its comment previously justified the exemption as "all-lowercase runs are words, not tokens" and now names the real reason (a provider routing segment), pinning the replacement for the deleted rule.

**Actually executed:**

- Against pre-fix `WebhookPost.ts` (reverted, tests kept): **5 failed / 89 passed** — exactly the five new cases.
- With the fix: `NotifyTask` + `NotifyTaskTransport` + `FetchUrlSsrf` → **173 passed**.
- Whole `packages/test/src/test/task/` directory: **67 files, 1055 passed, 24 skipped**.
- `prettier --check` clean.

No pre-existing test asserted on `statusText`; the private-destination cases assert `toContain("400")` and `httpStatus`, and the public paths use `"Not Found"` / `"Bad Request"`, which survive redaction unchanged. Confirmed by the full-directory run.

## Risk / blast radius

Two behaviour changes a reviewer has to accept:

1. **A generic webhook whose path carries a long lowercase word** (`/notifications/deploy`) now has that word redacted out of echoed diagnostics. This is the stated cost of dropping the exemption; there is no signal separating such a word from a lowercase token. Pinned by its own test so it cannot surprise anyone later.
2. **`httpStatusText` is now `undefined` for a private destination**, where it previously carried the reason phrase. Consumers reading that field for private posts see a missing value rather than a string.

Confined to `redactWebhookUrlIn` and the failure-throw in `postWebhookJson`. Both are shared by all three notification tasks; `WebhookNotifyTask` never surfaces bodies, so only its `httpStatusText` behaviour changes.

## Unverified

- No fuzzing over URL shapes; coverage is the six cases above plus the pre-existing redaction suite.
- Whether any downstream consumer depends on `httpStatusText` being present for a private destination was not audited outside this repo.
- `tsc -p packages/tasks` cannot run cleanly in this checkout (unbuilt `.d.ts` under `use-source` mode); no type check against real build output was possible.
- Run under Node v22.22.2, not the Node 24 the repo asks for.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H797qbH356jjznKgUax63o)_