### PR TITLE
fix(scripts): validate WORKGLOW_TEST_TARGET and rank the unresolved-specifier causes

### DIFF
--- a/scripts/lib/workspaceSource.ts
+++ b/scripts/lib/workspaceSource.ts
@@ -39,11 +39,74 @@ export const WORKSPACE_GROUPS = ["packages", "providers", "examples"] as const;
 /** Source extensions a dist entry can have come from, in resolution order. */
 const SOURCE_EXTENSIONS = [".ts", ".tsx"] as const;
 
+/**
+ * What a test run resolves `@workglow/*` specifiers to. `source` is the
+ * default; `dist` restores `exports` resolution so the built bundles are what
+ * gets exercised.
+ */
+export const TEST_TARGETS = ["source", "dist"] as const;
+
+export type TestTarget = (typeof TEST_TARGETS)[number];
+
+/**
+ * `WORKGLOW_TEST_TARGET` as a value both readers agree on.
+ *
+ * Every consumer previously compared against the literal `"dist"` and treated
+ * anything else as `source`, silently and independently. A workflow edited to
+ * `"dist "` or `Dist` therefore turned the dist job into a byte-identical rerun
+ * of the source job: green, a full runner slot spent, and zero coverage of the
+ * bundles it exists to check. Nothing anywhere said so.
+ *
+ * Unset and empty mean `source`, since that is the default a caller who set
+ * nothing is asking for. Everything else THROWS naming the value: no
+ * lowercasing and no prefix matching, because both turn a typo into a silent
+ * reinterpretation, which is the failure being fixed rather than a fix for it.
+ */
+export function resolveTestTarget(raw: string | undefined): TestTarget {
+  const value = raw ?? "";
+  // Trimmed only to decide "nothing was set"; the comparison below is against
+  // the raw value, so `"dist "` is a typo that fails rather than a target.
+  if (value.trim() === "") return "source";
+  const match = TEST_TARGETS.find((target) => target === value);
+  if (match !== undefined) return match;
+  throw new Error(
+    `WORKGLOW_TEST_TARGET="${raw}" is not a known test target. ` +
+      `Expected one of: ${TEST_TARGETS.join(", ")} (or unset for "source").`
+  );
+}
+
 export interface WorkspacePackage {
   /** Package name as published, e.g. `@workglow/util`. */
   readonly name: string;
   /** Absolute workspace directory. */
   readonly dir: string;
+  /**
+   * The manifest's `exports` field, verbatim, or `undefined` when it declares
+   * none. Read here because the manifest is already parsed — a diagnostic that
+   * has to re-read it would be one more thing to keep in step.
+   */
+  readonly exports: unknown;
+  /** Every name this package lists in any dependency block. */
+  readonly dependencies: ReadonlySet<string>;
+}
+
+/** Dependency blocks that make a package resolvable from another one. */
+const DEPENDENCY_BLOCKS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+/** Every package name a manifest declares in any dependency block. */
+function declaredDependencies(manifest: Record<string, unknown>): ReadonlySet<string> {
+  const names = new Set<string>();
+  for (const block of DEPENDENCY_BLOCKS) {
+    const value = manifest[block];
+    if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
+    for (const name of Object.keys(value)) names.add(name);
+  }
+  return names;
 }
 
 /**
@@ -67,8 +130,16 @@ export function listWorkspacePackages(root: string): WorkspacePackage[] {
       try {
         const manifest = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as {
           name?: unknown;
+          exports?: unknown;
         };
-        if (typeof manifest.name === "string") found.push({ name: manifest.name, dir });
+        if (typeof manifest.name === "string") {
+          found.push({
+            name: manifest.name,
+            dir,
+            exports: manifest.exports,
+            dependencies: declaredDependencies(manifest),
+          });
+        }
       } catch {
         // Not a package directory (or unreadable manifest) — nothing to map.
       }
@@ -110,6 +181,28 @@ export function ownerOf(
   return packages.find((pkg) => source === pkg.name || source.startsWith(`${pkg.name}/`));
 }
 
+/** Everything the unresolved-specifier diagnostic reasons from. */
+export interface UnresolvedWorkspaceContext {
+  /** The specifier that resolved to nothing. */
+  readonly source: string;
+  /** The workspace package that owns {@link source}. */
+  readonly owner: WorkspacePackage;
+  /** The importing file, when Vite reported one. */
+  readonly importer: string | undefined;
+  /** The workspace package the importer lives in, or `undefined` outside one. */
+  readonly importerPackage: WorkspacePackage | undefined;
+  /**
+   * Whether {@link importerPackage} lists {@link owner} in any dependency
+   * block. `undefined` when the importer is outside a workspace package, where
+   * the question does not apply rather than answering "no".
+   */
+  readonly importerDeclaresDependency: boolean | undefined;
+  /** Whether the owner's `exports` declares the subpath the specifier asks for. */
+  readonly ownerDeclaresSubpath: boolean;
+  /** Whether the owner's `dist` holds anything at all. */
+  readonly distHasBuiltEntries: boolean;
+}
+
 /**
  * The diagnostic for a workspace specifier that resolved to nothing.
  *
@@ -119,33 +212,110 @@ export function ownerOf(
  * entry there, resolution fails before the rewrite can happen and the error
  * blames the manifest, naming neither this plugin nor anything to do about it.
  *
- * `distHasBuiltEntries` is passed in rather than probed here so the message
- * stays a pure function of its inputs. The two branches need opposite
- * responses, which is why they are not one sentence: an empty or absent `dist`
- * means the package has simply never been built, whereas a POPULATED `dist`
- * that still does not carry this entry is the "added an `exports` subpath and
- * did not rebuild" case — where "run build" on its own reads as wrong advice to
- * someone looking at a directory full of bundles.
+ * Every input is passed in rather than probed here so the message stays a pure
+ * function of its inputs.
+ *
+ * The causes are RANKED, because resolution fails from the IMPORTER's
+ * `node_modules` and only the last two are about the owner's `dist` at all.
+ * With `linker = "isolated"` an importer sees only what it declares, so an
+ * undeclared workspace dependency — or a subpath the owner's `exports` never
+ * published — fails while the owner's `dist` is fully populated. Offering only
+ * "never built" or "stale dist" there is confident, wrong advice: rebuilding
+ * changes nothing, and the reader is sent to look at a directory that is fine.
  */
-export function unresolvedWorkspaceMessage(
-  source: string,
-  owner: WorkspacePackage,
-  distHasBuiltEntries: boolean,
-  importer: string | undefined
-): string {
+export function unresolvedWorkspaceMessage(context: UnresolvedWorkspaceContext): string {
+  const {
+    source,
+    owner,
+    importer,
+    importerPackage,
+    importerDeclaresDependency,
+    ownerDeclaresSubpath,
+    distHasBuiltEntries,
+  } = context;
   const from = importer === undefined ? "" : ` (imported from ${importer})`;
-  const remedy = distHasBuiltEntries
-    ? `${owner.dir}/dist carries built entries but none for this specifier. A new "exports" ` +
-      `subpath was most likely added without rebuilding, so dist is stale rather than absent: ` +
-      `re-run \`bun run build\` (or \`bun run use-source\`).`
-    : `${owner.dir}/dist is missing or empty — ${owner.name} has never been built in this ` +
-      `checkout. Run \`bun run build\`, or \`bun run use-source\` to write source stubs into dist.`;
+
+  let remedy: string;
+  if (importerDeclaresDependency === false && importerPackage !== undefined) {
+    remedy =
+      `${importerPackage.name} does not list ${owner.name} in any of its dependency blocks. ` +
+      `bunfig sets linker = "isolated", so a workspace package resolves only what it ` +
+      `declares: nothing is linked into ${importerPackage.dir}/node_modules for this ` +
+      `specifier no matter what ${owner.name} has built. Add ${owner.name} to ` +
+      `${importerPackage.name}'s package.json and re-run \`bun i\`.`;
+  } else if (!ownerDeclaresSubpath) {
+    remedy =
+      `${owner.name}'s "exports" does not declare this subpath, so resolution fails at the ` +
+      `manifest and never reaches dist. Add the subpath to ${owner.dir}/package.json — this ` +
+      `one is missing from the manifest, not from the build output.`;
+  } else if (distHasBuiltEntries) {
+    remedy =
+      `The remaining likely cause: ${owner.dir}/dist carries built entries but none for this ` +
+      `specifier. A new "exports" subpath was most likely added without rebuilding, so dist ` +
+      `is stale rather than absent: re-run \`bun run build\` (or \`bun run use-source\`).`;
+  } else {
+    remedy =
+      `The remaining likely cause: ${owner.dir}/dist is missing or empty — ${owner.name} has ` +
+      `never been built in this checkout. Run \`bun run build\`, or \`bun run use-source\` to ` +
+      `write source stubs into dist.`;
+  }
+
   return (
     `[workglow:workspace-source] cannot resolve "${source}"${from}. ` +
     `It is owned by the workspace package ${owner.name}. Resolution goes through that ` +
     `package's "exports", which point at ./dist/*, so the built entry has to exist even ` +
     `though this plugin then rewrites it to src. ${remedy}`
   );
+}
+
+/**
+ * The workspace package a file belongs to — the DEEPEST directory containing
+ * it, so a nested workspace is not attributed to an ancestor.
+ */
+export function importerPackageOf(
+  packages: readonly WorkspacePackage[],
+  importer: string | undefined
+): WorkspacePackage | undefined {
+  if (importer === undefined) return undefined;
+  let best: WorkspacePackage | undefined;
+  for (const pkg of packages) {
+    if (!importer.startsWith(`${pkg.dir}/`)) continue;
+    if (best === undefined || pkg.dir.length > best.dir.length) best = pkg;
+  }
+  return best;
+}
+
+/** The `exports` subpath key a specifier asks its owner for (`.`, `./worker`, …). */
+export function subpathOf(owner: WorkspacePackage, source: string): string {
+  return source === owner.name ? "." : `.${source.slice(owner.name.length)}`;
+}
+
+/**
+ * Whether an owner's `exports` publishes a subpath.
+ *
+ * A manifest with no `exports` at all publishes its whole directory, so the
+ * question does not apply and the answer is yes — reporting "not exported"
+ * there would send the reader to add a field the package deliberately omits.
+ */
+export function declaresSubpath(owner: WorkspacePackage, subpath: string): boolean {
+  const map = owner.exports;
+  if (map === undefined || map === null) return true;
+  // A string or a bare condition map IS the "." entry and publishes nothing else.
+  if (typeof map !== "object" || Array.isArray(map)) return subpath === ".";
+  const keys = Object.keys(map as Record<string, unknown>);
+  if (!keys.some((key) => key === "." || key.startsWith("./"))) return subpath === ".";
+  return keys.some((key) => {
+    if (key === subpath) return true;
+    const star = key.indexOf("*");
+    if (star === -1) return false;
+    const prefix = key.slice(0, star);
+    const suffix = key.slice(star + 1);
+    return (
+      subpath.length >= prefix.length + suffix.length &&
+      subpath.startsWith(prefix) &&
+      subpath.endsWith(suffix)
+    );
+  });
 }
 
 /**
@@ -185,8 +355,17 @@ export function workspaceSourcePlugin(root: string): Plugin {
       if (!resolved) {
         // Throwing, not warning: an unresolvable @workglow/* specifier already
         // fails the run a moment later. This only replaces the message.
+        const importerPackage = importerPackageOf(packages, importer);
         throw new Error(
-          unresolvedWorkspaceMessage(source, owner, hasBuiltEntries(owner.dir), importer)
+          unresolvedWorkspaceMessage({
+            source,
+            owner,
+            importer,
+            importerPackage,
+            importerDeclaresDependency: importerPackage?.dependencies.has(owner.name),
+            ownerDeclaresSubpath: declaresSubpath(owner, subpathOf(owner, source)),
+            distHasBuiltEntries: hasBuiltEntries(owner.dir),
+          })
         );
       }
       if (resolved.external) return resolved;

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -28,6 +28,7 @@ import {
   matchesKind,
   ROOT,
 } from "./lib/testDiscovery";
+import { resolveTestTarget } from "./lib/workspaceSource";
 
 const KNOWN_RUNNERS = ["bun", "vitest"] as const;
 
@@ -119,7 +120,7 @@ function buildVitestArgs(files: string[]): string[] {
   // A `dist`-targeted run measures the bundles, not the sources the coverage
   // denominator names, so every one of the ~1286 `src` files would be reported
   // at 0%. Skip coverage there rather than merging a fragment that says nothing.
-  if (process.env.CI && process.env.WORKGLOW_TEST_TARGET !== "dist") {
+  if (process.env.CI && resolveTestTarget(process.env.WORKGLOW_TEST_TARGET) !== "dist") {
     args.push("--coverage");
   }
   args.push(...relFiles);

--- a/scripts/workspaceSource.test.ts
+++ b/scripts/workspaceSource.test.ts
@@ -9,10 +9,13 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { stubSpecsFor, type PackageManifest } from "./lib/sourceStubs";
 import { ROOT } from "./lib/testDiscovery";
+import type { UnresolvedWorkspaceContext, WorkspacePackage } from "./lib/workspaceSource";
 import {
   distToSource,
   listWorkspacePackages,
   ownerOf,
+  resolveTestTarget,
+  TEST_TARGETS,
   unresolvedWorkspaceMessage,
   WORKSPACE_GROUPS,
 } from "./lib/workspaceSource";
@@ -114,14 +117,36 @@ describe("workspace source resolution", () => {
   });
 
   describe("unresolved specifier diagnostic", () => {
-    const owner = { name: "@workglow/ai", dir: "/repo/packages/ai" };
+    const owner: WorkspacePackage = {
+      name: "@workglow/ai",
+      dir: "/repo/packages/ai",
+      exports: { ".": "./dist/node.js", "./worker": "./dist/worker.js" },
+      dependencies: new Set<string>(),
+    };
+    const importerPackage: WorkspacePackage = {
+      name: "@workglow/huggingface-transformers",
+      dir: "/repo/providers/hft",
+      exports: { "./ai": "./dist/ai.js" },
+      dependencies: new Set(["@workglow/ai"]),
+    };
+
+    /** The healthy case for every input the ranking does not exercise. */
+    function context(overrides: Partial<UnresolvedWorkspaceContext>): UnresolvedWorkspaceContext {
+      return {
+        source: "@workglow/ai/worker",
+        owner,
+        importer: undefined,
+        importerPackage: undefined,
+        importerDeclaresDependency: undefined,
+        ownerDeclaresSubpath: true,
+        distHasBuiltEntries: false,
+        ...overrides,
+      };
+    }
 
     it("names the specifier, the owning package and the importer", () => {
       const message = unresolvedWorkspaceMessage(
-        "@workglow/ai/worker",
-        owner,
-        false,
-        "/repo/providers/hft/src/x.ts"
+        context({ importer: "/repo/providers/hft/src/x.ts" })
       );
       expect(message).toContain("@workglow/ai/worker");
       expect(message).toContain("@workglow/ai");
@@ -131,8 +156,8 @@ describe("workspace source resolution", () => {
 
     // The two cases need opposite responses, so they must not read the same.
     it("distinguishes a never-built package from a stale dist", () => {
-      const neverBuilt = unresolvedWorkspaceMessage("@workglow/ai/worker", owner, false, undefined);
-      const staleDist = unresolvedWorkspaceMessage("@workglow/ai/worker", owner, true, undefined);
+      const neverBuilt = unresolvedWorkspaceMessage(context({ distHasBuiltEntries: false }));
+      const staleDist = unresolvedWorkspaceMessage(context({ distHasBuiltEntries: true }));
 
       expect(neverBuilt).toContain("missing or empty");
       expect(neverBuilt).toContain("never been built");
@@ -144,9 +169,97 @@ describe("workspace source resolution", () => {
     });
 
     it("omits the importer clause when there is no importer", () => {
-      expect(unresolvedWorkspaceMessage("@workglow/ai", owner, true, undefined)).not.toContain(
+      expect(unresolvedWorkspaceMessage(context({ distHasBuiltEntries: true }))).not.toContain(
         "imported from"
       );
+    });
+
+    /**
+     * Resolution fails from the IMPORTER's `node_modules`, and under isolated
+     * linking that is a different question from whether the owner is built. A
+     * fully populated dist is the normal state in these two cases, so offering
+     * the built/stale pair is confident, wrong advice: it names a directory
+     * that is fine and a rebuild that changes nothing.
+     */
+    it("blames an undeclared dependency before the owner's dist", () => {
+      const message = unresolvedWorkspaceMessage(
+        context({
+          importer: "/repo/providers/hft/src/x.ts",
+          importerPackage: { ...importerPackage, dependencies: new Set<string>() },
+          importerDeclaresDependency: false,
+          // The owner is built and exports the subpath — nothing to fix there.
+          distHasBuiltEntries: true,
+        })
+      );
+
+      expect(message).toContain("isolated");
+      expect(message).toContain("@workglow/huggingface-transformers");
+      expect(message).toContain("bun i");
+      expect(message).not.toContain("stale rather than absent");
+      expect(message).not.toContain("never been built");
+    });
+
+    it("blames an undeclared subpath before the owner's dist", () => {
+      const message = unresolvedWorkspaceMessage(
+        context({
+          source: "@workglow/ai/capability",
+          importerPackage,
+          importerDeclaresDependency: true,
+          ownerDeclaresSubpath: false,
+          distHasBuiltEntries: true,
+        })
+      );
+
+      expect(message).toContain('"exports" does not declare this subpath');
+      expect(message).toContain("missing from the manifest, not from the build output");
+      expect(message).not.toContain("stale rather than absent");
+    });
+
+    it("falls back to the built/stale pair once the earlier causes are ruled out", () => {
+      const message = unresolvedWorkspaceMessage(
+        context({
+          importerPackage,
+          importerDeclaresDependency: true,
+          ownerDeclaresSubpath: true,
+          distHasBuiltEntries: true,
+        })
+      );
+      expect(message).toContain("The remaining likely cause");
+      expect(message).toContain("stale rather than absent");
+    });
+
+    it("does not read an importer outside any workspace as an undeclared dependency", () => {
+      // `undefined` is "the question does not apply", not "no".
+      const message = unresolvedWorkspaceMessage(
+        context({ importer: "/repo/vitest.config.ts", distHasBuiltEntries: true })
+      );
+      expect(message).not.toContain("isolated");
+      expect(message).toContain("stale rather than absent");
+    });
+  });
+
+  /**
+   * `WORKGLOW_TEST_TARGET` had two independent readers, each treating anything
+   * that was not literally `"dist"` as source. A workflow edited to `"dist "`
+   * or `Dist` turned the dist job into a byte-identical rerun of the source
+   * job — green, a runner slot spent, and no bundle coverage at all.
+   */
+  describe("resolveTestTarget", () => {
+    it("defaults to source when unset or empty", () => {
+      expect(resolveTestTarget(undefined)).toBe("source");
+      expect(resolveTestTarget("")).toBe("source");
+    });
+
+    it("accepts every declared target", () => {
+      for (const target of TEST_TARGETS) expect(resolveTestTarget(target)).toBe(target);
+    });
+
+    it("throws on anything else, naming the offending value", () => {
+      // No lowercasing and no prefix matching: reinterpreting a typo is the
+      // failure being fixed, not a fix for it.
+      for (const raw of ["dist ", "Dist", "1"]) {
+        expect(() => resolveTestTarget(raw)).toThrow(`WORKGLOW_TEST_TARGET="${raw}"`);
+      }
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { configDefaults, defineConfig } from "vitest/config";
 // Extension is required: Vite's native config loader cannot resolve an
 // extensionless relative import here.
 import { discoverTestFiles, listTestProjects } from "./scripts/lib/testDiscovery.ts";
-import { workspaceSourcePlugin } from "./scripts/lib/workspaceSource.ts";
+import { resolveTestTarget, workspaceSourcePlugin } from "./scripts/lib/workspaceSource.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const abs = (p: string): string => path.join(__dirname, p);
@@ -69,7 +69,7 @@ const shared = {
  * informational and never blocks a merge, so the blocking guard is the
  * `test-vitest-dist` CI job, which sets this variable.
  */
-const testsRunAgainstSource = (process.env.WORKGLOW_TEST_TARGET ?? "source") !== "dist";
+const testsRunAgainstSource = resolveTestTarget(process.env.WORKGLOW_TEST_TARGET) !== "dist";
 
 const discovered = discoverTestFiles();
 


### PR DESCRIPTION
Stacked on #741 (`claude/coverage-dist-bundle-fix-ew0vj8`). Two independent fixes to the machinery that PR introduced.

## (a) `WORKGLOW_TEST_TARGET` is validated, not guessed

`vitest.config.ts:72` and `scripts/test.ts:122` each read the variable and each treated any value other than the literal `"dist"` as source mode — silently, and independently of the other.

The failure that buys: a workflow edit to `"dist "` (trailing space) or `Dist` turns `test-vitest-dist` into a **byte-identical rerun of `test-vitest-unit`**. It goes green, spends ~15 minutes of runner time, and provides zero coverage of the built bundles — which is the entire reason that job exists. Nothing anywhere says so; the only symptom is a job that always passes.

`TEST_TARGETS` and `resolveTestTarget(raw)` now live in `scripts/lib/workspaceSource.ts` and both call sites route through them, so they can no longer disagree. Unset and whitespace-only mean `"source"` (the default a caller who set nothing is asking for). Everything else **throws**, naming the offending value. Deliberately **no** lowercasing and **no** prefix matching: reinterpreting a typo is the failure being fixed, not a fix for it.

Confirmed at runtime — `WORKGLOW_TEST_TARGET="Dist" npx vitest run …` now fails at config load with:

```
Error: WORKGLOW_TEST_TARGET="Dist" is not a known test target. Expected one of: source, dist (or unset for "source").
```

## (b) The unresolved-specifier diagnostic stops guessing at `dist`

`unresolvedWorkspaceMessage` offered exactly two causes — "never built" or "stale dist" — chosen from `hasBuiltEntries(owner.dir)`. But resolution fails from the **importer's** `node_modules`, and `bunfig.toml` sets `linker = "isolated"`. An importing workspace package that does not declare the owner, or a subpath the owner's `exports` never published, fails while the owner's `dist` is completely populated. The message then confidently tells the reader to `bun run build` — advice that changes nothing, pointing at a directory that is fine.

The causes are now **ranked**:

1. **undeclared dependency** under isolated linking → add the owner to the importer's `package.json` and re-run `bun i`;
2. **subpath absent from the owner's `exports`** → missing from the manifest, not from the build output;
3. otherwise the existing built/stale pair, now prefixed "The remaining likely cause".

Both new inputs are passed in as **data**, keeping the message a pure function of its inputs (the convention the function already used for `distHasBuiltEntries`). `WorkspacePackage` gains the parsed `exports` and a set of every declared dependency — both read from the manifest `listWorkspacePackages` already parses — and the plugin resolves the importer by walking up to the nearest workspace dir (`importerPackageOf`, deepest match, so a nested workspace is not attributed to an ancestor). `importerDeclaresDependency` is `boolean | undefined`, where `undefined` means "the importer is outside a workspace, so the question does not apply" rather than "no".

## What the tests catch

`scripts/workspaceSource.test.ts`:

- (a) `undefined` and `""` → `"source"`; each of `TEST_TARGETS` round-trips; `"dist "`, `"Dist"`, `"1"` each throw with the raw value in the message. RED before — the export did not exist.
- (b) an undeclared-dependency case whose message contains `isolated` and the importer package name and does **not** contain the stale-dist wording. Impossible to express against the old signature: the file fails to typecheck first, then fails on content.
- (b) an undeclared-subpath case, and an "importer outside any workspace" case proving `undefined` is not read as `false`.
- (b) the two existing built/stale assertions stay green on the fallback path.

## Verification

- `bun scripts/test.ts scripts vitest` — 4 files, 29 tests, all passing (the 5th is a `bun:test` file the runner filters).
- `npx vitest run --project test packages/test/src/test/util/` — 8 files / 41 tests, exercising the plugin end to end with the extended `WorkspacePackage`.
- `WORKGLOW_TEST_TARGET=dist` run of the scripts project — still green.
- `npx prettier --check` on all four changed files — clean.
- Typecheck: `scripts/` is not covered by any package `tsconfig`. Checked against an ad-hoc config extending the root one; it reports the **same six pre-existing errors** with and without this change (`Cannot find module 'vite'` from the root under isolated linking, the untyped `resolveId` params that follow from it, and two unrelated ones in `testDiscovery.test.ts` / `vitest.config.ts`). **No new type error is introduced**, but there is also no clean typecheck baseline for `scripts/` to point at.

## Out of scope, and worth doing next: the coverage-shrink smoke test

The third finding is **not** in this PR. Recording what was verified, because the gap is larger than it looks:

- `test-vitest-dist` runs **only the unit tier** (`bun run test:vitest:unit`). A package entry reached solely by an integration test is therefore never loaded from `dist` by any blocking job. `@workglow/duckdb` is the clean example: its only test-side importer is `packages/test/src/test/storage-tabular/DuckDbTabularStorage.integration.test.ts` (the `workglow` meta-package barrel also re-exports it, but nothing in `packages/test` imports that barrel).
- `@workglow/electron`, `@workglow/playwright` and `@workglow/bun-webview` are reached only from `packages/test/src/test/browser/*.integration.test.ts`. `test:vitest:integration` excludes `browser` **by name**, and grepping `.github/workflows/test.yml` for `browser` returns nothing — **no CI job runs that tier at all**. Those three packages have zero blocking coverage of any kind, dist or source.

Recommendation: a **unit-tier smoke test that imports every workspace `exports` subpath**. It runs inside the existing dist job, costs seconds rather than minutes, and needs no new secrets. Prefer it over a second dist job running the integration tier: that job would need `WORKGLOW_SECRETS_PASSPHRASE`, which is unavailable on fork PRs, so the guard would silently degrade to nothing exactly where review matters most.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RomTUtZSTgUbFCYqFs4pcu)_