### PR TITLE
Enforce config validation for already-constructed tasks in own()

### DIFF
--- a/examples/cli/src/test/map-iteration-rows.test.ts
+++ b/examples/cli/src/test/map-iteration-rows.test.ts
@@ -56,7 +56,9 @@ class HarvestedFilingTask extends Task<{ item: number }, Record<string, never>> 
     return EMPTY_OUT;
   }
   override async execute(input: { item: number }, context: IExecuteContext) {
-    const child = context.own(new NestedSectionTask(), { title: "Nested section work" });
+    // The row shows the task's own static title; `own` takes no config for an
+    // already-constructed task.
+    const child = context.own(new NestedSectionTask());
     await child.run(input, { signal: context.signal });
     return {};
   }
@@ -78,15 +80,14 @@ const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*[A-Z]/gi, "");
 describe("WorkflowRunApp map iteration rows", () => {
   it("attaches the live clone graph on iteration_start during a real map run", async () => {
     const workflow = new Workflow();
-    workflow
-      .map({ concurrencyLimit: 1, maxIterations: 2 })
-      .addTask(HarvestedFilingTask)
-      .endMap();
+    workflow.map({ concurrencyLimit: 1, maxIterations: 2 }).addTask(HarvestedFilingTask).endMap();
 
     const mapTask = workflow.graph.getTasks()[0] as ITask;
     let state = new Map<string, IterationSlotRow[]>();
     const setter = (
-      updater: Map<string, IterationSlotRow[]> | ((prev: Map<string, IterationSlotRow[]>) => Map<string, IterationSlotRow[]>)
+      updater:
+        | Map<string, IterationSlotRow[]>
+        | ((prev: Map<string, IterationSlotRow[]>) => Map<string, IterationSlotRow[]>)
     ) => {
       state = typeof updater === "function" ? updater(state) : updater;
     };
@@ -147,10 +148,7 @@ describe("WorkflowRunApp map iteration rows", () => {
     }
 
     const workflow = new Workflow();
-    workflow
-      .map({ concurrencyLimit: 1, maxIterations: 1 })
-      .addTask(OuterFilingTask)
-      .endMap();
+    workflow.map({ concurrencyLimit: 1, maxIterations: 1 }).addTask(OuterFilingTask).endMap();
 
     const stdout = new CapturingStdout();
     let finished = false;
@@ -184,10 +182,7 @@ describe("WorkflowRunApp map iteration rows", () => {
 
   it("renders live map children as tasks, not numbered placeholders, and only the in-flight ones", async () => {
     const workflow = new Workflow();
-    workflow
-      .map({ concurrencyLimit: 1, maxIterations: 4 })
-      .addTask(HarvestedFilingTask)
-      .endMap();
+    workflow.map({ concurrencyLimit: 1, maxIterations: 4 }).addTask(HarvestedFilingTask).endMap();
 
     const stdout = new CapturingStdout();
     let finished = false;

--- a/packages/task-graph/src/task-graph/Conversions.ts
+++ b/packages/task-graph/src/task-graph/Conversions.ts
@@ -6,6 +6,7 @@
 
 import type { IExecuteContext, ITask } from "../task/ITask";
 import { Task } from "../task/Task";
+import { TaskConfigurationError } from "../task/TaskError";
 import type { DataPorts } from "../task/TaskTypes";
 import type { ITaskGraph } from "./ITaskGraph";
 import type { IWorkflow } from "./IWorkflow";
@@ -123,13 +124,27 @@ export function ensureTask<I extends DataPorts, O extends DataPorts>(
   arg: Taskish<I, O>,
   config: any = {}
 ): ITask<any, any, any> {
-  if (arg instanceof Task) {
-    return arg;
-  }
   // `isOwned` is a wrapper-construction flag, not task config: every branch
   // below has to keep it out of the config it forwards, or `Task`'s config
   // validation rejects the unknown property.
-  const { isOwned, ...cleanConfig } = config;
+  const { isOwned, ...cleanConfig } = config ?? {};
+  if (arg instanceof Task) {
+    // Only the branches below *construct* a task, so only they have somewhere
+    // to put a config. An instance arrives already built and validated against
+    // its own `configSchema()`, and merging into it afterwards would skip that
+    // validation, desync the frozen `originalConfig` that `toJSON` reads, and —
+    // for `id` — rename a node the DAG has already keyed. So it cannot be
+    // honored; say so instead of dropping it. `own()` and `addTask()` type this
+    // out of reach, but both are reachable through a cast.
+    const ignored = Object.keys(cleanConfig);
+    if (ignored.length > 0) {
+      throw new TaskConfigurationError(
+        `ensureTask(): ${arg.type} is already a task, so config (${ignored.join(", ")}) cannot be applied. ` +
+          `Pass it to the constructor, or use setTitle() to relabel a reused instance.`
+      );
+    }
+    return arg;
+  }
   if (arg instanceof TaskGraph) {
     return graphWrapperFactory()({
       subGraph: arg,

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -30,6 +30,18 @@ import type { JsonTaskItem, TaskGraphItemJson, TaskGraphJsonOptions } from "./Ta
 import type { TaskRunner } from "./TaskRunner";
 import type { TaskConfig, TaskInput, TaskOutput, TaskStatus } from "./TaskTypes";
 
+declare const ownConfigNotApplicable: unique symbol;
+
+/**
+ * The type {@link IExecuteContext.own} gives its `config` parameter when the
+ * argument is already an `ITask`. Uninhabited (the brand key cannot be
+ * produced), so passing anything there is a compile error — one that names the
+ * reason, where a bare `never` would only report "type 'undefined'".
+ */
+export interface ConfigNotApplicableToAnExistingTask {
+  readonly [ownConfigNotApplicable]: never;
+}
+
 export interface IExecuteContext {
   signal: AbortSignal;
   /**
@@ -52,10 +64,18 @@ export interface IExecuteContext {
    *
    * A graph or workflow is adapted into a wrapper task the caller never sees,
    * so `config` is the only way to name one — without it every owned workflow
-   * renders as the same anonymous `Own[Workflow]` row. An argument that is
-   * already an `ITask` keeps its own config; name those at construction.
+   * renders as the same anonymous `Own[Workflow]` row.
+   *
+   * An argument that is already an `ITask` was constructed and validated with
+   * its own config, so there is nothing left for a second one to configure and
+   * the parameter is typed away for that case (passing one anyway — through a
+   * cast — throws rather than being dropped). Name those at construction, or
+   * call {@link ITask.setTitle} to relabel a reused instance.
    */
-  own: <T extends ITask | ITaskGraph | IWorkflow>(i: T, config?: TaskConfig) => T;
+  own: <T extends ITask | ITaskGraph | IWorkflow>(
+    i: T,
+    config?: T extends ITask ? ConfigNotApplicableToAnExistingTask : TaskConfig
+  ) => T;
   /**
    * Release a task previously registered with {@link IExecuteContext.own}, so
    * the running task stops holding it once its work is done.

--- a/packages/task-graph/src/task/StreamProcessor.ts
+++ b/packages/task-graph/src/task/StreamProcessor.ts
@@ -11,7 +11,7 @@ import type { StreamPortCodec } from "../cache/streamCodec";
 import { getStreamPortCodec } from "../cache/streamCodec";
 import type { Taskish } from "../task-graph/Conversions";
 import { BackpressureGate } from "./BackpressureGate";
-import type { ITask } from "./ITask";
+import type { ConfigNotApplicableToAnExistingTask, ITask } from "./ITask";
 import type { StreamEvent, StreamMode, Usage } from "./StreamTypes";
 import {
   assertBinaryFormat,
@@ -73,7 +73,10 @@ export interface StreamProcessorDeps {
     message?: string,
     ...args: any[]
   ) => Promise<void>;
-  readonly own: <T extends Taskish<any, any>>(i: T, config?: TaskConfig) => T;
+  readonly own: <T extends Taskish<any, any>>(
+    i: T,
+    config?: TaskConfig | ConfigNotApplicableToAnExistingTask
+  ) => T;
   readonly disown: <T extends Taskish<any, any>>(i: T) => void;
   /**
    * Per-port stream sinks, one per streamable mode (`append` / `object` /

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -23,7 +23,7 @@ import type { Taskish } from "../task-graph/Conversions";
 import { ensureTask } from "../task-graph/Conversions";
 import { CacheCoordinator } from "./CacheCoordinator";
 import { resolveSchemaInputs, schemaHasFormatAnnotations } from "./InputResolver";
-import type { IRunConfig, ITask } from "./ITask";
+import type { ConfigNotApplicableToAnExistingTask, IRunConfig, ITask } from "./ITask";
 import type { ITaskRunner } from "./ITaskRunner";
 import type { BinaryRefSink, StreamSink } from "./StreamProcessor";
 import { StreamProcessor } from "./StreamProcessor";
@@ -947,7 +947,14 @@ export class TaskRunner<
     return this.task.subGraph.getTask(wrapper.id) !== undefined;
   }
 
-  protected own<T extends Taskish<any, any>>(i: T, config: TaskConfig = {}): T {
+  // Wider than the {@link IExecuteContext.own} signature callers see, which
+  // refuses a config for an argument that is already an `ITask` (nothing would
+  // apply it). This one stays uniform over `Taskish` so the runner has a single
+  // body; `ensureTask` enforces the rule for whatever reaches here past a cast.
+  protected own<T extends Taskish<any, any>>(
+    i: T,
+    config: TaskConfig | ConfigNotApplicableToAnExistingTask = {}
+  ): T {
     const trackable = isOwnTrackable(i);
     if (trackable) {
       // `ensureTask` returns a plain ITask as-is, so owning one twice throws on

--- a/packages/test/src/test/task/OwnTask.test.ts
+++ b/packages/test/src/test/task/OwnTask.test.ts
@@ -1,5 +1,5 @@
-import type { IExecuteContext, TaskOutput } from "@workglow/task-graph";
-import { Task, TaskGraph, Workflow } from "@workglow/task-graph";
+import type { IExecuteContext, TaskConfig, TaskOutput } from "@workglow/task-graph";
+import { Task, TaskConfigurationError, TaskGraph, Workflow } from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
 
 import { TaskCreatorTask } from "@workglow/task-graph/test";
@@ -92,6 +92,63 @@ describe("Task own functionality", () => {
         "Own[Graph]",
         "Own[Workflow]",
       ]);
+    });
+
+    // An already-constructed task has nowhere to put a second config: applying it
+    // would skip the constructor's schema validation, desync `originalConfig`,
+    // and (for `id`) rename a node the DAG has already keyed. The signature types
+    // the argument away, so reaching this needs a cast — and a cast that silently
+    // did nothing is what this guards.
+    it("refuses config for an argument that is already a task", async () => {
+      class RelabelTask extends Task {
+        public static override readonly type = "RelabelTask";
+        public static override readonly title = "Relabel";
+
+        public caught: unknown;
+
+        override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+          const child = new SimpleTask();
+          try {
+            (context.own as (i: Task, config: TaskConfig) => Task)(child, {
+              title: "Fetch facts for CIK 320193",
+            });
+          } catch (error) {
+            this.caught = error;
+          }
+          // Nothing was owned, and the child kept the config it was built with.
+          expect(this.subGraph.getTasks()).toHaveLength(0);
+          expect(child.title).toBe("Simple");
+          return {};
+        }
+      }
+
+      const task = new RelabelTask();
+      await task.run();
+
+      expect(task.caught).toBeInstanceOf(TaskConfigurationError);
+      expect((task.caught as Error).message).toContain("SimpleOwnedTask");
+      expect((task.caught as Error).message).toContain("title");
+      expect((task.caught as Error).message).toContain("setTitle()");
+    });
+
+    // The empty config `own` itself injects (`isOwned`) is not a caller config,
+    // so owning a plain task with no config of its own still works.
+    it("owns a plain task with no config", async () => {
+      class PlainOwnerTask extends Task {
+        public static override readonly type = "PlainOwnerTask";
+        public static override readonly title = "Plain owner";
+
+        override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+          const child = context.own(new SimpleTask());
+          await child.run();
+          return {};
+        }
+      }
+
+      const task = new PlainOwnerTask();
+      await task.run();
+
+      expect(task.subGraph.getTasks().map((t) => t.title)).toEqual(["Simple"]);
     });
   });
 
@@ -323,7 +380,9 @@ describe("Task own functionality", () => {
 
     // `Taskish` admits a pipe function, and `ensureTask` wraps one in a task like
     // any other — but the wrapper is nameable only if `own` records it, and a
-    // function is not `typeof "object"`.
+    // function is not `typeof "object"`. `IExecuteContext.own` does not admit a
+    // pipe function at all, hence the casts: this exercises the runner's wider
+    // `Taskish` contract, not the interface's.
     it("owns and disowns a pipe function", async () => {
       class FnOwnerTask extends Task {
         public static override readonly type = "FnOwnerTask";
@@ -333,8 +392,9 @@ describe("Task own functionality", () => {
 
         override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
           const fn = async (input: TaskOutput): Promise<TaskOutput> => input;
+          const ownTaskish = context.own as (i: unknown, config?: TaskConfig) => unknown;
           for (let i = 0; i < 3; i++) {
-            context.own(fn as never, { title: `Pass ${i}` });
+            ownTaskish(fn, { title: `Pass ${i}` });
             this.counts.push(this.subGraph.getTasks().length);
             context.disown(fn as never);
             this.counts.push(this.subGraph.getTasks().length);


### PR DESCRIPTION
## Summary

This change prevents silent failures when attempting to apply a config to an already-constructed task via `IExecuteContext.own()`. Previously, passing a config to an existing `ITask` instance would be silently ignored; now it throws a `TaskConfigurationError` with a clear message directing users to the correct approach.

## Key Changes

- **Type-level enforcement**: Added `ConfigNotApplicableToAnExistingTask` branded interface to make passing config to an existing task a compile error in normal usage. The type is uninhabited (cannot be constructed), so any value passed there is rejected at compile time with a message naming the reason.

- **Runtime validation**: Updated `ensureTask()` in `Conversions.ts` to detect and reject non-empty configs passed to already-constructed `ITask` instances, throwing `TaskConfigurationError` with guidance to use the constructor or `setTitle()` instead.

- **Signature refinement**: Narrowed `IExecuteContext.own()` signature to accept `ConfigNotApplicableToAnExistingTask` (unreachable) when the argument is already an `ITask`, and `TaskConfig` for graphs/workflows. The `TaskRunner.own()` implementation remains wider to handle the uniform `Taskish` union internally, with `ensureTask()` enforcing the rule.

- **Test coverage**: Added two new test cases:
  - `refuses config for an argument that is already a task` — verifies the error is thrown with helpful message
  - `owns a plain task with no config` — confirms that owning a task without config still works

- **Documentation updates**: Clarified in `IExecuteContext.own()` JSDoc that configs cannot be applied to existing tasks, and updated example code in `map-iteration-rows.test.ts` to remove the now-invalid config parameter.

## Implementation Details

The fix leverages TypeScript's branded types to make the invalid case unrepresentable in the type system for callers, while `ensureTask()` provides the runtime guard for cases that bypass the type system via casts. This prevents the confusing scenario where a developer casts to work around the type error but the config is silently dropped, leaving them debugging why their relabeling didn't work.

https://claude.ai/code/session_016ymc7PEuA4ymXDAieCZvVg