### PR TITLE
fix(test): count examples/* source in the coverage denominator

### DIFF
--- a/scripts/workspaceSource.test.ts
+++ b/scripts/workspaceSource.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { stubSpecsFor, type PackageManifest } from "./lib/sourceStubs";
 import { ROOT } from "./lib/testDiscovery";
-import { distToSource, listWorkspacePackages } from "./lib/workspaceSource";
+import { distToSource, listWorkspacePackages, WORKSPACE_GROUPS } from "./lib/workspaceSource";
 
 const packages = listWorkspacePackages(ROOT);
 
@@ -60,5 +60,28 @@ describe("workspace source resolution", () => {
     expect(existsSync(invented)).toBe(false);
     expect(distToSource(invented)).toBeUndefined();
     expect(distToSource(join(ROOT, "packages/ai/src/node.ts"))).toBeUndefined();
+  });
+
+  /**
+   * The invariant that actually broke: the resolver covers all three workspace
+   * groups, but the coverage denominator listed only two, so `examples/*`
+   * source was rewritten to `src`, executed by its own tests, and then left out
+   * of the denominator entirely. All three example packages are published and
+   * none is `private`, so there is no "not really shipped" argument for the
+   * omission — and a missing group is invisible in a coverage report, which
+   * shows a smaller file list rather than an error.
+   *
+   * Reads the ACTUAL config rather than re-deriving it, so the two cannot drift
+   * back apart.
+   */
+  it("counts every workspace group in the coverage denominator", async () => {
+    const mod = (await import("../vitest.config.ts")) as {
+      default: { test?: { coverage?: { include?: string[] } } };
+    };
+    const include = mod.default.test?.coverage?.include ?? [];
+    const missing = WORKSPACE_GROUPS.filter(
+      (group) => !include.some((glob) => glob.startsWith(`${group}/`))
+    );
+    expect(missing).toEqual([]);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -106,13 +106,31 @@ export default defineConfig({
       provider: "v8", // or 'istanbul'
       reporter: ["text", "json", "json-summary", "html"],
       /**
+       * Base directory the globs below resolve against. Pinned rather than
+       * inherited: `include`/`exclude` are documented as relative to
+       * `coverage.root`, which otherwise follows the run's root — and this
+       * config is invoked from package directories too
+       * (`vitest run --config ../../vitest.config.ts`), where a repo-relative
+       * glob would match nothing.
+       */
+      root: __dirname,
+      /**
        * The denominator is every package's own `src`, stated explicitly. Left
        * to vitest's default (files loaded during the run), a package's score
        * silently omits the modules no test imports at all — the ones a coverage
        * report exists to surface — and its file list changes with whichever
        * section CI happened to run.
+       *
+       * All THREE workspace groups, matching `WORKSPACE_GROUPS`: `examples/*`
+       * holds published, non-private packages with tests of their own, so
+       * omitting it drops real source from the denominator while still counting
+       * the tests that cover it.
        */
-      include: ["packages/*/src/**/*.{ts,tsx}", "providers/*/src/**/*.{ts,tsx}"],
+      include: [
+        "packages/*/src/**/*.{ts,tsx}",
+        "providers/*/src/**/*.{ts,tsx}",
+        "examples/*/src/**/*.{ts,tsx}",
+      ],
       exclude: [
         ...configDefaults.exclude,
         // Built output is never the unit of measure. Nothing should resolve
@@ -122,6 +140,10 @@ export default defineConfig({
         "**/dist/**",
         // The cross-package suite is the harness, not the subject.
         "packages/test/**",
+        // The examples keep their suites in `src/test`, which also holds the
+        // odd non-`.test.` helper (`chromeAvailability.ts`) that the filename
+        // rules below cannot catch.
+        "examples/*/src/test/**",
         // Tests, fixtures and testing-only helpers: counting them inflates
         // every package by the coverage of code that exists to be run.
         "**/__tests__/**",


### PR DESCRIPTION
Based on #741 (retarget to `main` once that merges). Rebased onto `origin/main` (`67bed681`). Independent of #748 — deliberately separate, since adding a CI job and changing the denominator in one PR makes the coverage delta unreadable.

> ### ⚠️ `build` is red, inherited from `main`
>
> `main` has not built since `5b94e05a` — `@workglow/anthropic#build-types` fails with `Anthropic_StructuredGeneration.ts(57,41): error TS2739 … missing max_tokens, messages, model`. This branch previously passed `build` only because its base predated the break; after rebasing onto current `main` it inherits the failure. **Not caused by this PR and not fixed here** — another agent owns that fix. Every job downstream of `build` is blocked by it.

## What

`examples` is a first-class workspace group in both `scripts/lib/workspaceSource.ts` (`WORKSPACE_GROUPS`) and `scripts/lib/testDiscovery.ts`. All three example packages are **published and none is `private`** — `@workglow/cli`, `@workglow/eval`, `@workglow/web`, all at 0.3.38 — and they carry 24 test files between them (7 / 14 / 3).

`coverage.include` listed only `packages/*/src` and `providers/*/src`. So example source was rewritten to `src` by the resolver, executed by its own tests, and then omitted from the measurement. Demonstrated:

```
# before
$ cd examples/cli && vitest run --config ../../vitest.config.ts --project cli --coverage
File      | % Stmts | % Branch | % Funcs | % Lines
All files |       0 |        0 |       0 |       0

# after
All files          |   24.15 |    14.71 |   26.22 |   24.87
 src/ui            |   26.87 |    12.19 |   26.08 |   27.54
 src/ui/components |   50.76 |    53.48 |   54.54 |   54.23
 src/ui/rows       |   44.25 |    37.73 |   41.66 |   45.03
```

Not merely a wrong number: 28 passing tests were contributing coverage to nothing at all.

## Why this fix

**`include` gains `examples/*/src/**/*.{ts,tsx}`**, and the adjacent comment now names all three groups so the next reader cannot infer the omission was intentional.

**`coverage.root: __dirname`** rather than making the globs absolute. `coverage.root` is the documented base for `include`/`exclude`, and this config is invoked from package directories too (`vitest run --config ../../vitest.config.ts --project cli`), where a repo-relative glob would otherwise match nothing. It also sidesteps the question of whether vitest 4 accepts absolute glob patterns, which could not be settled here. From the repo root it is a no-op, since root and `__dirname` coincide.

**`examples/*/src/test/**` added to `exclude`.** Found while verifying: the examples keep their suites in `src/test`, which also holds `examples/cli/src/test/chromeAvailability.ts` — a test helper with no `.test.` in its name, so the existing filename rules miss it. It showed up as `src/test | 18.75%`. Counting testing-only helpers is exactly what the neighbouring `packages/test/**` and `**/testing/**` entries exist to prevent.

## Tests

`scripts/workspaceSource.test.ts` gains the invariant that actually broke: **every entry in `WORKSPACE_GROUPS` must be the prefix of some `coverage.include` glob.** It reads the real `vitest.config.ts` (the idiom `testDiscovery.test.ts` already uses for project roots) rather than re-deriving it, so the resolver and the denominator cannot drift apart again.

A missing group is otherwise invisible: a coverage report shows a shorter file list, never an error — which is how this survived in the first place.

**Actually executed:**

- `vitest --project scripts`: **3 files, 15 passed**.
- With `vitest.config.ts` reverted: **1 failed / 14 passed**, `AssertionError: expected [ 'examples' ] to deeply equal []` — it names the missing group.
- Coverage from `examples/cli` before and after (output above).
- Coverage from the repo root across two projects: example source listed, `packages/*` rows still present, so `coverage.root` did not disturb the existing globs.
- `prettier --check` clean.

**Not executed:** a full `bun run test:vitest:unit --coverage` over all 518 files. Too slow here; the narrow runs above exercise both invocation styles.

## Risk / blast radius

**The reported total will move**, and probably down — three packages' source joins the denominator at whatever their real coverage is (`~24%` for `cli`). That is a corrected measurement, not a regression, but a reviewer watching a coverage gate must expect the step change. This is why it is not bundled with #748.

Config-only otherwise. No product code, no test behaviour, nothing shipped to consumers.

## Unverified

- vitest 4's exact base directory for `coverage.include` was not observed directly; `coverage.root` was chosen because it is the documented base and does not depend on that answer. Both invocation styles were checked empirically instead.
- Whether any coverage threshold or badge downstream is keyed to the old total.
- The **`build` failure inherited from `main`** (see the note at the top).
- Run under Node v22.22.2, not the Node 24 the repo asks for.