### PR TITLE
fix(tasks): bound an endpoint-supplied Retry-After so it cannot strand a job

### DIFF
--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -1109,7 +1109,17 @@ export class JobQueueWorker<
     try {
       job.status = JobStatus.PENDING;
       const nextAvailableTime = await this.limiter.getNextAvailableTime();
-      job.visibleAt = retryDate instanceof Date ? retryDate : nextAvailableTime;
+      // `instanceof Date` alone is a type check wearing a validity check's
+      // clothes: an Invalid Date passes it, its NaN reaches `delaySeconds`
+      // below, and `claim.retry` throws a RangeError out of `toISOString()` —
+      // caught here, so the job is silently never rescheduled at all. The
+      // date comes from a job, provider or third-party error object, any of
+      // which can construct one. No clamping happens here: whatever parses
+      // the remote hint owns the retry-delay policy; this worker only refuses
+      // the impossible.
+      const usableRetryDate =
+        retryDate instanceof Date && Number.isFinite(retryDate.getTime()) ? retryDate : undefined;
+      job.visibleAt = usableRetryDate ?? nextAvailableTime;
       job.progress = 0;
       job.progressMessage = "";
       job.progressDetails = null;

--- a/packages/job-queue/src/job/__tests__/JobQueueWorker.test.ts
+++ b/packages/job-queue/src/job/__tests__/JobQueueWorker.test.ts
@@ -6,6 +6,7 @@
 
 import type { IJobExecuteContext, JobStorageFormat } from "@workglow/job-queue";
 import {
+  DelayLimiter,
   InMemoryQueueStorage,
   InMemoryRateLimiterStorage,
   Job,
@@ -426,6 +427,72 @@ describe("JobQueueWorker limit overrides", () => {
     });
     // @ts-expect-error accessing protected internal for the assertion
     expect(worker.limiterMaxWakeMs).toBe(DEFAULT_LIMITS.jobQueueLimiterMaxWakeMs);
+    await storage.deleteAll();
+  });
+});
+
+describe("JobQueueWorker retry date validity", () => {
+  // An Invalid Date passes `instanceof Date`, so it used to be accepted as the
+  // job's next visible time. Its NaN then reached `claim.retry`'s
+  // `delaySeconds`, where `new Date(NaN).toISOString()` throws a RangeError —
+  // swallowed by rescheduleJob's own catch, leaving the claim dropped and the
+  // job never rescheduled at all. The observable bug is a stranded job, not a
+  // bad timestamp.
+  it("falls back to the limiter time when handed an invalid retry date", async () => {
+    const queueName = `retry-date-${uuid4()}`;
+    const storage = new InMemoryQueueStorage<TI, TO>(queueName);
+    await storage.migrate();
+    const { messageQueue, jobStore } = wrapQueueStorage(storage);
+
+    // A limiter time distinct from "now" so the fallback is unmistakable.
+    const limiter = new DelayLimiter();
+    const fallbackTime = new Date(Date.now() + 60_000);
+    await limiter.setNextAvailableTime(fallbackTime);
+
+    const worker = new JobQueueWorker<TI, TO, TJob>(TJob, {
+      messageQueue,
+      jobStore,
+      queueName,
+      pollIntervalMs: 5,
+      stopTimeoutMs: 0,
+      limiter,
+    });
+
+    const id = await storage.add({
+      input: { taskType: "default", data: "x" },
+      visible_at: null,
+      completed_at: null,
+      deadline_at: null,
+    } as any);
+
+    const claims = await messageQueue.receive({ workerId: "test-worker", leaseMs: 30_000, max: 1 });
+    expect(claims.length).toBe(1);
+    const claim = claims[0]!;
+
+    const retryDelays: (number | undefined)[] = [];
+    const originalRetry = claim.retry.bind(claim);
+    (claim as { retry: (opts?: { delaySeconds?: number }) => Promise<void> }).retry = async (
+      opts
+    ) => {
+      retryDelays.push(opts?.delaySeconds);
+      await originalRetry(opts);
+    };
+
+    const job = new TJob({ queueName, input: { taskType: "default", data: "x" }, id: claim.id });
+    // @ts-expect-error reaching the private claim registry the worker settles through
+    worker.activeClaims.set(claim.id, claim);
+
+    // @ts-expect-error rescheduleJob is protected; the invalid date is the point
+    await worker.rescheduleJob(job, new Date(NaN));
+
+    expect(retryDelays.length).toBe(1);
+    expect(Number.isFinite(retryDelays[0]!)).toBe(true);
+    expect(job.visibleAt.getTime()).toBe(fallbackTime.getTime());
+
+    const row = await storage.get(claim.id as any);
+    expect(row?.status).toBe(JobStatus.PENDING);
+    expect(Number.isFinite(Date.parse(String(row?.visible_at)))).toBe(true);
+
     await storage.deleteAll();
   });
 });

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -25,6 +25,7 @@ import {
   Workflow,
 } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
+import { retryDateFromRetryAfterHeader } from "../util/RetryAfter";
 import { safeFetch } from "../util/SafeFetch";
 import { classifyUrl, urlResourcePattern } from "../util/UrlClassifier";
 import { applyCredentialToHeaders } from "./FetchUrlCredentials";
@@ -331,25 +332,10 @@ export class FetchUrlJob<
         );
       }
     } else {
-      let retryDate: Date | undefined;
-      if (
-        response.status === 429 ||
-        response.status === 503 ||
-        response.headers.get("Retry-After")
-      ) {
-        const retryAfterStr = response.headers.get("Retry-After");
-        if (retryAfterStr) {
-          const seconds = Number(retryAfterStr);
-          if (Number.isFinite(seconds) && seconds > 0) {
-            retryDate = new Date(Date.now() + seconds * 1000);
-          } else {
-            const parsedDate = new Date(retryAfterStr);
-            if (!isNaN(parsedDate.getTime()) && parsedDate > new Date()) {
-              retryDate = parsedDate;
-            }
-          }
-        }
-      }
+      // The header is remote-controlled, so the bounded parser owns the
+      // arithmetic: an unbounded value either parks the job for millennia or
+      // overflows into an Invalid Date the queue cannot reschedule from.
+      const retryDate = retryDateFromRetryAfterHeader(response.headers.get("Retry-After"));
 
       throw createFetchUrlHttpError(input.url!, response.status, response.statusText, retryDate);
     }

--- a/packages/tasks/src/util/RetryAfter.ts
+++ b/packages/tasks/src/util/RetryAfter.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The single place a remote-supplied retry hint becomes a `Date`.
+ *
+ * `Retry-After` — the header, and the JSON `retry_after` some providers answer
+ * a 429 with — is attacker-controlled input. A retry date built from it
+ * unchecked is not merely a long wait: a large enough delay pushes the
+ * timestamp past the maximum representable `Date`, and the resulting Invalid
+ * Date survives an `instanceof Date` check downstream, where its NaN turns
+ * into a `RangeError` from `toISOString()` and the job is never rescheduled at
+ * all. Everything that parses one of these values funnels through here so the
+ * ceiling cannot be applied at one call site and forgotten at the next.
+ */
+
+import { SECURITY_LIMITS } from "@workglow/util";
+
+/** Ceiling in milliseconds derived from {@link SECURITY_LIMITS.httpRetryAfterMaxSeconds}. */
+const MAX_RETRY_AFTER_MS = SECURITY_LIMITS.httpRetryAfterMaxSeconds * 1000;
+
+/**
+ * Turns an absolute epoch-milliseconds instant into a bounded retry date,
+ * clamped to `[now, now + httpRetryAfterMaxSeconds]`.
+ *
+ * The `Number.isFinite(date.getTime())` gate is the single return gate for
+ * every retry date this module produces. It is unreachable once the clamp has
+ * run — which is the point: no caller has to remember that a `Date` can be
+ * invalid, because none can be handed one from here.
+ */
+export function retryDateFromEpochMs(epochMs: number): Date | undefined {
+  if (!Number.isFinite(epochMs)) {
+    return undefined;
+  }
+  const now = Date.now();
+  const clamped = Math.min(Math.max(epochMs, now), now + MAX_RETRY_AFTER_MS);
+  const date = new Date(clamped);
+  return Number.isFinite(date.getTime()) ? date : undefined;
+}
+
+/**
+ * Parses a `Retry-After` header value in either RFC 9110 form — delay seconds
+ * or an HTTP date — into a bounded retry date.
+ *
+ * Both forms need the ceiling: `"1e20"` overflows the timestamp outright, and
+ * `"Fri, 01 Jan 9999 00:00:00 GMT"` parses perfectly well into a date that
+ * parks a job for millennia. A date already in the past carries no usable
+ * hint and yields `undefined`, so a caller can fall through to its next
+ * source rather than retrying immediately on a stale value.
+ */
+export function retryDateFromRetryAfterHeader(header: string | null | undefined): Date | undefined {
+  if (header === null || header === undefined) {
+    return undefined;
+  }
+  const trimmed = header.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  const seconds = Number(trimmed);
+  if (Number.isFinite(seconds) && seconds > 0) {
+    return retryDateFromEpochMs(Date.now() + seconds * 1000);
+  }
+  const parsed = Date.parse(trimmed);
+  if (Number.isFinite(parsed) && parsed > Date.now()) {
+    return retryDateFromEpochMs(parsed);
+  }
+  return undefined;
+}

--- a/packages/tasks/src/util/WebhookPost.ts
+++ b/packages/tasks/src/util/WebhookPost.ts
@@ -33,6 +33,7 @@ import {
   httpStatusToFetchUrlErrorCode,
   isFetchUrlJobError,
 } from "../task/FetchUrlJobError";
+import { retryDateFromEpochMs, retryDateFromRetryAfterHeader } from "./RetryAfter";
 import { isSafeFetchRedirectError, safeFetch } from "./SafeFetch";
 import { classifyUrl, urlResourcePattern } from "./UrlClassifier";
 
@@ -306,22 +307,19 @@ export interface WebhookPostResult {
  * Derives a retry date from a rate-limited response. The `Retry-After` header
  * is authoritative; Discord instead returns `{"retry_after": <seconds>}` in a
  * JSON body, which is consulted as a secondary source.
+ *
+ * Both sources are remote-controlled, so neither builds its own `Date`:
+ * {@link retryDateFromRetryAfterHeader} / {@link retryDateFromEpochMs} apply
+ * the ceiling that keeps a hostile value from parking the job.
  */
 function retryDateFromResponse(
   response: Response,
   bodyText: string,
   parseJsonBody: boolean
 ): Date | undefined {
-  const header = response.headers.get("Retry-After");
-  if (header) {
-    const seconds = Number(header);
-    if (Number.isFinite(seconds) && seconds > 0) {
-      return new Date(Date.now() + seconds * 1000);
-    }
-    const parsedDate = new Date(header);
-    if (!isNaN(parsedDate.getTime()) && parsedDate > new Date()) {
-      return parsedDate;
-    }
+  const fromHeader = retryDateFromRetryAfterHeader(response.headers.get("Retry-After"));
+  if (fromHeader !== undefined) {
+    return fromHeader;
   }
 
   if (!parseJsonBody || bodyText.length === 0) {
@@ -331,7 +329,7 @@ function retryDateFromResponse(
     const parsed = JSON.parse(bodyText) as { readonly retry_after?: unknown };
     const seconds = Number(parsed?.retry_after);
     if (Number.isFinite(seconds) && seconds > 0) {
-      return new Date(Date.now() + seconds * 1000);
+      return retryDateFromEpochMs(Date.now() + seconds * 1000);
     }
   } catch {
     // A non-JSON failure body simply carries no retry hint.

--- a/packages/test/src/test/task/NotifyTask.test.ts
+++ b/packages/test/src/test/task/NotifyTask.test.ts
@@ -233,6 +233,62 @@ describe("Webhook notification tasks", () => {
       expect(error.retryDate!.getTime()).toBeLessThan(expected + 1000);
     });
 
+    // `Retry-After` is whatever the endpoint says it is. Unclamped, a huge
+    // delay pushes the timestamp past the maximum representable Date, and the
+    // resulting Invalid Date is what the job queue reschedules from: its NaN
+    // delay throws a RangeError out of `toISOString()`, which the worker
+    // swallows, so the job is never rescheduled at all.
+    test("an absurd Retry-After is clamped instead of overflowing the date", async () => {
+      const before = Date.now();
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response("rate_limited", {
+            status: 429,
+            statusText: "Too Many Requests",
+            headers: { "Retry-After": "1e20" },
+          })
+        )
+      );
+
+      const error = (await slackNotify({ url: SLACK_URL, text: "hi" }).catch(
+        (e: unknown) => e
+      )) as RetryableJobError;
+
+      expect(error).toBeInstanceOf(RetryableJobError);
+      expect(error.retryDate).toBeInstanceOf(Date);
+      expect(Number.isFinite(error.retryDate!.getTime())).toBe(true);
+      expect(error.retryDate!.getTime()).toBeGreaterThanOrEqual(before);
+      expect(error.retryDate!.getTime()).toBeLessThanOrEqual(
+        before + SECURITY_LIMITS.httpRetryAfterMaxSeconds * 1000 + 1000
+      );
+    });
+
+    // The HTTP-date form of the header needs the same ceiling for a different
+    // reason: this one parses into a perfectly valid Date, and parks the job
+    // until the year 9999.
+    test("a far-future HTTP-date Retry-After is clamped to the ceiling", async () => {
+      const before = Date.now();
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response("rate_limited", {
+            status: 429,
+            statusText: "Too Many Requests",
+            headers: { "Retry-After": "Fri, 01 Jan 9999 00:00:00 GMT" },
+          })
+        )
+      );
+
+      const error = (await slackNotify({ url: SLACK_URL, text: "hi" }).catch(
+        (e: unknown) => e
+      )) as RetryableJobError;
+
+      expect(error).toBeInstanceOf(RetryableJobError);
+      expect(error.retryDate).toBeInstanceOf(Date);
+      expect(error.retryDate!.getTime()).toBeLessThanOrEqual(
+        before + SECURITY_LIMITS.httpRetryAfterMaxSeconds * 1000 + 1000
+      );
+    });
+
     test("a network rejection becomes a retryable network error", async () => {
       mockFetch.mockImplementation(() =>
         Promise.reject(new TypeError("connect ECONNREFUSED 93.184.216.34:443"))
@@ -329,6 +385,33 @@ describe("Webhook notification tasks", () => {
       const expected = before + 5_000;
       expect(error.retryDate!.getTime()).toBeGreaterThan(expected - 1000);
       expect(error.retryDate!.getTime()).toBeLessThan(expected + 1000);
+    });
+
+    // The JSON body is even more directly attacker-controlled than the header:
+    // it is a number straight out of the response payload.
+    test("an absurd JSON retry_after is clamped instead of overflowing the date", async () => {
+      const before = Date.now();
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ retry_after: 1e20 }), {
+            status: 429,
+            statusText: "Too Many Requests",
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const error = (await discordNotify({ url: DISCORD_URL, content: "hi" }).catch(
+        (e: unknown) => e
+      )) as RetryableJobError;
+
+      expect(error).toBeInstanceOf(RetryableJobError);
+      expect(error.retryDate).toBeInstanceOf(Date);
+      expect(Number.isFinite(error.retryDate!.getTime())).toBe(true);
+      expect(error.retryDate!.getTime()).toBeGreaterThanOrEqual(before);
+      expect(error.retryDate!.getTime()).toBeLessThanOrEqual(
+        before + SECURITY_LIMITS.httpRetryAfterMaxSeconds * 1000 + 1000
+      );
     });
   });
 

--- a/packages/util/src/limits.ts
+++ b/packages/util/src/limits.ts
@@ -86,4 +86,14 @@ export const SECURITY_LIMITS = {
   slackBlocksMaxDepth: 32,
   /** Max accepted length (characters) of an encoded tabular storage pagination cursor. */
   tabularMaxCursorLength: 8 * 1024,
+  /**
+   * Max seconds an endpoint's `Retry-After` (header or JSON body) may defer a
+   * retry by. The value is remote-controlled, so without a ceiling a hostile
+   * or broken server parks a job indefinitely — and a large enough number
+   * pushes the computed timestamp past the maximum representable Date, whose
+   * NaN then propagates into the job queue's reschedule arithmetic. 24h is
+   * far beyond any real provider's back-off and keeps the millisecond
+   * arithmetic well inside the safe-integer range.
+   */
+  httpRetryAfterMaxSeconds: 86_400,
 } as const satisfies Record<string, number>;


### PR DESCRIPTION
Follow-up fixes on top of #744 (based on `claude/notify-merge-main`, not `main`).

## What breaks

`Retry-After` is attacker-controlled input. Four sites turned it into a retry `Date` with no ceiling:

| site | source |
| --- | --- |
| `WebhookPost.ts` `retryDateFromResponse` (header, delay-seconds form) | `Number(header)` |
| `WebhookPost.ts` `retryDateFromResponse` (header, HTTP-date form) | `new Date(header)` |
| `WebhookPost.ts` `retryDateFromResponse` (Discord JSON body) | `Number(body.retry_after)` — straight out of the response payload |
| `FetchUrlTask.ts` (429/503 branch) | the identical unbounded parse |

Two distinct failure shapes:

- **`Retry-After: 1e20`** — `Number.isFinite(1e20)` is `true`, so the guard passes; `Date.now() + 1e23` exceeds the maximum representable timestamp, so `new Date(...)` is an **Invalid Date**.
- **`Retry-After: Fri, 01 Jan 9999 00:00:00 GMT`** — parses perfectly well and is genuinely in the future, so it passes every existing check and parks the job for ~8000 years. No overflow needed.

## The full consequence: a stranded job, not just a bad timestamp

Verified against the source on this branch, and reproduced in the new job-queue test (the RangeError is visible in the failing run's log):

1. `JobQueueWorker.rescheduleJob` accepted the value with `retryDate instanceof Date ? retryDate : nextAvailableTime` — an Invalid Date **passes** `instanceof Date`. `instanceof` is a type check wearing a validity check's clothes.
2. `const delaySeconds = Math.max(0, (job.visibleAt.getTime() - Date.now()) / 1000)` → `Math.max(0, NaN)` is **`NaN`**, not `0`.
3. `claim.retry({ delaySeconds })` → `wrapQueueStorage.ts`'s claim implementation computes `new Date(Date.now() + delay * 1000).toISOString()`, which **throws `RangeError: Invalid time value`**. (The same shape exists in `applySendOptions` on the send path; the retry path is the one reached here.)
4. That throw happens **before** any storage write, and is swallowed by `rescheduleJob`'s own `catch` (it only logs). The `job_retry` event is never emitted, and the `finally` drops the claim from `activeClaims`.

So the observable bug is not a wrong timestamp — it is that **the retry never happens**. The row is left in `PROCESSING` holding its lease, recoverable only by lease expiry (and not at all if the worker is stopped). A hostile or merely broken endpoint answering one 429 takes a job out of circulation.

## Fix

- **`packages/util/src/limits.ts`** — new `SECURITY_LIMITS.httpRetryAfterMaxSeconds: 86_400`. In `SECURITY_LIMITS`, not `DEFAULT_LIMITS`: a caller able to raise it re-opens the hole. 24h is far beyond any real provider's back-off and keeps the millisecond arithmetic well inside the safe-integer range.
- **`packages/tasks/src/util/RetryAfter.ts`** (new) — one funnel.
  - `retryDateFromEpochMs(ms)` returns `undefined` for non-finite input, clamps to `[now, now + max]`, and gates the return on `Number.isFinite(date.getTime())`. That gate lives here as the single return point rather than at each call site, and it is unreachable after the clamp — which is the point: no caller can be handed an invalid `Date` from this module, so none has to remember that a `Date` can be invalid.
  - `retryDateFromRetryAfterHeader(header)` routes **both** RFC 9110 forms (delay-seconds and HTTP-date) through it. A date already in the past still yields `undefined`, preserving today's fall-through to the next source.
- **`WebhookPost.ts`** — `retryDateFromResponse` delegates all three branches; the inline `new Date(Date.now() + seconds * 1000)` constructions are gone.
- **`FetchUrlTask.ts`** — the identical unbounded parse, replaced by the same funnel.
- **`JobQueueWorker.ts`** — accepts a retry date only when `retryDate instanceof Date && Number.isFinite(retryDate.getTime())`, else falls back to `nextAvailableTime`. Deliberately **no clamping here**: the parse site bounds policy, the worker rejects the impossible. Any job, provider, or third-party error object can construct an Invalid Date, so this guard is not redundant with the parse-site fix.

### Intentional scope extension beyond #744

`FetchUrlTask` is included on purpose. It is **the path that actually reaches `JobQueueWorker` today** — the notify tasks call `postWebhookJson` inline and never go through a queue, so the stranded-job consequence above is currently only reachable via `FetchUrlTask`. Fixing only `WebhookPost` would have hardened the path that cannot yet strand a job and left the live one open.

## What the tests catch

`packages/test/src/test/task/NotifyTask.test.ts` (all three RED before the fix, verified by reverting `WebhookPost.ts` alone):

- `Retry-After: 1e20` on a 429 → finite `Date` within the ceiling. Was: `expected false to be true` (`Number.isFinite(retryDate.getTime())`).
- Discord 429 body `{"retry_after": 1e20}` → same. Was: `expected false to be true`.
- `Retry-After: Fri, 01 Jan 9999 00:00:00 GMT` → clamped. Was: `expected 253370764800000 to be less than or equal to 1786697386149`.
- The existing `Retry-After: 30` case still yields ~30s (unchanged, green).

`packages/job-queue/src/job/__tests__/JobQueueWorker.test.ts` — `rescheduleJob(job, new Date(NaN))` against a **real** claim from `wrapQueueStorage`: asserts `claim.retry` is called with a finite `delaySeconds`, that `job.visibleAt` falls back to the limiter's time (a `DelayLimiter` set 60s out, so the fallback is unmistakable), and that the stored row lands in `PENDING` with a parseable `visible_at`. RED before the fix, with `error: RangeError: Invalid time value` in the run log and no retry scheduled.

## Verification

Run in a clean worktree off `claude/notify-merge-main` (Node v22.22.2 — the repo asks for 24+; nothing here is ABI-sensitive, but noting it):

- `bun install` — ok (1880 packages), `bun run use-source` — ok
- `bun run build:types` — **41/41 successful** (this repo has no `bun run types`; `build:types` is the equivalent)
- `bun scripts/test.ts task vitest` — **67 files, 1062 passed, 24 skipped**
- `bun scripts/test.ts job-queue vitest` — **13 files, 118 passed** (this section covers the co-located `packages/job-queue/src/**/__tests__` files, including the new one)
- `prettier --check` and `eslint` clean on every touched file

---
_Generated by [Claude Code](https://claude.ai/code/session_01RomTUtZSTgUbFCYqFs4pcu)_