### PR TITLE
fix(hft): choose the background-removal encoder by runtime, not by method existence

### DIFF
--- a/packages/test/src/test/ai-provider-hft/HFT_BackgroundRemoval.test.ts
+++ b/packages/test/src/test/ai-provider-hft/HFT_BackgroundRemoval.test.ts
@@ -5,13 +5,14 @@
  */
 
 import { rawImageToImageValue } from "@workglow/huggingface-transformers/ai-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 /**
- * `RawImage` carries different encoders per runtime — `toBlob()` is
- * canvas-backed and browser-only, `toSharp()` is node-only — and transformers.js
- * has changed which of them exist. The run-fn probes rather than assuming, so
- * the probe order and the failure message are pinned here.
+ * A real `RawImage` carries BOTH encoders on its prototype in every runtime —
+ * `toBlob()` throws "only supported in browser environments" off-web and
+ * `toSharp()` throws the mirror on-web. Method existence therefore says nothing
+ * about usability, so what is pinned here is the runtime-ordered attempt and the
+ * recovery when the first guess is the wrong one.
  */
 describe("rawImageToImageValue", () => {
   // A 1x1 transparent PNG — the smallest thing sharp will accept.
@@ -22,30 +23,88 @@ describe("rawImageToImageValue", () => {
     (c) => c.charCodeAt(0)
   );
 
-  it("prefers toBlob when the runtime provides it", async () => {
-    const toBlob = vi.fn(async () => new Blob([PNG_1X1], { type: "image/png" }));
-    const toSharp = vi.fn();
-
-    const value = await rawImageToImageValue({ toBlob, toSharp });
-
-    expect(toBlob).toHaveBeenCalledWith("image/png");
-    expect(toSharp).not.toHaveBeenCalled();
-    expect(value).toBeDefined();
-  });
-
-  it("falls back to toSharp when toBlob is absent", async () => {
+  const workingToBlob = () => vi.fn(async () => new Blob([PNG_1X1], { type: "image/png" }));
+  const workingToSharp = () => {
     const toBuffer = vi.fn(async () => PNG_1X1);
     const toSharp = vi.fn(() => ({ png: () => ({ toBuffer }) }));
+    return { toSharp, toBuffer };
+  };
 
-    const value = await rawImageToImageValue({ toSharp });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses toSharp when toBlob throws the browser-only error (the real 4.2.0 Node shape)", async () => {
+    const toBlob = vi.fn(async () => {
+      throw new Error("toBlob() is only supported in browser environments.");
+    });
+    const { toSharp, toBuffer } = workingToSharp();
+
+    const value = await rawImageToImageValue({ toBlob, toSharp });
 
     expect(toBuffer).toHaveBeenCalled();
     expect(value).toBeDefined();
   });
 
+  it("uses toBlob when toSharp throws the server-only error (the real 4.2.0 browser shape)", async () => {
+    const toBlob = workingToBlob();
+    const toSharp = vi.fn(() => {
+      throw new Error("toSharp() is only supported in server-side environments.");
+    }) as unknown as () => { png: () => { toBuffer: () => Promise<Uint8Array> } };
+
+    const value = await rawImageToImageValue({ toBlob, toSharp });
+
+    expect(toBlob).toHaveBeenCalledWith("image/png");
+    expect(value).toBeDefined();
+  });
+
+  it("tries toSharp first off-web so the browser encoder is never probed", async () => {
+    const toBlob = workingToBlob();
+    const { toSharp, toBuffer } = workingToSharp();
+
+    const value = await rawImageToImageValue({ toBlob, toSharp });
+
+    expect(toBuffer).toHaveBeenCalled();
+    expect(toBlob).not.toHaveBeenCalled();
+    expect(value).toBeDefined();
+  });
+
+  it("tries toBlob first on web", async () => {
+    const toBlob = workingToBlob();
+    const { toSharp } = workingToSharp();
+
+    vi.stubGlobal("OffscreenCanvas", class {});
+    try {
+      const value = await rawImageToImageValue({ toBlob, toSharp });
+
+      expect(toBlob).toHaveBeenCalledWith("image/png");
+      expect(toSharp).not.toHaveBeenCalled();
+      expect(value).toBeDefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("reports both encoder failures when neither works", async () => {
+    const toBlob = vi.fn(async () => {
+      throw new Error("toBlob() is only supported in browser environments.");
+    });
+    const toSharp = vi.fn(() => {
+      throw new Error("Could not load the sharp module");
+    }) as unknown as () => { png: () => { toBuffer: () => Promise<Uint8Array> } };
+
+    const error = await rawImageToImageValue({ toBlob, toSharp }).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error!.message).toContain("only supported in browser environments");
+    expect(error!.message).toContain("Could not load the sharp module");
+  });
+
   it("throws a diagnosable error when neither encoder exists", async () => {
-    // The transformers 4.2.0 shape that made the previous `toBase64` call fail:
-    // a RawImage with neither encoder must name both, not just one.
+    // A transformers version shipping neither encoder must name both, not just one.
     await expect(rawImageToImageValue({})).rejects.toThrow(/toBlob\(\) nor toSharp\(\)/);
   });
 });

--- a/providers/huggingface-transformers/src/ai/common/HFT_BackgroundRemoval.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_BackgroundRemoval.ts
@@ -21,8 +21,9 @@ import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pi
 
 /**
  * The subset of `RawImage` this module uses. Declared structurally rather than
- * as `RawImage` so the encoder probe stays independent of which methods a given
- * transformers.js version happens to ship.
+ * as `RawImage` so encoding stays independent of which methods a given
+ * transformers.js version happens to ship. Both members are optional for that
+ * reason; a real `RawImage` carries both.
  */
 export interface EncodableRawImage {
   toBlob?: (type?: string, quality?: number) => Promise<Blob>;
@@ -30,24 +31,84 @@ export interface EncodableRawImage {
 }
 
 /**
+ * Mirrors transformers.js `apis.IS_WEB_ENV` closely enough to order the encoder
+ * attempts; correctness does not depend on it being exact, because a wrong
+ * guess is recovered from. `OffscreenCanvas` is the half that matters in a
+ * browser Web Worker, which has no `document`.
+ *
+ * Evaluated per call rather than once at module load so a test (and a runtime
+ * that installs a canvas polyfill late) can flip it.
+ */
+function isWebEncodingEnv(): boolean {
+  return typeof document !== "undefined" || typeof OffscreenCanvas !== "undefined";
+}
+
+/**
  * Encode a pipeline's `RawImage` result as an {@link ImageValue}, preserving
  * the alpha channel background removal produces.
  *
  * `RawImage` exposes different encoders per runtime: `toBlob()` goes through a
- * canvas and is browser-only, `toSharp()` is node-only. Probe rather than
- * assume — this run-fn is registered for both the inline and worker runtimes.
+ * canvas and is browser-only, `toSharp()` is node-only. Both exist as prototype
+ * methods in every runtime and each THROWS when called outside its own, so
+ * probing for method existence answers nothing — this run-fn is registered for
+ * both the inline and worker runtimes, so the environment picks the order and
+ * the try/catch guarantees the result.
  */
 export async function rawImageToImageValue(image: EncodableRawImage): Promise<ImageValue> {
-  if (typeof image.toBlob === "function") {
-    return blobToImageValue(await image.toBlob("image/png"));
+  const encoders = isWebEncodingEnv()
+    ? ([toImageValueViaBlob, toImageValueViaSharp] as const)
+    : ([toImageValueViaSharp, toImageValueViaBlob] as const);
+
+  const failures: Error[] = [];
+  for (const encode of encoders) {
+    const result = await encode(image, failures);
+    if (result !== undefined) return result;
   }
-  if (typeof image.toSharp === "function") {
-    return pngBytesToImageValue(await image.toSharp().png().toBuffer(), "png");
+
+  if (failures.length === 0) {
+    throw new Error(
+      "HFT_BackgroundRemoval: RawImage exposes neither toBlob() nor toSharp() in this transformers version"
+    );
   }
 
   throw new Error(
-    "HFT_BackgroundRemoval: RawImage exposes neither toBlob() nor toSharp() in this transformers version"
+    `HFT_BackgroundRemoval: could not encode the result image. ${failures
+      .map((failure) => failure.message)
+      .join(" / ")}`,
+    { cause: failures[0] }
   );
+}
+
+async function toImageValueViaBlob(
+  image: EncodableRawImage,
+  failures: Error[]
+): Promise<ImageValue | undefined> {
+  if (typeof image.toBlob !== "function") return undefined;
+  try {
+    return blobToImageValue(await image.toBlob("image/png"));
+  } catch (error) {
+    failures.push(asError("toBlob()", error));
+    return undefined;
+  }
+}
+
+async function toImageValueViaSharp(
+  image: EncodableRawImage,
+  failures: Error[]
+): Promise<ImageValue | undefined> {
+  if (typeof image.toSharp !== "function") return undefined;
+  try {
+    return pngBytesToImageValue(await image.toSharp().png().toBuffer(), "png");
+  } catch (error) {
+    failures.push(asError("toSharp()", error));
+    return undefined;
+  }
+}
+
+function asError(encoder: string, error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  const wrapped = new Error(`${encoder} failed: ${message}`, { cause: error });
+  return wrapped;
 }
 
 export const HFT_BackgroundRemoval: AiProviderRunFn<


### PR DESCRIPTION
## The bug

`rawImageToImageValue` picks `toBlob()` whenever `typeof image.toBlob === "function"`. In `@huggingface/transformers` 4.2.0 (the pinned catalog version) **both** `toBlob` and `toSharp` are unconditional prototype methods on `RawImage`; each throws based on `apis.IS_WEB_ENV`:

- `toBlob`: `if (!apis.IS_WEB_ENV) throw new Error('toBlob() is only supported in browser environments.')`
- `toSharp`: the mirror.

Existence says nothing about usability, and there is one `runtime.ts` serving both the node and browser workers.

**Failure:** run `BackgroundRemovalTask` through the HFT provider in Node/Bun (the `hftWorker` path the CLI uses) — the pipeline succeeds, then `toBlob("image/png")` throws `toBlob() is only supported in browser environments.` The task fails exactly as it did before, only with a different message.

## The fix

The environment picks the attempt **order**; a try/catch guarantees **correctness**.

- Off-web: `toSharp()` first, then `toBlob()`. On-web: the reverse.
- Each attempt still runs only if the method is a function, keeping the transformers-version guard.
- Both attempted and both threw → one error naming both underlying messages, `cause` set to the first failure. Strictly more diagnosable than propagating whichever was tried first (a libvips mismatch now reads as itself, not as "browser environments").
- Neither method present → the existing message is unchanged.

`isWebEncodingEnv()` is a **per-call function**, not a module-level constant: a constant is baked at import time and could not be flipped by a runtime that installs a canvas polyfill late, nor by a test. It checks `OffscreenCanvas` as well as `document`, because a browser Web Worker — where HFT actually runs in the browser — has no `document`. It is deliberately an approximation of upstream's `IS_WEB_ENV`; correctness does not depend on it being exact, because a wrong guess is recovered from. Reading `apis` from the SDK would be exact but would make this pure helper depend on an optional peer dep that is not installed in the test checkout, and the unit test would stop running.

## Tests

The two existing stub-shape tests are **deleted**. They handed the helper objects that omit the encoder they wanted skipped — a shape a real `RawImage` never has — so neither could ever fail on this bug, and "prefers toBlob when the runtime provides it" asserted exactly the wrong preference for Node.

Five replace them, plus the kept version guard:

| test | what it catches |
|---|---|
| `toBlob` throws browser-only, both present (the real 4.2.0 Node shape) | **the shipped bug** |
| `toSharp` throws server-only, both present (the real browser shape) | a fix that hard-codes `toSharp` |
| tries `toSharp` first off-web | dropping the predicate for a blind try-`toBlob`-first |
| tries `toBlob` first on web (under `vi.stubGlobal("OffscreenCanvas", …)`) | why the predicate must be a per-call function |
| both encoders fail | the aggregate message names both causes |

Three of the five fail against the pre-fix code (the two order-mirror tests pass before and after by construction — they guard the fix's direction, not the bug).

## Verification

- `bunx vitest run --project test src/test/ai-provider-hft/HFT_BackgroundRemoval.test.ts` → 6 passed (red on 3 before the fix).
- `bun scripts/test.ts provider-hft vitest` → this file green. Two unrelated integration suites (`ZeroShotTasks`, model-download timeouts at 30s) fail intermittently in this sandbox; they neither import nor exercise this code.

Other HFT run-fns are unaffected: `HFT_ImageSegmentation.ts` has its own `rawImageToImageValue` that never calls either encoder — it branches on `typeof Buffer === "undefined"`, already an environment probe. A repo-wide grep confirms these are the only `toBlob`/`toSharp` call sites outside `node_modules`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKvKnyVeQQQCm6FhtaLyMa)_