### PR TITLE
Fix disown to clear per-child sink stamp records

### DIFF
--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -1078,6 +1078,13 @@ export class TaskRunner<
    * {@link ownedWrappers}. A value this runner never owned is a no-op, so
    * disowning after an `own` that was an identity no-op against a stub context
    * is harmless.
+   *
+   * Every per-child record `own` created is dropped here, not just the subgraph
+   * node — {@link ownedSinkStamps} is a strong Map keyed by the child, so a
+   * stamp left behind pins that child (and its whole subgraph) until the
+   * PARENT's run ends. For a sweep that owns one child per work item that is
+   * the entire worklist retained in memory, which is precisely the retention
+   * `disown` exists to prevent.
    */
   protected disown<T extends Taskish<any, any>>(i: T): void {
     if (!isOwnTrackable(i)) return;
@@ -1090,6 +1097,16 @@ export class TaskRunner<
     if (off) {
       off();
       this.ownedUsageUnsubs.delete(i);
+    }
+    // Restore before dropping, exactly as `run()`'s `finally` does: the child
+    // is no longer owned, so it must not keep carrying this run's sinks into a
+    // later standalone `child.run()`.
+    if (hasRunConfig(i)) {
+      const prior = this.ownedSinkStamps.get(i);
+      if (prior !== undefined) {
+        Object.assign(i.runConfig, prior);
+        this.ownedSinkStamps.delete(i);
+      }
     }
     if (!this.isStillOwned(wrapper)) return;
     this.task.subGraph.removeTask(wrapper.id);

--- a/packages/test/src/test/task/OwnTask.test.ts
+++ b/packages/test/src/test/task/OwnTask.test.ts
@@ -184,6 +184,46 @@ describe("Task own functionality", () => {
       expect(task.subGraph.getTasks()).toHaveLength(0);
     });
 
+    // The subgraph is only half of what `own` records. `ownedSinkStamps` is a
+    // strong Map keyed by the child, cleared only when the PARENT's run ends —
+    // so a `disown` that left its entry behind still pinned every child (and
+    // everything each child's own subgraph held) for the whole sweep. An owner
+    // that disowns per item would then grow exactly as if it never disowned at
+    // all, which is the one thing `disown` is for.
+    it("drops every per-child record, not just the subgraph node", async () => {
+      class StampLoopTask extends Task {
+        public static override readonly type = "StampLoopTask";
+        public static override readonly title = "Stamp loop";
+
+        public peakStamps = 0;
+        public sinkAfterDisown: unknown = "unset";
+
+        override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+          const stamps = (): number =>
+            (this.runner as unknown as { ownedSinkStamps: Map<unknown, unknown> }).ownedSinkStamps
+              .size;
+          for (let i = 0; i < 5; i++) {
+            const child = context.own(new SimpleTask({ title: `Item ${i}` }));
+            await child.run();
+            this.peakStamps = Math.max(this.peakStamps, stamps());
+            context.disown(child);
+            // Restored at disown, not deferred to the parent's `finally`: the
+            // child is no longer owned and must not carry this run's sinks into
+            // a later standalone `child.run()`.
+            this.sinkAfterDisown = child.runConfig.usageSink;
+          }
+          return { stampsAtEnd: stamps() };
+        }
+      }
+
+      const task = new StampLoopTask();
+      const result = (await task.run()) as { stampsAtEnd: number };
+
+      expect(task.peakStamps).toBe(1);
+      expect(result.stampsAtEnd).toBe(0);
+      expect(task.sinkAfterDisown).toBeUndefined();
+    });
+
     it("resolves a workflow to the wrapper task the subgraph actually holds", async () => {
       class DisownWorkflowTask extends Task {
         public static override readonly type = "DisownWorkflowTask";


### PR DESCRIPTION
## Summary

Fix a memory retention issue in `disown()` where per-child sink stamp records were not being cleared, causing owned children to remain pinned in memory until the parent task's run completed. This is particularly problematic for tasks that own and disown multiple children per work item.

## Changes

- **TaskRunner.disown()**: Added logic to restore the child's `runConfig` from `ownedSinkStamps` and delete the stamp entry when disowning. This ensures that:
  - The child is no longer carrying this run's sinks into later standalone runs
  - The `ownedSinkStamps` Map entry is cleared immediately, not deferred to the parent's `finally` block
  - Children disowned per work item don't accumulate in memory for the entire parent sweep

- **Test coverage**: Added `StampLoopTask` test that verifies:
  - Peak stamp count stays at 1 (only one child owned at a time)
  - No stamps remain at the end of execution
  - Child's `usageSink` is properly restored to `undefined` after disown

## Implementation Details

The fix mirrors the restoration logic already present in `run()`'s `finally` block, but applies it immediately during `disown()`. The `ownedSinkStamps` Map is keyed by the child task, and leaving entries behind would pin the entire child subgraph until the parent's run ended—defeating the purpose of `disown()` for iterative ownership patterns.

https://claude.ai/code/session_01Hb4HVCBHPTHQJ4hAMK59do