### PR TITLE
ci: keep a blocking job that exercises the built bundles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -404,9 +404,16 @@ source also collapses the two module identities a mixed package/relative import 
 otherwise produces.
 
 `WORKGLOW_TEST_TARGET=dist` restores the old behavior for a check that the built bundles
-themselves are wired correctly. Bundle integrity is not left unguarded by the default: the
-Bun runner resolves `exports` natively, so the nightly parity workflow runs the whole suite
-against `dist` either way.
+themselves are wired correctly. The plugin is attached to every project unconditionally,
+not only to coverage runs, so with the default in force NO vitest job resolves a
+`@workglow/*` specifier through `exports` — and there is no `bun test` job in the blocking
+workflow at all. The nightly Bun parity run does resolve `exports` natively, but it is
+explicitly informational, never blocks a merge, runs on a cron, and excludes six sections.
+So the `test-vitest-dist` job in `.github/workflows/test.yml` is what keeps bundle
+integrity blocking: it reuses the `build-output` artifact and runs the unit tier with
+`WORKGLOW_TEST_TARGET=dist`. It produces no coverage fragment — `scripts/test.ts` skips
+`--coverage` when targeting `dist`, since measuring bundles against a `src` denominator
+reports every source file at 0% — so `merge-vitest-coverage` is unaffected.
 
 The coverage denominator is stated explicitly (`packages/*/src/**/*.{ts,tsx}`, same for
 `providers/`) rather than left to vitest's default of "files loaded during the run" — that

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,35 @@ jobs:
           path: vitest-unit-coverage.json
           retention-days: 1
 
+  # The one blocking job that resolves `@workglow/*` through `exports` rather
+  # than through the source-rewrite plugin. Every other vitest job here now
+  # runs against `src`, and there is no `bun test` job in this workflow at all,
+  # so without this a `bun build` entry that silently dropped a re-export would
+  # reach main and only surface in the nightly parity run, which never blocks.
+  # No coverage fragment is produced (scripts/test.ts skips `--coverage` when
+  # targeting dist), so merge-vitest-coverage needs no change.
+  test-vitest-dist:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun i
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-output
+          path: .
+      - name: Run unit tests against the built bundles
+        env:
+          WORKGLOW_TEST_TARGET: dist
+        run: bun run test:vitest:unit
+
   test-vitest-integration:
     runs-on: ubuntu-latest
     needs: build
@@ -344,6 +373,7 @@ jobs:
     needs:
       [
         test-vitest-unit,
+        test-vitest-dist,
         test-vitest-integration,
         test-vitest-rag,
         test-vitest-ai-provider-hft,

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -116,7 +116,10 @@ function buildVitestArgs(files: string[]): string[] {
     // pipelines). The job's timeout-minutes covers the longer serial wall-clock.
     args.push("--no-file-parallelism");
   }
-  if (process.env.CI) {
+  // A `dist`-targeted run measures the bundles, not the sources the coverage
+  // denominator names, so every one of the ~1286 `src` files would be reported
+  // at 0%. Skip coverage there rather than merging a fragment that says nothing.
+  if (process.env.CI && process.env.WORKGLOW_TEST_TARGET !== "dist") {
     args.push("--coverage");
   }
   args.push(...relFiles);

--- a/scripts/testRunnerArgs.test.ts
+++ b/scripts/testRunnerArgs.test.ts
@@ -11,12 +11,18 @@ import { ROOT } from "./lib/testDiscovery";
 /**
  * Runs the test runner in dry-run mode, which prints the command it would have
  * spawned as a JSON array instead of executing it.
+ *
+ * `target` is always passed explicitly rather than left to the ambient
+ * environment. The `test-vitest-dist` CI job exports `WORKGLOW_TEST_TARGET` for
+ * its whole step, so an inherited value silently rewrites the source-target
+ * case into a second copy of the dist case — which is exactly how this file
+ * first failed, in the very job it exists to support.
  */
-function dryRunCommand(env: Readonly<Record<string, string>>): string {
+function dryRunCommand(target: "source" | "dist"): string {
   const stdout = execFileSync("bun", ["scripts/test.ts", "unit", "vitest", "--dry-run"], {
     cwd: ROOT,
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    env: { ...process.env, CI: "1", WORKGLOW_TEST_TARGET: target },
   });
   const line = stdout
     .split("\n")
@@ -30,7 +36,7 @@ describe("scripts/test.ts coverage flag", () => {
   // The baseline the second case is measured against: CI runs are the ones
   // that produce the coverage fragments `merge-vitest-coverage` merges.
   it("asks for coverage on an ordinary CI run", () => {
-    expect(dryRunCommand({ CI: "1" })).toContain('"--coverage"');
+    expect(dryRunCommand("source")).toContain('"--coverage"');
   });
 
   /**
@@ -45,6 +51,6 @@ describe("scripts/test.ts coverage flag", () => {
    * `test:vitest:unit` unchanged rather than needing its own invocation.
    */
   it("does not ask for coverage when the run targets the built bundles", () => {
-    expect(dryRunCommand({ CI: "1", WORKGLOW_TEST_TARGET: "dist" })).not.toContain('"--coverage"');
+    expect(dryRunCommand("dist")).not.toContain('"--coverage"');
   });
 });

--- a/scripts/testRunnerArgs.test.ts
+++ b/scripts/testRunnerArgs.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { ROOT } from "./lib/testDiscovery";
+
+/**
+ * Runs the test runner in dry-run mode, which prints the command it would have
+ * spawned as a JSON array instead of executing it.
+ */
+function dryRunCommand(env: Readonly<Record<string, string>>): string {
+  const stdout = execFileSync("bun", ["scripts/test.ts", "unit", "vitest", "--dry-run"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+  const line = stdout
+    .split("\n")
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith("["));
+  expect(line, `no command line in dry-run output:\n${stdout}`).toBeDefined();
+  return line as string;
+}
+
+describe("scripts/test.ts coverage flag", () => {
+  // The baseline the second case is measured against: CI runs are the ones
+  // that produce the coverage fragments `merge-vitest-coverage` merges.
+  it("asks for coverage on an ordinary CI run", () => {
+    expect(dryRunCommand({ CI: "1" })).toContain('"--coverage"');
+  });
+
+  /**
+   * A `dist`-targeted run exercises the built bundles, but the coverage
+   * denominator names `packages/*` and `providers/*` SOURCES. Collecting
+   * coverage there produces a fragment reporting all ~1286 source files at 0%,
+   * which is not a measurement of anything — and if such a fragment were ever
+   * merged it would drag the reported total toward zero for reasons unrelated
+   * to how well the tree is tested.
+   *
+   * This is what lets the blocking `test-vitest-dist` CI job reuse
+   * `test:vitest:unit` unchanged rather than needing its own invocation.
+   */
+  it("does not ask for coverage when the run targets the built bundles", () => {
+    expect(dryRunCommand({ CI: "1", WORKGLOW_TEST_TARGET: "dist" })).not.toContain('"--coverage"');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -62,10 +62,12 @@ const shared = {
  * reading as untested. It also collapses the two module identities a mixed
  * package/relative import graph otherwise produces.
  *
- * `dist` restores the old behavior for the rare check that the built bundles
- * themselves are wired correctly. Bundle integrity is not left unguarded by
- * the default: the Bun runner resolves `exports` natively, so the nightly
- * parity workflow still runs the whole suite against `dist`.
+ * `dist` restores the old behavior for the check that the built bundles
+ * themselves are wired correctly. The plugin below is attached to every project
+ * unconditionally, so under the default NO vitest run resolves a `@workglow/*`
+ * specifier through `exports`. The nightly Bun parity workflow does, but it is
+ * informational and never blocks a merge, so the blocking guard is the
+ * `test-vitest-dist` CI job, which sets this variable.
  */
 const testsRunAgainstSource = (process.env.WORKGLOW_TEST_TARGET ?? "source") !== "dist";
 


### PR DESCRIPTION
Based on #741 (retarget to `main` once that merges). Rebased onto `origin/main` (`67bed681`).

> ### ⚠️ Two CI notes, read these first
>
> **1. `build` is red, and it is inherited.** `main` has not built since `5b94e05a` — `@workglow/anthropic#build-types` fails with `Anthropic_StructuredGeneration.ts(57,41): error TS2739 … missing max_tokens, messages, model`. This stack previously passed `build` only because its base predated the break; after rebasing onto current `main` it inherits the failure. **Not caused by this PR and not fixed here** — another agent owns that fix.
>
> **2. The `test-vitest-dist` job failed on its first run. It has been diagnosed and fixed — and the bundles were not the problem.** Details below.

## What

#741 makes vitest resolve every `@workglow/*` specifier to the package's `src`, which is what makes the coverage numbers mean anything. But `vitest.config.ts` attaches the plugin to **every project unconditionally** — not only to coverage runs — and `testsRunAgainstSource` defaults to `source`.

Enumerating the jobs in `.github/workflows/test.yml`: `typecheck-budget`, `test-discovery`, `build`, six `test-vitest-*`, `merge-vitest-coverage`, `cleanup`. **There is no `bun test` job in the blocking workflow at all** (`grep test:bun .github/workflows/test.yml` → nothing). So after #741, no job that can block a merge resolves a `@workglow/*` specifier through `exports`. A `bun build` entry that silently dropped a re-export reaches `main` and surfaces only in `nightly-bun-parity.yml`, which states in its own header that "Failures here are informational. They never block a merge", runs on a cron, and excludes `rag,browser,provider-hft,provider-nodellama,provider-api,provider-cactus`.

The `.claude/CLAUDE.md` sentence and the matching `vitest.config.ts` JSDoc both asserted that bundle integrity "is not left unguarded by the default" because of that nightly run. Wrong on both counts — it is not blocking, and it is not the whole suite.

## Why this fix

1. **`test-vitest-dist`**, a blocking job — `needs: build`, downloads the existing `build-output` artifact, runs `bun run test:vitest:unit` with `WORKGLOW_TEST_TARGET: dist`. It reuses the artifact the six existing jobs already share, so it costs a runner, not a build.
2. **`scripts/test.ts` skips `--coverage` when targeting `dist`.** The denominator names `packages/*/src` and `providers/*/src`, so a bundle-targeted run reported all ~1286 source files at 0% — not a measurement of anything, and merging such a fragment would drag the total toward zero for reasons unrelated to how well the tree is tested. Skipping it is also what lets the new job reuse `test:vitest:unit` verbatim and produce no fragment, so `merge-vitest-coverage` needs no change.
3. **The two stale claims corrected**, in `.claude/CLAUDE.md` and in the `vitest.config.ts` JSDoc that repeats it.

**Explicitly rejected alternative — "scope the plugin to coverage runs only".** It does not fix this. `scripts/test.ts` adds `--coverage` whenever `CI` is set, so in CI *every* run is a coverage run and would still resolve to `src`. The gap would be exactly as wide, with the config now implying otherwise.

**Beyond the original plan:** `test-vitest-dist` was added to `cleanup`'s `needs` list. `cleanup` deletes the `build-output` artifact, and without that edge it could race a still-downloading `test-vitest-dist`.

## What the first `test-vitest-dist` run actually found

**The bundles are fine.** The job ran the entire unit tier against built output and reported:

```
Test Files  1 failed | 514 passed | 3 skipped (518)
     Tests  1 failed | 5879 passed | 71 skipped (5951)
```

5879 tests passed against `dist`. The single failure was **this PR's own new test**, not a wiring defect:

```
FAIL  scripts  testRunnerArgs.test.ts > scripts/test.ts coverage flag
      > asks for coverage on an ordinary CI run
AssertionError: expected '["npx","vitest","run","examples/cli/s…' to contain '"--coverage"'
```

Root cause: the test spawned the runner with `{...process.env, CI: "1"}` and let `WORKGLOW_TEST_TARGET` come from the ambient environment. The `test-vitest-dist` job exports that variable **for the whole step**, so inside that job the "ordinary CI run" case inherited `dist` and became a second copy of the dist case — asserting `--coverage` is present while the runner correctly omitted it. The test failed in the one job it was added to support.

Fixed by pinning the variable explicitly in both cases (`"source"` / `"dist"`) rather than inheriting it. Verified by re-running under the job's exact ambient environment:

```
$ WORKGLOW_TEST_TARGET=dist CI=1 vitest run --project scripts scripts/testRunnerArgs.test.ts
  Test Files  1 passed (1) / Tests  2 passed (2)

# and the old form reproduced under the same env, for contrast:
OLD form (inherits WORKGLOW_TEST_TARGET) has --coverage: false   ← the failure
NEW form (explicit source)               has --coverage: true
```

So the job is working exactly as intended: it ran the tier against the bundles, and the only thing it caught was an environment-dependent assumption in a brand-new test. That is a better first result than a green run would have been.

The other red job on this run, `test-vitest-ai-provider-api`, is a pre-existing job this PR does not touch.

## Tests

`scripts/testRunnerArgs.test.ts` (2 cases), spawning the runner in `--dry-run` mode, which prints the command it would have spawned:

| case | pre-fix |
|---|---|
| `CI=1`, target `source` → command contains `--coverage` (the baseline) | passes |
| `CI=1`, target `dist` → command does **not** contain `--coverage` | **fails** |

Deliberately a **vitest** file, not an addition to `scripts/test.test.ts` — that one imports `bun:test`, and a regression test for "blocking CI does not cover X" that itself does not run in blocking CI would be self-defeating. `scripts` is a real vitest project, so this runs in `test:vitest:unit`.

**Actually executed locally:**

- `vitest --project scripts`: **4 files, 16 passed**; and **2 passed** under `WORKGLOW_TEST_TARGET=dist CI=1`.
- With `scripts/test.ts` reverted: **1 failed / 15 passed** — the dist case, as expected.
- Manual confirmation of both dry-run outputs.
- `.github/workflows/test.yml` parsed with a YAML loader: 12 jobs, `test-vitest-dist` present with `needs: build` and `WORKGLOW_TEST_TARGET: dist`, `cleanup.needs` includes it, `merge-vitest-coverage.needs` unchanged.
- `prettier --check` clean.

**Executed in CI:** the new job itself — see above.

## Risk / blast radius

**One extra CI job**, running the full unit tier a second time. From the first run: ~3m20s wall clock (03:04:05 → 03:07:26), comparable to the existing tiers and fully parallel with them.

If that ever proves unacceptable, the cheaper follow-up is a single `dist`-targeted suite that dynamically imports every runtime entry from `stubSpecsFor` and asserts each bundle namespace's export names are a superset of the source module's — narrower and aimed exactly at "a `bun build` entry silently dropped a re-export". Flagged as follow-up rather than primary because importing every entry has real side-effect and native-module hazards under Node, which the full tier does not.

A local `CI=1 WORKGLOW_TEST_TARGET=dist` run no longer writes `coverage/`. Nothing in the workflow reads it on that path.

The coverage denominator itself is untouched here — that is #749, deliberately separate, so the coverage delta stays readable.

## Unverified

- The **`build` failure inherited from `main`** (see the note at the top) is not diagnosed or fixed here.
- Local runs were under Node v22.22.2, not the Node 24 CI uses; CI is the authority and has now exercised the real path.