### PR TITLE
test(exports): check every implementation key and cross-sibling condition order

### DIFF
--- a/packages/test/src/test/util/ExportTypesPairing.test.ts
+++ b/packages/test/src/test/util/ExportTypesPairing.test.ts
@@ -47,6 +47,17 @@ interface BranchLocation {
   readonly manifest: string;
   readonly subpath: string;
   readonly condition: string;
+  /**
+   * Which of {@link IMPLEMENTATION_KEYS} named this implementation, or
+   * `undefined` for the string-shorthand form where the condition's own value
+   * IS the implementation and there is no separate key.
+   *
+   * Part of the identity because one object can now yield several branches —
+   * `{types, require, default}` produces one per string-valued implementation
+   * key — and they would otherwise share a label, colliding as the key for
+   * `ALLOWED_MISMATCHES` and the staleness check.
+   */
+  readonly implementationKey: string | undefined;
   readonly implementation: string;
   readonly expectedTypes: string;
 }
@@ -113,6 +124,7 @@ function collectBranches(
         manifest,
         subpath,
         condition,
+        implementationKey: undefined,
         types: undefined,
         reason: "missing",
         implementation: node,
@@ -123,18 +135,24 @@ function collectBranches(
   }
   if (typeof node !== "object" || node === null || Array.isArray(node)) return;
   const entry = node as Record<string, unknown>;
-  const implementationKey = IMPLEMENTATION_KEYS.find((key) => typeof entry[key] === "string");
-  if (implementationKey !== undefined) {
+  // EVERY string-valued implementation key, not just the first. A dual-package
+  // object writes them flat — `{types, import: "./a.mjs", require: "./a.cjs"}` —
+  // and taking only `import` left `require` unchecked, so a `.cjs` paired with a
+  // `.d.ts` sailed through. The file's own `.cjs` fixtures use the nested form,
+  // which is why the flat shape was never exercised.
+  const implementationKeys = IMPLEMENTATION_KEYS.filter((key) => typeof entry[key] === "string");
+  const keys = Object.keys(entry);
+  for (const implementationKey of implementationKeys) {
     const implementation = entry[implementationKey] as string;
     const location: BranchLocation = {
       manifest,
       subpath,
       condition,
+      implementationKey,
       implementation,
       expectedTypes: declarationFor(implementation),
     };
     const types = entry.types;
-    const keys = Object.keys(entry);
     out.push(
       typeof types === "string"
         ? {
@@ -162,7 +180,8 @@ function collectBranches(
 }
 
 function label(branch: Branch): string {
-  return `${branch.manifest} exports["${branch.subpath}"] [${branch.condition}]`;
+  const key = branch.implementationKey === undefined ? "" : ` > ${branch.implementationKey}`;
+  return `${branch.manifest} exports["${branch.subpath}"] [${branch.condition}${key}]`;
 }
 
 function isViolation(branch: Branch): boolean {
@@ -197,6 +216,70 @@ function findViolations(manifest: string, exportsMap: Record<string, unknown>): 
     .filter(isViolation)
     .filter((branch) => !ALLOWED_MISMATCHES.has(label(branch)))
     .map(violationMessage);
+}
+
+function isImplementationString(entry: Record<string, unknown>, key: string): boolean {
+  return (IMPLEMENTATION_KEYS as readonly string[]).includes(key) && typeof entry[key] === "string";
+}
+
+/**
+ * Condition keys made unreachable by a SIBLING declared before them.
+ *
+ * The pairing rule and its `typesBeforeImplementation` flag both look inside a
+ * single object, so they see nothing wrong with a map whose branches are
+ * individually well formed but ordered so that one can never be selected.
+ * Resolution stops at the first key that matches, so:
+ *
+ * - `{types, browser: {…}, import}` — TypeScript matches the outer `types` and
+ *   never looks at `browser`, which is exactly the browser-typed-as-node bug
+ *   this file exists to prevent, expressed through ordering instead of through
+ *   a wrong target; and
+ * - `{import, browser: {…}}` — a runtime honoring `browser` still matches
+ *   `import` first, so the browser build never loads.
+ *
+ * Both shapes yield `violations: []` and `late: []` from the existing checks.
+ *
+ * The string-shorthand form (`browser: "./dist/x.js"`) is included: it is just
+ * as dead as the object form, and this repo demonstrably writes it.
+ */
+function orderViolations(manifest: string, exportsMap: Record<string, unknown>): string[] {
+  const out: string[] = [];
+  const walk = (subpath: string, conditionPath: readonly string[], node: unknown): void => {
+    if (typeof node !== "object" || node === null || Array.isArray(node)) return;
+    const entry = node as Record<string, unknown>;
+    const keys = Object.keys(entry);
+    const typesIndex = keys.indexOf("types");
+    const implementationIndex = keys.findIndex((key) => isImplementationString(entry, key));
+    const where = conditionPath.join(" > ") || "(default)";
+    const at = `${manifest} exports["${subpath}"] [${where}]`;
+
+    keys.forEach((key, index) => {
+      // Only condition keys can be shadowed. `types` and the implementation
+      // strings are the things that DO the shadowing.
+      if (key === "types" || isImplementationString(entry, key)) return;
+      if (typesIndex >= 0 && typesIndex < index) {
+        out.push(
+          `${at}: condition "${key}" is declared after "types", so TypeScript resolves ` +
+            `"types" first and "${key}" is never reached`
+        );
+      }
+      if (implementationIndex >= 0 && implementationIndex < index) {
+        out.push(
+          `${at}: condition "${key}" is declared after "${keys[implementationIndex]}", so ` +
+            `resolution stops there and "${key}" is never reached`
+        );
+      }
+    });
+
+    for (const [key, value] of Object.entries(entry)) {
+      if (key === "types" || typeof value === "string") continue;
+      walk(subpath, [...conditionPath, key], value);
+    }
+  };
+  for (const [subpath, value] of Object.entries(exportsMap)) {
+    walk(subpath, [], value);
+  }
+  return out;
 }
 
 interface WorkspaceRoot {
@@ -316,6 +399,13 @@ describe("workspace exports maps", () => {
     expect(late).toEqual([]);
   });
 
+  it("declares every condition before the siblings that would shadow it", () => {
+    const shadowed = manifests.flatMap((manifest) =>
+      orderViolations(manifest.relative, manifest.exports)
+    );
+    expect(shadowed).toEqual([]);
+  });
+
   it("keeps the allowlist free of entries that no longer mismatch", () => {
     const stale = [...ALLOWED_MISMATCHES].filter(
       (entry) => !branches.some((branch) => label(branch) === entry && isViolation(branch))
@@ -413,9 +503,42 @@ describe("exports map violation detection", () => {
         },
       })
     ).toEqual([
-      'fixture/package.json exports["."] [browser]: implementation "./dist/ai.browser.js" ' +
-        'declares no types (expected types="./dist/ai.browser.d.ts")',
+      'fixture/package.json exports["."] [browser > import]: implementation ' +
+        '"./dist/ai.browser.js" declares no types (expected types="./dist/ai.browser.d.ts")',
     ]);
+  });
+
+  /**
+   * A flat dual-package object. `IMPLEMENTATION_KEYS.find(...)` stopped at
+   * `import`, so `require`'s `.cjs` was never paired against anything and its
+   * `.d.ts` mismatch went unreported. The nested `require: {types, default}`
+   * form the fixtures below use is what hid this.
+   */
+  it("checks every implementation key in a flat dual-package branch", () => {
+    expect(
+      findViolations("fixture/package.json", {
+        ".": {
+          types: "./dist/a.d.ts",
+          import: "./dist/a.js",
+          require: "./dist/a.cjs",
+        },
+      })
+    ).toEqual([
+      'fixture/package.json exports["."] [(default) > require]: types="./dist/a.d.ts" but ' +
+        'implementation is "./dist/a.cjs" (expected types="./dist/a.d.cts")',
+    ]);
+  });
+
+  it("does not turn extra agreeing implementation keys into noise", () => {
+    expect(
+      findViolations("fixture/package.json", {
+        ".": {
+          types: "./dist/a.d.ts",
+          import: "./dist/a.js",
+          default: "./dist/a.js",
+        },
+      })
+    ).toEqual([]);
   });
 
   it("accepts a `.cjs`/`.mjs` implementation declared by its own extension", () => {
@@ -440,8 +563,8 @@ describe("exports map violation detection", () => {
         },
       })
     ).toEqual([
-      'fixture/package.json exports["."] [require]: types="./dist/ai.d.ts" but implementation ' +
-        'is "./dist/ai.cjs" (expected types="./dist/ai.d.cts")',
+      'fixture/package.json exports["."] [require > default]: types="./dist/ai.d.ts" but ' +
+        'implementation is "./dist/ai.cjs" (expected types="./dist/ai.d.cts")',
     ]);
   });
 
@@ -449,6 +572,76 @@ describe("exports map violation detection", () => {
     expect(findViolations("fixture/package.json", { "./package.json": "./package.json" })).toEqual(
       []
     );
+  });
+
+  /**
+   * Ordering hazards. Each shape is internally well formed — every `types`
+   * names the right target beside the right implementation — so the pairing
+   * rule and the `typesBeforeImplementation` flag both pass them, which is the
+   * whole reason the order check has to exist separately.
+   */
+  describe("condition ordering", () => {
+    const outerTypesFirst = {
+      ".": {
+        types: "./dist/node.d.ts",
+        browser: { types: "./dist/browser.d.ts", import: "./dist/browser.js" },
+        import: "./dist/node.js",
+      },
+    };
+
+    it("reports a nested condition shadowed by an outer `types`", () => {
+      // Documenting WHY a second check is needed: the pairing rule is silent
+      // here, so without this the dead `browser` branch ships unnoticed.
+      expect(findViolations("fixture/package.json", outerTypesFirst)).toEqual([]);
+
+      expect(orderViolations("fixture/package.json", outerTypesFirst)).toEqual([
+        'fixture/package.json exports["."] [(default)]: condition "browser" is declared after ' +
+          '"types", so TypeScript resolves "types" first and "browser" is never reached',
+      ]);
+    });
+
+    it("reports a nested condition shadowed by an implementation key", () => {
+      const implementationFirst = {
+        ".": {
+          import: "./dist/node.js",
+          browser: { types: "./dist/browser.d.ts", import: "./dist/browser.js" },
+        },
+      };
+      expect(orderViolations("fixture/package.json", implementationFirst)).toEqual([
+        'fixture/package.json exports["."] [(default)]: condition "browser" is declared after ' +
+          '"import", so resolution stops there and "browser" is never reached',
+      ]);
+    });
+
+    // Guards against an "objects only" implementation: a string shorthand is
+    // just as dead, and this repo writes that form.
+    it("reports a string-shorthand condition declared after `types`", () => {
+      const shorthandLate = {
+        ".": {
+          types: "./dist/node.d.ts",
+          import: "./dist/node.js",
+          browser: "./dist/browser.js",
+        },
+      };
+      expect(orderViolations("fixture/package.json", shorthandLate)).toEqual([
+        'fixture/package.json exports["."] [(default)]: condition "browser" is declared after ' +
+          '"types", so TypeScript resolves "types" first and "browser" is never reached',
+        'fixture/package.json exports["."] [(default)]: condition "browser" is declared after ' +
+          '"import", so resolution stops there and "browser" is never reached',
+      ]);
+    });
+
+    it("accepts a condition declared before both", () => {
+      expect(
+        orderViolations("fixture/package.json", {
+          ".": {
+            browser: { types: "./dist/browser.d.ts", import: "./dist/browser.js" },
+            types: "./dist/node.d.ts",
+            import: "./dist/node.js",
+          },
+        })
+      ).toEqual([]);
+    });
   });
 
   it("derives a source entry from a dist target", () => {


### PR DESCRIPTION
Based on #717 (retarget to `main` once that merges). Both branches rebased onto `origin/main` (`67bed681`). Deliberately **not** combined with the manifest changes already on #717 — those are verified correct and this is purely about the guard that protects them.

## Rebase note

#717 was 94 commits behind. It rebased onto current `main` with **zero conflicts** (4 replayed commits), confirming the earlier merge-preview prediction — including that `main` had independently landed the byte-identical `./worker` types change, which git resolved silently. This branch was then rebased onto the updated #717. The guard suite was re-run against the **post-rebase** manifest set, which matters because `main` moved 94 commits: **20 passed**, with the new workspace-wide order check finding **0 violations** across today's real manifests.

## What

Two coverage gaps in `ExportTypesPairing.test.ts`. Both are **latent**: no workspace manifest violates either rule today, which is precisely why neither was noticed.

**1. Only the first implementation key per object was examined.** `IMPLEMENTATION_KEYS.find(...)` stopped at the first match, and the recursion `continue`d past string-valued implementation keys. So a flat dual-package object —

```json
{ "types": "./dist/a.d.ts", "import": "./dist/a.js", "require": "./dist/a.cjs" }
```

— had `require` checked by nothing at all. A `.cjs` implementation declared by a `.d.ts` (which TypeScript does not honour: `.cjs` wants `.d.cts`) passes silently. The file's own `.cjs` fixtures use the **nested** `require: {types, default}` form, which is exactly what kept the flat shape from ever being exercised.

**2. Condition order across sibling keys was never checked.** `typesBeforeImplementation` compares indices *within one object*. A map whose branches are each internally well formed but ordered wrongly passes everything:

```json
{ "types": "./dist/node.d.ts",
  "browser": { "types": "./dist/browser.d.ts", "import": "./dist/browser.js" },
  "import": "./dist/node.js" }
```

Every `types` here names the right target beside the right implementation, so `violations` is `[]` and `late` is `[]` — while TypeScript matches the outer `types` first and never looks at `browser`. That is the browser-typed-as-node bug this file exists to prevent, expressed through **ordering** instead of a wrong target. `{import, browser: {…}}` is the runtime equivalent: resolution stops at `import`, so the browser build never loads.

## Why this fix

**MEDIUM-2 landed first within the PR** because it changes `label()`, which MEDIUM-1's fixtures quote.

Collecting every string-valued implementation key means one object can now yield several branches, which would **collide in `label()`** — the key for both `ALLOWED_MISMATCHES` and the staleness check. So `implementationKey` joins the branch identity and the label reads `[condition > key]`. The string-shorthand form keeps its bare `[condition]`: there the condition's value *is* the implementation, so there is no key to name, and typing it `string | undefined` says that rather than inventing one. `ALLOWED_MISMATCHES` ships empty, so **no allowlist migration** — only failure-message text changes.

`orderViolations` walks each subpath object recursively and reports any key that is neither `types` nor a string-valued implementation key when a `types` or an implementation string precedes it. **The string-shorthand form is included** (`browser: "./dist/x.js"` after `types`): it is just as dead as the object form, and the file's existing fixtures prove this repo writes that shape.

## Tests

20 pass (was 15, then 13 on the rebased base). New fixtures:

| fixture | pre-fix |
|---|---|
| flat dual-package `{types, import, require}` → one message naming `require`, `./dist/a.cjs`, expected `./dist/a.d.cts` | **fails** (returns `[]`) |
| `{types, import, default}` where both agree → `[]` (extra branches must not become noise) | passes |
| outer-`types`-before-nested-`browser` → reported, **and** `findViolations` asserted `[]` explicitly | **fails** |
| `{import, browser:{…}}` → reported | **fails** |
| string shorthand after `types` → reported (both reasons) | **fails** |
| correct order `{browser:{…}, types, import}` → `[]` | passes |

Plus a new workspace-wide assertion: every manifest must declare each condition before the siblings that would shadow it.

The `findViolations(...) === []` assertion inside the order fixture is deliberate. It documents *why* a second check is needed and is the permanent, inline demonstration that the existing rule is blind to this shape.

**Actually executed** (this is the part the plan could only reason about):

- Full suite on the rebased branch: **20 passed**, including the workspace-wide order check — so **0 order violations across today's real manifests**, confirming the check is safe to add with no allowlist entry. Condition keys in use are `browser`, `bun`, `react-native`.
- Simulating the old single-key collection (`.slice(0, 1)`): **1 failed / 19 passed** — the flat dual-package fixture.
- Stubbing `orderViolations` to return `[]`: **3 failed / 17 passed** — exactly the three positive order fixtures.
- Updated the two existing fixtures whose expected strings carry the new label (`[browser > import]`, `[require > default]`); the `> 50` branch-count floor still holds, since branch count grows only where a second implementation key exists — nowhere today.
- `prettier --check` clean.

## Risk / blast radius

**Test-only. Nothing ships to consumers.** No manifest is modified by this PR.

Two things a reviewer must accept:

1. **Failure-message text changes** for any branch whose implementation came from an object key — `[browser]` becomes `[browser > import]`. Harmless today (`ALLOWED_MISMATCHES` is empty) but it *would* invalidate allowlist entries if any existed, so future entries must use the new form.
2. The guard is now **stricter**. A manifest added later with a flat dual-package map, or with a condition ordered after `types`, fails CI where it previously passed. That is the intent.

## Unverified

- The suite was run under **Node v22.22.2**, not the Node 24 the repo asks for, and in `use-source` mode. This file only reads `package.json` files off disk, so neither should matter.
- **Dropped from the plan, deliberately:** the LOW finding that the `> 50` vacuity floor cannot detect a whole workspace GROUP disappearing (`workspaceManifests` `continue`s on a missing group dir; `workspaceRoot` drops any `workspaces` glob still containing `*` after the `/**` strip). It is real, but it is not a rider on either fix here. The one-line follow-up is to assert a non-zero count **per group**.