### PR TITLE
fix(tasks): stop a response body deciding whether a fetch decode failure retries

### DIFF
--- a/packages/tasks/src/task/FetchUrlJobError.ts
+++ b/packages/tasks/src/task/FetchUrlJobError.ts
@@ -176,6 +176,17 @@ export function createFetchUrlHttpError(
  * not be classified as {@link FetchUrlErrorCode.RESPONSE_PARSE_ERROR}.
  *
  * Abort is excluded: a cancelled fetch is not a transient network blip.
+ *
+ * A `SyntaxError` is excluded from the MESSAGE heuristic — never from the
+ * `code` / `cause` checks — because a decode failure's message embeds
+ * server-controlled bytes: V8 quotes a snippet of the body into it
+ * (`Unexpected token 'G', "Gateway timeout..." is not valid JSON`), so a
+ * response could otherwise choose its own error code and keep the queue
+ * retrying a URL that can never decode. A body that reached `JSON.parse` at all
+ * arrived complete — the stream errors before the parser runs when the peer
+ * drops mid-body — so a `SyntaxError`'s message is never network evidence.
+ * Discriminated by `name` rather than `instanceof` because this classifier is
+ * reachable from worker-hosted job code, where realms differ.
  */
 export function isFetchUrlNetworkCause(error: unknown, depth = 0): boolean {
   if (error === null || typeof error !== "object" || depth > 4) return false;
@@ -186,12 +197,12 @@ export function isFetchUrlNetworkCause(error: unknown, depth = 0): boolean {
     if (NETWORK_ERRNO_PATTERN.test(code) || NETWORK_UNDICI_CODES.has(code)) return true;
   }
   const message = typeof e.message === "string" ? e.message : "";
-  if (NETWORK_MESSAGE_PATTERN.test(message)) return true;
+  if (e.name !== "SyntaxError" && NETWORK_MESSAGE_PATTERN.test(message)) return true;
   return e.cause !== undefined ? isFetchUrlNetworkCause(e.cause, depth + 1) : false;
 }
 
 const NETWORK_ERRNO_PATTERN =
-  /^E(CONNRESET|TIMEDOUT|PIPE|AI_AGAIN|NOTFOUND|HOSTUNREACH|NETUNREACH|CONNREFUSED)$/;
+  /^E(?:CONNRESET|TIMEDOUT|PIPE|AI_AGAIN|NOTFOUND|HOSTUNREACH|NETUNREACH|CONNREFUSED)$/;
 
 const NETWORK_UNDICI_CODES: ReadonlySet<string> = new Set([
   "UND_ERR_SOCKET",

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -32,6 +32,8 @@ import {
   FetchUrlJob,
   FetchUrlTask,
   isFetchUrlJobError,
+  isFetchUrlNetworkCause,
+  isFetchUrlRetryableErrorCode,
   registerSafeFetch,
   type SafeFetchFn,
 } from "@workglow/tasks";
@@ -857,6 +859,81 @@ describe("FetchUrlTask", () => {
       expect((jobErr as { code?: string }).code).toBe(FetchUrlErrorCode.NETWORK_ERROR);
       expect(jobErr).toBeInstanceOf(RetryableJobError);
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // A decode failure's message embeds SERVER-CONTROLLED BYTES — V8 quotes a
+  // snippet of the body into the SyntaxError. Matching the network-message
+  // heuristic against it lets the response decide whether the job is retryable.
+  // -------------------------------------------------------------------------
+  describe("isFetchUrlNetworkCause", () => {
+    test("returns false for a SyntaxError quoting a network-looking response body", () => {
+      const decodeFailure = new SyntaxError(
+        `Unexpected token 'G', "Gateway timeout at: https://registry.example/pkg" is not valid JSON`
+      );
+
+      expect(isFetchUrlNetworkCause(decodeFailure)).toBe(false);
+    });
+
+    test("still returns true for a SyntaxError carrying a network errno code", () => {
+      const withCode = new SyntaxError("network timeout") as NodeJS.ErrnoException;
+      withCode.code = "ECONNRESET";
+
+      expect(isFetchUrlNetworkCause(withCode)).toBe(true);
+    });
+
+    test("still returns true for a SyntaxError whose cause is a socket error", () => {
+      const withCause = new SyntaxError("not valid JSON");
+      withCause.cause = Object.assign(new Error("terminated"), { code: "UND_ERR_SOCKET" });
+
+      expect(isFetchUrlNetworkCause(withCause)).toBe(true);
+    });
+
+    test("keeps message matching for non-SyntaxError decode failures", () => {
+      // The Bun body-abort shape: a bare Error with no code and no cause.
+      expect(
+        isFetchUrlNetworkCause(new Error("The socket connection was closed unexpectedly"))
+      ).toBe(true);
+    });
+
+    test("returns true for the undici terminated/UND_ERR_SOCKET shape", () => {
+      const terminated = new TypeError("terminated");
+      terminated.cause = Object.assign(new Error("other side closed"), {
+        code: "UND_ERR_SOCKET",
+      });
+
+      expect(isFetchUrlNetworkCause(terminated)).toBe(true);
+    });
+  });
+
+  describe("decode failures whose body reads like a network error", () => {
+    const decodeBodies: ReadonlyArray<string> = [
+      "network timeout at: https://registry.example/pkg",
+      "Gateway timeout",
+      "ECONNRESET while proxying",
+    ];
+
+    for (const body of decodeBodies) {
+      test(`"${body}" served as 200 JSON is a permanent parse error`, async () => {
+        mockFetch.mockImplementation(() =>
+          Promise.resolve(
+            new Response(body, {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            })
+          )
+        );
+
+        const error = await fetchUrl({ url: "https://api.example.com/decode-fail" }).catch(
+          (e: unknown) => e
+        );
+        const jobErr = (error as { jobError?: unknown }).jobError ?? error;
+
+        expect((jobErr as { code?: string }).code).toBe(FetchUrlErrorCode.RESPONSE_PARSE_ERROR);
+        expect(jobErr).toBeInstanceOf(PermanentJobError);
+        expect(isFetchUrlRetryableErrorCode((jobErr as { code?: string }).code)).toBe(false);
+      });
+    }
   });
 
   describe("credentials", () => {


### PR DESCRIPTION
## The bug

`isFetchUrlNetworkCause` falls back to matching `NETWORK_MESSAGE_PATTERN` against `error.message`. Its **only** call site is the catch around `response.json()` / `.text()` / `.blob()` (`FetchUrlTask.ts:329`), where the thrown error is usually a V8 `SyntaxError` whose message *embeds a snippet of the response body*:

```
Unexpected token 'G', "Gateway timeout at: https://..." is not valid JSON
```

So server-controlled bytes decide the error code — and the classifier is consulted for the top-level error, not just nested causes.

**Failure:** a URL returns `200 application/json` with body `network timeout at: https://…` (a real registry/proxy error-page shape). `JSON.parse` fails, the message matches `/network|timeout/i`, and a **permanent** decode failure is wrapped as `FETCH_NETWORK_ERROR` → `RetryableJobError`. The queue burns its whole retry budget on a URL that can never decode, `isFetchUrlRetryableErrorCode` tells downstream sweeps to re-fetch forever, and the persisted error reads "Network error fetching …" for a body that arrived complete.

## The fix

One line: the message heuristic no longer applies to a `SyntaxError`.

```diff
-  if (NETWORK_MESSAGE_PATTERN.test(message)) return true;
+  if (e.name !== "SyntaxError" && NETWORK_MESSAGE_PATTERN.test(message)) return true;
```

The `code` and `cause` checks are untouched, so a `SyntaxError` carrying real network evidence is still classified network. The justifying invariant, now stated in the JSDoc: a body that reached `JSON.parse` at all **arrived complete** — the stream errors before the parser runs when the peer drops mid-body — so a `SyntaxError`'s message is never network evidence.

Discriminated on `name`, matching the `AbortError` / `AbortSignalJobError` checks two lines above, rather than `instanceof`: `name` is cross-realm safe, which matters because this classifier is reachable from worker-hosted job code.

## Every error shape reaching the call site

| shape | before | after |
|---|---|---|
| Node/undici body abort — `TypeError: terminated`, cause `SocketError { code: "UND_ERR_SOCKET" }` | network (via cause code) | **unchanged** |
| Bun body abort — `Error: The socket connection was closed unexpectedly`, no code, no cause | network (via message) | **unchanged** |
| `.text()` / `.blob()` / `.arrayBuffer()` failures — never `SyntaxError` | — | **unchanged** |
| Truncated JSON — `Unexpected end of JSON input` doesn't match the pattern today | permanent | **unchanged** |
| JSON.parse failure quoting a network-ish body | retryable | **permanent** ← the fix |

The only reclassification is retryable → permanent, only for `SyntaxError`. No path moves permanent → retryable.

This is why the alternative fix — restricting the message heuristic to the cause chain (`depth > 0`) — is **rejected**: it would break the Bun body-abort case, which is the shape the existing test at `FetchTask.test.ts:261` covers.

`isFetchUrlNetworkCause` is re-exported from `@workglow/tasks`, so this narrows public API; the JSDoc change is the contract note.

## Tests

Direct unit tests for the predicate plus an end-to-end block:

- `SyntaxError` quoting a network-looking body → `false` — **the test that would have caught this**
- `SyntaxError` with `.code = "ECONNRESET"` → still `true` (the narrowing is message-only)
- `SyntaxError` whose cause is `UND_ERR_SOCKET` → still `true`
- non-`SyntaxError` `"The socket connection was closed unexpectedly"` → still `true` — **guards the bad regression direction (Bun body abort)**
- undici `terminated` / `UND_ERR_SOCKET` shape → `true`
- end-to-end: bodies `network timeout at: …`, `Gateway timeout`, `ECONNRESET while proxying` served as 200 JSON each assert `RESPONSE_PARSE_ERROR` + `PermanentJobError` + `isFetchUrlRetryableErrorCode === false`

Asserted on code/class rather than call count — the existing retryable test shows this harness does not retry, so a call count proves nothing. 4 of the 8 new tests fail red pre-fix; the other 4 are the regression guards above.

## Verification

- `bunx vitest run --project test src/test/task/FetchTask.test.ts` → 68 passed (4 red before the fix). The three existing `erroredBodyResponse` tests stay green as the positive control.
- `bun scripts/test.ts task vitest` → **65 files, 957 passed, 24 skipped**.
- eslint + prettier clean.

Also makes `NETWORK_ERRNO_PATTERN`'s group non-capturing. It was never read, and the pre-commit lint gate rejects the file until it is fixed; matching behavior is unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKvKnyVeQQQCm6FhtaLyMa)_