### PR TITLE
fix(ai): expose TurboQuant padding on VectorQuantizeTask and correct its guidance

### DIFF
--- a/packages/ai/src/task/VectorQuantizeTask.ts
+++ b/packages/ai/src/task/VectorQuantizeTask.ts
@@ -8,6 +8,7 @@ import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, TypedArray } from "@workglow/util/schema";
 import {
+  nextPowerOf2,
   normalizeNumberArray,
   TensorType,
   turboQuantizeToTypedArray,
@@ -61,7 +62,7 @@ const inputSchema = {
       enum: Object.values(QuantizationMethod),
       title: "Method",
       description:
-        "Quantization method: 'linear' for simple min-max scaling, 'turbo' for TurboQuant (randomized Hadamard rotation + uniform scalar quantization at the MSE-optimal Gaussian clipping range). Turbo requires a signed integer targetType (int8 or int16) AND a power-of-2 vector dimensionality: it rotates in nextPowerOf2(d) dimensions, so a non-power-of-2 input is rejected rather than silently degraded. At equal byte width linear is measurably more accurate at the common embedding sizes — measured int8 cosine RMSE, turbo vs linear: 0.0164 vs 0.0027 at d=768, 0.0126 vs 0.0033 at d=1536, 0.0094 vs 0.0026 at d=3072. Turbo wins only at d=1024 (0.0008 vs 0.0033).",
+        "Quantization method: 'linear' for simple min-max scaling, 'turbo' for TurboQuant (randomized Hadamard rotation + uniform scalar quantization at the MSE-optimal Gaussian clipping range). Turbo requires a signed integer targetType (int8 or int16). It rotates in nextPowerOf2(d) dimensions, so a non-power-of-2 input needs turboPadToPowerOf2: true, which widens the output to nextPowerOf2(d); without it such an input is rejected rather than silently degraded. Padded turbo is substantially MORE accurate than linear at the common embedding sizes — measured int8 cosine RMSE over 40 seeded pairs, padded turbo vs linear: 0.00034 vs 0.00269 at d=768, 0.00024 vs 0.00331 at d=1536, 0.00021 vs 0.00263 at d=3072. Choose linear when the output must keep its input length.",
       default: QuantizationMethod.LINEAR,
     },
     turboSeed: {
@@ -70,6 +71,13 @@ const inputSchema = {
       description:
         "Seed for the random rotation in TurboQuant. All vectors in the same collection must use the same seed for similarity search to work.",
       default: 42,
+    },
+    turboPadToPowerOf2: {
+      type: "boolean",
+      title: "TurboQuant Pad To Power Of 2",
+      description:
+        "Allow method 'turbo' on a non-power-of-2 dimensionality by widening the output to nextPowerOf2(d). Defaults to false because enabling it lengthens the output vector: a storage column sized to d will reject the result, so it has to be an explicit choice rather than a silent one. Ignored unless method is 'turbo'.",
+      default: false,
     },
   },
   required: ["vector", "targetType"],
@@ -132,6 +140,11 @@ export type VectorQuantizeTaskInput = {
   targetType: "float16" | "float32" | "float64" | "int8" | "uint8" | "int16" | "uint16";
   readonly method?: QuantizationMethod | undefined;
   readonly turboSeed?: number | undefined;
+  /**
+   * Opt into a `nextPowerOf2(d)`-length output for `method: "turbo"` at a non-power-of-2
+   * dimensionality. Defaults to false: it lengthens the output vector.
+   */
+  readonly turboPadToPowerOf2?: boolean | undefined;
 };
 export type VectorQuantizeTaskOutput = {
   vector: TypedArray | TypedArray[];
@@ -143,13 +156,6 @@ export type VectorQuantizeTaskOutput = {
   readonly turboSeed: number | undefined;
 };
 export type VectorQuantizeTaskConfig = TaskConfig<VectorQuantizeTaskInput>;
-
-/** Smallest power of 2 that is >= n. Doubles rather than shifts to stay 32-bit safe. */
-function nextPowerOf2(n: number): number {
-  let p = 1;
-  while (p < n) p *= 2;
-  return p;
-}
 
 /**
  * Task for quantizing vectors to reduce storage and improve performance.
@@ -188,6 +194,7 @@ export class VectorQuantizeTask extends Task<
       normalize = true,
       method = QuantizationMethod.LINEAR,
       turboSeed = 42,
+      turboPadToPowerOf2 = false,
     } = input;
     const isArray = Array.isArray(vector);
     const vectors = isArray ? vector : [vector];
@@ -205,19 +212,30 @@ export class VectorQuantizeTask extends Task<
         );
       }
       // Checked here rather than left to turboQuantizeToTypedArray so the message names
-      // the task's own remedies. Turbo rotates in nextPowerOf2(d) dimensions and cannot
-      // return a d-length result without discarding coordinates, which measures worse
-      // than linear at exactly the dimensionalities embedding models use.
-      const unpadded = vectors.find((v) => v.length !== nextPowerOf2(v.length));
+      // the task's own input rather than the util's option object. Turbo rotates in
+      // nextPowerOf2(d) dimensions, so at a non-power-of-2 d it either widens the output
+      // or discards coordinates; only the first is offered.
+      const unpadded = turboPadToPowerOf2
+        ? undefined
+        : vectors.find((v) => v.length !== nextPowerOf2(v.length));
       if (unpadded !== undefined) {
+        const padded = nextPowerOf2(unpadded.length);
         throw new Error(
-          `VectorQuantizeTask: method "turbo" requires a power of 2 vector dimensionality, got ${unpadded.length}. ` +
-            `Either use method: "linear" at this dimensionality (it is measurably more accurate here — ` +
-            `int8 cosine RMSE at d=768: linear 0.0027 vs turbo 0.0164), or zero-pad the vectors to ` +
-            `${nextPowerOf2(unpadded.length)} before quantizing and size the storage column to match.`
+          `VectorQuantizeTask: method "turbo" needs turboPadToPowerOf2: true at a non-power-of-2 ` +
+            `vector dimensionality, got ${unpadded.length}. Setting it widens the output from ` +
+            `${unpadded.length} to ${padded} values, so size any fixed-width storage column to ` +
+            `${padded}. Padded turbo is the more accurate option at this size — measured int8 ` +
+            `cosine RMSE over 40 seeded pairs, padded turbo vs this task's linear path: 0.00034 ` +
+            `vs 0.00269 at d=768, 0.00024 vs 0.00331 at d=1536, 0.00021 vs 0.00263 at d=3072. ` +
+            `Use method: "linear" instead if the output must keep its ${unpadded.length} length.`
         );
       }
-      quantized = vectors.map((v) => turboQuantizeToTypedArray(v, targetType, turboSeed));
+      quantized = vectors.map((v) =>
+        turboQuantizeToTypedArray(v, targetType, {
+          seed: turboSeed,
+          padToPowerOf2: turboPadToPowerOf2,
+        })
+      );
     } else {
       quantized = vectors.map((v) => this.vectorQuantize(v, targetType, normalize));
     }

--- a/packages/test/src/test/rag/VectorQuantizeTask.test.ts
+++ b/packages/test/src/test/rag/VectorQuantizeTask.test.ts
@@ -12,6 +12,21 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { report, snap } from "../../binding/testTiming";
 
+/**
+ * Deterministic PRNG (mulberry32). The accuracy comparison below asserts a ratio between
+ * two quantizers, so a `Math.random()` draw would make a real regression and an unlucky
+ * sample indistinguishable.
+ */
+function makeRandom(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
 let _snap = snap();
 beforeEach(() => {
   _snap = snap();
@@ -312,32 +327,123 @@ describe("VectorQuantizeTask", () => {
 
     test("should reject a non-power-of-2 dimensionality with an actionable message", async () => {
       // 768 is MiniLM's dimensionality, so this is the common case rather than an edge
-      // one. Turbo would have to discard 256 of 1024 rotated coordinates to return a
-      // 768-length vector, which measures worse than linear at that size — so the task
-      // refuses and names both remedies instead of silently returning worse vectors.
+      // one. Turbo rotates in 1024 dimensions, so it either widens the output or discards
+      // 256 coordinates; the task offers only the first, behind an explicit opt-in.
       const vector = new Float32Array(768);
       for (let i = 0; i < 768; i++) vector[i] = Math.sin(i * 0.1);
 
-      await expect(
-        vectorQuantize({ vector, targetType: TensorType.INT8, method: "turbo", turboSeed: 42 })
-      ).rejects.toThrow(/power of 2/);
+      const rejection = async (): Promise<Error> => {
+        try {
+          await vectorQuantize({
+            vector,
+            targetType: TensorType.INT8,
+            method: "turbo",
+            turboSeed: 42,
+          });
+        } catch (error) {
+          return error as Error;
+        }
+        throw new Error("expected turbo at d=768 to be rejected");
+      };
+      const message = (await rejection()).message;
 
-      await expect(
-        vectorQuantize({ vector, targetType: TensorType.INT8, method: "turbo", turboSeed: 42 })
-      ).rejects.toThrow(/768/);
+      expect(message).toMatch(/768/);
+      expect(message).toMatch(/1024/);
+      // The padding opt-in has to be named, and named first: it is the accurate remedy,
+      // and a user cannot discover an input the message does not mention.
+      expect(message).toMatch(/turboPadToPowerOf2/);
+      expect(message).toMatch(/linear/);
 
-      // Both remedies are named: switch method, or pad to the next power of 2.
-      await expect(
-        vectorQuantize({ vector, targetType: TensorType.INT8, method: "turbo", turboSeed: 42 })
-      ).rejects.toThrow(/linear/);
-
-      await expect(
-        vectorQuantize({ vector, targetType: TensorType.INT8, method: "turbo", turboSeed: 42 })
-      ).rejects.toThrow(/1024/);
+      // The stale figure the message used to quote is the CROPPED variant's RMSE, which
+      // this code path no longer emits. Quoting it steered users to `linear` on a
+      // comparison that does not describe either option now on offer.
+      expect(message).not.toContain("0.0164");
 
       // The same vector is fine under linear quantization.
       const linear = await vectorQuantize({ vector, targetType: TensorType.INT8 });
       expect((linear.vector as Int8Array).length).toBe(768);
+    });
+
+    test("should widen to the next power of 2 when turboPadToPowerOf2 is set", async () => {
+      const vector = new Float32Array(768);
+      for (let i = 0; i < 768; i++) vector[i] = Math.sin(i * 0.1);
+
+      const result = await vectorQuantize({
+        vector,
+        targetType: TensorType.INT8,
+        method: "turbo",
+        turboSeed: 42,
+        turboPadToPowerOf2: true,
+      });
+
+      const out = result.vector as Int8Array;
+      expect(out).toBeInstanceOf(Int8Array);
+      // The output is LONGER than the input. That is the whole reason the flag defaults
+      // to false: a storage column declared at 768 would reject this vector.
+      expect(out.length).toBe(1024);
+      expect(result.method).toBe("turbo");
+      expect(result.turboSeed).toBe(42);
+    });
+
+    test("should beat the linear path on similarity error at d=768 when padded", async () => {
+      // The measurement behind the rejection message, asserted rather than quoted. The
+      // message previously cited cropped-turbo RMSE (0.0164 at d=768) and told users
+      // linear was more accurate; padded turbo is roughly 8x MORE accurate here, so the
+      // guidance was backwards for the option the task now offers.
+      const d = 768;
+      const pairs = 40;
+      const rnd = makeRandom(d);
+
+      const cosine = (a: ArrayLike<number>, b: ArrayLike<number>): number => {
+        let dot = 0;
+        let na = 0;
+        let nb = 0;
+        for (let i = 0; i < a.length; i++) {
+          dot += a[i] * b[i];
+          na += a[i] * a[i];
+          nb += b[i] * b[i];
+        }
+        return dot / Math.sqrt(na * nb);
+      };
+
+      let turboSquaredError = 0;
+      let linearSquaredError = 0;
+      for (let p = 0; p < pairs; p++) {
+        const a = new Float32Array(d);
+        const b = new Float32Array(d);
+        for (let i = 0; i < d; i++) {
+          a[i] = rnd() - 0.5;
+          b[i] = rnd() - 0.5;
+        }
+        const exact = cosine(a, b);
+
+        const turboOf = async (v: Float32Array): Promise<Int8Array> =>
+          (
+            await vectorQuantize({
+              vector: v,
+              targetType: TensorType.INT8,
+              method: "turbo",
+              turboSeed: 42,
+              turboPadToPowerOf2: true,
+            })
+          ).vector as Int8Array;
+        const linearOf = async (v: Float32Array): Promise<Int8Array> =>
+          (await vectorQuantize({ vector: v, targetType: TensorType.INT8 })).vector as Int8Array;
+
+        const turboError = cosine(await turboOf(a), await turboOf(b)) - exact;
+        turboSquaredError += turboError * turboError;
+        const linearError = cosine(await linearOf(a), await linearOf(b)) - exact;
+        linearSquaredError += linearError * linearError;
+      }
+
+      const turboRmse = Math.sqrt(turboSquaredError / pairs);
+      const linearRmse = Math.sqrt(linearSquaredError / pairs);
+
+      // Measured: padded turbo 0.00034, linear 0.00269 — a 7.8x gap. The assertion
+      // demands only 4x so an unrelated tweak does not fail it, but the direction is
+      // exactly what the old message got wrong and must not silently reverse.
+      expect(turboRmse).toBeLessThan(linearRmse / 4);
+      expect(turboRmse).toBeLessThan(0.001);
     });
 
     test("should report method and turboSeed on the output", async () => {

--- a/packages/util/src/vector/TurboQuantize.ts
+++ b/packages/util/src/vector/TurboQuantize.ts
@@ -372,8 +372,14 @@ function fastWalshHadamard(data: Float64Array): void {
  * Doubling uses `*= 2` rather than `<<= 1`: the shift operators coerce to 32-bit
  * signed integers, so at p = 2^30 a shift wraps to -2147483648 and then to 0,
  * leaving `p < n` true forever.
+ *
+ * Exported because every caller that reasons about TurboQuant's padded width needs
+ * exactly this function INCLUDING its {@link assertDimensions} guard. A local
+ * reimplementation without that guard accepts a non-integer, a zero, or a length past
+ * {@link MAX_TURBO_DIMENSIONS} and hands it on, so the caller's own carefully worded
+ * validation is bypassed and the failure surfaces later as a low-level message.
  */
-function nextPowerOf2(n: number): number {
+export function nextPowerOf2(n: number): number {
   assertDimensions(n);
   let p = 1;
   while (p < n) p *= 2;
@@ -929,20 +935,31 @@ export interface TurboQuantizeToTypedArrayOptions {
  * a per-seed change of basis, so mixing them yields meaningless rankings with no
  * error raised anywhere.
  *
- * ## Power-of-2 dimensions required
+ * ## Power-of-2 dimensions required, or opt into padding
  *
- * The rotation operates on `nextPowerOf2(d)` coordinates. Keeping only the first `d` of
- * them would make this a lossy random projection rather than an orthogonal rotation, and
- * it measures WORSE than plain linear quantization at exactly the dimensionalities real
- * embedding models use — cosine RMSE against the exact similarity (int8, seed 42, 40
- * random pairs), turbo vs linear: 0.0164 vs 0.0027 at d=768 (MiniLM), 0.0126 vs 0.0033 at
- * d=1536, 0.0094 vs 0.0026 at d=3072; turbo wins only at d=1024 (0.0008 vs 0.0033).
+ * The rotation operates on `nextPowerOf2(d)` coordinates, so a non-power-of-2 `d` has to
+ * either widen the output or discard coordinates. This function does the first on request
+ * and never the second.
  *
- * A non-power-of-2 `d` is therefore rejected rather than silently degraded. Pass
- * `{ padToPowerOf2: true }` to opt into a `nextPowerOf2(d)`-length result instead — note
- * this output is LONGER than the input, so a fixed-width storage column must be declared
- * at the padded width. {@link turboQuantize} is unaffected either way: it keeps all
- * `paddedLen` coordinates and stays fully invertible at any dimensionality.
+ * Pass `{ padToPowerOf2: true }` to receive a `nextPowerOf2(d)`-length result. Padding
+ * keeps the transform orthogonal, and at that width TurboQuant is the more accurate
+ * choice by a wide margin — cosine RMSE against the exact similarity (int8, seed 42, 40
+ * seeded pairs), padded turbo vs linear quantization: 0.00034 vs 0.00269 at d=768
+ * (MiniLM), 0.00024 vs 0.00331 at d=1536, 0.00021 vs 0.00263 at d=3072. The cost is
+ * purely the width: the output is LONGER than the input, so a fixed-width storage column
+ * must be declared at the padded width.
+ *
+ * Without that option a non-power-of-2 `d` is rejected rather than silently degraded. The
+ * rejected alternative is CROPPING — keeping the first `d` of the rotated coordinates —
+ * which makes this a lossy random projection rather than an orthogonal rotation and
+ * measures worse than plain linear quantization at exactly the sizes real embedding
+ * models use: cropped turbo vs linear, 0.0164 vs 0.0027 at d=768, 0.0126 vs 0.0033 at
+ * d=1536, 0.0094 vs 0.0026 at d=3072. Those cropped figures are recorded here only to
+ * explain why the variant is not offered; this function no longer emits it, so do not
+ * quote them as the cost of turbo at these dimensionalities — padding is.
+ *
+ * {@link turboQuantize} is unaffected either way: it keeps all `paddedLen` coordinates
+ * and stays fully invertible at any dimensionality.
  *
  * Note: The vector norm is not preserved (cosine similarity is scale-invariant,
  * so this is fine for similarity search).
@@ -984,10 +1001,13 @@ export function turboQuantizeToTypedArray(
   if (paddedLen !== d && padToPowerOf2 !== true) {
     throw new Error(
       `turboQuantizeToTypedArray requires a power of 2 dimensionality, got ${d}. ` +
-        `Returning only the first ${d} of ${paddedLen} rotated coordinates is a lossy random ` +
-        `projection that measures worse than linear quantization at this size (int8 cosine RMSE ` +
-        `at d=768: turbo 0.0164 vs linear 0.0027). Pass { padToPowerOf2: true } to receive ` +
-        `${paddedLen} values instead, or quantize linearly.`
+        `Pass { padToPowerOf2: true } to receive ${paddedLen} values instead — padding keeps the ` +
+        `rotation orthogonal and is the most accurate option at this size (int8 cosine RMSE at ` +
+        `d=768: padded turbo 0.00034 vs linear 0.00269), at the cost of an output LONGER than the ` +
+        `input, so size any fixed-width storage column to ${paddedLen}. Quantize linearly instead ` +
+        `if the output must keep its ${d} length. Returning only the first ${d} of ${paddedLen} ` +
+        `rotated coordinates is not offered: cropping is a lossy random projection that measures ` +
+        `worse than linear here (0.0164 vs 0.0027).`
     );
   }
 


### PR DESCRIPTION
Fixes on top of #354.

## What breaks

`packages/ai/src/task/VectorQuantizeTask.ts` hard-rejected **every** non-power-of-2 dimensionality for `method: "turbo"`, never exposed `turboQuantizeToTypedArray`'s `{ padToPowerOf2: true }`, and — the part that actually misleads — quoted RMSE figures for the **cropped** variant the util no longer emits, using them to steer users toward `linear`:

> `int8 cosine RMSE at d=768: linear 0.0027 vs turbo 0.0164`

Cropping (keeping the first `d` of `nextPowerOf2(d)` rotated coordinates) really is worse than linear — that is why the util stopped offering it. But those numbers describe a code path that no longer exists, and the message presented them as the cost of *turbo*. So the task told users that linear was the accurate choice at 768/1536/3072 while the accurate choice, padding, was unreachable from the task at all.

## Measured

Re-measured myself, 40 seeded pairs, int8, seed 42 — padded turbo vs **this task's own linear path**, RMSE of the quantized cosine against the exact cosine:

| d | padded turbo | task linear | turbo advantage |
| --- | --- | --- | --- |
| 768 (MiniLM) | **0.00034** | 0.00269 | 7.8x |
| 1536 | **0.00024** | 0.00331 | 13.8x |
| 3072 | **0.00021** | 0.00263 | 12.8x |

Padded turbo is roughly an order of magnitude **more** accurate at exactly the three sizes the old message named as reasons to avoid it. (Directionally identical to the figures in the brief; the multiples differ because the draws do.)

## The fix

- **New `turboPadToPowerOf2` input, defaulting to `false`.** Enabling it widens the output from `d` to `nextPowerOf2(d)`. That is a real consequence — a storage column declared at `d` will reject the result — so it is an opt-in, never inferred. When set, the task passes `{ seed: turboSeed, padToPowerOf2: true }` through to the util.
- **Rejection message rewritten** to lead with the flag, state the widening and the column sizing, quote the real measurement, and name `linear` second as the option that *preserves length* — which is the honest reason to pick it now.
- **Same correction to the `method` description** in `inputSchema` and to the util's JSDoc and `throw`. The cropped figures survive in the util's JSDoc, but explicitly labelled as the cropped variant's and marked as not to be quoted as the cost of turbo — they explain why the variant is not offered, which is still worth recording.
- **Deduplicated `nextPowerOf2`.** The util's copy calls `assertDimensions` first (rejecting non-integers, `n < 1`, `n > 2**20`); the task's local copy did neither. An oversized vector therefore bypassed the task's carefully worded error and surfaced the low-level one instead. The util's helper is now exported (with a comment on why callers must not reimplement it) and the local copy deleted.

## What the new tests catch

All three were confirmed **RED against the base branch** before the fix, then green after:

- A 768-dim vector with `turboPadToPowerOf2: true` returns length **1024** (red today: unknown input property).
- Padded turbo beats `method: "linear"` on measured RMSE over seeded pairs at d=768. Asserted as `turboRmse < linearRmse / 4` — measured gap is 7.8x, so there is headroom, but the *direction* is precisely what the old message got wrong and must not silently reverse.
- The existing rejection test now also asserts the message mentions `turboPadToPowerOf2` and does **not** contain the stale `0.0164`.

The comparison uses the file's seeded `makeRandom`, not `Math.random()`: it asserts a ratio between two quantizers, where an unlucky sample and a real regression would otherwise look the same.

## Verification

Run in a worktree off this PR's base, `bun install` + `bun run use-source`:

- `bun scripts/test.ts rag vitest` — **24 files, 233 tests passed, 0 failed**.
- `bun run build:types` — 40/41 tasks successful. The one failure is **pre-existing on the base branch and unrelated to this PR**: `packages/test/src/test/util/TurboQuantize.test.ts` imports `getTestingLogger` from `../../binding/TestingLogger`, which does not exist. Confirmed by stashing this PR's changes and re-running: identical single error. It is fixed in the companion PR (#757), which also means that whole test file currently fails to load and none of its tests run. This PR is unaffected either way.
- `prettier --check` clean on all three changed files.

Environment note: Node 22.22.2, not the Node 24 `CLAUDE.md` asks for. Nothing here touches native deps, but CI on Node 24 is the authority.

## Follow-ups, deliberately not in this PR

Both are additive API design that deserves its own review:

- **A prepared-query API (`turboPrepareQuery`)**.
- **A seed/method provenance tag on the stored record.** Partially served today by the task's `method` / `turboSeed` outputs, but a padded vector is now a third thing a consumer may need to distinguish, since its length no longer matches the source embedding.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RomTUtZSTgUbFCYqFs4pcu)_