### PR TITLE
fix(task-graph): derive branch ports for conditionConfig-driven ConditionalTask

### DIFF
--- a/packages/task-graph/src/task-graph/RunScheduler.ts
+++ b/packages/task-graph/src/task-graph/RunScheduler.ts
@@ -75,32 +75,23 @@ export class RunScheduler {
 
     // Check if this is a ConditionalTask with selective branching
     if (isConditionalTask(node) && effectiveStatus === TaskStatus.COMPLETED) {
-      // Build a map of output port -> branch ID for lookup
-      const branches = node.config.branches ?? [];
-      const portToBranch = new Map<string, string>();
-      for (const branch of branches) {
-        portToBranch.set(branch.outputPort, branch.id);
-      }
-
-      const activeBranches = node.getActiveBranches();
+      // The task is the sole authority on its own port layout. Reconstructing
+      // it here from `config.branches` silently produced an empty map for a
+      // task driven by a serialized `conditionConfig` (which has no
+      // `config.branches`), so every branch edge fell through to the
+      // non-branch-port case and no downstream task was ever disabled.
+      const portActiveStatus = node.getPortActiveStatus();
 
       for (const dataflow of dataflows) {
         // Preserve FAILED edges (e.g. transform chain failure) rather than
         // overwriting with the source task's completion status.
         if (dataflow.status === TaskStatus.FAILED) continue;
-        const branchId = portToBranch.get(dataflow.sourceTaskPortId);
-        if (branchId !== undefined) {
-          // This dataflow is from a branch port
-          if (activeBranches.has(branchId)) {
-            // Branch is active - dataflow gets completed status
-            dataflow.setStatus(TaskStatus.COMPLETED);
-          } else {
-            // Branch is inactive - dataflow gets disabled status
-            dataflow.setStatus(TaskStatus.DISABLED);
-          }
-        } else {
+        const isActive = portActiveStatus.get(dataflow.sourceTaskPortId);
+        if (isActive === undefined) {
           // Not a branch port (e.g., _activeBranches metadata) - use normal status
           dataflow.setStatus(effectiveStatus);
+        } else {
+          dataflow.setStatus(isActive ? TaskStatus.COMPLETED : TaskStatus.DISABLED);
         }
       }
 

--- a/packages/task-graph/src/task/ConditionalTask.README.md
+++ b/packages/task-graph/src/task/ConditionalTask.README.md
@@ -148,6 +148,12 @@ const multiRouter = new ConditionalTask(
 
 ## Output Behavior
 
+There are two output shapes, selected by how the branches were supplied. The
+instance `outputSchema()` describes whichever one applies, so dataflows wired
+off either shape pass the graph's compatibility check.
+
+### Function branches (`config.branches` with `ConditionFn`)
+
 For each active branch, the task passes through its entire input to that branch's output port:
 
 ```typescript
@@ -160,7 +166,52 @@ For each active branch, the task passes through its entire input to that branch'
 }
 ```
 
-The `_activeBranches` property is always present and contains the IDs of all active branches.
+The `_activeBranches` property is always present and contains the IDs of all
+active branches. It is metadata, not a branch port: an edge wired off it follows
+the task's own status and is never disabled.
+
+### Serialized `conditionConfig` (from `config` or the input port)
+
+The UI condition builder supplies branches as data rather than functions. In that
+mode each **input port** is re-emitted with a branch suffix — `<port>_<n>` for
+branch _n_ (1-based), and `<port>_else` when the config is exclusive — and there
+is **no** `_activeBranches` property:
+
+```typescript
+const gate = new ConditionalTask({
+  inputSchema: {
+    type: "object",
+    properties: {
+      categories: { type: "array", items: { type: "string" } },
+      message: { type: "string" },
+    },
+  },
+  conditionConfig: {
+    branches: [{ id: "confident", field: "score", operator: "greater_or_equal", value: "0.8" }],
+    exclusive: true,
+  },
+});
+
+// Ports: categories_1, message_1, categories_else, message_else
+
+// Input: { score: 0.9, categories: ["billing"], message: "hello" }
+// Output (the "confident" branch matched):
+{
+  categories_1: ["billing"],
+  message_1: "hello"
+}
+// Input: { score: 0.2, ... } -> { categories_else: [...], message_else: "..." }
+```
+
+Each derived port carries its input port's own schema, so types survive the gate.
+The `conditionConfig` input is control data and is never routed to an output port.
+In non-exclusive mode the `_else` ports do not exist and every matching branch's
+ports activate independently.
+
+Declaring `config.inputSchema` is what makes these ports derivable. When it is
+absent — or when the `conditionConfig` arrives only on the input port at runtime —
+the output schema stays fully open, so edges still resolve (as `"runtime"`
+compatibility) but carry no static type.
 
 ## Dataflow Wiring
 
@@ -210,6 +261,11 @@ for (const [port, isActive] of portStatus) {
   console.log(`Port ${port}: ${isActive ? "active" : "inactive"}`);
 }
 ```
+
+`getPortActiveStatus()` covers both output shapes and is what the scheduler reads
+to decide which outgoing dataflows are `COMPLETED` and which are `DISABLED`. It
+lists every port the run could have written, not just the ones it did — a port
+missing from the map is not a branch port and follows the task's own status.
 
 ## Events
 

--- a/packages/task-graph/src/task/ConditionalTask.README.md
+++ b/packages/task-graph/src/task/ConditionalTask.README.md
@@ -266,6 +266,20 @@ for (const [port, isActive] of portStatus) {
 to decide which outgoing dataflows are `COMPLETED` and which are `DISABLED`. It
 lists every port the run could have written, not just the ones it did — a port
 missing from the map is not a branch port and follows the task's own status.
+That list is the declared input ports union the ones that actually arrived, and
+activation follows the **branch**: a declared port that arrived empty still
+belongs to the taken branch, so its edge stays enabled.
+
+## Caching
+
+`ConditionalTask` declares `cacheable = false`, and must stay that way. Its real
+product is the routing decision the scheduler reads back off the instance, and a
+cache hit returns the output without entering `execute`, so that state is never
+populated. A cached gate mis-routes in both modes: a `conditionConfig` gate
+reports no branch ports at all (nothing is disabled, so the untaken branch runs)
+and a function-branch gate reports every port inactive (everything is disabled,
+so the taken branch does not run). Evaluating a condition is cheap — there is
+nothing here worth caching.
 
 ## Events
 

--- a/packages/task-graph/src/task/ConditionalTask.ts
+++ b/packages/task-graph/src/task/ConditionalTask.ts
@@ -61,15 +61,13 @@ export type ConditionalTaskConfig = TaskConfig & {
  * Inactive branches DISABLE their outgoing dataflows, cascading to downstream tasks
  * with no other active inputs.
  *
- * TWO OUTPUT SHAPES (selected by how branches are supplied):
+ * TWO OUTPUT SHAPES (selected by how branches are supplied), both described by
+ * the instance {@link outputSchema}:
  * - Function branches (config.branches with ConditionFn) -> {@link buildOutput}:
- *   `{ _activeBranches: string[], [outputPort]: { ...input } }`. This is the shape
- *   the instance `outputSchema()` describes.
+ *   `{ _activeBranches: string[], [outputPort]: { ...input } }`.
  * - Serialized `conditionConfig` (from input or config, no function branches) ->
  *   {@link buildConditionConfigOutput}: UI-style `key_<n>` / `key_else` suffixed
- *   keys with NO `_activeBranches`. The declared outputSchema does NOT describe
- *   this shape, so consumers wiring dataflows off a conditionConfig-driven
- *   ConditionalTask must account for the suffixed keys explicitly.
+ *   keys with NO `_activeBranches`, one per declared input port per branch.
  */
 export class ConditionalTask<
   Input extends TaskInput = TaskInput,
@@ -108,6 +106,14 @@ export class ConditionalTask<
    * determine which dataflows should be enabled vs disabled.
    */
   public activeBranches: Set<string> = new Set();
+
+  /**
+   * Per-output-port activation recorded by the last run, covering the full port
+   * universe the run could have written (not only the ports it did write).
+   * `undefined` before the first run — {@link getPortActiveStatus} then falls
+   * back to deriving from `config.branches`.
+   */
+  private portActiveStatus: Map<string, boolean> | undefined;
 
   // ========================================================================
   // Execution methods
@@ -195,6 +201,7 @@ export class ConditionalTask<
 
     // Clear previous branch activation state
     this.activeBranches.clear();
+    this.portActiveStatus = undefined;
 
     const { branches, isExclusive, defaultBranch, fromConditionConfig } =
       this.resolveBranches(input);
@@ -236,6 +243,12 @@ export class ConditionalTask<
   /**
    * Builds output in the UI-style format where inputs are passed through
    * with numbered suffixes based on matched branches.
+   *
+   * Also records the activation of every port this shape could have produced —
+   * not just the ones it did — so the scheduler can DISABLE the edges hanging
+   * off the branches that were not taken. Deriving that from `config.branches`
+   * instead (as the scheduler used to) yields nothing here, because a
+   * conditionConfig-driven task has no `config.branches` at all.
    */
   protected buildConditionConfigOutput(
     input: Input,
@@ -278,6 +291,23 @@ export class ConditionalTask<
       }
     }
 
+    // Full port universe: every branch port for every pass-through key, plus
+    // the `_else` ports when exclusive. Ports written into `output` are active;
+    // the rest are inactive and their edges must be disabled.
+    const portStatus = new Map<string, boolean>();
+    for (const key of inputKeys) {
+      for (let i = 0; i < branches.length; i++) {
+        portStatus.set(`${key}_${i + 1}`, false);
+      }
+      if (isExclusive) {
+        portStatus.set(`${key}_else`, false);
+      }
+    }
+    for (const key of Object.keys(output)) {
+      portStatus.set(key, true);
+    }
+    this.portActiveStatus = portStatus;
+
     return output as Output;
   }
 
@@ -294,14 +324,21 @@ export class ConditionalTask<
     };
 
     const branches = this.config.branches ?? [];
+    const portStatus = new Map<string, boolean>();
 
     // For each active branch, populate its output port with the input data
     for (const branch of branches) {
-      if (this.activeBranches.has(branch.id)) {
+      const isActive = this.activeBranches.has(branch.id);
+      portStatus.set(branch.outputPort, isActive);
+      if (isActive) {
         // Pass through all input properties to the active branch's output port
         output[branch.outputPort] = { ...input };
       }
     }
+
+    // `_activeBranches` is deliberately absent: it is metadata, not a branch
+    // port, and its edge must follow the task's own status.
+    this.portActiveStatus = portStatus;
 
     return output as Output;
   }
@@ -319,7 +356,23 @@ export class ConditionalTask<
     return new Set(this.activeBranches);
   }
 
+  /**
+   * Per-output-port activation, and the single authority the scheduler uses to
+   * decide which outgoing dataflows are COMPLETED and which are DISABLED. A
+   * port absent from the map is not a branch port and follows the task's own
+   * status.
+   *
+   * After a run this is what the run itself recorded, so it describes whichever
+   * output shape actually ran. Before a run (and for a cached completion that
+   * never entered `execute`) it falls back to deriving from `config.branches`.
+   *
+   * Returns a copy to prevent external modification.
+   */
   public getPortActiveStatus(): Map<string, boolean> {
+    if (this.portActiveStatus) {
+      return new Map(this.portActiveStatus);
+    }
+
     const status = new Map<string, boolean>();
     const branches = this.config.branches ?? [];
 
@@ -349,8 +402,73 @@ export class ConditionalTask<
     } as const satisfies DataPortSchema;
   }
 
+  /**
+   * The input ports data is routed through: the declared input ports minus
+   * `conditionConfig`, which is control data rather than something to route.
+   */
+  private routedInputPorts(): Record<string, unknown> {
+    const schema = this.inputSchema();
+    if (typeof schema === "boolean" || !schema.properties) return {};
+    const { conditionConfig: _controlPort, ...ports } = schema.properties as Record<
+      string,
+      unknown
+    >;
+    return ports;
+  }
+
+  /**
+   * Derives the suffixed output ports a {@link buildConditionConfigOutput} run
+   * produces: `<inputPort>_<branchIndex + 1>` for every branch, plus
+   * `<inputPort>_else` when the config is exclusive. Each derived port reuses
+   * its input port's own schema, so downstream compatibility checks see the
+   * real type rather than an opaque object.
+   */
+  private conditionConfigOutputSchema(conditionConfig: UIConditionConfig): DataPortSchema {
+    // An empty branch list still runs one implicit "default" branch (see
+    // buildBranchesFromConditionConfig), so the port universe is never empty.
+    const branchCount = Math.max(conditionConfig.branches?.length ?? 0, 1);
+    const isExclusive = conditionConfig.exclusive !== false;
+    const properties: Record<string, unknown> = {};
+
+    for (const [key, portSchema] of Object.entries(this.routedInputPorts())) {
+      for (let i = 0; i < branchCount; i++) {
+        properties[`${key}_${i + 1}`] = portSchema;
+      }
+      if (isExclusive) {
+        properties[`${key}_else`] = portSchema;
+      }
+    }
+
+    return {
+      type: "object",
+      properties,
+      additionalProperties: true,
+    } as DataPortSchema;
+  }
+
   override outputSchema(): DataPortSchema {
     const branches = this.config?.branches ?? [];
+    const hasFunctionBranches = branches.length > 0 && typeof branches[0].condition === "function";
+
+    if (!hasFunctionBranches) {
+      const conditionConfig = this.config?.conditionConfig;
+      if (conditionConfig) {
+        return this.conditionConfigOutputSchema(conditionConfig);
+      }
+      if (branches.length === 0) {
+        // Nothing to derive from: the conditionConfig can still arrive on the
+        // input port at runtime. Stay fully open so a dataflow off a suffixed
+        // port resolves to "runtime" compatibility rather than "incompatible"
+        // (an undefined source property is rejected before the target is even
+        // consulted, so a closed schema would silently drop the edge's data).
+        return {
+          type: "object",
+          properties: {},
+          additionalProperties: true,
+        } as const satisfies DataPortSchema;
+      }
+    }
+
     const properties: Record<string, any> = {
       _activeBranches: {
         type: "array",
@@ -384,6 +502,14 @@ export class ConditionalTask<
   }
 
   override inputSchema(): DataPortSchema {
+    const declared = this.config?.inputSchema;
+    if (declared && typeof declared === "object") {
+      // Forcing `additionalProperties: true` keeps this a pure widening of the
+      // previous always-open schema: honoring a declared `false` here would
+      // turn existing compatible input edges (`conditionConfig`, and any port
+      // the config forgot to declare) incompatible.
+      return { ...declared, additionalProperties: true } as DataPortSchema;
+    }
     return {
       type: "object",
       properties: {},

--- a/packages/task-graph/src/task/ConditionalTask.ts
+++ b/packages/task-graph/src/task/ConditionalTask.ts
@@ -85,6 +85,19 @@ export class ConditionalTask<
    * check keeps `instanceof` semantics.
    */
   static readonly isConditionalTask = true;
+
+  /**
+   * Never cached. The routing decision this task makes lives in instance state
+   * ({@link activeBranches} / {@link getPortActiveStatus}) that the scheduler
+   * reads to enable and disable outgoing dataflows — and a cache hit returns the
+   * output without ever entering `execute`, so that state is never populated. A
+   * cached gate therefore mis-routes in both modes: a `conditionConfig` gate
+   * reports no branch ports at all (nothing is disabled, so the untaken branch
+   * runs) and a function-branch gate reports every port inactive (everything is
+   * disabled, so the taken branch does not run). Evaluating a condition is
+   * cheap; there is nothing here worth caching.
+   */
+  static override cacheable = false;
   static override type: TaskTypeName = "ConditionalTask";
   static override category = "Flow Control";
   static override title = "Condition";
@@ -291,20 +304,34 @@ export class ConditionalTask<
       }
     }
 
-    // Full port universe: every branch port for every pass-through key, plus
-    // the `_else` ports when exclusive. Ports written into `output` are active;
-    // the rest are inactive and their edges must be disabled.
-    const portStatus = new Map<string, boolean>();
-    for (const key of inputKeys) {
+    // Which branch suffixes this run activated. Activation is a property of the
+    // BRANCH, not of whether a given key carried data: a declared port that
+    // arrived empty still belongs to the taken branch, and disabling its edge
+    // would stop a downstream task the condition actually selected.
+    const activeSuffixes = new Set<string>();
+    if (isExclusive) {
+      activeSuffixes.add(matchedBranchNumber !== null ? String(matchedBranchNumber) : "else");
+    } else {
       for (let i = 0; i < branches.length; i++) {
-        portStatus.set(`${key}_${i + 1}`, false);
-      }
-      if (isExclusive) {
-        portStatus.set(`${key}_else`, false);
+        if (this.activeBranches.has(branches[i].id)) activeSuffixes.add(String(i + 1));
       }
     }
-    for (const key of Object.keys(output)) {
-      portStatus.set(key, true);
+
+    // Full port universe: every branch port for every routed key, plus the
+    // `_else` ports when exclusive. The keys are the DECLARED input ports union
+    // the ones that actually arrived — deriving them from the arrived data
+    // alone leaves a declared-but-unfed port missing from the map, and a
+    // missing port reads to the scheduler as "not a branch port", which is
+    // exactly the undisabled edge this map exists to prevent.
+    const routedKeys = new Set([...Object.keys(this.routedInputPorts()), ...inputKeys]);
+    const portStatus = new Map<string, boolean>();
+    for (const key of routedKeys) {
+      for (let i = 0; i < branches.length; i++) {
+        portStatus.set(`${key}_${i + 1}`, activeSuffixes.has(String(i + 1)));
+      }
+      if (isExclusive) {
+        portStatus.set(`${key}_else`, activeSuffixes.has("else"));
+      }
     }
     this.portActiveStatus = portStatus;
 

--- a/packages/task-graph/src/task/__tests__/ConditionalTaskCondition.test.ts
+++ b/packages/task-graph/src/task/__tests__/ConditionalTaskCondition.test.ts
@@ -7,6 +7,7 @@
 import type { UIConditionConfig } from "@workglow/task-graph";
 import { ConditionalTask } from "@workglow/task-graph";
 import { setLogger } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
 import { getTestingLogger } from "@workglow/util/test";
 import { describe, expect, it } from "vitest";
 
@@ -352,6 +353,145 @@ describe("ConditionalTask with serialized conditionConfig", () => {
 
       // Function branch should win
       expect(task.isBranchActive("fn-branch")).toBe(true);
+    });
+  });
+
+  describe("derived output schema", () => {
+    const triageInputSchema = {
+      type: "object",
+      properties: {
+        categories: { type: "array", items: { type: "string" } },
+        message: { type: "string" },
+      },
+      additionalProperties: true,
+    } as const satisfies DataPortSchema;
+
+    const triageConditionConfig: UIConditionConfig = {
+      branches: [{ id: "confident", field: "score", operator: "greater_or_equal", value: "0.8" }],
+      exclusive: true,
+    };
+
+    it("derives suffixed ports from conditionConfig and the declared input ports", () => {
+      const task = new ConditionalTask({
+        inputSchema: triageInputSchema,
+        conditionConfig: triageConditionConfig,
+      });
+
+      const schema = task.outputSchema();
+      expect(typeof schema).toBe("object");
+      const properties = (schema as Exclude<DataPortSchema, boolean>).properties as Record<
+        string,
+        any
+      >;
+
+      expect(properties).toHaveProperty("categories_1");
+      expect(properties).toHaveProperty("message_1");
+      expect(properties).toHaveProperty("categories_else");
+      expect(properties).toHaveProperty("message_else");
+
+      // buildConditionConfigOutput never emits `_activeBranches` in this mode.
+      expect(properties).not.toHaveProperty("_activeBranches");
+      // `conditionConfig` is control data, not a routed port.
+      expect(properties).not.toHaveProperty("conditionConfig_1");
+
+      // Each derived port reuses its input port's schema, so types survive.
+      expect(properties.categories_1.type).toBe("array");
+      expect(properties.categories_else.type).toBe("array");
+      expect(properties.message_1.type).toBe("string");
+    });
+
+    it("omits the _else ports when the conditionConfig is not exclusive", () => {
+      const task = new ConditionalTask({
+        inputSchema: triageInputSchema,
+        conditionConfig: {
+          branches: [
+            { id: "a", field: "score", operator: "greater_than", value: "0.8" },
+            { id: "b", field: "score", operator: "less_or_equal", value: "0.8" },
+          ],
+          exclusive: false,
+        },
+      });
+
+      const properties = (task.outputSchema() as Exclude<DataPortSchema, boolean>)
+        .properties as Record<string, any>;
+
+      expect(properties).toHaveProperty("categories_1");
+      expect(properties).toHaveProperty("categories_2");
+      expect(properties).not.toHaveProperty("categories_else");
+      expect(properties).not.toHaveProperty("message_else");
+    });
+
+    it("keeps the function-branch output shape unchanged", () => {
+      const task = new ConditionalTask({
+        branches: [
+          { id: "high", condition: (i: any) => i.value > 5, outputPort: "high" },
+          { id: "low", condition: (i: any) => i.value <= 5, outputPort: "low" },
+        ],
+      });
+
+      const schema = task.outputSchema() as Exclude<DataPortSchema, boolean>;
+      const properties = schema.properties as Record<string, any>;
+
+      expect(properties).toHaveProperty("_activeBranches");
+      expect(properties).toHaveProperty("high");
+      expect(properties).toHaveProperty("low");
+      expect(schema.additionalProperties).toBe(false);
+    });
+
+    it("falls back to an open schema when the conditionConfig arrives only via the port", () => {
+      const task = new ConditionalTask({});
+
+      const schema = task.outputSchema() as Exclude<DataPortSchema, boolean>;
+
+      // Nothing is derivable, so the schema must stay open — an open source port
+      // resolves to "runtime" compatibility rather than "incompatible".
+      expect(schema.additionalProperties).toBe(true);
+      expect(Object.keys((schema.properties ?? {}) as Record<string, any>)).toHaveLength(0);
+    });
+
+    it("widens the declared input schema rather than replacing it", () => {
+      const task = new ConditionalTask({
+        inputSchema: {
+          type: "object",
+          properties: { message: { type: "string" } },
+          additionalProperties: false,
+        },
+        conditionConfig: triageConditionConfig,
+      });
+
+      const schema = task.inputSchema() as Exclude<DataPortSchema, boolean>;
+      expect((schema.properties as Record<string, any>).message.type).toBe("string");
+      // Forced open so no existing graph's input edge can regress to incompatible.
+      expect(schema.additionalProperties).toBe(true);
+    });
+
+    it("reports per-port activation after a run", async () => {
+      const task = new ConditionalTask({
+        inputSchema: triageInputSchema,
+        conditionConfig: triageConditionConfig,
+      });
+
+      await task.run({ score: 0.9, categories: ["billing"], message: "hello" });
+
+      const status = task.getPortActiveStatus();
+      expect(status.get("categories_1")).toBe(true);
+      expect(status.get("message_1")).toBe(true);
+      expect(status.get("categories_else")).toBe(false);
+      expect(status.get("message_else")).toBe(false);
+    });
+
+    it("reports the else ports active when no branch matches", async () => {
+      const task = new ConditionalTask({
+        inputSchema: triageInputSchema,
+        conditionConfig: triageConditionConfig,
+      });
+
+      await task.run({ score: 0.1, categories: ["billing"], message: "hello" });
+
+      const status = task.getPortActiveStatus();
+      expect(status.get("categories_1")).toBe(false);
+      expect(status.get("categories_else")).toBe(true);
+      expect(status.get("message_else")).toBe(true);
     });
   });
 });

--- a/packages/task-graph/src/task/__tests__/ConditionalTaskCondition.test.ts
+++ b/packages/task-graph/src/task/__tests__/ConditionalTaskCondition.test.ts
@@ -493,5 +493,41 @@ describe("ConditionalTask with serialized conditionConfig", () => {
       expect(status.get("categories_else")).toBe(true);
       expect(status.get("message_else")).toBe(true);
     });
+
+    it("covers a declared input port that carried no data", async () => {
+      const task = new ConditionalTask({
+        inputSchema: triageInputSchema,
+        conditionConfig: triageConditionConfig,
+      });
+
+      // `categories` is declared but never arrives.
+      await task.run({ score: 0.1, message: "hello" });
+
+      const status = task.getPortActiveStatus();
+      // Present in the map at all: a port missing from it reads as "not a
+      // branch port" and its edge is left enabled.
+      expect(status.get("categories_1")).toBe(false);
+      expect(status.get("categories_else")).toBe(true);
+    });
+
+    it("keeps an empty port of the TAKEN branch active", async () => {
+      const task = new ConditionalTask({
+        inputSchema: triageInputSchema,
+        conditionConfig: triageConditionConfig,
+      });
+
+      await task.run({ score: 0.9, message: "hello" });
+
+      const status = task.getPortActiveStatus();
+      // Branch 1 matched, so its ports are active even where no data flowed —
+      // activation belongs to the branch, not to the presence of a value.
+      expect(status.get("categories_1")).toBe(true);
+      expect(status.get("message_1")).toBe(true);
+      expect(status.get("categories_else")).toBe(false);
+    });
+
+    it("is never cached: the routing decision lives in instance state", () => {
+      expect(ConditionalTask.cacheable).toBe(false);
+    });
   });
 });

--- a/packages/test/src/test/task/ConditionalTask.test.ts
+++ b/packages/test/src/test/task/ConditionalTask.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ConditionalTask, Dataflow, TaskGraph, TaskStatus } from "@workglow/task-graph";
+import { ConditionalTask, Dataflow, Task, TaskGraph, TaskStatus } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { describe, expect, it } from "vitest";
 
@@ -16,6 +16,65 @@ import {
 } from "@workglow/task-graph/test";
 import { setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
+
+/** Emits the two ports a serialized `conditionConfig` gate routes on. */
+class GateSourceTask extends Task<
+  { score: number; value: string },
+  { score: number; value: string }
+> {
+  static override type = "GateSourceTask";
+  static override category = "Test";
+  static override title = "Gate Source";
+
+  static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { score: { type: "number" }, value: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+
+  static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { score: { type: "number" }, value: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+
+  override async execute(input: {
+    score: number;
+    value: string;
+  }): Promise<{ score: number; value: string }> {
+    return { score: input.score, value: input.value };
+  }
+}
+
+/** Records whether it ran and what it received, so a disabled branch is observable. */
+class GateSinkTask extends Task<{ received: string }, { seen: string }> {
+  static override type = "GateSinkTask";
+  static override category = "Test";
+  static override title = "Gate Sink";
+
+  public calls = 0;
+
+  static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { received: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+
+  static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { seen: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+
+  override async execute(input: { received: string }): Promise<{ seen: string }> {
+    this.calls++;
+    return { seen: input.received };
+  }
+}
 
 // ============================================================================
 // Basic Tests
@@ -597,6 +656,108 @@ describe("ConditionalTask", () => {
 
         expect(activeDataflow.status).toBe(TaskStatus.COMPLETED);
         expect(inactiveDataflow.status).toBe(TaskStatus.DISABLED);
+      });
+    });
+
+    describe("Serialized conditionConfig Gates", () => {
+      const gateInputSchema = {
+        type: "object",
+        properties: {
+          score: { type: "number" },
+          value: { type: "string" },
+        },
+        additionalProperties: true,
+      } as const satisfies DataPortSchema;
+
+      it("delivers data through the suffixed ports of a conditionConfig gate", async () => {
+        const source = new GateSourceTask({ id: "source" });
+        const gate = new ConditionalTask({
+          id: "gate",
+          inputSchema: gateInputSchema,
+          conditionConfig: {
+            branches: [
+              { id: "confident", field: "score", operator: "greater_or_equal", value: "0.8" },
+            ],
+            exclusive: true,
+          },
+        });
+        const sink = new GateSinkTask({ id: "sink" });
+
+        const graph = new TaskGraph();
+        graph.addTasks([source, gate, sink]);
+        graph.addDataflow(new Dataflow(source.id, "score", gate.id, "score"));
+        graph.addDataflow(new Dataflow(source.id, "value", gate.id, "value"));
+        graph.addDataflow(new Dataflow(gate.id, "value_1", sink.id, "received"));
+
+        await graph.run({ score: 0.9, value: "payload" });
+
+        expect(sink.calls).toBe(1);
+        expect(sink.status).toBe(TaskStatus.COMPLETED);
+        expect(sink.runOutputData.seen).toBe("payload");
+      });
+
+      it("disables the branch edge and cascades when a conditionConfig gate falls to else", async () => {
+        const source = new GateSourceTask({ id: "source" });
+        const gate = new ConditionalTask({
+          id: "gate",
+          inputSchema: gateInputSchema,
+          conditionConfig: {
+            branches: [
+              { id: "confident", field: "score", operator: "greater_or_equal", value: "0.8" },
+            ],
+            exclusive: true,
+          },
+        });
+        const sink = new GateSinkTask({ id: "sink" });
+
+        const graph = new TaskGraph();
+        graph.addTasks([source, gate, sink]);
+        graph.addDataflow(new Dataflow(source.id, "score", gate.id, "score"));
+        graph.addDataflow(new Dataflow(source.id, "value", gate.id, "value"));
+        const branchDataflow = new Dataflow(gate.id, "value_1", sink.id, "received");
+        graph.addDataflow(branchDataflow);
+
+        await graph.run({ score: 0.2, value: "payload" });
+
+        expect(branchDataflow.status).toBe(TaskStatus.DISABLED);
+        expect(sink.status).toBe(TaskStatus.DISABLED);
+        expect(sink.calls).toBe(0);
+      });
+
+      it("activates matching ports independently in non-exclusive mode", async () => {
+        const source = new GateSourceTask({ id: "source" });
+        const gate = new ConditionalTask({
+          id: "gate",
+          inputSchema: gateInputSchema,
+          conditionConfig: {
+            branches: [
+              { id: "one", field: "score", operator: "greater_than", value: "0.1" },
+              { id: "two", field: "score", operator: "greater_than", value: "0.2" },
+              { id: "three", field: "score", operator: "greater_than", value: "0.9" },
+            ],
+            exclusive: false,
+          },
+        });
+        const sinkOne = new GateSinkTask({ id: "sinkOne" });
+        const sinkTwo = new GateSinkTask({ id: "sinkTwo" });
+        const sinkThree = new GateSinkTask({ id: "sinkThree" });
+
+        const graph = new TaskGraph();
+        graph.addTasks([source, gate, sinkOne, sinkTwo, sinkThree]);
+        graph.addDataflow(new Dataflow(source.id, "score", gate.id, "score"));
+        graph.addDataflow(new Dataflow(source.id, "value", gate.id, "value"));
+        graph.addDataflow(new Dataflow(gate.id, "value_1", sinkOne.id, "received"));
+        graph.addDataflow(new Dataflow(gate.id, "value_2", sinkTwo.id, "received"));
+        graph.addDataflow(new Dataflow(gate.id, "value_3", sinkThree.id, "received"));
+
+        await graph.run({ score: 0.5, value: "payload" });
+
+        expect(sinkOne.status).toBe(TaskStatus.COMPLETED);
+        expect(sinkOne.runOutputData.seen).toBe("payload");
+        expect(sinkTwo.status).toBe(TaskStatus.COMPLETED);
+        expect(sinkTwo.runOutputData.seen).toBe("payload");
+        expect(sinkThree.status).toBe(TaskStatus.DISABLED);
+        expect(sinkThree.calls).toBe(0);
       });
     });
   });

--- a/packages/test/src/test/task/ConditionalTask.test.ts
+++ b/packages/test/src/test/task/ConditionalTask.test.ts
@@ -4,7 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ConditionalTask, Dataflow, Task, TaskGraph, TaskStatus } from "@workglow/task-graph";
+import {
+  ConditionalTask,
+  Dataflow,
+  Task,
+  TaskGraph,
+  TaskGraphRunner,
+  TaskStatus,
+} from "@workglow/task-graph";
+import { InMemoryTaskOutputRepository } from "@workglow/task-graph/test";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { describe, expect, it } from "vitest";
 
@@ -758,6 +766,53 @@ describe("ConditionalTask", () => {
         expect(sinkTwo.runOutputData.seen).toBe("payload");
         expect(sinkThree.status).toBe(TaskStatus.DISABLED);
         expect(sinkThree.calls).toBe(0);
+      });
+
+      it("routes the same way on a second run sharing an output cache", async () => {
+        // A cache hit returns the output without entering `execute`, so the
+        // gate's in-memory routing state is never populated. Fresh task
+        // instances (a reloaded graph) are what expose it: the gate must still
+        // disable the untaken branch rather than serve a cached completion.
+        const repo = new InMemoryTaskOutputRepository();
+
+        const build = () => {
+          const source = new GateSourceTask({ id: "source" });
+          const gate = new ConditionalTask({
+            id: "gate",
+            inputSchema: gateInputSchema,
+            conditionConfig: {
+              branches: [
+                { id: "confident", field: "score", operator: "greater_or_equal", value: "0.8" },
+              ],
+              exclusive: true,
+            },
+          });
+          const sink = new GateSinkTask({ id: "sink" });
+          const graph = new TaskGraph();
+          graph.addTasks([source, gate, sink]);
+          graph.addDataflow(new Dataflow(source.id, "score", gate.id, "score"));
+          graph.addDataflow(new Dataflow(source.id, "value", gate.id, "value"));
+          const branch = new Dataflow(gate.id, "value_1", sink.id, "received");
+          graph.addDataflow(branch);
+          return { graph, sink, branch };
+        };
+
+        const first = build();
+        await new TaskGraphRunner(first.graph).runGraph(
+          { score: 0.2, value: "payload" },
+          { outputCache: repo }
+        );
+        expect(first.branch.status).toBe(TaskStatus.DISABLED);
+        expect(first.sink.calls).toBe(0);
+
+        const second = build();
+        await new TaskGraphRunner(second.graph).runGraph(
+          { score: 0.2, value: "payload" },
+          { outputCache: repo }
+        );
+        expect(second.branch.status).toBe(TaskStatus.DISABLED);
+        expect(second.sink.status).toBe(TaskStatus.DISABLED);
+        expect(second.sink.calls).toBe(0);
       });
     });
   });


### PR DESCRIPTION
## The defect

A `ConditionalTask` driven by a serialized `conditionConfig` — the shape the UI condition builder saves — **delivered no data and disabled no branch**. Downstream tasks ran on *both* paths, every one of them with `undefined` inputs.

Two independent causes, both from reconstructing the branch layout out of `config.branches`, which is empty in that mode:

1. **The edge carried no data.** The instance `outputSchema()` listed only `config.branches` ports and closed itself with `additionalProperties: false`. `Dataflow.semanticallyCompatible` therefore left `sourceSchemaProperty === undefined`, and `areSemanticallyCompatible` (`packages/util/src/json-schema/SchemaUtils.ts`) returns `"incompatible"` on an undefined source *before* it looks at the target — so an open target could not rescue it. `EdgeMaterializer` logged "not compatible, not setting port data" and moved on.
2. **No branch was ever disabled.** `RunScheduler.pushStatusFromNodeToEdges` built its *own* port → branch map from the same empty list, so every gate edge missed it, fell through to the non-branch-port case, and got `COMPLETED`.

The two modes diverged precisely because the scheduler kept a duplicate copy of knowledge that belongs to the task.

## The fix

- **Instance `inputSchema()`** returns `config.inputSchema` when declared, with `additionalProperties: true` **forced** on the returned object. That forcing is load-bearing rather than cosmetic: it keeps the change a pure widening of the previous always-open schema, so no existing graph's input edge (the `conditionConfig` port itself, or any port the saved config forgot to declare) can regress from compatible to incompatible.
- **Instance `outputSchema()`** now branches on mode:
  - *Function branches* — unchanged, down to `additionalProperties: false` and the `_activeBranches` property.
  - *`conditionConfig`* — derives `<port>_<i+1>` per branch index and `<port>_else` **only when `exclusive !== false`**, over the declared input ports minus the `conditionConfig` control port. This is the same rule the builder UI already implements when it writes the node's handles. Each derived property reuses that input port's own schema, so types survive the gate. No `_activeBranches` — `buildConditionConfigOutput` never produces one.
  - *Nothing derivable* (the `conditionConfig` arrives only on the input port) — a fully open object, so compatibility resolves to `"runtime"` instead of `"incompatible"`.
- **`getPortActiveStatus()`** becomes the single authority for both modes. Each build path records a map covering the **full port universe it could have written**, marking active exactly what it did write. The getter returns that recorded map after a run and otherwise falls back to today's `config.branches` derivation (pre-run callers, cached completions that never entered `execute`).
- **`RunScheduler.pushStatusFromNodeToEdges`** drops its own `portToBranch` map and its `getActiveBranches()` call and reads `node.getPortActiveStatus()`: `undefined` → today's non-branch-port behavior, `true` → `COMPLETED`, `false` → `DISABLED`. The FAILED-edge preservation guard and the trailing `propagateDisabledStatus` call are unchanged.

Docs: the class JSDoc warning that "the declared outputSchema does NOT describe this shape" is deleted — this fix makes it false — and the README's **Output Behavior** section now documents both shapes, including the non-exclusive case and the open-schema fallback.

## ⚠️ Risk — behavior-visible for already-saved graphs

This changes runtime behavior for **any** existing `conditionConfig`-driven graph, in both directions:

- data that never flowed **now flows** (a downstream task that received `undefined` now receives the real value);
- a downstream task on the **untaken** branch, which previously ran unconditionally, now goes `DISABLED` and does not run.

A graph that "worked" by accident — because a downstream node tolerated `undefined`, or because the user never noticed the untaken branch also executing — will visibly stop running that branch. That is the fix, but it belongs in the release notes.

## Tests

Written first and confirmed red against the current code, then green:

**`packages/task-graph/src/task/__tests__/ConditionalTaskCondition.test.ts`** — new `describe("derived output schema")`: derives the suffixed ports from `conditionConfig` + declared inputs (`categories_1`, `message_1`, `categories_else`, `message_else` present; `_activeBranches` absent; `categories_1.type === "array"`); omits `_else` under `exclusive: false`; keeps the function-branch shape with `_activeBranches` and `additionalProperties: false`; falls back to an open schema when the `conditionConfig` comes only via the port; widens rather than replaces a declared input schema; reports per-port activation after a run, on both the matched and the `else` path. 6 of the 7 were red before the fix (the function-branch shape guard was green by construction).

**`packages/test/src/test/task/ConditionalTask.test.ts`** — new `describe("Serialized conditionConfig Gates")` inside `ConditionalTask Graph Integration`, each running a real `TaskGraph`: *"delivers data through the suffixed ports of a conditionConfig gate"* (source → gate → sink wired off `value_1`; the sink executes and receives the value — previously `undefined`), *"disables the branch edge and cascades when a conditionConfig gate falls to else"* (dataflow `DISABLED`, sink `DISABLED`, sink never invoked — previously it ran), *"activates matching ports independently in non-exclusive mode"* (three branches, two matching, the third `DISABLED`). All three red before, green after.

## Verification

| command | result |
| --- | --- |
| `bun scripts/test.ts task vitest` | 65 files, 952 passed / 24 skipped, exit 0 |
| `bun scripts/test.ts graph vitest` | 50 files, 490 passed, exit 0 |
| `bun scripts/test.ts task-graph vitest` (extra, not requested) | 97/98 files passed. The one failure is `resolveOutput.test.ts`'s wall-clock assertion (`326ms < 250ms`) under a loaded container; it passes on its own re-run and touches nothing in this change. |
| `turbo run build-types --filter=@workglow/task-graph` | exit 0 (type check) |
| `eslint` + `prettier --check` on all changed files | clean |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKvKnyVeQQQCm6FhtaLyMa)_