### PR TITLE
fix(tasks): bound the webhook timeout port so it cannot throw a RangeError or fire after 1 ms

### DIFF
--- a/packages/tasks/README.md
+++ b/packages/tasks/README.md
@@ -150,7 +150,7 @@ output schema and error messages report only the endpoint's origin.
 - `url` (string, optional): Webhook endpoint to POST to. Kept out of errors and output, but a value set here is stored verbatim in the graph JSON — use `url_credential_key` to keep the secret out of the saved workflow.
 - `payload` (object, required): JSON body to send
 - `headers` (object, optional): Additional headers, merged over the JSON content type
-- `timeout` (number, optional): Request timeout in milliseconds. Default: `30000`
+- `timeout` (integer, optional): Request timeout in milliseconds, a whole number from 1 to 2147483647 (~24.8 days). Default: `30000`
 - `allow_private_destination` (boolean, optional): Permit posting to a private/internal/loopback destination. Requires the `network:private` entitlement. Default: `false`
 - `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`. A value that is not an absolute `http(s)` URL (e.g. a bearer token) is rejected with a configuration error.
 
@@ -209,7 +209,7 @@ Sends a message to a Slack incoming webhook.
 - `username` (string, optional): Overrides the display name of the posting bot
 - `icon_emoji` (string, optional): Overrides the bot icon, e.g. `:rocket:`
 - `allow_mentions` (boolean, optional): Send `text` unmodified. Default: `false`
-- `timeout` (number, optional): Request timeout in milliseconds. Default: `30000`
+- `timeout` (integer, optional): Request timeout in milliseconds, a whole number from 1 to 2147483647 (~24.8 days). Default: `30000`
 - `allow_private_destination` (boolean, optional): Permit posting to a private/internal/loopback destination. Requires the `network:private` entitlement. Default: `false`
 - `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`.
 
@@ -266,7 +266,7 @@ Sends a message to a Discord webhook.
 - `avatar_url` (string, optional): Overrides the avatar of the webhook
 - `embeds` (array, optional): Discord embed objects
 - `allow_mentions` (boolean, optional): Let the message ping. Default: `false`
-- `timeout` (number, optional): Request timeout in milliseconds. Default: `30000`
+- `timeout` (integer, optional): Request timeout in milliseconds, a whole number from 1 to 2147483647 (~24.8 days). Default: `30000`
 - `allow_private_destination` (boolean, optional): Permit posting to a private/internal/loopback destination. Requires the `network:private` entitlement. Default: `false`
 - `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`.
 

--- a/packages/tasks/src/task/DiscordNotifyTask.ts
+++ b/packages/tasks/src/task/DiscordNotifyTask.ts
@@ -14,6 +14,7 @@ import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import {
   compactPayload,
+  MAX_REQUEST_TIMEOUT_MS,
   postWebhookJson,
   resolveWebhookUrl,
   webhookBaseEntitlements,
@@ -60,12 +61,13 @@ const inputSchema = {
         "Let the message ping. By default `allowed_mentions: { parse: [] }` is sent, suppressing @everyone/@here, role and user pings so piped or model-generated content cannot notify a whole server.",
     },
     timeout: {
-      type: "number",
+      type: "integer",
       default: 30000,
       minimum: 1,
+      maximum: MAX_REQUEST_TIMEOUT_MS,
       title: "Timeout",
       description:
-        "Request timeout in milliseconds. There is no 'wait forever' setting: a black-holed endpoint would pin the task until the caller aborts.",
+        "Request timeout in milliseconds, a whole number no greater than 2147483647 (~24.8 days). There is no 'wait forever' setting: a black-holed endpoint would pin the task until the caller aborts, and a larger value would silently fire after 1 ms.",
     },
     allow_private_destination: {
       type: "boolean",

--- a/packages/tasks/src/task/SlackNotifyTask.ts
+++ b/packages/tasks/src/task/SlackNotifyTask.ts
@@ -15,6 +15,7 @@ import { SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import {
   compactPayload,
+  MAX_REQUEST_TIMEOUT_MS,
   postWebhookJson,
   resolveWebhookUrl,
   webhookBaseEntitlements,
@@ -62,12 +63,13 @@ const inputSchema = {
         "Send 'text' and 'blocks' unmodified. By default channel-wide broadcasts are neutralized in both — the text forms (<!channel>, <!here>, <!everyone>, <!subteam^ID>) by escaping, and the rich_text broadcast/usergroup element shapes by rewriting — so piped or model-generated content cannot notify a whole workspace.",
     },
     timeout: {
-      type: "number",
+      type: "integer",
       default: 30000,
       minimum: 1,
+      maximum: MAX_REQUEST_TIMEOUT_MS,
       title: "Timeout",
       description:
-        "Request timeout in milliseconds. There is no 'wait forever' setting: a black-holed endpoint would pin the task until the caller aborts.",
+        "Request timeout in milliseconds, a whole number no greater than 2147483647 (~24.8 days). There is no 'wait forever' setting: a black-holed endpoint would pin the task until the caller aborts, and a larger value would silently fire after 1 ms.",
     },
     allow_private_destination: {
       type: "boolean",

--- a/packages/tasks/src/task/WebhookNotifyTask.ts
+++ b/packages/tasks/src/task/WebhookNotifyTask.ts
@@ -14,6 +14,7 @@ import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { classifyUrl } from "../util/UrlClassifier";
 import {
+  MAX_REQUEST_TIMEOUT_MS,
   postWebhookJson,
   resolveWebhookUrl,
   webhookBaseEntitlements,
@@ -43,12 +44,13 @@ const inputSchema = {
       description: "Additional headers merged over the JSON content type",
     },
     timeout: {
-      type: "number",
+      type: "integer",
       default: 30000,
       minimum: 1,
+      maximum: MAX_REQUEST_TIMEOUT_MS,
       title: "Timeout",
       description:
-        "Request timeout in milliseconds. There is no 'wait forever' setting: a black-holed endpoint would pin the task until the caller aborts.",
+        "Request timeout in milliseconds, a whole number no greater than 2147483647 (~24.8 days). There is no 'wait forever' setting: a black-holed endpoint would pin the task until the caller aborts, and a larger value would silently fire after 1 ms.",
     },
     allow_private_destination: {
       type: "boolean",

--- a/packages/tasks/src/util/WebhookPost.ts
+++ b/packages/tasks/src/util/WebhookPost.ts
@@ -49,6 +49,23 @@ const MAX_RESPONSE_BODY_CHARS = 1024;
 /** Maximum characters of a failure body surfaced in an error message. */
 const MAX_ERROR_BODY_CHARS = 256;
 
+/**
+ * Largest request timeout the platform timer honors, in milliseconds.
+ *
+ * `AbortSignal.timeout` validates its delay as a uint32 and accepts up to
+ * 2^32-1, but anything above the SIGNED 32-bit range is stored in a 32-bit int
+ * and clamped to 1 ms with a `TimeoutOverflowWarning` — so a caller asking to
+ * "effectively never time out" would abort instantly and the failure would be
+ * reported against the endpoint. Accepted-but-silently-wrong is worse than
+ * rejected, so the bound is the signed maximum rather than the unsigned one.
+ *
+ * Deliberately not part of `SECURITY_LIMITS`: that object holds hard ceilings
+ * against resource exhaustion and injection, and this is a platform-timer
+ * bound. Keeping it here lets the three task schemas import the same literal,
+ * so the schema bound and the runtime guard below cannot drift.
+ */
+export const MAX_REQUEST_TIMEOUT_MS = 2147483647;
+
 function truncate(text: string, max: number): string {
   return text.length <= max ? text : `${text.slice(0, max)}...`;
 }
@@ -259,7 +276,14 @@ export interface WebhookPostRequest {
   readonly payload: unknown;
   /** Extra request headers merged over the JSON content type. */
   readonly headers: Readonly<Record<string, string>> | undefined;
-  /** Request timeout in milliseconds. */
+  /**
+   * Request timeout in milliseconds: a whole number from 1 to
+   * {@link MAX_REQUEST_TIMEOUT_MS}. Anything else is a permanent configuration
+   * error, raised before the timer is armed.
+   *
+   * `undefined` means no timer at all, which only a direct caller can ask for
+   * — all three notify task schemas carry `default: 30000`.
+   */
   readonly timeout: number | undefined;
   readonly signal: AbortSignal;
   /**
@@ -615,10 +639,24 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
   if (isPrivate) {
     await assertPrivateDestinationGranted(request.registry, url, label);
   }
-  const timeoutSignal =
-    request.timeout !== undefined && request.timeout > 0
-      ? AbortSignal.timeout(request.timeout)
-      : undefined;
+  // Validated BEFORE the signal is armed, for the same reason the
+  // `JSON.stringify` guard below exists: `AbortSignal.timeout` throws a bare
+  // `RangeError` for a non-integer delay, which is not a `FetchUrlJobError`, so
+  // a queued consumer cannot classify it and retries a permanent configuration
+  // mistake forever.
+  const timeout = request.timeout;
+  if (
+    timeout !== undefined &&
+    (!Number.isInteger(timeout) || timeout < 1 || timeout > MAX_REQUEST_TIMEOUT_MS)
+  ) {
+    throw createFetchUrlJobError(
+      FetchUrlErrorCode.CONFIGURATION,
+      `Cannot post ${label} to ${redactWebhookUrl(url)}: 'timeout' must be a whole number of ` +
+        `milliseconds between 1 and ${MAX_REQUEST_TIMEOUT_MS}; received ${String(timeout)}.`,
+      { url: redactWebhookUrl(url) }
+    );
+  }
+  const timeoutSignal = timeout === undefined ? undefined : AbortSignal.timeout(timeout);
   const signal = timeoutSignal ? AbortSignal.any([request.signal, timeoutSignal]) : request.signal;
 
   // Built BEFORE the request `try`. A payload carrying a circular reference or

--- a/packages/test/src/test/task/NotifyTask.test.ts
+++ b/packages/test/src/test/task/NotifyTask.test.ts
@@ -10,6 +10,7 @@ import {
   PermanentJobError,
   RetryableJobError,
 } from "@workglow/job-queue";
+import type { IExecuteContext } from "@workglow/task-graph";
 import {
   createPolicyEnforcer,
   createProfilePolicy,
@@ -79,6 +80,21 @@ function lastCall(): { url: string; options: SafeFetchOptions } {
 
 function requestHeaders(): Record<string, string> {
   return lastCall().options.headers as Record<string, string>;
+}
+
+/**
+ * Minimal execute context, used by the few cases that must reach `execute()`
+ * directly to bypass schema validation and exercise a runtime guard.
+ */
+function makeContext(): IExecuteContext {
+  return {
+    signal: new AbortController().signal,
+    updateProgress: async () => {},
+    own: <T>(t: T) => t,
+    disown: () => {},
+    registry: undefined as unknown as IExecuteContext["registry"],
+    resourceScope: undefined,
+  };
 }
 
 describe("Webhook notification tasks", () => {
@@ -1239,6 +1255,92 @@ describe("Webhook notification tasks", () => {
       expect(error).toBeInstanceOf(AbortSignalJobError);
       expect(error).not.toBeInstanceOf(RetryableJobError);
       expect((error as { code?: string }).code).not.toBe(FetchUrlErrorCode.NETWORK_ERROR);
+    });
+
+    // `AbortSignal.timeout` validates its delay as a uint32 INTEGER: a
+    // fractional value throws a bare `RangeError` a queued consumer cannot
+    // classify, and anything past the SIGNED 32-bit range is clamped to 1 ms
+    // with a `TimeoutOverflowWarning` — so "effectively never time out" aborts
+    // instantly and blames the endpoint. Both are refused, at the schema and
+    // again at the runtime guard.
+    test("the schema rejects a fractional timeout before any request", async () => {
+      const error = await slackNotify({ url: SLACK_URL, text: "hi", timeout: 500.5 }).catch(
+        (e: unknown) => e
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      // Rejected by validation, not by the platform timer blowing up on it.
+      expect(error).not.toBeInstanceOf(RangeError);
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    test("the schema rejects a timeout past the 32-bit timer bound", async () => {
+      const error = await slackNotify({
+        url: SLACK_URL,
+        text: "hi",
+        timeout: 3_000_000_000,
+      }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    // Reached through `execute` directly, bypassing schema validation, because
+    // that is what a queued consumer classifying a failure sees: the guard has
+    // to produce a PERMANENT, coded error rather than the platform's
+    // `RangeError`, which would be retried forever.
+    test("the timeout guard is a classifiable configuration error, not a RangeError", async () => {
+      const error = (await new SlackNotifyTask()
+        .execute({ url: SLACK_URL, text: "hi", timeout: 500.5 } as never, makeContext())
+        .catch((e: unknown) => e)) as PermanentJobError;
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error).not.toBeInstanceOf(RetryableJobError);
+      expect(error.code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect(error.message).toContain("2147483647");
+      expect(error.message).not.toContain("SECRETTOKEN");
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    test("a timeout past the bound is refused rather than firing after 1 ms", async () => {
+      const error = (await new SlackNotifyTask()
+        .execute({ url: SLACK_URL, text: "hi", timeout: 3_000_000_000 } as never, makeContext())
+        .catch((e: unknown) => e)) as PermanentJobError;
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error.code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect(error.message).not.toContain("Timed out");
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    test("the largest honored timeout is accepted", async () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+      try {
+        await expect(
+          slackNotify({ url: SLACK_URL, text: "hi", timeout: 2147483647 })
+        ).resolves.toBeDefined();
+        expect(timeoutSpy).toHaveBeenLastCalledWith(2147483647);
+      } finally {
+        timeoutSpy.mockRestore();
+      }
+    });
+
+    // The port is duplicated across three task schemas, so the bound is
+    // asserted on all three: fixing one and missing the others is the shape
+    // this defect already had.
+    test("all three notify tasks bound the timeout port identically", () => {
+      for (const schema of [
+        SlackNotifyTask.inputSchema(),
+        DiscordNotifyTask.inputSchema(),
+        WebhookNotifyTask.inputSchema(),
+      ]) {
+        expect((schema.properties as Record<string, unknown>).timeout).toMatchObject({
+          type: "integer",
+          minimum: 1,
+          maximum: 2147483647,
+          default: 30000,
+        });
+      }
     });
   });
 


### PR DESCRIPTION
## Problem

`postWebhookJson` calls `AbortSignal.timeout(request.timeout)` outside any `try`, guarded only by `> 0`. Node validates that delay as a **uint32 integer**, but the `timeout` port is declared `type: "number", minimum: 1` with no maximum in all three notify tasks — so schema validation passes values the timer does not accept.

Two concrete failures, both reproduced on Node v22:

- `slackNotify({url, text, timeout: 500.5})` — `AbortSignal.timeout(500.5)` throws `RangeError [ERR_OUT_OF_RANGE]`. That is not a `FetchUrlJobError`, so a queued consumer cannot classify it and retries a permanent configuration mistake forever. This is exactly the hazard the sibling `JSON.stringify` guard 20 lines below exists to prevent.
- `timeout: 3_000_000_000` ("effectively never time out") — passes validation, logs `TimeoutOverflowWarning`, and aborts after **1 ms**. The failure is then reported as `Timed out posting Slack webhook to https://hooks.slack.com`, blaming the endpoint.

Note the two thresholds differ: `AbortSignal.timeout` only throws above 2^32-1, but the *silent* clamp starts at 2^31 — accepted-but-silently-wrong is worse than rejected, which is why the bound is the signed maximum.

## Change

- `MAX_REQUEST_TIMEOUT_MS = 2147483647` exported from `WebhookPost.ts`, imported by all three task schemas so the schema bound and the runtime guard share one literal and cannot drift. Deliberately not added to `SECURITY_LIMITS`, which holds ceilings against resource exhaustion and injection; this is a platform-timer bound.
- The port becomes `type: "integer", minimum: 1, maximum: MAX_REQUEST_TIMEOUT_MS` in `SlackNotifyTask`, `DiscordNotifyTask` and `WebhookNotifyTask` (the whole enumeration — there is no fourth site). `FromSchema` maps `integer` to `number`, so the input types are unchanged and no call site needs touching.
- `postWebhookJson` validates before the signal is armed and raises a classifiable `FetchUrlErrorCode.CONFIGURATION` error naming the bound. `Number.isInteger` also rejects `NaN`, `Infinity` and a non-number that slipped through an `as`.

Dropping the old `> 0` test is deliberate: it silently meant "wait forever", contradicting the port's own documented behavior. `undefined` still means no timer, and is only reachable from a direct `postWebhookJson` caller since all three schemas carry `default: 30000` — now stated in the `WebhookPostRequest.timeout` JSDoc.

`packages/tasks/README.md` restates the port as integer-bounded in all three task sections.

## Tests

Six cases in `NotifyTask.test.ts`, `describe("request timeouts")`. Five were confirmed failing against the pre-fix tree; the sixth (`the largest honored timeout is accepted`) passes both before and after and is an off-by-one regression guard only.

The load-bearing one is **"the timeout guard is a classifiable configuration error, not a RangeError"**: it reaches `execute()` directly to bypass schema validation and asserts `PermanentJobError` / `FetchUrlErrorCode.CONFIGURATION` / the bound in the message / no token leak / no request made. Before the fix it fails with the raw `RangeError`. **"all three notify tasks bound the timeout port identically"** catches the port being fixed in one task and missed in the other two, which is the specific shape of this defect.

The existing "arms an abort signal from the default timeout" and "an endpoint that never answers is aborted by the timeout" are unchanged, as the regression net for a guard that is too strict.

## Verification

- `bunx vitest run --project test packages/test/src/test/task/NotifyTask.test.ts` — 111 passed
- `bun scripts/test.ts task vitest` — 67 files, 1075 passed, 24 skipped
- `bun run build:types` — 41/41 packages clean (this typechecks the test package too)

## Out of scope, recorded here

`FetchUrlTask.ts:76` declares a `timeout` port that nothing in that file reads — a dead port, untouched by this PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKvKnyVeQQQCm6FhtaLyMa)_