### PR TITLE
fix(tasks)!: let allow_private_destination govern the transport it declares

### DIFF
--- a/packages/tasks/README.md
+++ b/packages/tasks/README.md
@@ -151,14 +151,14 @@ output schema and error messages report only the endpoint's origin.
 - `payload` (object, required): JSON body to send
 - `headers` (object, optional): Additional headers, merged over the JSON content type
 - `timeout` (integer, optional): Request timeout in milliseconds, a whole number from 1 to 2147483647 (~24.8 days). Default: `30000`
-- `allow_private_destination` (boolean, optional): Permit posting to a private/internal/loopback destination. Requires the `network:private` entitlement. Default: `false`
+- `allow_private_destination` (boolean, optional): Permit posting to a private/internal/loopback destination — including a public-looking hostname that resolves into private address space. Requires the `network:private` entitlement, re-checked at execute time against the URL actually resolved. A declared private destination's reply body and reason phrase are never surfaced. Default: `false`
 - `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`. A value that is not an absolute `http(s)` URL (e.g. a bearer token) is rejected with a configuration error.
 
 **Output Schema:**
 
 - `success` (boolean): Always `true`; a non-2xx response throws
 - `status` (number): HTTP status code returned by the endpoint
-- `response` (string): Response body, truncated to 1KB. Always empty for a private/internal destination
+- `response` (string): Response body, truncated to 1KB. Always empty for a declared private destination
 
 **Examples:**
 
@@ -189,8 +189,8 @@ const workflow = new Workflow()
 
 - Runs inline through the SSRF-aware `safeFetch` wrapper
 - **Redirects are refused** — a webhook that answers `3xx` fails rather than re-sending the payload and headers to the new origin. Point `url` at the final endpoint
-- **A private/internal destination is refused unless `allow_private_destination` is set** — which also declares the `network:private` entitlement, scoped to `url` when no credential key is configured. Without the flag the post fails with `PRIVATE_DENIED` before any request is made, and, when an entitlement enforcer is registered, the `network:private` grant is re-checked at execute time against the URL actually resolved — so a run-input or credential-supplied private destination cannot slip past the declaration the enforcer graded
-- A permitted private/internal destination is reachable but its response body is **never echoed** — `response` is always `""`. Notification needs no reply body, and returning one would make this task an SSRF read primitive (e.g. POSTing to a cloud metadata endpoint and reading the answer back into the graph)
+- **A private/internal destination is refused unless `allow_private_destination` is set** — which also declares the `network:private` entitlement, scoped to `url` when no credential key is configured. Without the flag the post fails with `PRIVATE_DENIED` before any request is made, and, when an entitlement enforcer is registered, the `network:private` grant is re-checked at execute time against the URL actually resolved — so a run-input or credential-supplied private destination cannot slip past the declaration the enforcer graded. The flag governs the transport whatever the URL's spelling: a public-looking hostname that resolves into private address space is reachable exactly when the grant covers it, so every widened request is entitlement-checked
+- A declared private destination is reachable but its response body is **never echoed** — `response` is always `""`, whatever the URL's spelling, because the URL alone cannot say whether the host was internal. Notification needs no reply body, and returning one would make this task an SSRF read primitive (e.g. POSTing to a cloud metadata endpoint and reading the answer back into the graph)
 - 429/503 and 5xx raise `RetryableJobError`; retries require a `@workglow/job-queue` consumer, which these inline tasks do not have
 - Response bodies are read as a stream and abandoned past 1MB, so an endpoint answering with an unbounded body cannot exhaust runner memory — on the failure path too
 - Requests time out after 30s by default (`timeout`); a caller abort surfaces as an abort error rather than a retryable network failure
@@ -210,7 +210,7 @@ Sends a message to a Slack incoming webhook.
 - `icon_emoji` (string, optional): Overrides the bot icon, e.g. `:rocket:`
 - `allow_mentions` (boolean, optional): Send `text` unmodified. Default: `false`
 - `timeout` (integer, optional): Request timeout in milliseconds, a whole number from 1 to 2147483647 (~24.8 days). Default: `30000`
-- `allow_private_destination` (boolean, optional): Permit posting to a private/internal/loopback destination. Requires the `network:private` entitlement. Default: `false`
+- `allow_private_destination` (boolean, optional): Permit posting to a private/internal/loopback destination — including a public-looking hostname that resolves into private address space. Requires the `network:private` entitlement, re-checked at execute time against the URL actually resolved. A declared private destination's reply body and reason phrase are never surfaced. Default: `false`
 - `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`.
 
 **Output Schema:**
@@ -247,8 +247,8 @@ const workflow = new Workflow().slackNotify({
 
 - Absent optional fields are omitted from the payload rather than sent as `null`
 - **Redirects are refused** — a webhook that answers `3xx` fails rather than re-sending the payload and headers to the new origin. Point `url` at the final endpoint
-- **A private/internal destination is refused unless `allow_private_destination` is set**, which also declares the `network:private` entitlement, and, when an entitlement enforcer is registered, the `network:private` grant is re-checked at execute time against the URL actually resolved — so a run-input or credential-supplied private destination cannot slip past the declaration the enforcer graded
-- Slack answers `200` with the body `ok`; failure bodies (`invalid_payload`, `no_service`) are surfaced in the error message — but **only for a public destination**. A private/internal endpoint's reply body is never spliced into the error, which would otherwise make the task an SSRF read primitive; its status is still reported
+- **A private/internal destination is refused unless `allow_private_destination` is set**, which also declares the `network:private` entitlement, and, when an entitlement enforcer is registered, the `network:private` grant is re-checked at execute time against the URL actually resolved — so a run-input or credential-supplied private destination cannot slip past the declaration the enforcer graded. The flag governs the transport whatever the URL's spelling: a public-looking hostname that resolves into private address space is reachable exactly when the grant covers it, so every widened request is entitlement-checked
+- Slack answers `200` with the body `ok`; failure bodies (`invalid_payload`, `no_service`) are surfaced in the error message — but **only for a destination not declared private**. A declared private destination's reply body and reason phrase are never spliced into the error, which would otherwise make the task an SSRF read primitive; its status is still reported
 - **Channel-wide broadcasts in `text` and `blocks` are neutralized by default**, by two mechanisms, because Slack has two ways to say the same thing. _Lexical:_ Slack has no `allowed_mentions`; its documented control is HTML-entity escaping, so the literal `<!` is escaped to `&lt;!`. That defuses `<!channel>`, `<!here>`, `<!everyone>` and `<!subteam^ID>` while leaving `<https://…|label>` links and single-user `<@U123>` mentions intact, and `link_names: false` is sent explicitly. `blocks` is walked to every string leaf, so a broadcast written inside a section, a `fields[]` entry or an `elements[]` entry is defused too. _Structural:_ a `rich_text` message expresses the same ping as an element shape with no `<!` in it at all — `{type: "broadcast", range: "channel"}` or `{type: "usergroup", usergroup_id: "S…"}` — so such an element is rewritten to a plain text node (`@channel`) rather than deleted, since dropping it could leave an `elements[]` empty and Slack rejects that. Residual: a new structural notification element type Slack introduces later is uncovered until it is added to the recognized set. Set `allow_mentions: true` to send both verbatim
 - Requests time out after 30s by default (`timeout`)
 - Response bodies are capped at 1MB while being read
@@ -267,7 +267,7 @@ Sends a message to a Discord webhook.
 - `embeds` (array, optional): Discord embed objects
 - `allow_mentions` (boolean, optional): Let the message ping. Default: `false`
 - `timeout` (integer, optional): Request timeout in milliseconds, a whole number from 1 to 2147483647 (~24.8 days). Default: `30000`
-- `allow_private_destination` (boolean, optional): Permit posting to a private/internal/loopback destination. Requires the `network:private` entitlement. Default: `false`
+- `allow_private_destination` (boolean, optional): Permit posting to a private/internal/loopback destination — including a public-looking hostname that resolves into private address space. Requires the `network:private` entitlement, re-checked at execute time against the URL actually resolved. A declared private destination's reply body and reason phrase are never surfaced. Default: `false`
 - `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`.
 
 **Output Schema:**
@@ -304,8 +304,8 @@ const workflow = new Workflow().discordNotify({
 
 - A successful post answers `204 No Content`, so no response body is read or parsed
 - **Redirects are refused** — a webhook that answers `3xx` fails rather than re-sending the payload and headers to the new origin. Point `url` at the final endpoint
-- **A private/internal destination is refused unless `allow_private_destination` is set**, which also declares the `network:private` entitlement, and, when an entitlement enforcer is registered, the `network:private` grant is re-checked at execute time against the URL actually resolved — so a run-input or credential-supplied private destination cannot slip past the declaration the enforcer graded
-- A failure body is surfaced in the error message **only for a public destination**; a private/internal endpoint's reply body is never spliced in, which would otherwise make the task an SSRF read primitive
+- **A private/internal destination is refused unless `allow_private_destination` is set**, which also declares the `network:private` entitlement, and, when an entitlement enforcer is registered, the `network:private` grant is re-checked at execute time against the URL actually resolved — so a run-input or credential-supplied private destination cannot slip past the declaration the enforcer graded. The flag governs the transport whatever the URL's spelling: a public-looking hostname that resolves into private address space is reachable exactly when the grant covers it, so every widened request is entitlement-checked
+- A failure body is surfaced in the error message **only for a destination not declared private**; a declared private destination's reply body and reason phrase are never spliced in, which would otherwise make the task an SSRF read primitive
 - Rate limits arrive as `429` and may carry the delay as `{"retry_after": <seconds>}` in the body instead of a `Retry-After` header; both are parsed onto the raised `RetryableJobError`. Nothing acts on the value — retries require a `@workglow/job-queue` consumer, which these inline tasks do not have
 - **Mass mentions are suppressed by default** — `allowed_mentions: { parse: [] }` is sent, so `@everyone`/`@here`, role and user pings in `content` do nothing even when the content was piped in from a fetch or a model. Set `allow_mentions: true` to let the message ping
 - Requests time out after 30s by default (`timeout`)

--- a/packages/tasks/src/task/DiscordNotifyTask.ts
+++ b/packages/tasks/src/task/DiscordNotifyTask.ts
@@ -74,7 +74,7 @@ const inputSchema = {
       default: false,
       title: "Allow Private Destination",
       description:
-        "Permit posting to a private/internal/loopback destination. Requires the `network:private` entitlement.",
+        "Permit posting to a private/internal/loopback destination — including a public-looking hostname that resolves into private address space. Requires the `network:private` entitlement, re-checked at execute time against the URL actually resolved. A declared private destination's reply body and reason phrase are never surfaced.",
     },
     url_credential_key: {
       type: "string",

--- a/packages/tasks/src/task/SlackNotifyTask.ts
+++ b/packages/tasks/src/task/SlackNotifyTask.ts
@@ -76,7 +76,7 @@ const inputSchema = {
       default: false,
       title: "Allow Private Destination",
       description:
-        "Permit posting to a private/internal/loopback destination. Requires the `network:private` entitlement.",
+        "Permit posting to a private/internal/loopback destination — including a public-looking hostname that resolves into private address space. Requires the `network:private` entitlement, re-checked at execute time against the URL actually resolved. A declared private destination's reply body and reason phrase are never surfaced.",
     },
     url_credential_key: {
       type: "string",

--- a/packages/tasks/src/task/WebhookNotifyTask.ts
+++ b/packages/tasks/src/task/WebhookNotifyTask.ts
@@ -12,7 +12,6 @@ import type {
 } from "@workglow/task-graph";
 import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-import { classifyUrl } from "../util/UrlClassifier";
 import {
   MAX_REQUEST_TIMEOUT_MS,
   postWebhookJson,
@@ -57,7 +56,7 @@ const inputSchema = {
       default: false,
       title: "Allow Private Destination",
       description:
-        "Permit posting to a private/internal/loopback destination. Requires the `network:private` entitlement.",
+        "Permit posting to a private/internal/loopback destination — including a public-looking hostname that resolves into private address space. Requires the `network:private` entitlement, re-checked at execute time against the URL actually resolved. A declared private destination's reply body and reason phrase are never surfaced.",
     },
     url_credential_key: {
       type: "string",
@@ -145,13 +144,6 @@ export class WebhookNotifyTask<
       Object.hasOwn(input, "url_credential_key"),
       "WebhookNotifyTask"
     );
-    // A private destination is reachable only once `allow_private_destination`
-    // declares it (enforced in postWebhookJson), but the `response` port would
-    // turn this task into an SSRF *read* primitive: a POST to
-    // http://169.254.169.254/latest/meta-data/iam/security-credentials/ would
-    // hand a kilobyte of the reply back into the graph. Notification needs no
-    // reply body, so the private path never reads one.
-    const isPrivate = classifyUrl(url).kind === "private";
     const result = await postWebhookJson({
       url,
       payload: input.payload,
@@ -159,7 +151,14 @@ export class WebhookNotifyTask<
       timeout: input.timeout,
       signal: context.signal,
       registry: context.registry,
-      readSuccessBody: !isPrivate,
+      // A ceiling, not the decision: `postWebhookJson` forces this to `false`
+      // for a DECLARED private destination and is the single decider, because
+      // the `response` port would otherwise turn this task into an SSRF *read*
+      // primitive — a POST to
+      // http://169.254.169.254/latest/meta-data/iam/security-credentials/ would
+      // hand a kilobyte of the reply back into the graph. Classifying the URL a
+      // second time here is how the two halves drift apart.
+      readSuccessBody: true,
       includeBodyInError: false,
       retryAfterFromJsonBody: false,
       allowPrivateDestination: input.allow_private_destination === true,
@@ -168,7 +167,7 @@ export class WebhookNotifyTask<
     return {
       success: true,
       status: result.status,
-      response: isPrivate ? "" : result.body,
+      response: result.body,
     } as Output;
   }
 }

--- a/packages/tasks/src/util/WebhookPost.ts
+++ b/packages/tasks/src/util/WebhookPost.ts
@@ -289,15 +289,17 @@ export interface WebhookPostRequest {
   /**
    * Read and return the success body. Endpoints replying 204 pass `false`.
    *
-   * A ceiling, not a switch: {@link postWebhookJson} forces it to `false` for a
-   * private/internal destination, whose body is never surfaced.
+   * A ceiling, not a switch: {@link postWebhookJson} forces it to `false`
+   * whenever {@link allowPrivateDestination} is set, because a DECLARED private
+   * destination's body is never surfaced.
    */
   readonly readSuccessBody: boolean;
   /**
    * Include a truncated failure body in the thrown error message.
    *
-   * A ceiling, not a switch: {@link postWebhookJson} forces it to `false` for a
-   * private/internal destination, whose body is never surfaced.
+   * A ceiling, not a switch: {@link postWebhookJson} forces it to `false`
+   * whenever {@link allowPrivateDestination} is set, because a DECLARED private
+   * destination's body is never surfaced.
    */
   readonly includeBodyInError: boolean;
   /** Also read `retry_after` (seconds) from a JSON failure body. */
@@ -310,6 +312,12 @@ export interface WebhookPostRequest {
    * URL happened to resolve to. The `network:private` grant is what authorizes
    * the post, and it is re-checked against the resolved URL via
    * {@link assertPrivateDestinationGranted}.
+   *
+   * It governs the transport whatever the URL's spelling, so it also covers a
+   * public-looking hostname that resolves into private space. The invariant
+   * that follows: A CALLER WHO DECLARED THE DESTINATION MAY BE PRIVATE NEVER
+   * GETS ITS REPLY BACK — neither body nor reason phrase — because the URL
+   * alone cannot say whether it was.
    */
   readonly allowPrivateDestination: boolean;
   /**
@@ -566,6 +574,11 @@ async function readBodyText(
  * credential-backed URL does not exist yet at that point either. The
  * declaration is therefore advisory; this is the check that binds.
  *
+ * It runs for every DECLARED private destination, not only for one whose URL
+ * classifies private as a string — so it also guards a destination that merely
+ * RESOLVES private, which is the case the static classification cannot see and
+ * the one `network:private` exists to authorize.
+ *
  * No enforcer registered means no policy to satisfy, and the post proceeds.
  */
 export async function assertPrivateDestinationGranted(
@@ -603,12 +616,21 @@ export async function assertPrivateDestinationGranted(
  * granted against — and, when an enforcer is registered, that grant is
  * re-checked here against the URL actually resolved
  * ({@link assertPrivateDestinationGranted}), because the declaration graded at
- * entitlement-evaluation time need not be the one `execute()` receives. A
- * permitted private destination additionally overrides
- * `readSuccessBody` and `includeBodyInError` to `false`: those flags
- * are a ceiling set by the calling task, and no reply from an internal host is
- * ever surfaced — otherwise a notification task doubles as an SSRF read
- * primitive with the answer smuggled out through an error message.
+ * entitlement-evaluation time need not be the one `execute()` receives.
+ *
+ * The declaration — not the URL's static classification — is what widens the
+ * transport, so a public-looking hostname resolving into private space is
+ * reachable exactly when the grant covers it. Every request receiving the
+ * widened transport is therefore entitlement-checked, which the classification
+ * could not do for a name it reads as public.
+ *
+ * A declared private destination additionally overrides `readSuccessBody` and
+ * `includeBodyInError` to `false`, and withholds the reason phrase: those flags
+ * are a ceiling set by the calling task, and no reply from a possibly-internal
+ * host is ever surfaced — otherwise a notification task doubles as an SSRF read
+ * primitive with the answer smuggled out through an error message. The
+ * suppression follows the declaration for the same reason the transport does:
+ * the URL alone cannot say whether the host was internal.
  *
  * Redirects are refused rather than followed. Following one would re-issue this
  * exact request — method, serialized payload and caller headers — at whatever
@@ -627,8 +649,17 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
     );
   }
 
-  const isPrivate = classification.kind === "private";
-  if (isPrivate && !request.allowPrivateDestination) {
+  const staticallyPrivate = classification.kind === "private";
+  // The DECLARATION governs the transport, not the URL's spelling. A hostname
+  // that is no literal IP and matches no reserved suffix classifies public even
+  // when it resolves into private space (split-horizon DNS), so deriving this
+  // from the classification leaves the declaration unable to reach the
+  // destination it declares — with no configuration short of hard-coding the
+  // address that makes the post work. The `network:private` GRANT is what
+  // authorizes the widening, and it is re-checked below against the URL
+  // actually resolved.
+  const allowPrivate = request.allowPrivateDestination;
+  if (staticallyPrivate && !allowPrivate) {
     throw createFetchUrlJobError(
       FetchUrlErrorCode.PRIVATE_DENIED,
       `Refusing to post ${label} to a private/internal destination. ` +
@@ -636,7 +667,11 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
       { url: redactWebhookUrl(url) }
     );
   }
-  if (isPrivate) {
+  // Computed ONCE: the pattern the enforcer grades and the scope the transport
+  // re-enforces have to be the same string, or the grant that was checked and
+  // the reachability that was handed out can diverge.
+  const privateScope = urlResourcePattern(url);
+  if (allowPrivate) {
     await assertPrivateDestinationGranted(request.registry, url, label);
   }
   // Validated BEFORE the signal is armed, for the same reason the
@@ -686,15 +721,15 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
       body,
       signal,
       redirect: "error",
-      allowPrivate: isPrivate,
-      privateResourceScopes: isPrivate ? [urlResourcePattern(url)] : undefined,
+      allowPrivate,
+      privateResourceScopes: allowPrivate ? [privateScope] : undefined,
     });
   } catch (err) {
     throw toRedactedWebhookError(err, url, label, request.signal);
   }
 
   if (response.ok) {
-    if (!request.readSuccessBody || isPrivate) {
+    if (!request.readSuccessBody || allowPrivate) {
       // Slack answers 200 with a short `ok` body even though we don't want it.
       // An unconsumed body keeps the underlying connection out of the agent's
       // pool until GC, so cancel it explicitly instead of dropping it.
@@ -728,14 +763,14 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
   // The status is still reported for a private destination — the reply BODY is
   // what would turn a POST at an internal service into a read of it.
   const bodySuffix =
-    request.includeBodyInError && !isPrivate && failureBody.length > 0
+    request.includeBodyInError && !allowPrivate && failureBody.length > 0
       ? `: ${truncate(redactWebhookUrlIn(failureBody, url), MAX_ERROR_BODY_CHARS)}`
       : "";
   // The reason phrase is caller-controlled text like the body, so it gets the
   // same two treatments: withheld entirely for a private destination, and
   // redacted otherwise. A server is free to put anything in it, and the well
   // known phrases ("Not Found", "Bad Request") survive redaction unchanged.
-  const statusText = isPrivate ? "" : redactWebhookUrlIn(response.statusText, url);
+  const statusText = allowPrivate ? "" : redactWebhookUrlIn(response.statusText, url);
 
   throw createFetchUrlJobError(
     httpStatusToFetchUrlErrorCode(response.status),

--- a/packages/test/src/test/task/NotifyTask.test.ts
+++ b/packages/test/src/test/task/NotifyTask.test.ts
@@ -31,6 +31,7 @@ import {
   registerSafeFetch,
   slackNotify,
   SlackNotifyTask,
+  urlResourcePattern,
   webhookNotify,
   WebhookNotifyTask,
   type SafeFetchFn,
@@ -1448,6 +1449,24 @@ describe("Webhook notification tasks", () => {
       expect(error.url).not.toContain("SECRETTOKEN");
     });
 
+    // The suppression follows the declaration for the same reason the
+    // transport does: the URL alone cannot say whether the host is internal,
+    // so a caller who declared it MAY be private never gets its reply back.
+    test("a declared private destination never echoes its body, even for a public-looking hostname", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response("AKIAEXAMPLESECRET", { status: 200 }))
+      );
+
+      const result = await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: {},
+        allow_private_destination: true,
+      });
+
+      expect(result.response).toBe("");
+      expect(JSON.stringify(result)).not.toContain("AKIA");
+    });
+
     test("still echoes a public destination's body", async () => {
       mockFetch.mockImplementation(() => Promise.resolve(new Response("pong", { status: 200 })));
 
@@ -1481,19 +1500,33 @@ describe("Webhook notification tasks", () => {
       expect(lastCall().options.privateResourceScopes).toEqual(["http://127.0.0.1:9200/*"]);
     });
 
-    // The DNS-rebinding invariant: the flag is a declaration about the
-    // destination, never a licence to widen the transport for a public
-    // hostname. A name that resolves into private space at connect time must
-    // still be refused there.
-    test("a public URL keeps allowPrivate false even when allow_private_destination is set", async () => {
+    // The DECLARATION governs the transport, not the URL's spelling. A
+    // hostname that is no literal IP and matches no reserved suffix classifies
+    // public even when it resolves into private space (split-horizon DNS), so
+    // deriving `allowPrivate` from that classification leaves the declaration
+    // unable to reach the destination it declares. What authorizes the
+    // widening is the `network:private` GRANT, re-checked against the URL
+    // actually resolved — see the graph-root enforcement cases below.
+    test("a declared private destination widens the transport even for a public-looking hostname", async () => {
       await webhookNotify({
         url: WEBHOOK_URL,
         payload: {},
         allow_private_destination: true,
       });
 
-      expect(lastCall().options.allowPrivate).toBe(false);
-      expect(lastCall().options.privateResourceScopes).toBeUndefined();
+      expect(lastCall().options.allowPrivate).toBe(true);
+      expect(lastCall().options.privateResourceScopes).toEqual(["https://example.com/*"]);
+    });
+
+    // The pattern the enforcer graded and the scope the transport re-enforces
+    // are the same string, computed once — two independent computations could
+    // drift and hand out a scope no grant covered.
+    test("the widened transport is scoped to exactly the pattern the grant was checked against", async () => {
+      await webhookNotify({ url: PRIVATE_URL, payload: {}, allow_private_destination: true });
+      expect(lastCall().options.privateResourceScopes).toEqual([urlResourcePattern(PRIVATE_URL)]);
+
+      await webhookNotify({ url: WEBHOOK_URL, payload: {}, allow_private_destination: true });
+      expect(lastCall().options.privateResourceScopes).toEqual([urlResourcePattern(WEBHOOK_URL)]);
     });
 
     test("Slack and Discord share the same transport arguments", async () => {
@@ -2017,6 +2050,48 @@ describe("Webhook notification tasks", () => {
       expect(error).toBeInstanceOf(PermanentJobError);
       expect(error.code).toBe(FetchUrlErrorCode.PRIVATE_DENIED);
       expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    // THE LOAD-BEARING CASE for letting the declaration govern the transport:
+    // the authorization check must key on the DECLARATION, not on the URL's
+    // static classification. Keyed on the classification, a public-looking
+    // hostname would receive the widened transport with no grant check at all.
+    test("a declared private destination is refused without the grant even when the URL looks public", async () => {
+      const error = (await new WebhookNotifyTask()
+        .run(
+          { url: WEBHOOK_URL, payload: {}, allow_private_destination: true },
+          { registry: browserRegistry() }
+        )
+        .catch((e: unknown) => e)) as PermanentJobError;
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error.code).toBe(FetchUrlErrorCode.PRIVATE_DENIED);
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    // A gate, not a blanket relaxation: the same post runs once the declared
+    // origin is granted.
+    test("a grant scoped to the declared origin permits a public-looking private destination", async () => {
+      const browserPolicy = createProfilePolicy("browser");
+      const registry = new ServiceRegistry(new Container());
+      registry.register(ENTITLEMENT_ENFORCER, () =>
+        createPolicyEnforcer({
+          deny: browserPolicy.deny,
+          grant: [
+            ...browserPolicy.grant,
+            { id: Entitlements.NETWORK_PRIVATE, resources: ["https://example.com/*"] },
+          ],
+          ask: browserPolicy.ask,
+        })
+      );
+
+      await expect(
+        new WebhookNotifyTask().run(
+          { url: WEBHOOK_URL, payload: {}, allow_private_destination: true },
+          { registry }
+        )
+      ).resolves.toBeDefined();
+      expect(lastCall().options.allowPrivate).toBe(true);
     });
 
     // The contract is opt-in: with no enforcer registered there is no policy to


### PR DESCRIPTION
> Stacked on #769. Base retargets to `claude/notify-merge-main` once that merges; review the top commit only.

## Problem

`postWebhookJson` derived `allowPrivate` from `classifyUrl(url).kind === "private"`. `classifyUrl` is string-only by construction and never resolves DNS, so a hostname that is not a literal IP and matches neither `PRIVATE_EXACT_HOSTS` nor `PRIVATE_DOMAIN_SUFFIXES` classifies **public** — and `allowPrivate: false` was sent even when the caller set `allow_private_destination: true` and held the `network:private` grant.

Split-horizon DNS is the concrete failure. `webhookNotify({url: "https://hooks.mycorp.com/hook", allow_private_destination: true})` where the name resolves to `10.1.2.3`, with `network:private` granted: `fetchOneHop`'s DNS loop throws `PRIVATE_DENIED` — *"resolved to private address 10.1.2.3 … Grant the 'network:private' entitlement to allow this request."* The operator has granted it, the flag is set, and no configuration makes the post work short of hard-coding the IP, which defeats their DNS and pins the request to an address that may move.

The code also contradicted its own JSDoc, which said the declaration exists precisely so `allowPrivate` is not "self-derived from whatever the URL happened to resolve to".

## Why widen rather than document the limit

The old behavior is not a conservative policy, it is an **unreachable** one. The flag's effect was fully determined by the URL text: for a literal private URL it was redundant with the classifier, and for a public-looking name it was inert. There is no input for which it added a security decision — it only added a message asking for a grant the operator already held.

The relaxation stays gated by the **grant**, not by the flag. What moves is the authorization *trigger*: from "the URL string looks private" to "the caller declared a private destination", which is a **superset**. Every request receiving the widened transport is now entitlement-checked, where the public-looking case previously received neither the transport nor a check.

The secrecy posture only tightens — see the second breaking change below.

## Breaking changes

1. **`allow_private_destination: true` on a genuinely public endpoint now requires the `network:private` grant to run at all**, and widens the transport. Fail-closed, and the flag's name says what it does.
2. **A declared private destination's reply body, failure body and reason phrase are withheld**, whatever the URL's spelling. These previously keyed on the static classification; they move to the same superset, so a public-looking name that is in fact internal stops echoing its reply.

Also worth stating: with no enforcer registered `assertPrivateDestinationGranted` returns immediately, so in an unpoliced host the flag alone widens the transport — unchanged from today's behavior for literal private URLs.

## What still enforces authorization

- `assertPrivateDestinationGranted` runs whenever `allowPrivateDestination` is set, not only when the URL classifies private. It checks `network:private` against the URL **actually resolved** — i.e. after credential resolution — so an origin-scoped policy grant still binds and a credential-supplied destination cannot slip past.
- `urlResourcePattern(url)` is computed **once** into a local used both for that grant check and for `privateResourceScopes`, so the pattern the enforcer graded and the scope the transport re-enforces cannot diverge.
- `redirect: "error"` is unchanged: exactly one hop, so a `Location` cannot pivot off the granted origin.
- `webhookPrivateEntitlements` is unchanged — an unset flag still fails closed and still declares `network:private`.

## Change

- `postWebhookJson`: `allowPrivate = request.allowPrivateDestination`; the static classification is kept only for the "private URL, flag not set" refusal. Body / failure-body / reason-phrase suppression follow `allowPrivate`.
- `WebhookNotifyTask`: the duplicate `classifyUrl(url).kind === "private"` is deleted (that duplicate was the drift), passing `readSuccessBody: true` as the ceiling it is and leaving `postWebhookJson` the single decider. `classifyUrl` import dropped.
- Schema descriptions for `allow_private_destination` in all three tasks, and the matching `packages/tasks/README.md` sections, now state that the flag covers a public-looking hostname resolving into private space and that the reply is never surfaced.

## Tests

Five new cases in `NotifyTask.test.ts`, all confirmed failing against the pre-fix tree.

**Replaced** `"a public URL keeps allowPrivate false even when allow_private_destination is set"` (and its comment) — it pinned the defect as if it were the invariant. Its successor asserts the widening plus the exact scope.

The load-bearing one is **"a declared private destination is refused without the grant even when the URL looks public"**, in `describe("graph-root entitlement enforcement")` under `browserRegistry()` (grants `network:http` + `credential`, not `network:private`). It catches the single most dangerous way to get this fix wrong: widening `allowPrivate` while leaving the authorization check keyed on the static classification, which would hand out private reachability with **no check at all**. Its counterpart, "a grant scoped to the declared origin permits a public-looking private destination", proves the result is a gate rather than a blanket relaxation.

Also: "the widened transport is scoped to exactly the pattern the grant was checked against" (catches the two values being computed independently) and "a declared private destination never echoes its body, even for a public-looking hostname".

Unchanged regression net: "refuses a private destination that was not declared", "a public destination is fetched with allowPrivate false and no scopes", "a credential resolving to a private URL is refused at execute time", and every case in `describe("graph-root entitlement enforcement")`.

## Coverage gap

There is **no test exercising a real split-horizon resolution** — the case that motivated the change. `SafeFetch.server.ts` calls `node:dns/promises.lookup` directly with no injection seam, so a name that classifies public and resolves private cannot be simulated. The tests here pin the arguments handed to the transport and the authorization decision around them; the DNS half of the path is covered only by `SafeFetch`'s own tests against literal addresses. Adding a resolver seam to `SafeFetch.server.ts` would close it and is left as follow-up.

## Also out of scope, recorded here

`SafeFetch.server.ts` applies `privateResourceScopes` only when the **static** classification is private, so a redirect-following caller reaching a private address via a public name is unscoped. Unreachable from the notify tasks, which use `redirect: "error"`.

## Verification

- `bunx vitest run --project test packages/test/src/test/task/NotifyTask.test.ts` — 115 passed
- `bun scripts/test.ts task vitest` — 67 files, 1079 passed, 24 skipped
- `bun run build:types` — 41/41 packages clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKvKnyVeQQQCm6FhtaLyMa)_