### PR TITLE
fix(workglow): drop sideEffects so bundlers keep the triggers prototype patch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -373,7 +373,7 @@
     },
     "packages/triggers": {
       "name": "@workglow/triggers",
-      "version": "0.3.37",
+      "version": "0.3.38",
       "devDependencies": {
         "@workglow/task-graph": "workspace:*",
         "@workglow/util": "workspace:*",

--- a/packages/test/src/test/util/PackageSideEffects.test.ts
+++ b/packages/test/src/test/util/PackageSideEffects.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+const workspaceRoots = ["packages", "providers"] as const;
+
+interface ExportsNode {
+  readonly [condition: string]: string | ExportsNode | undefined;
+}
+
+interface Manifest {
+  readonly name?: string | undefined;
+  readonly license?: string | undefined;
+  readonly private?: boolean | undefined;
+  readonly exports?: unknown;
+  readonly sideEffects?: unknown;
+}
+
+interface Workspace {
+  readonly name: string;
+  readonly manifest: Manifest;
+}
+
+const isExportsNode = (value: unknown): value is ExportsNode =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Every runtime (non-`types`) target reachable in an `exports` map. */
+const collectRuntimeTargets = (node: unknown, out: Set<string>): Set<string> => {
+  if (!isExportsNode(node)) return out;
+  for (const [condition, child] of Object.entries(node)) {
+    if (condition === "types") continue;
+    if (typeof child === "string") {
+      out.add(child);
+    } else {
+      collectRuntimeTargets(child, out);
+    }
+  }
+  return out;
+};
+
+const readWorkspaces = (): Workspace[] => {
+  const workspaces: Workspace[] = [];
+  for (const workspaceRoot of workspaceRoots) {
+    const rootDir = join(repoRoot, workspaceRoot);
+    for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      let manifest: Manifest;
+      try {
+        manifest = JSON.parse(readFileSync(join(rootDir, entry.name, "package.json"), "utf8"));
+      } catch {
+        continue; // no package.json in this directory
+      }
+      if (typeof manifest.name !== "string") continue;
+      workspaces.push({ name: manifest.name, manifest });
+    }
+  }
+  return workspaces.sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const workspaces = readWorkspaces();
+
+/**
+ * An array-form `sideEffects` is an allow-list: a bundler treats every file NOT
+ * named in it as side-effect-free and free to drop, along with the imports that
+ * reach it. That is safe only when the unlisted entry points are pure
+ * re-exports; an entry whose module body installs something — a prototype
+ * patch, a registry entry — must be listed, or the bundler is entitled to elide
+ * the import chain that would have run it.
+ *
+ * `workglow` got this wrong: it listed only `./dist/auto-bootstrap.js` while its
+ * `.` entry re-exports `@workglow/triggers`, whose module body patches
+ * `Workflow.prototype.trigger`. `@workglow/triggers` deliberately omits
+ * `sideEffects: false` to protect that patch, but webpack re-routes
+ * `import { Workflow } from "workglow"` straight to `@workglow/task-graph` and
+ * never consults the intermediary's own dependencies — so the patch was dropped
+ * in production bundles while dev and Node kept working.
+ *
+ * Omitting the field entirely (the conservative default every other package here
+ * relies on) is what this asserts back to: an entry point a consumer imports
+ * from must either be listed, or the package must not make the claim at all.
+ */
+describe("package sideEffects declarations", () => {
+  it("cover every exported entry point of the packages that declare them", () => {
+    const uncovered = workspaces.flatMap(({ name, manifest }) => {
+      const { sideEffects } = manifest;
+      if (!Array.isArray(sideEffects)) return [];
+      const targets = collectRuntimeTargets(manifest.exports, new Set<string>());
+      return [...targets]
+        .filter((target) => !sideEffects.includes(target))
+        .map((target) => `${name} ${target}`);
+    });
+    expect(uncovered).toEqual([]);
+  });
+
+  it("scans every workspace, so an empty result cannot pass vacuously", () => {
+    expect(workspaces.length).toBeGreaterThan(20);
+  });
+});
+
+describe("package licenses", () => {
+  it("are declared Apache-2.0 on every publishable manifest", () => {
+    const wrong = workspaces
+      .filter(({ manifest }) => manifest.private !== true)
+      .filter(({ manifest }) => manifest.license !== "Apache-2.0")
+      .map(({ name, manifest }) => `${name}: ${JSON.stringify(manifest.license)}`);
+    expect(wrong).toEqual([]);
+  });
+});

--- a/packages/triggers/package.json
+++ b/packages/triggers/package.json
@@ -2,6 +2,7 @@
   "name": "@workglow/triggers",
   "type": "module",
   "version": "0.3.38",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/workglow-dev/libs.git",

--- a/packages/triggers/src/common.ts
+++ b/packages/triggers/src/common.ts
@@ -10,7 +10,11 @@
 // the value exports guarantees `.trigger()` / `.listen()` exist on any Workflow
 // a consumer touches after importing this package. The package deliberately
 // does NOT declare `"sideEffects": false` — a bundler that believed it would
-// drop this patch and leave those methods undefined at runtime.
+// drop this patch and leave those methods undefined at runtime. Nor may a
+// package that re-exports this one: webpack re-routes an
+// `import { Workflow } from "workglow"` straight to `@workglow/task-graph` and
+// never consults this package's flag, so the barrel has to claim side effects
+// on its own behalf (i.e. by not declaring the field at all).
 import "./workflow/WorkflowTriggers";
 
 export * from "./cron/CronSchedule";

--- a/packages/workglow/package.json
+++ b/packages/workglow/package.json
@@ -193,9 +193,6 @@
     "dist",
     "src/**/*.md"
   ],
-  "sideEffects": [
-    "./dist/auto-bootstrap.js"
-  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Stacked on #679 (`claude/libs-issues-triage-prs-mh6x2o-237`) — review/merge that first.

## What breaks

`workflow.trigger(...)` and `workflow.listen(...)` throw `is not a function` in a production webpack / Vite / Rollup bundle, while working perfectly in dev and under Node.

## Why

`packages/workglow/package.json` declared:

```json
"sideEffects": ["./dist/auto-bootstrap.js"]
```

An array-form `sideEffects` is an **allow-list**: every file *not* named in it is declared side-effect-free, and a bundler is entitled to drop it along with the import chain that reaches it. The array named only `./dist/auto-bootstrap.js`, so the `.` entry (`dist/node.js` / `dist/browser.js`) — which carries `export * from "@workglow/triggers"` — was fair game.

`@workglow/triggers` is aware of this. Its `src/common.ts` opens with `import "./workflow/WorkflowTriggers"` (the module body that patches `Workflow.prototype`) and the package deliberately omits `sideEffects: false` for exactly that reason. **That flag is never consulted.** For `import { Workflow } from "workglow"`, webpack's `sideEffects` optimization re-routes the specifier straight to the re-exporting source — `@workglow/task-graph` — and excludes the intermediary `workglow` module from the graph entirely. Nothing ever asks `@workglow/triggers` whether it has side effects, because nothing ever reaches its `package.json`.

## The fix

Delete the `"sideEffects"` field from `packages/workglow/package.json`. Absent means "assume side effects", which is what `util`, `task-graph`, `storage`, `tasks` and `triggers` all already do.

A bare `import "@workglow/triggers"` inside the barrel was considered and rejected: a module declared side-effect-free has *all* of its imports treated as droppable, so adding an import statement to a file the bundler has already been told is inert is strictly weaker than not making the claim.

### This is a bundle-size tradeoff — stated plainly

Removing the field **disables webpack's skip-the-intermediary optimization** for `import ... from "workglow"`. Consumers importing through the meta-package will now pull the barrel module itself into the graph rather than having each named import re-routed to its owning package. That is the cost of correctness here; a broken `.trigger()` is not a bundle-size win.

The cleaner long-term shape is to **drop `@workglow/triggers` from the barrel entirely** in favour of an explicit `workglow/triggers` subpath export, so the prototype patch is something a consumer opts into by importing it and the barrel goes back to being purely re-exports. That is a public-API change and is left for the PR author to decide.

## Also: missing license field

`packages/triggers/package.json` had no `"license"` key, though the package ships a LICENSE file and Apache-2.0 SPDX headers on every source file. All 13 other `packages/*` declare it. Added `"license": "Apache-2.0"`.

(`bun.lock` also picks up a one-line sync: the base branch bumped `@workglow/triggers` to `0.3.38` in its manifest but the lockfile still recorded `0.3.37`.)

## What the test would have caught

New `packages/test/src/test/util/PackageSideEffects.test.ts`, modelled on the existing `BunExportConditions.test.ts` (which already walks every workspace manifest under `packages/` and `providers/`):

1. **`sideEffects` coverage** — for each manifest declaring `sideEffects` as an array, resolve every runtime target in its `exports` map and assert each is covered by the array. `@workglow/javascript` passes (`sideEffects: ["./dist/task.js"]`, sole export `./task` → `./dist/task.js`); `workglow` failed on `./dist/node.js` and `./dist/browser.js`.
2. **License** — every publishable (non-`private`) manifest declares `"license": "Apache-2.0"`.
3. A vacuity guard, so an empty scan cannot pass.

Both assertions verified RED on the pre-fix tree and green after:

```
# before
Tests  2 failed | 1 passed (3)
  AssertionError: expected [ 'workglow ./dist/browser.js', 'workglow ./dist/node.js' ] to deeply equal []
  AssertionError: expected [ '@workglow/triggers: undefined' ] to deeply equal []

# after
Tests  3 passed (3)
```

## Verification

Run in an isolated worktree off the PR base (`bun install`, `bun run use-source`):

| command | result |
| --- | --- |
| `bun run build:types` | 42 successful, 42 total |
| `bun scripts/test.ts trigger vitest` | 5 files, **147 passed** |
| `bun scripts/test.ts util vitest` | 54 files, **760 passed**, 10 skipped |
| `prettier --check` on touched files | clean |

Not verified: no actual webpack/Vite/Rollup production bundle was built to observe the drop or its absence — the diagnosis rests on webpack's documented `sideEffects` semantics, and the added test pins the manifest invariant rather than the bundler outcome.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RomTUtZSTgUbFCYqFs4pcu)_