### PR TITLE
fix(tasks): report the network cause, close two webhook leaks and a Slack escape gap

### DIFF
--- a/packages/tasks/src/task/SlackNotifyTask.ts
+++ b/packages/tasks/src/task/SlackNotifyTask.ts
@@ -193,12 +193,16 @@ export function neutralizeSlackBroadcastsDeep(value: unknown, depth: number = 0)
     const elementType = (value as { readonly type?: unknown }).type;
     if (typeof elementType === "string" && STRUCTURAL_BROADCAST_TYPES.has(elementType)) {
       const range = (value as { readonly range?: unknown }).range;
+      // `range` is caller-supplied and this is the one string leaf the
+      // traversal builds rather than visits, so it would otherwise be the
+      // single value in the whole payload that skips the lexical escape — a
+      // `range` of `x<!channel>y` would be handed back live inside the very
+      // node written to neutralize a broadcast.
       return {
         type: "text",
-        text:
-          elementType === "broadcast" && typeof range === "string"
-            ? `@${range}`
-            : `@${elementType}`,
+        text: neutralizeSlackBroadcasts(
+          elementType === "broadcast" && typeof range === "string" ? `@${range}` : `@${elementType}`
+        ),
       };
     }
     const escaped: Record<string, unknown> = {};
@@ -264,8 +268,17 @@ export class SlackNotifyTask<
       payload: compactPayload({
         text: allowMentions ? input.text : (neutralizeSlackBroadcastsDeep(input.text) as string),
         blocks: allowMentions ? input.blocks : neutralizeSlackBroadcastsDeep(input.blocks),
-        username: input.username,
-        icon_emoji: input.icon_emoji,
+        // Defence in depth, NOT a closed bypass: whether Slack parses
+        // broadcast syntax inside a display name or an emoji code is
+        // unconfirmed, so this is not evidence of a leak that was open. The
+        // escape is free and side-effect-free on both fields, which is reason
+        // enough not to leave the question standing.
+        username: allowMentions
+          ? input.username
+          : (neutralizeSlackBroadcastsDeep(input.username) as string | undefined),
+        icon_emoji: allowMentions
+          ? input.icon_emoji
+          : (neutralizeSlackBroadcastsDeep(input.icon_emoji) as string | undefined),
         link_names: allowMentions ? undefined : false,
       }),
       headers: undefined,

--- a/packages/tasks/src/util/WebhookPost.ts
+++ b/packages/tasks/src/util/WebhookPost.ts
@@ -339,8 +339,46 @@ function retryDateFromResponse(
   return undefined;
 }
 
+/**
+ * The `.stack` is checked alongside the message and the `url` field because
+ * V8 bakes the message into the stack string, and a frame can embed the URL on
+ * its own (a module specifier, a fetch wrapper argument). A typed error whose
+ * message happens to be clean but whose stack carries the token would
+ * otherwise be passed through untouched — and stacks are persisted by
+ * `formatErrorChainForDiagnostics`, so "logs are trusted" is not a defence.
+ */
 function leaksUrl(error: FetchUrlJobErrorInstance, url: string): boolean {
-  return error.message.includes(url) || error.url === url;
+  return (
+    error.message.includes(url) ||
+    error.url === url ||
+    (typeof error.stack === "string" && error.stack.includes(url))
+  );
+}
+
+/**
+ * Builds the diagnostic detail for an untyped throw, lifting ONE level of
+ * `.cause` message onto it.
+ *
+ * undici rejects every connection-level failure as `TypeError: fetch failed`
+ * and puts the text that says WHY — `ECONNREFUSED`, `ENOTFOUND`, a TLS
+ * failure — on `.cause`. Reporting the outer message alone renders every
+ * network failure as the same three unactionable words.
+ *
+ * Only the message is lifted, never the cause OBJECT — see the note in
+ * {@link toRedactedWebhookError}.
+ */
+function detailWithCause(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  if (!(error instanceof Error)) {
+    return detail;
+  }
+  const cause = (error as { readonly cause?: unknown }).cause;
+  const causeMessage = (cause as { readonly message?: unknown } | undefined)?.message;
+  if (typeof causeMessage !== "string" || causeMessage.length === 0) {
+    return detail;
+  }
+  // A wrapper that already quotes its cause needs no second copy.
+  return detail.includes(causeMessage) ? detail : `${detail}: ${causeMessage}`;
 }
 
 /**
@@ -409,15 +447,33 @@ function toRedactedWebhookError(
     // a PERSISTED job-error string, which would re-import the unredacted URL
     // this rebuild just stripped. `createFetchUrlJobError` sets no cause today
     // and none must be added here.
+    //
+    // The same reasoning is why the generic branch below lifts only the cause's
+    // MESSAGE — already redacted — into its own message, and never attaches the
+    // cause object itself.
     rebuilt.stack = redactedStackFrom(error, rebuilt, url);
     return rebuilt;
   }
-  const detail = error instanceof Error ? error.message : String(error);
+  // Redacted BEFORE truncating: cutting first can slice a token in half so it
+  // no longer matches the candidates, leaving a usable prefix behind — the same
+  // ordering the response-body path uses.
+  const detail = truncate(redactWebhookUrlIn(detailWithCause(error), url), MAX_ERROR_BODY_CHARS);
   return createFetchUrlJobError(
     FetchUrlErrorCode.NETWORK_ERROR,
-    `Network error posting ${label} to ${redactWebhookUrl(url)}: ${redactWebhookUrlIn(detail, url)}`,
+    `Network error posting ${label} to ${redactWebhookUrl(url)}: ${detail}`,
     { url: redactWebhookUrl(url) }
   );
+}
+
+/** What {@link readBodyText} read, and whether that is the whole body. */
+interface WebhookBodyRead {
+  readonly text: string;
+  /**
+   * False when the read stopped short of the end of the body — the byte cap
+   * was hit, or the stream errored mid-body. The caller marks such a body as
+   * truncated rather than presenting a fragment as the endpoint's full reply.
+   */
+  readonly complete: boolean;
 }
 
 /**
@@ -429,18 +485,26 @@ function toRedactedWebhookError(
  * unconditionally for all three notification tasks. Streaming lets the read be
  * abandoned mid-body: once the cap is passed the reader is cancelled and
  * whatever arrived so far is returned.
+ *
+ * `complete` is reported rather than inferred. A mid-stream failure returns
+ * exactly what a successful short read returns, so without the flag a
+ * connection that died halfway through the reply is indistinguishable from the
+ * endpoint's complete answer — and the fragment is surfaced as the task's
+ * `response` under `success: true`. It is a flag and not a throw on purpose:
+ * the POST already returned 2xx, so the notification WAS delivered, and
+ * throwing here would have the caller retry and post the message twice.
  */
 async function readBodyText(
   response: Response,
   maxBytes: number = SECURITY_LIMITS.webhookMaxResponseBodyBytes
-): Promise<string> {
+): Promise<WebhookBodyRead> {
   const body = response.body;
   if (body === null || body === undefined || typeof body.getReader !== "function") {
     // A bodiless response (204) or a runtime without streaming support.
     try {
-      return await response.text();
+      return { text: await response.text(), complete: true };
     } catch {
-      return "";
+      return { text: "", complete: false };
     }
   }
 
@@ -452,7 +516,7 @@ async function readBodyText(
     for (;;) {
       const { done, value } = await reader.read();
       if (done) {
-        return text + decoder.decode();
+        return { text: text + decoder.decode(), complete: true };
       }
       if (value === undefined) {
         continue;
@@ -463,11 +527,11 @@ async function readBodyText(
         await reader.cancel().catch(() => {});
         // Flush the decoder here too: abandoning the read mid-body can leave a
         // partial multi-byte sequence buffered, which is dropped otherwise.
-        return text + decoder.decode();
+        return { text: text + decoder.decode(), complete: false };
       }
     }
   } catch {
-    return text;
+    return { text, complete: false };
   }
 }
 
@@ -609,14 +673,20 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
     // A residual gap remains and is deliberately not closed here: `readBodyText`
     // stops at `SECURITY_LIMITS.webhookMaxResponseBodyBytes`, so a token
     // straddling that boundary can still leave a partial behind.
-    const text = await readBodyText(response);
+    const { text, complete } = await readBodyText(response);
+    const surfaced = truncate(redactWebhookUrlIn(text, url), MAX_RESPONSE_BODY_CHARS);
     return {
       status: response.status,
-      body: truncate(redactWebhookUrlIn(text, url), MAX_RESPONSE_BODY_CHARS),
+      // An incomplete read carries the same marker `truncate` uses, so a body
+      // cut short by the byte cap or a dead connection cannot be read as the
+      // endpoint's whole reply. `truncate` may already have added it.
+      body: complete || surfaced.endsWith("...") ? surfaced : `${surfaced}...`,
     };
   }
 
-  const failureBody = await readBodyText(response);
+  // The failure path ignores `complete`: the status error is what this throw
+  // reports, and a partial diagnostic body does not change it.
+  const { text: failureBody } = await readBodyText(response);
   const retryDate = retryDateFromResponse(response, failureBody, request.retryAfterFromJsonBody);
   const redacted = redactWebhookUrl(url);
   // The status is still reported for a private destination — the reply BODY is

--- a/packages/test/src/test/task/NotifyTask.test.ts
+++ b/packages/test/src/test/task/NotifyTask.test.ts
@@ -246,6 +246,55 @@ describe("Webhook notification tasks", () => {
       expect(error.code).toBe(FetchUrlErrorCode.NETWORK_ERROR);
       expect(error.message).toContain("ECONNREFUSED");
     });
+
+    // undici rejects EVERY connection failure as `TypeError: fetch failed` and
+    // puts the text that says why on `.cause`. Reporting only the outer message
+    // makes a refused connection, an unresolvable host and a TLS failure read
+    // identically. The cause's message is lifted; the cause OBJECT is not,
+    // because `formatErrorChainForDiagnostics` persists every link's message
+    // and stack and would re-import the unredacted URL.
+    test("a network rejection lifts its cause message without importing the URL", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.reject(
+          new TypeError("fetch failed", {
+            cause: new Error(`connect ECONNREFUSED to ${SLACK_URL}`),
+          })
+        )
+      );
+
+      const error = (await slackNotify({ url: SLACK_URL, text: "hi" }).catch(
+        (e: unknown) => e
+      )) as RetryableJobError;
+
+      expect(error).toBeInstanceOf(RetryableJobError);
+      expect(error.message).toContain("ECONNREFUSED");
+      expect(error.message).not.toContain("SECRETTOKEN");
+      expect(error.cause).toBeUndefined();
+      expect(formatErrorChainForDiagnostics(error)).not.toContain("SECRETTOKEN");
+    });
+
+    // `leaksUrl` used to ask only the message and the `url` field. A typed
+    // error can carry the token in its STACK alone — V8 bakes the message of
+    // whatever threw into it — and such an error was passed through untouched.
+    test("a typed error leaking the token only through its stack is rewritten", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.reject(
+          Object.assign(
+            createFetchUrlJobError(FetchUrlErrorCode.NETWORK_ERROR, "socket hang up", {
+              url: "https://hooks.slack.com",
+            }),
+            { stack: `FetchUrlJobError: socket hang up\n    at post (${SLACK_URL}:1:1)` }
+          )
+        )
+      );
+
+      const error = (await slackNotify({ url: SLACK_URL, text: "hi" }).catch(
+        (e: unknown) => e
+      )) as RetryableJobError;
+
+      expect(String(error.stack)).not.toContain("SECRETTOKEN");
+      expect(formatErrorChainForDiagnostics(error)).not.toContain("SECRETTOKEN");
+    });
   });
 
   describe("DiscordNotifyTask", () => {
@@ -425,6 +474,39 @@ describe("Webhook notification tasks", () => {
       expect(result.response).not.toContain("SECRETTOKEN");
       // The origin stays as the useful diagnostic.
       expect(result.response).toContain("https://example.com");
+    });
+
+    // A body cut short by a dead connection used to be returned exactly as a
+    // complete short body is, and surfaced as the task's `response` under
+    // `success: true` — a fragment presented as the endpoint's whole reply.
+    // It is marked, not thrown on: the POST already returned 2xx, so the
+    // notification WAS delivered and a throw would post it twice on retry.
+    test("a body whose stream fails mid-read is marked truncated, not passed off as whole", async () => {
+      // The error must land on a LATER read than the chunk: erroring in the
+      // same turn discards what was already enqueued, which would make the
+      // fixture a bodiless failure rather than a body cut in half.
+      mockFetch.mockImplementation(() => {
+        let reads = 0;
+        return Promise.resolve(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              pull(controller) {
+                if (reads++ === 0) {
+                  controller.enqueue(new TextEncoder().encode("partial-"));
+                  return;
+                }
+                controller.error(new Error("connection reset"));
+              },
+            }),
+            { status: 200 }
+          )
+        );
+      });
+
+      const result = await webhookNotify({ url: WEBHOOK_URL, payload: {} });
+
+      expect(result.success).toBe(true);
+      expect(result.response).toBe("partial-...");
     });
 
     // An endpoint routinely echoes only PART of the URL, which the literal
@@ -929,6 +1011,32 @@ describe("Webhook notification tasks", () => {
       // which would turn this control into an availability bug. `link_names`
       // is already false, so the literal text cannot auto-link.
       expect(body).toContain("@channel");
+    });
+
+    // `range` is caller-controlled and the replacement node is BUILT from it
+    // rather than visited, so it was the one string leaf in the whole traversal
+    // that skipped the lexical escape — a live `<!channel>` handed back inside
+    // the node written to neutralize a broadcast.
+    test("Slack escapes a broadcast range that smuggles its own sigil", async () => {
+      await slackNotify({
+        url: SLACK_URL,
+        text: "ok",
+        blocks: [
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [{ type: "broadcast", range: "x<!channel>y" }],
+              },
+            ],
+          },
+        ],
+      });
+
+      const body = lastCall().options.body as string;
+      expect(body).not.toContain("<!channel>");
+      expect(body).toContain("&lt;!channel>");
     });
 
     test("Slack neutralizes a rich_text usergroup ping", async () => {

--- a/packages/test/src/test/task/NotifyTaskTransport.test.ts
+++ b/packages/test/src/test/task/NotifyTaskTransport.test.ts
@@ -28,7 +28,7 @@
  * proceeds.
  */
 
-import { PermanentJobError } from "@workglow/job-queue";
+import { PermanentJobError, RetryableJobError } from "@workglow/job-queue";
 import { discordNotify, getSafeFetchImpl, slackNotify } from "@workglow/tasks";
 import { SECURITY_LIMITS } from "@workglow/util";
 import http from "node:http";
@@ -60,6 +60,18 @@ async function closeServer(server: http.Server): Promise<void> {
   // callback never fires and the hook times out.
   server.closeAllConnections();
   await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+/**
+ * Binds an ephemeral loopback port and immediately releases it, so a connection
+ * to it is refused. Not registered for teardown — it is already closed.
+ */
+async function refusedOrigin(): Promise<string> {
+  const server = http.createServer(() => {});
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return `http://127.0.0.1:${port}`;
 }
 
 /** Timer that is cleared on teardown, so a stalling handler cannot leak one. */
@@ -181,6 +193,29 @@ describe("Notification tasks over the real server transport (no mocks)", () => {
     expect(error).toBeInstanceOf(PermanentJobError);
     expect(error.httpStatus).toBe(400);
     // The URL is the credential; it must not survive into the diagnostic.
+    expect(error.message).not.toContain("SECRETTOKEN");
+
+    await drainRejections();
+    expect(unhandled).toEqual([]);
+  });
+
+  // The reason this case belongs in the real-transport file: the `.cause` here
+  // is undici's own, not a fixture's. undici rejects a refused connection as
+  // `TypeError: fetch failed` and puts the only actionable text — the errno —
+  // on the cause, so an operator reading the job error saw three words that
+  // never distinguished a refused port from an unresolvable host or a TLS
+  // failure.
+  test("a refused connection reports the underlying cause, not just 'fetch failed'", async () => {
+    const origin = await refusedOrigin();
+
+    const error = (await slackNotify({
+      url: `${origin}${slackPath}`,
+      text: "hi",
+      allow_private_destination: true,
+    }).catch((e: unknown) => e)) as RetryableJobError;
+
+    expect(error).toBeInstanceOf(RetryableJobError);
+    expect(error.message).toContain("ECONNREFUSED");
     expect(error.message).not.toContain("SECRETTOKEN");
 
     await drainRejections();


### PR DESCRIPTION
Follow-up fixes on top of #744 (based on `claude/notify-merge-main`, not `main`). Four independent, small fixes; sibling of #758.

## (a) [MEDIUM] Every connection failure reported the same three words

`toRedactedWebhookError`'s generic branch built its detail from `error.message` alone. undici rejects **every** connection-level failure as `TypeError: fetch failed` and puts the only actionable text — `ECONNREFUSED`, `ENOTFOUND`, a TLS failure — on `.cause`. Verified against the real transport: a POST to a closed loopback port produced

```
Network error posting Slack webhook to http://127.0.0.1:38101: fetch failed
```

A refused port, an unresolvable host and a certificate failure were indistinguishable in the persisted job error.

**Fix** — `detailWithCause` appends **one** level of `cause.message` when it is a non-empty string not already contained in the outer message. Order matters and is now explicit: the assembled string goes through `redactWebhookUrlIn(detail, url)` **before** `truncate(..., MAX_ERROR_BODY_CHARS)`. Truncating first can slice a token so it no longer matches a redaction candidate, leaving a usable prefix behind — the same ordering rule the response-body path already follows.

The `cause` **object** is still never attached, and the existing comment now says why in both places: `formatErrorChainForDiagnostics` walks `.cause` and persists every link's message *and* stack, so attaching it would re-import the unredacted URL the rewrite just stripped.

## (b) [LOW] `leaksUrl` never asked the stack

`leaksUrl` gated the redaction rewrite on `error.message` and `error.url` only. A typed `FetchUrlJobError` whose message is clean but whose **stack** embeds the URL was passed through untouched — and V8 bakes the throwing message into the stack, frames can carry a URL on their own, and stacks are persisted. Now also `|| (typeof error.stack === "string" && error.stack.includes(url))`.

## (c) [LOW] A half-read body was presented as the endpoint's whole reply

`readBodyText`'s outer `catch { return text; }` made a mid-stream failure byte-identical to a complete short read, and on the success path that fragment became the task's `response` output under `success: true`.

It now returns `{ text, complete }`, and the success path appends the same `...` marker `truncate` uses when `complete` is false (skipping it when `truncate` already added one). The byte-cap path reports `complete: false` too — there genuinely is more body than what is here.

Deliberately **not** a throw: the POST already returned 2xx, so the notification *was* delivered, and throwing would have the caller retry and post the message twice. The failure path ignores `complete` — the status error is what that throw reports.

## (d) [LOW] The one string leaf the Slack traversal built rather than visited

`neutralizeSlackBroadcastsDeep` rewrites a structural `{type: "broadcast", range}` element into `{type: "text", text: "@" + range}`. `range` is caller-controlled, and this replacement node is *built* rather than *visited*, so it was the single string in the whole payload that skipped `neutralizeSlackBroadcasts` — a `range` of `x<!channel>y` came back **live**, inside the very node written to neutralize a broadcast. Verified: the pre-fix body was

```json
{"type":"text","text":"@x<!channel>y"}
```

Now wrapped.

Also applied `neutralizeSlackBroadcastsDeep` to `username` / `icon_emoji` when `allow_mentions` is false. The comment labels this **defence in depth, not a closed bypass** — I could not confirm that Slack parses broadcast syntax in a display name or an emoji code, so this is not evidence of a leak that was open; the escape is free and side-effect-free, which is reason enough not to leave the question standing.

## What the tests catch

All five new cases confirmed RED against the unfixed sources (both source files reverted, tests kept):

| test | file | failure before the fix |
| --- | --- | --- |
| a refused connection reports the underlying cause | `NotifyTaskTransport.test.ts` (**real** transport — the cause is undici's own, not a fixture's) | `expected 'Network error posting Slack webhook to http://127.0.0.1:38101: fetch failed' to contain 'ECONNREFUSED'` |
| a network rejection lifts its cause message without importing the URL | `NotifyTask.test.ts` | same, on a mocked `new TypeError("fetch failed", { cause: … SLACK_URL })`; also asserts no token in the message, `error.cause === undefined`, and no token in `formatErrorChainForDiagnostics(error)` |
| a typed error leaking the token only through its stack is rewritten | `NotifyTask.test.ts` | `expected 'FetchUrlJobError: socket hang up…' not to contain 'SECRETTOKEN'` |
| a body whose stream fails mid-read is marked truncated | `NotifyTask.test.ts` | `expected 'partial-' to be 'partial-...'` |
| Slack escapes a broadcast range that smuggles its own sigil | `NotifyTask.test.ts` | body contained `"text":"@x<!channel>y"` |

The mid-read fixture errors the stream on a **later** read than the chunk it enqueues — erroring in the same turn discards the queued chunk, which would make it a bodiless failure rather than a body cut in half.

## Deliberately out of scope — follow-ups for whoever picks this up

**1. The `allowPrivate` / declared-destination fix.** Not attempted here because it cannot ship in pieces. `postWebhookJson` currently derives `allowPrivate` for `safeFetch` from what the URL *resolved to* (`isPrivate`) rather than from what the caller *declared*, and the body-suppression sites key off the same `isPrivate`. Doing it properly needs three changes landing atomically: pass the declared flag through to `safeFetch`; **relocate** `assertPrivateDestinationGranted` so it runs whenever `allowPrivate` will be true (not only when the URL already classified private); and switch the three body-suppression sites in `WebhookPost.ts` (~597/625/632 — success-body cancel, failure-body suffix, reason phrase) plus the three in `WebhookNotifyTask`. Any subset genuinely **widens** the SSRF posture into a read primitive. It also requires rewriting a deliberately-pinned test (`NotifyTask.test.ts:1195`) whose comment misnames the current behavior as the DNS-rebinding invariant. Too risky to bundle with these four.

**2. A credential-backed header port for `WebhookNotifyTask`.** Today `headers` is a plain input, so a bearer token for a generic webhook is stored verbatim in the saved graph JSON — the same problem `url_credential_key` already solves for the URL. Wants a matching `format: "credential"` port resolved at execute time.

## Verification

Run in a clean worktree off `claude/notify-merge-main` (Node v22.22.2 — the repo asks for 24+; nothing here is ABI-sensitive, but noting it):

- `bun install` — ok, `bun run use-source` — ok
- `bun run build:types` — **41/41 successful** (this repo has no `bun run types`; `build:types` is the equivalent)
- `bun scripts/test.ts task vitest` — **67 files, 1064 passed, 24 skipped** (this section includes both notify test files)
- `prettier --check` and `eslint` clean on every touched file

---
_Generated by [Claude Code](https://claude.ai/code/session_01RomTUtZSTgUbFCYqFs4pcu)_