### PR TITLE
fix(ai): refuse to settle an estimated usage snapshot in StreamEventAccumulator

### DIFF
--- a/packages/ai/src/capability/StreamEventAccumulator.ts
+++ b/packages/ai/src/capability/StreamEventAccumulator.ts
@@ -62,6 +62,9 @@ export class StreamEventAccumulator<T extends TaskOutput = TaskOutput> {
   private refusalCategory: string | undefined;
   // Mirrors StreamProcessor: `usage` events are cumulative snapshots of the
   // in-flight call, so they replace; `finish` states the call total and settles.
+  // Mirrored down to the estimate guard — a snapshot flagged `estimated` is a
+  // character-count guess kept for live display, so it is never promoted into
+  // the settled total the run reports as its spend.
   private settledUsage: Usage | undefined;
   private liveUsage: Usage | undefined;
   /**
@@ -139,7 +142,11 @@ export class StreamEventAccumulator<T extends TaskOutput = TaskOutput> {
     this.finishData = event.data;
     // Merged rather than replaced: a consumer driving several finishes through
     // one accumulator (a tool-calling loop) is billed for every turn.
-    this.settledUsage = mergeUsage(this.settledUsage, event.usage ?? this.liveUsage);
+    // `?? promotable` keeps a provider that emitted snapshots but no finish
+    // usage — unless that snapshot is a character-count estimate, which is
+    // display feedback and must not settle as this run's spend.
+    const promotable = this.liveUsage?.estimated ? undefined : this.liveUsage;
+    this.settledUsage = mergeUsage(this.settledUsage, event.usage ?? promotable);
     this.liveUsage = undefined;
     this.lastEventType = "finish";
   }
@@ -206,9 +213,15 @@ export class StreamEventAccumulator<T extends TaskOutput = TaskOutput> {
    * Folds accumulated token counts into the reserved `usage` output field.
    * No-op when no provider reported usage, so the key is absent rather than
    * present-and-empty.
+   *
+   * A still-live snapshot is reachable when a provider emits usage AFTER the
+   * finish it belongs to (a tool-calling loop whose last turn never finished).
+   * It is folded in for the same reason the finish path folds one — but an
+   * estimate is a guess, so it is dropped rather than reported as spend.
    */
   private applyUsage(output: T): T {
-    const usage = mergeUsage(this.settledUsage, this.liveUsage);
+    const promotable = this.liveUsage?.estimated ? undefined : this.liveUsage;
+    const usage = mergeUsage(this.settledUsage, promotable);
     if (!usage) return output;
     const base = (output !== null && typeof output === "object" ? output : {}) as Record<
       string,

--- a/packages/ai/src/capability/__tests__/StreamEventAccumulator.test.ts
+++ b/packages/ai/src/capability/__tests__/StreamEventAccumulator.test.ts
@@ -313,6 +313,67 @@ describe("usage snapshots", () => {
     // the other's finish carries its own usage that overwrites the result.
     expect((acc.materialize() as Record<string, unknown>).usage).toEqual(usage(100, 7));
   });
+
+  /**
+   * A provider that states no billed totals (HFI text run-fns, OpenAI-shaped
+   * chat with no usage trailer) still drives a live ↑↓ counter from
+   * character-count guesses. Those are display feedback: settling one makes it
+   * this run's recorded spend, which then reaches the output cache, the `usage`
+   * event and the `gen_ai.usage.*` span attributes as if the provider had
+   * stated it. StreamProcessor refuses the promotion; so does this.
+   */
+  const estimate = (input: number | undefined, output: number | undefined): Usage => ({
+    ...usage(input, output),
+    estimated: true,
+  });
+
+  it("records no usage at all when finish states none and the snapshot was a guess", () => {
+    const acc = new StreamEventAccumulator();
+    acc.observe({ type: "usage", usage: estimate(30, 2) });
+    acc.observe({ type: "finish", data: {} });
+
+    // Absent, not zeroed: a counter nobody reported must not read as a total.
+    expect("usage" in (acc.materialize() as Record<string, unknown>)).toBe(false);
+  });
+
+  it("keeps a stated finish total when a guessed snapshot arrives after it", () => {
+    const acc = new StreamEventAccumulator();
+    acc.observe({ type: "finish", data: {}, usage: usage(28, 5) });
+    // Reachable when a provider emits usage after the finish it belongs to.
+    acc.observe({ type: "usage", usage: estimate(30, 2) });
+
+    expect((acc.materialize() as Record<string, unknown>).usage).toEqual(usage(28, 5));
+  });
+
+  it("keeps only the stated turn across a multi-turn stated/estimated sequence", () => {
+    const acc = new StreamEventAccumulator();
+    acc.observe({ type: "finish", data: {}, usage: usage(10, 2) });
+    acc.observe({ type: "usage", usage: estimate(40, 3) });
+    acc.observe({ type: "finish", data: {} });
+
+    // A tool-calling loop bills every turn, so the second finish merges rather
+    // than replaces — which is exactly how an unrefused estimate would be added
+    // to a real total instead of merely standing in for a missing one.
+    expect((acc.materialize() as Record<string, unknown>).usage).toEqual(usage(10, 2));
+  });
+
+  it("lets a stated finish supersede a guessed snapshot with no estimated flag left", () => {
+    const acc = new StreamEventAccumulator();
+    acc.observe({ type: "usage", usage: estimate(30, 2) });
+    acc.observe({ type: "finish", data: {}, usage: usage(28, 5) });
+
+    expect((acc.materialize() as Record<string, unknown>).usage).toEqual(usage(28, 5));
+  });
+
+  it("still promotes a stated snapshot when finish reports no usage", () => {
+    const acc = new StreamEventAccumulator();
+    acc.observe({ type: "usage", usage: usage(50, 4) });
+    acc.observe({ type: "finish", data: {} });
+
+    // The guard is scoped to guesses: a provider that states a running total
+    // and omits it from the finish is still billed for what it stated.
+    expect((acc.materialize() as Record<string, unknown>).usage).toEqual(usage(50, 4));
+  });
 });
 
 describe("mergeUsage", () => {


### PR DESCRIPTION
## What breaks

`StreamProcessor` was taught to refuse promoting a `liveUsage` snapshot into `settledUsage` when `usage.estimated` is set (`StreamProcessor.ts:356`). The accumulator that mirrors it — `packages/ai/src/capability/StreamEventAccumulator.ts`, `observeFinish` at `:142` and `applyUsage` at `:211` — was not, despite its own field comment at `~:63` claiming it mirrors StreamProcessor.

Concretely: a provider that never states billed totals (HFI text run-fns, OpenAI-shaped chat completions with no usage trailer) drives a live ↑↓ counter from `createEstimatedOutputUsageReporter` character-count guesses (`ceil(chars / 4)`). Under the accumulator, a finish carrying no usage promoted that guess into the settled total.

## What actually leaks — accurate framing

This is **not** "indistinguishable from provider-stated counts". `mergeUsage` does propagate `estimated: true`, and both `estimateCost` and `GraphUsageAggregator` already skip flagged usage. What a settled estimate does reach:

- `output[USAGE_OUTPUT_KEY]` → and from there the output cache,
- `this.runUsage`,
- the `usage` event,
- `gen_ai.usage.*` span attributes — `usageAttributes` in `UsageTelemetry.ts` has no `estimated` filter.

The deeper defect is the divergence itself: **the same event script yields different totals depending only on whether the output schema declares an `x-stream` port**, because that is what decides whether StreamProcessor or the accumulator folds the usage.

## The fix

Both promotion sites gated exactly as StreamProcessor gates its one:

```ts
const promotable = this.liveUsage?.estimated ? undefined : this.liveUsage;
this.settledUsage = mergeUsage(this.settledUsage, event.usage ?? promotable);
```

and the same gate on the trailing `this.liveUsage` in `applyUsage` — reachable when a provider emits a usage snapshot **after** a finish (a tool-calling loop whose last turn never finished). A provider-STATED `finish.usage` is untouched, and a stated snapshot still promotes; only character-count guesses are refused. The mirroring comment now names the guard so the next reader is not told the mirror is complete when it isn't.

## What the tests catch

Extends the `usage snapshots` describe in `packages/ai/src/capability/__tests__/StreamEventAccumulator.test.ts`, mirroring `packages/task-graph/src/task/__tests__/StreamUsageAccumulation.test.ts`.

RED before the fix (verified — exactly these three fail against `origin/main`'s source):

1. estimate snapshot then a finish with no usage → no `usage` key at all (absent, not zeroed);
2. a stated finish then an estimate snapshot → the stated value survives (`applyUsage` path);
3. multi-turn stated → estimate → unstated finish → only the stated turn is billed. The multi-turn case is the one that shows an unrefused estimate being *added* to a real total rather than merely standing in for a missing one.

Green both ways, as scope guards on the gate:

4. estimate snapshot + stated finish → stated wins, no `estimated` flag left behind;
5. stated snapshot + unstated finish → still promotes.

## Risk

An AiTask on a provider that never states usage now materializes **no** usage key instead of an approximate one. That is the trade already accepted in `StreamProcessor`; consistency between the two folding paths is the point of the change.

## Verification

- `npx tsgo -p packages/ai/tsconfig.test.json` — clean.
- `bun scripts/test.ts ai unit vitest` — 44 files, 358 tests, all passing.
- RED-before confirmed by reverting only the source file to `origin/main` and re-running: 3 failed / 35 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RomTUtZSTgUbFCYqFs4pcu)_