### PR TITLE
Fix HFT background removal to support both browser and Node runtimes

### DIFF
--- a/packages/test/src/test/ai-provider-hft/HFT_BackgroundRemoval.test.ts
+++ b/packages/test/src/test/ai-provider-hft/HFT_BackgroundRemoval.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { rawImageToImageValue } from "@workglow/huggingface-transformers/ai-runtime";
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * `RawImage` carries different encoders per runtime — `toBlob()` is
+ * canvas-backed and browser-only, `toSharp()` is node-only — and transformers.js
+ * has changed which of them exist. The run-fn probes rather than assuming, so
+ * the probe order and the failure message are pinned here.
+ */
+describe("rawImageToImageValue", () => {
+  // A 1x1 transparent PNG — the smallest thing sharp will accept.
+  const PNG_1X1 = Uint8Array.from(
+    atob(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+    ),
+    (c) => c.charCodeAt(0)
+  );
+
+  it("prefers toBlob when the runtime provides it", async () => {
+    const toBlob = vi.fn(async () => new Blob([PNG_1X1], { type: "image/png" }));
+    const toSharp = vi.fn();
+
+    const value = await rawImageToImageValue({ toBlob, toSharp });
+
+    expect(toBlob).toHaveBeenCalledWith("image/png");
+    expect(toSharp).not.toHaveBeenCalled();
+    expect(value).toBeDefined();
+  });
+
+  it("falls back to toSharp when toBlob is absent", async () => {
+    const toBuffer = vi.fn(async () => PNG_1X1);
+    const toSharp = vi.fn(() => ({ png: () => ({ toBuffer }) }));
+
+    const value = await rawImageToImageValue({ toSharp });
+
+    expect(toBuffer).toHaveBeenCalled();
+    expect(value).toBeDefined();
+  });
+
+  it("throws a diagnosable error when neither encoder exists", async () => {
+    // The transformers 4.2.0 shape that made the previous `toBase64` call fail:
+    // a RawImage with neither encoder must name both, not just one.
+    await expect(rawImageToImageValue({})).rejects.toThrow(/toBlob\(\) nor toSharp\(\)/);
+  });
+});

--- a/providers/huggingface-transformers/src/ai/common/HFT_BackgroundRemoval.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_BackgroundRemoval.ts
@@ -4,25 +4,50 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { BackgroundRemovalPipeline, RawImage } from "@huggingface/transformers";
+import type { BackgroundRemovalPipeline } from "@huggingface/transformers";
 import type {
   AiProviderRunFn,
   BackgroundRemovalTaskInput,
   BackgroundRemovalTaskOutput,
 } from "@workglow/ai";
-import { dataUriToImageValue, imageValueToBlob } from "@workglow/ai/provider-utils";
+import {
+  blobToImageValue,
+  imageValueToBlob,
+  pngBytesToImageValue,
+} from "@workglow/ai/provider-utils";
 import type { ImageValue } from "@workglow/util/media";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
 import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
-function rawImageToBase64Png(image: RawImage): string {
-  const fn = (image as unknown as { toBase64?: () => string }).toBase64;
-  if (typeof fn !== "function") {
-    throw new Error(
-      "HFT_BackgroundRemoval: RawImage.toBase64 unavailable in this transformers version"
-    );
+/**
+ * The subset of `RawImage` this module uses. Declared structurally rather than
+ * as `RawImage` so the encoder probe stays independent of which methods a given
+ * transformers.js version happens to ship.
+ */
+export interface EncodableRawImage {
+  toBlob?: (type?: string, quality?: number) => Promise<Blob>;
+  toSharp?: () => { png: () => { toBuffer: () => Promise<Uint8Array> } };
+}
+
+/**
+ * Encode a pipeline's `RawImage` result as an {@link ImageValue}, preserving
+ * the alpha channel background removal produces.
+ *
+ * `RawImage` exposes different encoders per runtime: `toBlob()` goes through a
+ * canvas and is browser-only, `toSharp()` is node-only. Probe rather than
+ * assume — this run-fn is registered for both the inline and worker runtimes.
+ */
+export async function rawImageToImageValue(image: EncodableRawImage): Promise<ImageValue> {
+  if (typeof image.toBlob === "function") {
+    return blobToImageValue(await image.toBlob("image/png"));
   }
-  return fn.call(image);
+  if (typeof image.toSharp === "function") {
+    return pngBytesToImageValue(await image.toSharp().png().toBuffer(), "png");
+  }
+
+  throw new Error(
+    "HFT_BackgroundRemoval: RawImage exposes neither toBlob() nor toSharp() in this transformers version"
+  );
 }
 
 export const HFT_BackgroundRemoval: AiProviderRunFn<
@@ -36,12 +61,11 @@ export const HFT_BackgroundRemoval: AiProviderRunFn<
     const result = await remover(imageArg);
 
     const resultImage = Array.isArray(result) ? result[0] : result;
-    const dataUri = `data:image/png;base64,${rawImageToBase64Png(resultImage)}`;
 
     emit({
       type: "finish",
       data: {
-        image: await dataUriToImageValue(dataUri),
+        image: await rawImageToImageValue(resultImage),
       },
     });
   });

--- a/providers/huggingface-transformers/src/ai/runtime.ts
+++ b/providers/huggingface-transformers/src/ai/runtime.ts
@@ -14,6 +14,7 @@
 
 // organize-imports-ignore
 
+export * from "./common/HFT_BackgroundRemoval";
 export * from "./common/HFT_Constants";
 export * from "./common/HFT_Device";
 export * from "./common/HFT_ModelSchema";


### PR DESCRIPTION
## Summary

Replace the deprecated `RawImage.toBase64()` method with a runtime-aware encoder that probes for available methods (`toBlob()` for browser, `toSharp()` for Node) and falls back gracefully. This fixes background removal in both inline and worker runtimes where transformers.js versions may differ in which encoders they expose.

## Changes

- **Added `rawImageToImageValue()` function** in `HFT_BackgroundRemoval.ts`:
  - Probes for `toBlob()` first (browser-compatible, canvas-backed)
  - Falls back to `toSharp()` (Node-only, sharp-backed)
  - Throws a clear error naming both methods if neither exists
  - Preserves PNG alpha channel from background removal output

- **Declared `EncodableRawImage` interface**:
  - Structural type capturing only the encoder methods this module uses
  - Keeps the encoder probe independent of transformers.js version specifics

- **Updated `HFT_BackgroundRemoval` run function**:
  - Replaced `rawImageToBase64Png()` + `dataUriToImageValue()` with direct `rawImageToImageValue()` call
  - Eliminates intermediate base64 encoding step

- **Added comprehensive test suite** (`HFT_BackgroundRemoval.test.ts`):
  - Verifies `toBlob()` is preferred when available
  - Verifies fallback to `toSharp()` when `toBlob()` is absent
  - Verifies clear error message when neither encoder exists

- **Exported `rawImageToImageValue`** from `ai/runtime.ts` for use across runtimes

## Implementation Details

The probe order is intentional: `toBlob()` is tried first because it's the standard Web API and works in both browser and Node (via polyfills in some transformers versions), while `toSharp()` is Node-specific. The error message explicitly names both methods to help diagnose which transformers.js version is in use.

https://claude.ai/code/session_01XviwL8YLSSthZwFrmbppDu