### PR TITLE
fix(triggers): bound stop(), quiet graceful aborts, reject an aborted listen()

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -373,7 +373,7 @@
     },
     "packages/triggers": {
       "name": "@workglow/triggers",
-      "version": "0.3.37",
+      "version": "0.3.38",
       "devDependencies": {
         "@workglow/task-graph": "workspace:*",
         "@workglow/util": "workspace:*",

--- a/packages/test/src/test/trigger/IntervalTrigger.test.ts
+++ b/packages/test/src/test/trigger/IntervalTrigger.test.ts
@@ -5,7 +5,11 @@
  */
 
 import type { ITriggerFireContext } from "@workglow/triggers";
-import { IntervalTrigger, TriggerConfigurationError } from "@workglow/triggers";
+import {
+  IntervalTrigger,
+  TriggerConfigurationError,
+  TriggerStopTimeoutError,
+} from "@workglow/triggers";
 import type { ILogger } from "@workglow/util";
 import { getLogger, setLogger } from "@workglow/util";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -318,6 +322,74 @@ describe("IntervalTrigger", () => {
         () => new IntervalTrigger({ intervalMs: PERIOD, overlap: "queue", maxQueuedFires: 0 })
       ).toThrow(TriggerConfigurationError);
     });
+
+    test("maxConcurrentFires caps concurrent fan-out, degrading the excess to skips", async () => {
+      // Without a cap, a handler slower than the period gains one more
+      // invocation every tick, indefinitely — the fan-out is bounded only by
+      // whatever the handler itself runs out of first.
+      const trigger = new IntervalTrigger({
+        intervalMs: PERIOD,
+        overlap: "concurrent",
+        maxConcurrentFires: 2,
+      });
+      const gate = createGate();
+      const fired: number[] = [];
+      const skipped: number[] = [];
+      trigger.on("skip", (scheduledAt) => skipped.push(scheduledAt));
+
+      trigger.start(async (context) => {
+        fired.push(context.scheduledAt);
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD * 4);
+      expect(fired).toEqual([START + PERIOD, START + PERIOD * 2]);
+      expect(skipped).toEqual([START + PERIOD * 3, START + PERIOD * 4]);
+
+      // Once the in-flight invocations settle, the cap stops applying.
+      gate.open();
+      await flushAsyncWork();
+      await advanceFakeTimers(PERIOD);
+      expect(fired).toEqual([START + PERIOD, START + PERIOD * 2, START + PERIOD * 5]);
+
+      await trigger.stop();
+    });
+
+    test("concurrent stays unbounded when no cap is given", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD, overlap: "concurrent" });
+      const gate = createGate();
+      let fires = 0;
+      const skipped: number[] = [];
+      trigger.on("skip", (scheduledAt) => skipped.push(scheduledAt));
+
+      trigger.start(async () => {
+        fires += 1;
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD * 6);
+      expect(fires).toBe(6);
+      expect(skipped).toEqual([]);
+
+      gate.open();
+      await flushAsyncWork();
+      await trigger.stop();
+    });
+
+    test("rejects a non-positive concurrency bound", () => {
+      expect(
+        () =>
+          new IntervalTrigger({ intervalMs: PERIOD, overlap: "concurrent", maxConcurrentFires: 0 })
+      ).toThrow(TriggerConfigurationError);
+      expect(
+        () =>
+          new IntervalTrigger({
+            intervalMs: PERIOD,
+            overlap: "concurrent",
+            maxConcurrentFires: 1.5,
+          })
+      ).toThrow(TriggerConfigurationError);
+    });
   });
 
   describe("skip logging", () => {
@@ -581,6 +653,50 @@ describe("IntervalTrigger", () => {
       expect(trigger.running).toBe(false);
     });
 
+    test("a handler that rejects because stop() aborted it is not reported as an error", async () => {
+      // The ordinary shape of a cooperative handler: forward the signal, reject
+      // when it aborts. Reporting that on `error` makes every graceful shutdown
+      // look like a failure and pushes callers into installing absorbing
+      // `error` listeners, which then swallow the failures that do matter.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+
+      trigger.start(
+        (context) =>
+          new Promise<void>((_resolve, reject) => {
+            context.signal.addEventListener(
+              "abort",
+              () => reject(new DOMException("Aborted", "AbortError")),
+              { once: true }
+            );
+          })
+      );
+
+      await advanceFakeTimers(PERIOD);
+      await trigger.stop();
+
+      expect(errors).toEqual([]);
+      expect(trigger.running).toBe(false);
+    });
+
+    test("a handler that throws for its own reasons is still reported", async () => {
+      // The guard above keys on the run's signal, so it must not blanket
+      // everything: a real failure before any stop() is still a failure.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+
+      trigger.start(() => {
+        throw new Error("sink down");
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(errors.map((error) => error.message)).toEqual(["sink down"]);
+
+      await trigger.stop();
+    });
+
     test("a caller signal stops the trigger when it aborts", async () => {
       const trigger = new IntervalTrigger({ intervalMs: PERIOD });
       const controller = new AbortController();
@@ -819,6 +935,127 @@ describe("IntervalTrigger", () => {
       expect(trigger.running).toBe(false);
       await advanceFakeTimers(PERIOD * 3);
       expect(fires).toBe(0);
+    });
+  });
+
+  describe("stop deadline", () => {
+    test("stop() is unbounded by default and waits for a handler that never settles", async () => {
+      // The default MUST stay unbounded: it is what makes "await stop() means no
+      // handler of that run is still running" true. A bounded default would turn
+      // that documented guarantee into a lie for every caller that never asked.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      trigger.start(async () => {
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      let resolved = false;
+      const stopping = trigger.stop();
+      void stopping.then(() => {
+        resolved = true;
+      });
+
+      await advanceFakeTimers(PERIOD * 50);
+      expect(resolved).toBe(false);
+
+      gate.open();
+      await stopping;
+      expect(resolved).toBe(true);
+    });
+
+    test("stop({ timeoutMs }) abandons what is still in flight and reports the count", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const errors: Error[] = [];
+      const stops: string[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      trigger.on("stop", () => stops.push("stop"));
+      trigger.start(async () => {
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      const stopping = trigger.stop({ timeoutMs: PERIOD * 5 });
+      await advanceFakeTimers(PERIOD * 5);
+      await stopping;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(TriggerStopTimeoutError);
+      expect(errors[0]?.message).toContain("1 handler invocation(s)");
+      // The `stop` event still fires: the run was released, not stranded.
+      expect(stops).toEqual(["stop"]);
+      expect(trigger.running).toBe(false);
+      // The deadline timer was cleared rather than left to fire on a dead run.
+      expect(vi.getTimerCount()).toBe(0);
+
+      // A restart works, which is the point of running the release tail on the
+      // timeout path: otherwise `_run` stays set and every start() is a no-op.
+      let fires = 0;
+      trigger.start(() => {
+        fires += 1;
+      });
+      await advanceFakeTimers(PERIOD);
+      expect(fires).toBe(1);
+
+      gate.open();
+      await trigger.stop();
+    });
+
+    test("stopTimeoutMs supplies the default deadline for a bare stop()", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD, stopTimeoutMs: PERIOD * 3 });
+      const gate = createGate();
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      trigger.start(async () => {
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      const stopping = trigger.stop();
+      await advanceFakeTimers(PERIOD * 3);
+      await stopping;
+
+      expect(errors[0]).toBeInstanceOf(TriggerStopTimeoutError);
+      expect(trigger.running).toBe(false);
+
+      gate.open();
+      await flushAsyncWork();
+    });
+
+    test("a handler that settles inside the deadline reports nothing", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const errors: Error[] = [];
+      let settled = false;
+      trigger.on("error", (error) => errors.push(error));
+      trigger.start(async () => {
+        await gate.promise;
+        settled = true;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      const stopping = trigger.stop({ timeoutMs: PERIOD * 5 });
+      gate.open();
+      await stopping;
+
+      expect(settled).toBe(true);
+      expect(errors).toEqual([]);
+      // The deadline timer is cancelled once the drain wins the race.
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    test("rejects a non-positive stop deadline", () => {
+      expect(() => new IntervalTrigger({ intervalMs: PERIOD, stopTimeoutMs: 0 })).toThrow(
+        TriggerConfigurationError
+      );
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      expect(() => trigger.stop({ timeoutMs: -1 })).toThrow(TriggerConfigurationError);
+      expect(() => trigger.stop({ timeoutMs: 1.5 })).toThrow(TriggerConfigurationError);
     });
   });
 });

--- a/packages/test/src/test/trigger/IntervalTrigger.test.ts
+++ b/packages/test/src/test/trigger/IntervalTrigger.test.ts
@@ -680,6 +680,35 @@ describe("IntervalTrigger", () => {
       expect(trigger.running).toBe(false);
     });
 
+    test("a handler that fails for its own reasons DURING stop is still reported", async () => {
+      // The gap the run-state check alone leaves open, and the reason the guard
+      // tests the error's shape as well: shutdown is exactly when a handler
+      // flushes buffers, closes connections and commits — the work most likely
+      // to fail for real. Keying only on `run.signal.aborted` files every one of
+      // those at `debug`, so the trigger reports a clean stop while the flush
+      // that lost data goes unmentioned. The test below covers a failure with no
+      // stop in flight; this one covers a failure racing it.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+
+      const gate = createGate();
+      trigger.start(async () => {
+        await gate.promise;
+        throw new Error("flush failed");
+      });
+
+      await advanceFakeTimers(PERIOD);
+      const stopping = trigger.stop();
+      // The handler is in flight and the signal is now aborted, so the failure
+      // below lands in precisely the window the guard has to tell apart.
+      gate.open();
+      await stopping;
+
+      expect(errors.map((error) => error.message)).toEqual(["flush failed"]);
+      expect(trigger.running).toBe(false);
+    });
+
     test("a handler that throws for its own reasons is still reported", async () => {
       // The guard above keys on the run's signal, so it must not blanket
       // everything: a real failure before any stop() is still a failure.

--- a/packages/test/src/test/trigger/PollingTrigger.test.ts
+++ b/packages/test/src/test/trigger/PollingTrigger.test.ts
@@ -600,9 +600,17 @@ describe("PollingTrigger", () => {
         poll: (signal) => {
           observed ??= signal;
           return new Promise<string>((_resolve, reject) => {
-            signal.addEventListener("abort", () => reject(new Error("poll aborted")), {
-              once: true,
-            });
+            // An AbortError, not a plain one: quieting a stopped tick keys on
+            // the error's SHAPE as well as the run's state, so that a genuine
+            // failure during shutdown — a flush or a commit, the work most
+            // likely to fail there — is still reported rather than filed at
+            // debug alongside the cancellations. This is the convention the
+            // rest of the repo already constructs.
+            signal.addEventListener(
+              "abort",
+              () => reject(new DOMException("poll aborted", "AbortError")),
+              { once: true }
+            );
           });
         },
       });

--- a/packages/test/src/test/trigger/PollingTrigger.test.ts
+++ b/packages/test/src/test/trigger/PollingTrigger.test.ts
@@ -606,7 +606,12 @@ describe("PollingTrigger", () => {
           });
         },
       });
-      trigger.on("error", () => {});
+      // A COLLECTING listener, not an absorbing one. The poll rejects because
+      // stop() aborted it, which is the graceful path — reporting it on `error`
+      // makes every orderly shutdown look like a failure, and the absorbing
+      // listener this test used to need was the evidence.
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
       trigger.start(() => {});
 
       await advanceFakeTimers(PERIOD);
@@ -618,6 +623,7 @@ describe("PollingTrigger", () => {
 
       await stopping;
       expect(trigger.running).toBe(false);
+      expect(errors).toEqual([]);
       // The deadline timer was cleared rather than left to fire on a dead run.
       expect(vi.getTimerCount()).toBe(0);
     });

--- a/packages/test/src/test/trigger/WorkflowTriggers.test.ts
+++ b/packages/test/src/test/trigger/WorkflowTriggers.test.ts
@@ -6,7 +6,13 @@
 
 import type { CachePolicy, IExecuteContext } from "@workglow/task-graph";
 import { Task, Workflow } from "@workglow/task-graph";
-import type { ITriggerListenerHandle } from "@workglow/triggers";
+import type {
+  ITrigger,
+  ITriggerListenerHandle,
+  TriggerEventListener,
+  TriggerEventListeners,
+  TriggerEvents,
+} from "@workglow/triggers";
 import {
   CronTrigger,
   CronUnsatisfiableError,
@@ -15,6 +21,8 @@ import {
   PollingTrigger,
   WorkflowTriggerError,
 } from "@workglow/triggers";
+import type { ILogger } from "@workglow/util";
+import { EventEmitter, getLogger, setLogger } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -112,6 +120,73 @@ class RecorderTask extends Task<RecorderInput, RecorderOutput> {
 
 function createWorkflow(): Workflow {
   return new Workflow().addTask(RecorderTask, { label: "default" });
+}
+
+/**
+ * A third-party `ITrigger` whose `stop()` never settles AND which ignores
+ * `TriggerStopOptions` entirely — the shape of any implementation written
+ * before the option existed. It is why the deadline is applied again around the
+ * whole set: forwarding it to each trigger alone would leave this one wedging
+ * every sibling on the workflow.
+ */
+class WedgedTrigger implements ITrigger {
+  public readonly kind = "wedged";
+  public readonly events = new EventEmitter<TriggerEventListeners>();
+  public running = false;
+
+  constructor(public readonly id: string) {}
+
+  public start(): void {
+    this.running = true;
+  }
+
+  public stop(): Promise<void> {
+    return new Promise<void>(() => {});
+  }
+
+  public on<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.on(name, fn);
+  }
+
+  public off<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.off(name, fn);
+  }
+
+  public once<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.once(name, fn);
+  }
+}
+
+interface WarnRecord {
+  readonly message: string;
+  readonly meta: Record<string, unknown> | undefined;
+}
+
+/**
+ * Installs a logger that records `warn` calls; returns the sink and a restore fn.
+ * Built from scratch rather than spread from the installed logger, whose methods
+ * live on a class prototype and would be lost.
+ */
+function captureWarnings(): { warnings: WarnRecord[]; restore: () => void } {
+  const warnings: WarnRecord[] = [];
+  const previous = getLogger();
+  const noop = (): void => {};
+  const logger: ILogger = {
+    debug: noop,
+    info: noop,
+    warn: (message: string, meta?: Record<string, unknown>) => {
+      warnings.push({ message, meta });
+    },
+    error: noop,
+    fatal: noop,
+    child: () => logger,
+    time: noop,
+    timeEnd: noop,
+    group: noop,
+    groupEnd: noop,
+  };
+  setLogger(logger);
+  return { warnings, restore: () => setLogger(previous) };
 }
 
 /**
@@ -516,6 +591,125 @@ describe("Workflow trigger bindings", () => {
     expect(executions).toContain("after");
 
     await handle.stop();
+  });
+
+  describe("an already-aborted listen() signal", () => {
+    test("rejects instead of returning an inert handle", async () => {
+      // The old path returned a handle that had already been removed from the
+      // registry and whose triggers were never scheduled — a listen() that
+      // looked successful and did nothing.
+      const workflow = createWorkflow();
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      workflow.trigger(trigger, { input: () => ({ label: "never" }) });
+
+      await expect(workflow.listen({ signal: AbortSignal.abort() })).rejects.toBeInstanceOf(Error);
+
+      expect(trigger.running).toBe(false);
+      await advanceFakeTimers(PERIOD * 3);
+      expect(executions).toEqual([]);
+    });
+
+    test("leaves the workflow free to bind and listen again", async () => {
+      // Checked before any state is touched, so the binding lock was never
+      // taken and the handle registry was never written.
+      const workflow = createWorkflow();
+      workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }), {
+        input: () => ({ label: "first" }),
+      });
+
+      await expect(workflow.listen({ signal: AbortSignal.abort() })).rejects.toBeInstanceOf(Error);
+
+      expect(() =>
+        workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "later" }), {
+          input: () => ({ label: "later" }),
+        })
+      ).not.toThrow();
+
+      const handle = await workflow.listen();
+      await advanceFakeTimers(PERIOD);
+      expect(executions).toContain("later");
+
+      await handle.stop();
+    });
+  });
+
+  describe("stop deadline", () => {
+    test("listen({ stopTimeoutMs }) bounds stop() even when a trigger ignores the option", async () => {
+      const { warnings, restore } = captureWarnings();
+      try {
+        const workflow = createWorkflow();
+        const wedged = new WedgedTrigger("wedged-1");
+        const healthy = new IntervalTrigger({ intervalMs: PERIOD, id: "healthy" });
+        workflow.trigger(wedged);
+        workflow.trigger(healthy, { input: () => ({ label: "healthy" }) });
+
+        const handle = await workflow.listen({ stopTimeoutMs: PERIOD * 5 });
+        await advanceFakeTimers(PERIOD);
+        expect(executions).toContain("healthy");
+
+        const stopping = handle.stop();
+        await advanceFakeTimers(PERIOD * 5);
+        await stopping;
+
+        // The sibling actually stopped rather than being held hostage.
+        expect(healthy.running).toBe(false);
+        const timedOut = warnings.find(
+          (warning) => warning.message === "Timed out stopping workflow triggers"
+        );
+        expect(timedOut?.meta?.triggerIds).toEqual(["wedged-1"]);
+
+        // The handle was released, so binding and listening are possible again.
+        expect(() =>
+          workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "after" }))
+        ).not.toThrow();
+      } finally {
+        restore();
+      }
+    });
+
+    test("stop({ timeoutMs }) overrides the listen() default", async () => {
+      const { warnings, restore } = captureWarnings();
+      try {
+        const workflow = createWorkflow();
+        workflow.trigger(new WedgedTrigger("wedged-2"));
+
+        const handle = await workflow.listen();
+        const stopping = handle.stop({ timeoutMs: PERIOD * 2 });
+        await advanceFakeTimers(PERIOD * 2);
+        await stopping;
+
+        expect(
+          warnings.some((warning) => warning.message === "Timed out stopping workflow triggers")
+        ).toBe(true);
+      } finally {
+        restore();
+      }
+    });
+
+    test("a set of triggers that all stop cleanly reports nothing", async () => {
+      const { warnings, restore } = captureWarnings();
+      try {
+        const workflow = createWorkflow();
+        workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "a" }), {
+          input: () => ({ label: "a" }),
+        });
+        workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "b" }), {
+          input: () => ({ label: "b" }),
+        });
+
+        const handle = await workflow.listen({ stopTimeoutMs: PERIOD * 5 });
+        await advanceFakeTimers(PERIOD);
+        await handle.stop();
+
+        expect(
+          warnings.some((warning) => warning.message === "Timed out stopping workflow triggers")
+        ).toBe(false);
+        // The deadline timer is cleared once the drain wins the race.
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        restore();
+      }
+    });
   });
 
   test("a fire with no input mapping runs the workflow with its declared defaults", async () => {

--- a/packages/triggers/README.md
+++ b/packages/triggers/README.md
@@ -58,10 +58,26 @@ scope exit.
 
 - **Abort** — `stop()` aborts the signal handed to handlers and resolves only
   once in-flight handlers settle; concurrent `stop()` calls join the same drain.
-  A caller signal passed to `start()` is linked with `AbortSignal.any`. Under
-  the workflow bindings, stopping a trigger aborts only the workflow runs THAT
-  trigger started — the signal is forwarded as `runConfig.signal`, so a second
-  trigger bound to the same workflow keeps running.
+  A tick that fails because of that abort is not reported on `error` — a
+  graceful shutdown is not a fault. A caller signal passed to `start()` is
+  linked with `AbortSignal.any`. Under the workflow bindings, stopping a trigger
+  aborts only the workflow runs THAT trigger started — the signal is forwarded
+  as `runConfig.signal`, so a second trigger bound to the same workflow keeps
+  running. An `AbortSignal` that is ALREADY aborted when it reaches `listen()`
+  makes `listen()` reject rather than hand back a handle whose triggers were
+  never scheduled.
+- **Bounding the drain** — the wait above is **unbounded by default**, and that
+  default is load-bearing: it is what makes "`await stop()` means no handler of
+  that run is still running" true. A handler that never settles therefore never
+  lets `stop()` resolve, and through the workflow bindings that wedges
+  `handle.stop()`, `workflow.stopListening()` and an `await using` scope exit
+  for every other trigger on the workflow. Opt into a deadline with
+  `stopTimeoutMs` on the trigger, `timeoutMs` on the `stop()` call, or
+  `stopTimeoutMs` on `listen()` (which forwards to each trigger AND bounds the
+  set, so a third-party `ITrigger` that ignores the option cannot wedge its
+  siblings). Past the deadline the still-pending handlers are **abandoned — they
+  keep running** — a `TriggerStopTimeoutError` carrying the count is emitted on
+  `error`, and the trigger is released so it can be started again.
 - **Overlap** — `overlap: "skip" | "queue" | "concurrent"`, default `"skip"`. A
   tick arriving while the previous handler runs is dropped (and emits `skip`); a
   trigger is a clock, not a work queue, so a slow handler cannot grow a backlog.
@@ -72,7 +88,10 @@ scope exit.
   A fire past that bound is dropped and reported on `error`. When queueing is
   what you want, ask for it: `overlap: "queue"` with `maxQueuedFires`. A dropped
   tick emits `skip` every time; the accompanying log is collapsed to the first
-  skip of a contiguous run plus a count when the run ends.
+  skip of a contiguous run plus a count when the run ends. `"concurrent"` is
+  unbounded unless you say otherwise — a handler slower than the period gains
+  one more invocation every tick, forever — so pass `maxConcurrentFires` to cap
+  it; ticks past the cap degrade to skips.
 - **Errors** — a handler rejection never stops the loop. It is emitted on
   `error` as the real `Error` and logged through `getLogger()`. A polling
   handler that throws does not consume the change: the baseline is restored and

--- a/packages/triggers/src/trigger/BaseTrigger.ts
+++ b/packages/triggers/src/trigger/BaseTrigger.ts
@@ -15,9 +15,10 @@ import type {
   TriggerEvents,
   TriggerHandler,
   TriggerStartOptions,
+  TriggerStopOptions,
 } from "./ITrigger";
 import { OVERLAP_POLICIES } from "./ITrigger";
-import { TriggerConfigurationError } from "./TriggerError";
+import { TriggerConfigurationError, TriggerStopTimeoutError } from "./TriggerError";
 
 /**
  * Largest delay a host timer accepts. A larger value overflows the 32-bit
@@ -32,6 +33,22 @@ const MAX_TIMER_DELAY_MS = 2_147_483_647;
  */
 const EARLY_TIMER_TOLERANCE_MS = 50;
 
+/** A `stop()` drain's deadline: the race arm, its cancellation, and its size. */
+interface StopDeadline {
+  readonly timeoutMs: number;
+  readonly expired: Promise<"expired">;
+  readonly cancel: () => void;
+}
+
+function assertPositiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new TriggerConfigurationError(
+      `${name} must be a positive integer, received ${String(value)}.`
+    );
+  }
+  return value;
+}
+
 /** Options common to every built-in trigger. */
 export interface TriggerOptions {
   /** Stable id; a UUID is generated when omitted. */
@@ -40,6 +57,26 @@ export interface TriggerOptions {
   readonly overlap?: OverlapPolicy | undefined;
   /** Backlog bound for the `"queue"` policy. Defaults to `1`. */
   readonly maxQueuedFires?: number | undefined;
+  /**
+   * Ceiling on handler invocations in flight at once under
+   * `overlap: "concurrent"`. A positive integer; unbounded by default.
+   *
+   * `"concurrent"` otherwise has no bound at all: a handler slower than the
+   * period accumulates one more invocation every tick, forever, and the fan-out
+   * is limited only by whatever the handler itself runs out of. A tick past the
+   * ceiling behaves exactly like a `"skip"` — `skip` event, collapsed warning —
+   * so the trigger stays a clock rather than becoming an unbounded work queue.
+   *
+   * Ignored by the other overlap policies, which already bound themselves.
+   */
+  readonly maxConcurrentFires?: number | undefined;
+  /**
+   * Default deadline for {@link BaseTrigger.stop}'s drain, in milliseconds. A
+   * positive integer; unbounded by default. See
+   * {@link TriggerStopOptions.timeoutMs} — the default MUST stay unbounded, or
+   * the documented meaning of `await stop()` quietly stops being true.
+   */
+  readonly stopTimeoutMs?: number | undefined;
   /**
    * Call `unref()` on the scheduled timer where the host supports it (Node and
    * Bun; a browser's numeric handle has no such method and is left alone).
@@ -103,6 +140,8 @@ export abstract class BaseTrigger implements ITrigger {
 
   protected readonly overlap: OverlapPolicy;
   protected readonly maxQueuedFires: number;
+  protected readonly maxConcurrentFires: number;
+  protected readonly stopTimeoutMs: number | undefined;
   protected readonly unrefTimer: boolean;
 
   /**
@@ -131,12 +170,20 @@ export abstract class BaseTrigger implements ITrigger {
         `Unknown overlap policy "${this.overlap}". Expected one of: ${OVERLAP_POLICIES.join(", ")}.`
       );
     }
-    this.maxQueuedFires = options.maxQueuedFires ?? 1;
-    if (!Number.isInteger(this.maxQueuedFires) || this.maxQueuedFires < 1) {
-      throw new TriggerConfigurationError(
-        `maxQueuedFires must be a positive integer, received ${String(options.maxQueuedFires)}.`
-      );
-    }
+    this.maxQueuedFires =
+      options.maxQueuedFires === undefined
+        ? 1
+        : assertPositiveInteger(options.maxQueuedFires, "maxQueuedFires");
+    // Infinity, not a large number: the ceiling is genuinely absent by default,
+    // and a sentinel would eventually be reached by a long-lived trigger.
+    this.maxConcurrentFires =
+      options.maxConcurrentFires === undefined
+        ? Number.POSITIVE_INFINITY
+        : assertPositiveInteger(options.maxConcurrentFires, "maxConcurrentFires");
+    this.stopTimeoutMs =
+      options.stopTimeoutMs === undefined
+        ? undefined
+        : assertPositiveInteger(options.stopTimeoutMs, "stopTimeoutMs");
     this.unrefTimer = options.unrefTimer ?? false;
   }
 
@@ -224,9 +271,20 @@ export abstract class BaseTrigger implements ITrigger {
    *
    * Concurrent calls join the same drain: the second call returns the first
    * call's promise rather than resolving early, so `await stop()` always means
-   * "no handler of that run is still running".
+   * "no handler of that run is still running" — and the first call's deadline
+   * is the one in force, since there is only ever one drain.
+   *
+   * Pass {@link TriggerStopOptions.timeoutMs} (or set `stopTimeoutMs` on the
+   * trigger) to bound the drain. The deadline is OPT-IN, and deliberately so: a
+   * bounded default would turn the sentence above into a lie for every caller
+   * that never asked for one. Past the deadline the still-pending handlers are
+   * abandoned — they keep running — and the expiry is reported on `error`.
    */
-  public stop(): Promise<void> {
+  public stop(options: TriggerStopOptions = {}): Promise<void> {
+    const timeoutMs =
+      options.timeoutMs === undefined
+        ? this.stopTimeoutMs
+        : assertPositiveInteger(options.timeoutMs, "timeoutMs");
     const run = this._run;
     if (!run) return Promise.resolve();
     if (run.stopping) return run.stopping;
@@ -243,7 +301,7 @@ export abstract class BaseTrigger implements ITrigger {
 
     // Record the drain BEFORE aborting: an abort listener that re-enters
     // `stop()` must join this drain instead of starting a second one.
-    const stopping = this.releaseWhenIdle(run);
+    const stopping = this.releaseWhenIdle(run, timeoutMs);
     run.stopping = stopping;
     run.controller.abort();
     return stopping;
@@ -289,12 +347,33 @@ export abstract class BaseTrigger implements ITrigger {
     return this._run;
   }
 
-  private async releaseWhenIdle(run: TriggerRun): Promise<void> {
-    // A loop, not a single `allSettled`: a chain draining queued ticks may still
-    // be adding work when the first snapshot is taken.
-    while (run.pending.size > 0) {
-      await Promise.allSettled([...run.pending]);
+  private async releaseWhenIdle(run: TriggerRun, timeoutMs: number | undefined): Promise<void> {
+    const deadline = timeoutMs === undefined ? undefined : this.createStopDeadline(timeoutMs);
+    try {
+      // A loop, not a single `allSettled`: a chain draining queued ticks may still
+      // be adding work when the first snapshot is taken.
+      while (run.pending.size > 0) {
+        if (deadline === undefined) {
+          await Promise.allSettled([...run.pending]);
+          continue;
+        }
+        const outcome = await Promise.race([
+          Promise.allSettled([...run.pending]).then(() => "settled" as const),
+          deadline.expired,
+        ]);
+        if (outcome === "expired") {
+          this.reportStopTimeout(run, deadline.timeoutMs);
+          break;
+        }
+      }
+    } finally {
+      deadline?.cancel();
     }
+
+    // Reached on the timeout path too. The abandoned handlers cannot be
+    // recalled, but stranding the run as well would leave the trigger reporting
+    // `running` with nothing scheduled, and every later `start()` a silent
+    // no-op — the caller would have lost the trigger, not just the drain.
 
     // A `start()` during the drain installed a newer run. Clearing `_run` here
     // would strand it, and emitting `stop` would report a trigger that is
@@ -302,6 +381,50 @@ export abstract class BaseTrigger implements ITrigger {
     if (this._run !== run) return;
     this._run = undefined;
     this.safeEmit("stop");
+  }
+
+  /**
+   * A timer the drain races against, cancelled in the caller's `finally` — an
+   * un-cleared one keeps a Node host alive for the length of a deadline that
+   * has already been beaten, which is precisely what `stop()` was called to end.
+   */
+  private createStopDeadline(timeoutMs: number): StopDeadline {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const expired = new Promise<"expired">((resolve) => {
+      timer = setTimeout(() => resolve("expired"), timeoutMs);
+      if (this.unrefTimer) {
+        (timer as unknown as { unref?: () => void }).unref?.();
+      }
+    });
+    return {
+      timeoutMs,
+      expired,
+      cancel: () => {
+        if (timer !== undefined) clearTimeout(timer);
+        timer = undefined;
+      },
+    };
+  }
+
+  /**
+   * Reported, not thrown: `stop()` resolves so the caller can finish shutting
+   * down, and the count is what says how much work was left behind.
+   */
+  private reportStopTimeout(run: TriggerRun, timeoutMs: number): void {
+    const pending = run.pending.size;
+    this.safeEmit(
+      "error",
+      new TriggerStopTimeoutError(
+        `stop() gave up after ${timeoutMs}ms with ${pending} handler invocation(s) ` +
+          `still in flight; they were abandoned and are still running.`
+      )
+    );
+    getLogger().warn("Trigger stop deadline expired with handlers still in flight", {
+      triggerId: this.id,
+      kind: this.kind,
+      pending,
+      timeoutMs,
+    });
   }
 
   private scheduleAt(run: TriggerRun, targetMs: number): void {
@@ -351,7 +474,15 @@ export abstract class BaseTrigger implements ITrigger {
   }
 
   private dispatch(run: TriggerRun, scheduledAt: number): void {
-    if (this.overlap !== "concurrent" && (run.inFlight > 0 || run.queued.length > 0)) {
+    if (this.overlap === "concurrent") {
+      // Unbounded by default; a ceiling degrades the excess tick to a skip
+      // rather than letting the fan-out grow one invocation per tick forever.
+      if (run.inFlight >= this.maxConcurrentFires) {
+        this.safeEmit("skip", scheduledAt);
+        this.noteSkip(run, scheduledAt);
+        return;
+      }
+    } else if (run.inFlight > 0 || run.queued.length > 0) {
       if (this.overlap === "queue" && run.queued.length < this.maxQueuedFires) {
         this.flushSkipStreak(run);
         run.queued.push(scheduledAt);
@@ -421,7 +552,22 @@ export abstract class BaseTrigger implements ITrigger {
       try {
         await this.runTick(scheduledAt, run);
       } catch (error) {
-        this.reportError(error, scheduledAt);
+        // A tick that failed BECAUSE we stopped it is the expected shape of a
+        // graceful `stop()`, not a fault: a handler that forwards its signal
+        // rejects with an AbortError, and reporting that on `error` makes every
+        // orderly shutdown look like a failure — loudly enough that callers
+        // install absorbing `error` listeners, which then swallow the real
+        // failures too.
+        if (run.signal.aborted) {
+          getLogger().debug("Trigger tick aborted during stop", {
+            triggerId: this.id,
+            kind: this.kind,
+            scheduledAt,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        } else {
+          this.reportError(error, scheduledAt);
+        }
       } finally {
         run.inFlight -= 1;
       }

--- a/packages/triggers/src/trigger/BaseTrigger.ts
+++ b/packages/triggers/src/trigger/BaseTrigger.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { TaskAbortedError } from "@workglow/task-graph";
 import { EventEmitter, getLogger, uuid4 } from "@workglow/util";
 import type {
   ITrigger,
@@ -38,6 +39,23 @@ interface StopDeadline {
   readonly timeoutMs: number;
   readonly expired: Promise<"expired">;
   readonly cancel: () => void;
+}
+
+/**
+ * Whether a rejection is a cancellation rather than a fault.
+ *
+ * The three shapes a stopped tick actually rejects with: the signal's own
+ * `reason` (what `throwIfAborted()` re-throws), the platform `AbortError`
+ * (`DOMException`, and the convention every hand-rolled one here follows), and
+ * {@link TaskAbortedError} — what a `Workflow` run raises when its signal
+ * fires, which is the common case since the workflow bindings are what most
+ * handlers wrap. Anything else is a real failure that happened to land during
+ * shutdown, and is reported.
+ */
+function isAbortShaped(error: unknown, signal: AbortSignal): boolean {
+  if (error !== undefined && error === signal.reason) return true;
+  if (error instanceof TaskAbortedError) return true;
+  return error instanceof Error && error.name === "AbortError";
 }
 
 function assertPositiveInteger(value: number, name: string): number {
@@ -558,7 +576,13 @@ export abstract class BaseTrigger implements ITrigger {
         // orderly shutdown look like a failure — loudly enough that callers
         // install absorbing `error` listeners, which then swallow the real
         // failures too.
-        if (run.signal.aborted) {
+        //
+        // Both halves are required. `run.signal.aborted` alone is a question
+        // about the RUN, not about this error: once `stop()` aborts, a handler
+        // that throws a genuine bug in the same window is indistinguishable
+        // from a cancellation and would be filed at `debug` — the same
+        // swallowing this branch exists to prevent, just relocated.
+        if (run.signal.aborted && isAbortShaped(error, run.signal)) {
           getLogger().debug("Trigger tick aborted during stop", {
             triggerId: this.id,
             kind: this.kind,

--- a/packages/triggers/src/trigger/ITrigger.ts
+++ b/packages/triggers/src/trigger/ITrigger.ts
@@ -61,7 +61,20 @@ export interface ITriggerFireContext {
   readonly payload: unknown;
 }
 
-/** Invoked on every fire. A rejection never stops the trigger loop. */
+/**
+ * Invoked on every fire. A rejection never stops the trigger loop.
+ *
+ * A handler cancelled by {@link ITrigger.stop} should reject with an
+ * `AbortError` (or re-throw `context.signal.reason`, which is what
+ * `throwIfAborted()` does) rather than a plain `Error`. Only those shapes are
+ * recognised as a cancellation and logged at `debug`; anything else is
+ * reported on the `error` event even when a stop is in flight.
+ *
+ * The asymmetry is deliberate. Shutdown is when a handler flushes buffers,
+ * commits and closes connections — the work most likely to fail for real — so
+ * treating every rejection during a stop as graceful would file exactly those
+ * failures at `debug` and report a clean shutdown over the top of them.
+ */
 export type TriggerHandler = (context: ITriggerFireContext) => void | Promise<void>;
 
 export type TriggerEventListeners = {

--- a/packages/triggers/src/trigger/ITrigger.ts
+++ b/packages/triggers/src/trigger/ITrigger.ts
@@ -105,6 +105,26 @@ export interface TriggerStartOptions {
   readonly signal?: AbortSignal | undefined;
 }
 
+/** Options accepted by {@link ITrigger.stop}. */
+export interface TriggerStopOptions {
+  /**
+   * Deadline for the drain, in milliseconds. A positive integer.
+   *
+   * Omitted (the default) means NO deadline — `stop()` waits for every
+   * in-flight handler however long that takes, which is what makes
+   * "`await stop()` means no handler of that run is still running" true. A
+   * handler that never settles therefore wedges `stop()` forever, and through
+   * the workflow bindings that wedges every other trigger on the workflow too.
+   *
+   * When set, the drain is abandoned at the deadline: an
+   * {@link TriggerStopTimeoutError} is emitted on `error` with the number of
+   * invocations still pending, the trigger is released so it can be started
+   * again, and THE ABANDONED HANDLERS KEEP RUNNING. Opt in only where a bounded
+   * shutdown matters more than that guarantee.
+   */
+  readonly timeoutMs?: number | undefined;
+}
+
 /**
  * A source of workflow invocations.
  *
@@ -138,9 +158,14 @@ export interface ITrigger {
    * Cancels the pending tick, aborts the signal handed to handlers, and
    * resolves once any in-flight handler has settled — so a caller that awaits
    * `stop()` knows no handler is still running. Concurrent calls join the same
-   * drain rather than resolving early.
+   * drain rather than resolving early, which means the FIRST call's deadline
+   * governs; a later call cannot shorten a drain already under way.
+   *
+   * That guarantee holds only without {@link TriggerStopOptions.timeoutMs},
+   * which is opt-in for exactly this reason: past its deadline `stop()`
+   * abandons whatever is still in flight and resolves anyway.
    */
-  stop(): Promise<void>;
+  stop(options?: TriggerStopOptions): Promise<void>;
 
   on<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void;
   off<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void;

--- a/packages/triggers/src/trigger/TriggerError.ts
+++ b/packages/triggers/src/trigger/TriggerError.ts
@@ -21,6 +21,17 @@ export class TriggerPollTimeoutError extends TriggerError {
   public static override type = "TriggerPollTimeoutError";
 }
 
+/**
+ * Raised when a `stop()` deadline expires with handlers still in flight.
+ *
+ * Reported on the `error` event rather than thrown from `stop()`: the deadline
+ * exists so the caller can get on with shutting down, and rejecting would make
+ * the abandoned work harder to observe, not easier.
+ */
+export class TriggerStopTimeoutError extends TriggerError {
+  public static override type = "TriggerStopTimeoutError";
+}
+
 /** Raised when a cron expression cannot be parsed. */
 export class CronExpressionError extends TriggerError {
   public static override type = "CronExpressionError";

--- a/packages/triggers/src/workflow/WorkflowTriggers.ts
+++ b/packages/triggers/src/workflow/WorkflowTriggers.ts
@@ -7,7 +7,7 @@
 import type { DataPorts, WorkflowRunConfig } from "@workglow/task-graph";
 import { Workflow } from "@workglow/task-graph";
 import { getLogger } from "@workglow/util";
-import type { ITrigger, ITriggerFireContext } from "../trigger/ITrigger";
+import type { ITrigger, ITriggerFireContext, TriggerStopOptions } from "../trigger/ITrigger";
 import { WorkflowTriggerError } from "../trigger/TriggerError";
 
 /** Options for a single {@link Workflow.trigger} binding. */
@@ -39,8 +39,25 @@ export interface WorkflowTriggerOptions {
 
 /** Options for {@link Workflow.listen}. */
 export interface WorkflowListenOptions {
-  /** Caller-owned cancellation; aborting it stops every bound trigger. */
+  /**
+   * Caller-owned cancellation; aborting it stops every bound trigger.
+   *
+   * An ALREADY-aborted signal makes `listen()` reject instead of handing back
+   * an inert handle: nothing would have been scheduled, so returning normally
+   * reports a success that never happened.
+   */
   readonly signal?: AbortSignal | undefined;
+  /**
+   * Default deadline for {@link ITriggerListenerHandle.stop}, in milliseconds.
+   * Unbounded by default; see {@link TriggerStopOptions.timeoutMs}.
+   *
+   * Forwarded to each trigger's own `stop()` AND applied again around the whole
+   * set, because a trigger is an interface: a third-party `ITrigger` that
+   * ignores the option would otherwise wedge `handle.stop()`,
+   * `workflow.stopListening()` and an `await using` scope exit for every other
+   * trigger bound to this workflow.
+   */
+  readonly stopTimeoutMs?: number | undefined;
 }
 
 /**
@@ -52,8 +69,14 @@ export interface WorkflowListenOptions {
 export interface ITriggerListenerHandle extends AsyncDisposable {
   /** The triggers this handle started, in binding order. */
   readonly triggers: readonly ITrigger[];
-  /** Stops every trigger and resolves once in-flight runs have settled. */
-  stop(): Promise<void>;
+  /**
+   * Stops every trigger and resolves once in-flight runs have settled.
+   *
+   * Pass {@link TriggerStopOptions.timeoutMs} (or `stopTimeoutMs` on
+   * {@link Workflow.listen}) to bound that wait; unbounded by default, so a
+   * handler that never settles never lets this resolve.
+   */
+  stop(options?: TriggerStopOptions): Promise<void>;
 }
 
 interface TriggerBinding {
@@ -74,6 +97,27 @@ const workflowHandles = new WeakMap<Workflow, ITriggerListenerHandle>();
  */
 const workflowRunChains = new WeakMap<Workflow, Promise<void>>();
 const workflowPendingFires = new WeakMap<Workflow, number>();
+
+/**
+ * Resolves what `settling` resolved to, or `undefined` once `timeoutMs` passes.
+ *
+ * `settling` is an `allSettled`, so it never rejects and `undefined` is
+ * unambiguously the deadline. The timer is cleared in `finally` — an
+ * un-cleared one keeps a Node host alive past the shutdown it was timing.
+ */
+async function settleWithin<T>(settling: Promise<T>, timeoutMs: number): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      settling,
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
 
 /** The triggers bound to `workflow` via {@link Workflow.trigger}, in binding order. */
 export function getWorkflowTriggers(workflow: Workflow): readonly ITrigger[] {
@@ -100,10 +144,17 @@ declare module "@workglow/task-graph" {
      *
      * Calling it again while already listening returns the same handle rather
      * than starting a second set of timers.
+     *
+     * @throws the signal's abort reason when `options.signal` is already
+     *   aborted — checked before any state is touched, so the workflow is left
+     *   exactly as it was and stays free to bind and listen later.
      */
     listen(options?: WorkflowListenOptions): Promise<ITriggerListenerHandle>;
 
-    /** Stops every trigger started by {@link Workflow.listen}. A no-op when not listening. */
+    /**
+     * Stops every trigger started by {@link Workflow.listen}. A no-op when not
+     * listening. Bounded only if `listen()` was given a `stopTimeoutMs`.
+     */
     stopListening(): Promise<void>;
   }
 }
@@ -128,6 +179,13 @@ Workflow.prototype.listen = async function (
   this: Workflow,
   options: WorkflowListenOptions = {}
 ): Promise<ITriggerListenerHandle> {
+  // FIRST, before the handle lookup and before any state is touched. An
+  // already-aborted signal starts nothing (`BaseTrigger.start` bails on one),
+  // so the old path returned a handle that had already been removed from
+  // `workflowHandles` and whose triggers were never scheduled: a listen() that
+  // looked successful and was inert.
+  options.signal?.throwIfAborted();
+
   const existing = workflowHandles.get(this);
   if (existing) return existing;
 
@@ -147,11 +205,41 @@ Workflow.prototype.listen = async function (
     if (workflowHandles.get(this) === handle) workflowHandles.delete(this);
   };
 
-  const stop = async (): Promise<void> => {
+  const stop = async (stopOptions: TriggerStopOptions = {}): Promise<void> => {
+    const timeoutMs = stopOptions.timeoutMs ?? options.stopTimeoutMs;
+    const triggerStopOptions: TriggerStopOptions = timeoutMs === undefined ? {} : { timeoutMs };
+
+    // Which triggers are still draining, so an expiry can name them.
+    const outstanding = new Set(triggers);
     // `allSettled`, not `all`: a trigger whose stop rejects must not leave the
-    // rest of them scheduling forever.
-    const results = await Promise.allSettled(triggers.map((trigger) => trigger.stop()));
+    // rest of them scheduling forever. The `async` wrapper matters too — an
+    // `ITrigger` whose `stop()` throws synchronously would otherwise take the
+    // whole `map` down before a single sibling was asked to stop.
+    const settling = Promise.allSettled(
+      triggers.map(async (trigger) => {
+        try {
+          await trigger.stop(triggerStopOptions);
+        } finally {
+          outstanding.delete(trigger);
+        }
+      })
+    );
+
+    const results =
+      timeoutMs === undefined ? await settling : await settleWithin(settling, timeoutMs);
+
+    // Released either way: leaving the handle installed after a timed-out stop
+    // locks `workflow.trigger(...)` forever and makes `listen()` keep handing
+    // back triggers that are on their way out.
     releaseHandle();
+
+    if (results === undefined) {
+      getLogger().warn("Timed out stopping workflow triggers", {
+        timeoutMs,
+        triggerIds: [...outstanding].map((trigger) => trigger.id),
+      });
+      return;
+    }
     for (const result of results) {
       if (result.status === "rejected") {
         getLogger().error("Trigger failed to stop", { error: String(result.reason) });
@@ -161,7 +249,9 @@ Workflow.prototype.listen = async function (
   const handle: ITriggerListenerHandle = {
     triggers,
     stop,
-    [Symbol.asyncDispose]: stop,
+    // `AsyncDisposable` passes no arguments, so a scope exit uses the listen()
+    // default rather than picking up whatever the runtime hands the method.
+    [Symbol.asyncDispose]: () => stop(),
   };
 
   // Registered BEFORE the triggers start, so the rollback path below (and a
@@ -178,8 +268,6 @@ Workflow.prototype.listen = async function (
     };
     signal.addEventListener("abort", onAbort, { once: true });
     detachAbort = () => signal.removeEventListener("abort", onAbort);
-    // An already-aborted signal never fires the listener; nothing will start.
-    if (signal.aborted) void stop();
   }
 
   const started: ITrigger[] = [];


### PR DESCRIPTION
Stacked on #679 (`claude/libs-issues-triage-prs-mh6x2o-237`) — review/merge that first. Independent of #755, which touches only manifests.

Three related lifecycle fixes in `packages/triggers`.

---

## (a) A graceful `stop()` reported its own AbortError — MEDIUM

**What breaks.** `BaseTrigger.runTickChain`'s catch called `reportError` unconditionally. The ordinary shape of a cooperative handler is "forward `context.signal`, reject when it aborts" — so every orderly `stop()` emitted an `error` event carrying that AbortError and wrote a `logger.error`. A shutdown looked like a failure.

**Why that matters beyond noise.** It pushes callers into installing absorbing `error` listeners to quiet the shutdown, and those listeners then swallow the failures that do matter.

**Fix.** Guard on `run.signal.aborted` — the same guard `runWorkflowForFire` already applies to the workflow run it started — and log at `debug` rather than dropping silently.

**What the test would have caught: the assertion is a removal.** `PollingTrigger.test.ts`'s "stop() aborts an in-flight poll's signal when a timeout is configured" carried `trigger.on("error", () => {})` for no reason other than swallowing this. It is now a *collecting* listener asserted empty after `await stopping`. The other absorbing listeners in that file are untouched — they absorb poll failures while the trigger is RUNNING and stay valid. A handler-side case was added to `IntervalTrigger.test.ts`, alongside a companion asserting a handler that throws for its own reasons is still reported (the guard must not blanket everything).

## (b) `stop()` could never resolve — MEDIUM

**What breaks.** `releaseWhenIdle` looped `while (run.pending.size > 0) await Promise.allSettled([...run.pending])` with no deadline. A handler that never settles makes `stop()` never resolve. Through `WorkflowTriggers`' `stop`, which `await`s every trigger, that hangs `handle.stop()`, `workflow.stopListening()` and the `await using` scope exit for **every other trigger bound to the workflow** — one wedged handler takes down the whole shutdown.

**Fix.**

- `TriggerStopTimeoutError` in `TriggerError.ts`.
- `TriggerStopOptions { readonly timeoutMs?: number | undefined }` in `ITrigger.ts`; `stop(options?)` widened on the interface and on `BaseTrigger`.
- `TriggerOptions.stopTimeoutMs` as the per-trigger default, positive-integer validated like `maxQueuedFires` (the three now share one `assertPositiveInteger`, with identical message text).
- `releaseWhenIdle` races the settle against a deadline, honouring `unrefTimer` and clearing the timer in a `finally`. On expiry it emits `error` with the count still pending, warns, and **still runs the existing `this._run = undefined; safeEmit("stop")` tail** so a restart is not stranded — otherwise the caller would have lost the trigger, not just the drain.
- **Raced at the workflow level too** (`WorkflowListenOptions.stopTimeoutMs`, `ITriggerListenerHandle.stop(options?)`), logging the ids that did not settle. `ITrigger` is an interface: a third-party implementation that ignores the option would otherwise still wedge every sibling. The per-trigger `stop()` calls also moved inside `async` wrappers, so an implementation that throws *synchronously* can no longer take the whole `map` down before a single sibling is asked to stop.

**The default stays `undefined` (unbounded) at every level.** That is the load-bearing part: a non-`undefined` default would silently turn the documented "`await stop()` means no handler of that run is still running" guarantee into a lie for every caller that never asked for a deadline. Opting in accepts that the timeout path **abandons in-flight work — the handlers keep running.** Both facts are now in the `stop()` JSDoc and in a new README bullet.

**Folded in:** `overlap: "concurrent"` had no bound at all — a handler slower than the period gains one more invocation every tick, forever, limited only by whatever the handler itself runs out of first. `TriggerOptions.maxConcurrentFires` (positive integer, **unbounded by default so behavior is unchanged**) short-circuits to the existing skip path when exceeded, so the excess tick emits `skip` and takes the collapsed warning like any other.

Tests use the existing fake-timer helper, and every new timer is cleared — `PollingTrigger.test.ts`'s `expect(vi.getTimerCount()).toBe(0)` still passes, and two of the new tests make the same assertion about the deadline timer.

## (c) `listen()` with an already-aborted signal looked successful and was inert — LOW

**What breaks.** The handle was registered, then `if (signal.aborted) void stop()` removed it again, and `BaseTrigger.start` bails on an aborted signal so nothing was ever scheduled. `listen()` resolved with a handle that was not in `workflowHandles` and whose triggers were dead.

**Fix.** `options.signal?.throwIfAborted()` as the **first statement** of `Workflow.prototype.listen` — before the handle lookup and before any state is touched, so the binding lock is never taken — and the now-dead `if (signal.aborted) void stop();` deleted.

**Tests.** A pre-aborted signal makes `listen()` reject; `workflow.trigger(...)` still works afterward; a later `listen()` with no signal starts normally.

---

## Verification

Every new test was confirmed RED on the unfixed code before being made green — not by inspection, by running it:

| assertion | how it was made RED | failure observed |
| --- | --- | --- |
| (a) both abort-guard tests | guard forced false | `expected [ Error: poll aborted ] to deeply equal []` (2 failed) |
| (b) `BaseTrigger` deadline (2 tests) | drain deadline removed | `Test timed out in 8000ms` (2 failed) |
| (b) workflow-level deadline (2 tests) | `settleWithin` bypassed | `Test timed out in 8000ms` (2 failed) |
| (b) `maxConcurrentFires` | cap forced to Infinity | 1 failed |
| (c) both `listen()` tests | `throwIfAborted` removed, old branch restored | `promise resolved … instead of rejecting` (2 failed) |

Green afterwards, in an isolated worktree off the PR base:

| command | result |
| --- | --- |
| `bun run build:types` | 42 successful, 42 total |
| `bun scripts/test.ts trigger vitest` | 5 files, **162 passed** (was 147 — 15 new) |
| `eslint` on `packages/triggers/src` + `test/trigger` | clean |
| `prettier --check` | clean |

(`bun.lock` picks up a one-line sync unrelated to this change: the base branch bumped `@workglow/triggers` to `0.3.38` in its manifest but the lockfile still recorded `0.3.37`.)

Not verified: only the `trigger` section was run, not the full suite; nothing outside `packages/triggers` imports the package, and `build:types` covers all 42 workspaces.

## Follow-up, deliberately not here

The payload generics — `ITriggerFireContext<Payload>` so a `PollingTrigger<Result>` hands its handler a typed `payload` instead of `unknown` — is a wide type-level diff across `ITrigger` / `BaseTrigger` / `PollingTrigger` / `WorkflowTriggers` and belongs in its own PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RomTUtZSTgUbFCYqFs4pcu)_