### PR TITLE
test: prove the dist→src rewrite is in effect, and make the dist job total

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -426,6 +426,28 @@ integrity blocking: it reuses the `build-output` artifact and runs the unit tier
 `--coverage` when targeting `dist`, since measuring bundles against a `src` denominator
 reports every source file at 0% — so `merge-vitest-coverage` is unaffected.
 
+That job runs the UNIT tier only, which on its own would make the blocking check
+**tier-shaped**: a bundle reachable only from an `.integration.test.ts` file would be
+loaded by no blocking job at all. Two entries were in exactly that position
+(`@workglow/openrouter/ai-runtime` and `@workglow/huggingface-inference/ai-runtime`,
+imported only by provider-api integration files, whose section the nightly Bun run also
+excludes) — a `bun build` change dropping a re-export from either would have left the file
+in place, satisfied every check, and broken consumers only after publish. What closes that
+gap, and what makes the unit tier sufficient, is
+`packages/test/src/test/util/PublishedEntryImports.test.ts`: a unit-tier file that
+enumerates every workspace manifest's `exports`, resolves each subpath under the Node
+conditions, and dynamically imports the resulting specifier, asserting the module is
+non-empty. Under `WORKGLOW_TEST_TARGET=dist` that one file loads every published bundle
+regardless of which tier a suite happens to exercise it from; under the default target it
+costs nothing, because it loads the same source files the rest of the suite already does.
+Its two exemption maps are deliberately tiny and each entry states its reason, so a new
+package defaults to being checked, and a stale exemption fails the test rather than
+silently exempting nothing.
+
+Adding a new published `exports` subpath therefore needs no CI change, and importing
+`workglow` — the meta-package `packages/test` now devDepends on — is what brings the
+provider bundles into that sweep transitively.
+
 The coverage denominator is stated explicitly (`packages/*/src/**/*.{ts,tsx}`, same for
 `providers/`) rather than left to vitest's default of "files loaded during the run" — that
 default omits the modules no test imports at all, which are exactly the ones a coverage

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -435,6 +435,16 @@ are excluded. `scripts/workspaceSource.test.ts` fails if any published runtime e
 a source counterpart: such an entry keeps resolving to its bundle, and the only symptom is
 one package's coverage collapsing back onto `dist/*`.
 
+That file also drives the hook itself. `resolveId`'s body lives in
+`resolveWorkspaceSourceId`, which takes the plugin context as a PARAMETER so a recording
+stub can stand in for Vite, and a separate check reads the real `vitest.config.ts` back and
+asserts every project carries the `workglow:workspace-source` plugin under the default
+target and none does under `dist`. Both are there because the failure is silent: hoisting
+`plugins` from the per-project object to the root `defineConfig` — projects are standalone
+Vite configs, so a root-level entry never reaches them — leaves every test passing and only
+makes coverage numbers quietly worse. Both directions stub `WORKGLOW_TEST_TARGET`
+explicitly, since `test-vitest-dist` runs this file with that variable already set.
+
 ### Developing without building
 
 `bun run use-source` (or `./scripts/bunsrc-workspace.ts source`) makes every package resolve to its source files instead of its built files, so you can develop without rebuilding. It does **not** touch `package.json`: `exports` keeps pointing at `./dist/*`, and the script writes tiny re-export stubs into each package's (gitignored) `dist` folder — `dist/node.js` becomes `export * from "../src/node.ts"`, `dist/node.d.ts` the declaration equivalent. Source mode therefore leaves `git status` clean and there is nothing to revert before committing.

--- a/bun.lock
+++ b/bun.lock
@@ -368,6 +368,7 @@
         "pg": "catalog:",
         "playwright": "catalog:",
         "vitest": "catalog:",
+        "workglow": "workspace:*",
       },
     },
     "packages/util": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -78,6 +78,7 @@
     "node-llama-cpp": "catalog:",
     "pg": "catalog:",
     "playwright": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "workglow": "workspace:*"
   }
 }

--- a/packages/test/src/test/util/PublishedEntryImports.test.ts
+++ b/packages/test/src/test/util/PublishedEntryImports.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+
+/** The root `workspaces` globs, in the order a manifest scan walks them. */
+const WORKSPACE_GROUPS = ["packages", "providers", "examples"] as const;
+
+/**
+ * The conditions a plain `import` from Node activates, and only those.
+ *
+ * `types` is a compiler artifact, `browser` and `bun` name runtimes this test
+ * is not running under, and entering either would import a bundle whose
+ * dependencies (DOM globals, `bun:sqlite`) do not exist here. Node's own
+ * algorithm is what is replicated: walk the object's keys IN ORDER and take the
+ * first one that names an active condition, so a `types`-first block resolves
+ * to whatever comes after it rather than to nothing.
+ */
+const NODE_CONDITIONS: ReadonlySet<string> = new Set(["node", "import", "default"]);
+
+/**
+ * Entries no CI job can import, each with the reason it cannot.
+ *
+ * Kept deliberately small and stated per entry, so a NEW package defaults to
+ * being checked: the value of this file is that a published entry nobody
+ * imports is a bug, and a permissive default would recreate exactly the hole it
+ * closes. Every key is proved to still exist below, so a package that is
+ * renamed or deleted takes its exemption with it.
+ */
+const UNCHECKABLE: Readonly<Record<string, string>> = {
+  "@workglow/cli":
+    "an example app, and `packages/test` does not depend on it — under bunfig's " +
+    "isolated linker the specifier does not resolve from here at all, so importing " +
+    "it would test the linker rather than the bundle",
+};
+
+/**
+ * Entries that load but legitimately export nothing, with the reason.
+ *
+ * These are still IMPORTED — that a side-effect module evaluates cleanly is the
+ * whole of what it promises — only the non-empty assertion is lifted.
+ */
+const SIDE_EFFECT_ONLY: Readonly<Record<string, string>> = {
+  "workglow/auto-bootstrap":
+    "registers the bundled providers as an import side effect and exports nothing by design",
+};
+
+interface PublishedEntry {
+  /** The package that publishes it. */
+  readonly packageName: string;
+  /** The specifier a consumer writes, e.g. `@workglow/util/schema`. */
+  readonly specifier: string;
+  /** The manifest-relative target Node resolves it to under `NODE_CONDITIONS`. */
+  readonly target: string;
+}
+
+/** The target a conditional `exports` value resolves to, or `undefined`. */
+function resolveUnderNode(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  for (const [condition, child] of Object.entries(value as Record<string, unknown>)) {
+    if (!NODE_CONDITIONS.has(condition)) continue;
+    const resolved = resolveUnderNode(child);
+    if (resolved !== undefined) return resolved;
+  }
+  return undefined;
+}
+
+/** Every published entry of every workspace package, by manifest. */
+function collectPublishedEntries(): PublishedEntry[] {
+  const entries: PublishedEntry[] = [];
+  for (const group of WORKSPACE_GROUPS) {
+    let directories: string[];
+    try {
+      directories = readdirSync(join(repoRoot, group));
+    } catch {
+      continue;
+    }
+    for (const directory of directories) {
+      let manifest: { name?: unknown; exports?: unknown };
+      try {
+        manifest = JSON.parse(
+          readFileSync(join(repoRoot, group, directory, "package.json"), "utf8")
+        );
+      } catch {
+        continue; // not a package directory
+      }
+      const { name, exports } = manifest;
+      if (typeof name !== "string") continue;
+      if (typeof exports !== "object" || exports === null || Array.isArray(exports)) continue;
+      for (const [subpath, value] of Object.entries(exports as Record<string, unknown>)) {
+        if (!subpath.startsWith(".")) continue; // a bare condition map, not a subpath
+        const target = resolveUnderNode(value);
+        if (target === undefined) continue; // browser-only entry; nothing for Node to load
+        entries.push({ packageName: name, specifier: name + subpath.slice(1), target });
+      }
+    }
+  }
+  return entries.sort((a, b) => a.specifier.localeCompare(b.specifier));
+}
+
+const entries = collectPublishedEntries();
+const checkable = entries.filter((entry) => !(entry.specifier in UNCHECKABLE));
+
+/**
+ * Import every entry this repo publishes, by the specifier a consumer writes.
+ *
+ * The blocking bundle-integrity check is `test-vitest-dist`, which runs the
+ * UNIT tier against the built bundles. That makes the check tier-shaped: an
+ * entry reachable only from an `.integration.test.ts` file is exercised by no
+ * blocking job at all, which was true of `@workglow/openrouter/ai-runtime` and
+ * `@workglow/huggingface-inference/ai-runtime` — a `bun build` change that
+ * dropped a re-export from either bundle would have left the file in place,
+ * satisfied every existing check, and broken consumers only after publish.
+ *
+ * Enumerating the manifests instead of the import graph makes the check TOTAL
+ * rather than tier-shaped, and it costs nothing under the default target (the
+ * same source files the rest of the suite already loads). It is a unit-tier
+ * file on purpose: that is the tier `test-vitest-dist` runs.
+ *
+ * The enumeration is local rather than shared with `scripts/lib/`:
+ * `packages/test` is a `composite` project rooted at `./src`, so importing from
+ * `scripts/` would put those files in its program and break `build-types`.
+ */
+describe("published entry imports", () => {
+  it("enumerates every workspace manifest, so an empty sweep cannot pass", () => {
+    // Anti-vacuity: a typo in the walk (wrong group, wrong key) yields a short
+    // list rather than an error, and a short list passes every assertion below.
+    expect(entries.length).toBeGreaterThan(60);
+    expect(new Set(entries.map((entry) => entry.packageName)).size).toBeGreaterThan(20);
+  });
+
+  it("resolves every entry to a built file under dist", () => {
+    // Every published entry is a bundle. A target outside `dist` means the
+    // manifest ships source, and one that is not `.js` means the walk above
+    // landed on a `types` (or other non-runtime) condition.
+    const offenders = entries
+      .filter((entry) => !/^\.\/dist\/.+\.js$/.test(entry.target))
+      .map((entry) => `${entry.specifier} -> ${entry.target}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps every exemption pinned to an entry that still exists", () => {
+    // An exemption that outlives its package silently exempts nothing, and
+    // reads as if a real hole were still open.
+    const published = new Set(entries.map((entry) => entry.specifier));
+    const stale = [...Object.keys(UNCHECKABLE), ...Object.keys(SIDE_EFFECT_ONLY)].filter(
+      (specifier) => !published.has(specifier)
+    );
+    expect(stale).toEqual([]);
+    for (const reason of [...Object.values(UNCHECKABLE), ...Object.values(SIDE_EFFECT_ONLY)]) {
+      expect(reason.length).toBeGreaterThan(20);
+    }
+  });
+
+  it.each(checkable.map((entry) => entry.specifier))("%s loads", async (specifier) => {
+    const loaded: Record<string, unknown> = await import(/* @vite-ignore */ specifier);
+    expect(loaded).toBeDefined();
+    if (specifier in SIDE_EFFECT_ONLY) return;
+    // A bundle that lost every re-export still resolves and still evaluates;
+    // the export list is the only thing that says the entry point works.
+    expect(Object.keys(loaded).length).toBeGreaterThan(0);
+  });
+});

--- a/scripts/lib/workspaceSource.ts
+++ b/scripts/lib/workspaceSource.ts
@@ -331,46 +331,111 @@ function hasBuiltEntries(packageDir: string): boolean {
   }
 }
 
+/** The part of a resolution result the rewrite reads. */
+export interface WorkspaceResolvedId {
+  /** Absolute path (or external id) resolution landed on. */
+  readonly id: string;
+  /** Externality, when the resolver reported any. */
+  readonly external?: boolean | string | undefined;
+}
+
+/** The only `this.resolve` option this forwards deliberately. */
+export interface WorkspaceResolveOptions {
+  readonly skipSelf?: boolean | undefined;
+}
+
 /**
- * Redirect workspace package imports from `dist` to `src`.
+ * The one capability {@link resolveWorkspaceSourceId} needs from Vite's plugin
+ * context, so the hook body is drivable by a plain object in a test.
+ *
+ * `resolve` is declared with METHOD syntax on purpose. Under
+ * `strictFunctionTypes` a property-syntax function is checked
+ * contravariantly in its parameters, and Vite's real `PluginContext.resolve`
+ * — whose `importer`/`options` are optional and whose options type is its own
+ * — would then need a cast at the one call site that matters. Method syntax
+ * keeps parameters bivariant, so `PluginContext` satisfies this interface
+ * structurally and the adapter below passes `this` through untouched.
+ *
+ * Generic in the result so the adapter's return type stays the resolver's own
+ * (`ResolvedId`), which is what Vite's `resolveId` hook is declared to return;
+ * widening it here would push a cast back into the plugin.
+ */
+export interface WorkspaceResolveContext<
+  TResolved extends WorkspaceResolvedId = WorkspaceResolvedId,
+> {
+  resolve(
+    source: string,
+    importer: string | undefined,
+    options: WorkspaceResolveOptions
+  ): Promise<TResolved | null | undefined>;
+}
+
+/**
+ * Resolve one specifier, rewriting a workspace package's built entry to its
+ * source file.
  *
  * Resolution runs normally first (so conditional exports still pick the
  * node/browser/bun target the runtime asked for) and only the RESULT is
  * rewritten. That ordering is the whole trick — replicating condition
  * resolution in an alias table is what a per-package fix would have to do.
+ *
+ * Extracted from the plugin so it can be driven directly: the hook is the one
+ * function this whole module exists for, and inside a `Plugin` object literal
+ * it is reachable only through a Vite build.
+ */
+export async function resolveWorkspaceSourceId<TResolved extends WorkspaceResolvedId>(
+  packages: readonly WorkspacePackage[],
+  context: WorkspaceResolveContext<TResolved>,
+  source: string,
+  importer: string | undefined,
+  // Forwarded verbatim (`kind`, `isEntry`, `custom` all steer resolution);
+  // only `skipSelf` is this function's own contribution.
+  options: object
+): Promise<TResolved | null> {
+  // Bare workspace specifiers only: a relative import already points at
+  // source, and resolving every third-party specifier twice would tax the
+  // whole run for nothing.
+  const owner = ownerOf(packages, source);
+  if (owner === undefined) return null;
+  const resolved = await context.resolve(source, importer, { ...options, skipSelf: true });
+  if (!resolved) {
+    // Throwing, not warning: an unresolvable @workglow/* specifier already
+    // fails the run a moment later. This only replaces the message.
+    const importerPackage = importerPackageOf(packages, importer);
+    throw new Error(
+      unresolvedWorkspaceMessage({
+        source,
+        owner,
+        importer,
+        importerPackage,
+        importerDeclaresDependency: importerPackage?.dependencies.has(owner.name),
+        ownerDeclaresSubpath: declaresSubpath(owner, subpathOf(owner, source)),
+        distHasBuiltEntries: hasBuiltEntries(owner.dir),
+      })
+    );
+  }
+  if (resolved.external) return resolved;
+  const sourceFile = distToSource(resolved.id);
+  return sourceFile === undefined ? resolved : { ...resolved, id: sourceFile };
+}
+
+/** The plugin name, so a test can assert attachment without repeating a literal. */
+export const WORKSPACE_SOURCE_PLUGIN_NAME = "workglow:workspace-source";
+
+/**
+ * Redirect workspace package imports from `dist` to `src`.
+ *
+ * A one-line adapter over {@link resolveWorkspaceSourceId}: the package list is
+ * read once, and every decision lives in that function.
  */
 export function workspaceSourcePlugin(root: string): Plugin {
   const packages = listWorkspacePackages(root);
 
   return {
-    name: "workglow:workspace-source",
+    name: WORKSPACE_SOURCE_PLUGIN_NAME,
     enforce: "pre",
     async resolveId(source, importer, options) {
-      // Bare workspace specifiers only: a relative import already points at
-      // source, and resolving every third-party specifier twice would tax the
-      // whole run for nothing.
-      const owner = ownerOf(packages, source);
-      if (owner === undefined) return null;
-      const resolved = await this.resolve(source, importer, { ...options, skipSelf: true });
-      if (!resolved) {
-        // Throwing, not warning: an unresolvable @workglow/* specifier already
-        // fails the run a moment later. This only replaces the message.
-        const importerPackage = importerPackageOf(packages, importer);
-        throw new Error(
-          unresolvedWorkspaceMessage({
-            source,
-            owner,
-            importer,
-            importerPackage,
-            importerDeclaresDependency: importerPackage?.dependencies.has(owner.name),
-            ownerDeclaresSubpath: declaresSubpath(owner, subpathOf(owner, source)),
-            distHasBuiltEntries: hasBuiltEntries(owner.dir),
-          })
-        );
-      }
-      if (resolved.external) return resolved;
-      const sourceFile = distToSource(resolved.id);
-      return sourceFile === undefined ? resolved : { ...resolved, id: sourceFile };
+      return resolveWorkspaceSourceId(packages, this, source, importer, options);
     },
   };
 }

--- a/scripts/workspaceSource.test.ts
+++ b/scripts/workspaceSource.test.ts
@@ -6,18 +6,27 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { stubSpecsFor, type PackageManifest } from "./lib/sourceStubs";
 import { ROOT } from "./lib/testDiscovery";
-import type { UnresolvedWorkspaceContext, WorkspacePackage } from "./lib/workspaceSource";
+import type {
+  UnresolvedWorkspaceContext,
+  WorkspacePackage,
+  WorkspaceResolveContext,
+  WorkspaceResolvedId,
+  WorkspaceResolveOptions,
+} from "./lib/workspaceSource";
 import {
   distToSource,
   listWorkspacePackages,
   ownerOf,
   resolveTestTarget,
+  resolveWorkspaceSourceId,
   TEST_TARGETS,
   unresolvedWorkspaceMessage,
   WORKSPACE_GROUPS,
+  WORKSPACE_SOURCE_PLUGIN_NAME,
+  workspaceSourcePlugin,
 } from "./lib/workspaceSource";
 
 const packages = listWorkspacePackages(ROOT);
@@ -92,6 +101,201 @@ describe("workspace source resolution", () => {
       (group) => !include.some((glob) => glob.startsWith(`${group}/`))
     );
     expect(missing).toEqual([]);
+  });
+
+  /**
+   * The hook the whole module exists for. Every case below was previously
+   * unreachable from any test: `resolveId` lived inside a `Plugin` object
+   * literal, so driving it needed a Vite build, and both CI modes pass under
+   * either resolution — `test-vitest-unit` and `test-vitest-dist` run the same
+   * files and the same assertions, differing only in which files load. Nothing
+   * distinguished "resolved to src" from "resolved to dist".
+   *
+   * `resolveWorkspaceSourceId` takes the plugin context as a parameter for
+   * exactly this reason, so a recording stub can stand in for Vite.
+   */
+  describe("resolveId", () => {
+    interface RecordedResolve {
+      readonly source: string;
+      readonly importer: string | undefined;
+      readonly options: WorkspaceResolveOptions;
+    }
+
+    /** A plugin context that answers with `result` and records every call. */
+    function recordingContext(result: WorkspaceResolvedId | null): {
+      readonly calls: RecordedResolve[];
+      readonly context: WorkspaceResolveContext;
+    } {
+      const calls: RecordedResolve[] = [];
+      return {
+        calls,
+        context: {
+          async resolve(source, importer, options) {
+            calls.push({ source, importer, options });
+            return result;
+          },
+        },
+      };
+    }
+
+    it("rewrites a resolved dist entry to its source twin", async () => {
+      const { calls, context } = recordingContext({ id: join(ROOT, "packages/ai/dist/node.js") });
+
+      const resolved = await resolveWorkspaceSourceId(
+        packages,
+        context,
+        "@workglow/ai",
+        undefined,
+        {}
+      );
+
+      expect(resolved?.id).toBe(join(ROOT, "packages/ai/src/node.ts"));
+      expect(calls).toHaveLength(1);
+    });
+
+    it("passes a non-workspace specifier through without resolving it", async () => {
+      // Resolving every third-party specifier a second time would tax the whole
+      // run for nothing, so the owner lookup has to short-circuit BEFORE the
+      // `this.resolve` round trip rather than after it.
+      const { calls, context } = recordingContext({ id: "/elsewhere/vitest.js" });
+
+      expect(await resolveWorkspaceSourceId(packages, context, "vitest", undefined, {})).toBeNull();
+      expect(calls).toEqual([]);
+    });
+
+    it("leaves an external resolution as it was resolved", async () => {
+      // A source twin exists for this id, so only the externality check stops
+      // the rewrite: rewriting an external id to an absolute source path would
+      // pull a module the resolver deliberately left out back into the graph.
+      const external = { id: join(ROOT, "packages/ai/dist/node.js"), external: true };
+      const { context } = recordingContext(external);
+
+      expect(await resolveWorkspaceSourceId(packages, context, "@workglow/ai", undefined, {})).toBe(
+        external
+      );
+    });
+
+    it("leaves build output with no source twin on the built file", async () => {
+      const generated = { id: join(ROOT, "packages/ai/dist/not-a-real-entry.js") };
+      expect(existsSync(generated.id)).toBe(false);
+      const { context } = recordingContext(generated);
+
+      expect(await resolveWorkspaceSourceId(packages, context, "@workglow/ai", undefined, {})).toBe(
+        generated
+      );
+    });
+
+    it("throws the workspace diagnostic when resolution yields nothing", async () => {
+      // The branch the diagnostic exists for, and the one with zero execution
+      // anywhere else: `unresolvedWorkspaceMessage` is unit-tested on its
+      // inputs, but nothing proved the hook ever calls it.
+      const { context } = recordingContext(null);
+
+      await expect(
+        resolveWorkspaceSourceId(
+          packages,
+          context,
+          "@workglow/ai/not-exported",
+          join(ROOT, "packages/test/src/x.ts"),
+          {}
+        )
+      ).rejects.toThrow(
+        /\[workglow:workspace-source\] cannot resolve "@workglow\/ai\/not-exported"/
+      );
+    });
+
+    it("forwards the hook's options and adds skipSelf", async () => {
+      // Without `skipSelf` this plugin re-enters itself and resolution never
+      // terminates; the rest of the options (`kind`, `isEntry`, `custom`) steer
+      // which conditional export is picked, so dropping them silently changes
+      // the target that then gets rewritten.
+      const { calls, context } = recordingContext({ id: join(ROOT, "packages/ai/dist/node.js") });
+      const importer = join(ROOT, "packages/test/src/x.ts");
+
+      await resolveWorkspaceSourceId(packages, context, "@workglow/ai", importer, {
+        isEntry: false,
+        kind: "import-statement",
+      });
+
+      expect(calls).toEqual([
+        {
+          source: "@workglow/ai",
+          importer,
+          options: { isEntry: false, kind: "import-statement", skipSelf: true },
+        },
+      ]);
+    });
+  });
+
+  /**
+   * The rewrite only takes effect where the plugin is ATTACHED, and it has to
+   * be attached per project: projects are standalone Vite configs, so a
+   * root-level `plugins` entry never reaches them. Hoisting the plugin to the
+   * root `defineConfig` — a natural "one instance instead of N" cleanup — is
+   * silent: every project resolves through `exports` to dist again, all tests
+   * still pass, and the only symptom is entry-point behavior reading as
+   * uncovered.
+   *
+   * Both directions stub the variable EXPLICITLY. `test-vitest-dist` runs this
+   * file with `WORKGLOW_TEST_TARGET=dist` ambient, so a test that read the
+   * ambient value would pass in one CI job and fail in the other.
+   */
+  describe("plugin attachment", () => {
+    interface ConfiguredProject {
+      readonly plugins?: readonly { readonly name?: string }[];
+    }
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    });
+
+    async function projectsForTarget(target: string): Promise<readonly ConfiguredProject[]> {
+      vi.stubEnv("WORKGLOW_TEST_TARGET", target);
+      // The config reads the variable at module scope, so a cached evaluation
+      // would answer for whichever target ran first.
+      vi.resetModules();
+      const mod = (await import("../vitest.config.ts")) as {
+        default: { test?: { projects?: readonly ConfiguredProject[] } };
+      };
+      const projects = mod.default.test?.projects ?? [];
+      // A zero-project config would satisfy "none is missing the plugin".
+      expect(projects.length).toBeGreaterThan(0);
+      return projects;
+    }
+
+    const carriesPlugin = (project: ConfiguredProject): boolean =>
+      (project.plugins ?? []).some((plugin) => plugin?.name === WORKSPACE_SOURCE_PLUGIN_NAME);
+
+    it("attaches the source rewrite to every project under the default target", async () => {
+      const projects = await projectsForTarget("source");
+      expect(projects.filter((project) => !carriesPlugin(project))).toEqual([]);
+    });
+
+    it("attaches it to no project when the target is dist", async () => {
+      const projects = await projectsForTarget("dist");
+      expect(projects.filter(carriesPlugin)).toEqual([]);
+    });
+
+    it("names the plugin the same thing the diagnostic does", () => {
+      expect(workspaceSourcePlugin(ROOT).name).toBe(WORKSPACE_SOURCE_PLUGIN_NAME);
+      expect(
+        unresolvedWorkspaceMessage({
+          source: "@workglow/ai",
+          owner: {
+            name: "@workglow/ai",
+            dir: "/repo/packages/ai",
+            exports: undefined,
+            dependencies: new Set(),
+          },
+          importer: undefined,
+          importerPackage: undefined,
+          importerDeclaresDependency: undefined,
+          ownerDeclaresSubpath: true,
+          distHasBuiltEntries: true,
+        })
+      ).toContain(`[${WORKSPACE_SOURCE_PLUGIN_NAME}]`);
+    });
   });
 
   /**


### PR DESCRIPTION
Targets `claude/coverage-dist-bundle-fix-ew0vj8` (#741), not `main`.

Two review findings, both the same shape: a guard that does not guard what it claims.

## 1. Nothing verified the dist→src rewrite is actually in effect

`resolveId` — the one function the whole plugin exists for — had no test, and nothing asserted the plugin reaches the generated projects. `workspaceSource.test.ts` covered only the pure helpers. Both CI modes pass under either resolution: `test-vitest-unit` and `test-vitest-dist` run the same files with the same assertions, differing only in which files load, so nothing distinguished "resolved to src" from "resolved to dist".

The failure that leaves is silent. Hoisting `plugins: [workspaceSourcePlugin(__dirname)]` from the per-project object to the root `defineConfig` — a natural "one instance instead of N" cleanup, and the exact mistake the comment there warns about — makes every project resolve through `exports` to dist again. All tests pass, `merge-vitest-coverage` succeeds, and the only symptom is entry-point behavior reading as uncovered.

**Extraction rather than casts.** The hook body moves to `resolveWorkspaceSourceId(packages, context, source, importer, options)`, which takes the plugin context as a parameter so a recording stub can stand in for Vite; `workspaceSourcePlugin` becomes a one-line adapter. Two details keep the call site cast-free, and I checked both against the installed vite typings rather than assuming:

- `WorkspaceResolveContext.resolve` uses **method syntax**, so parameter bivariance lets Vite's real `PluginContext` satisfy the interface structurally.
- The interface is **generic in the result**, so the adapter's return type stays `ResolvedId`. Non-generic with `external?: boolean | string`, the adapter fails to typecheck (`Type 'string' is not assignable to type '"absolute" | "relative" | boolean | undefined'`) and would need the cast the extraction exists to avoid.

New `describe("resolveId")` with a recording stub covers: the dist→src rewrite; a non-workspace specifier short-circuiting **without** calling `resolve`; an external resolution left as-is; dist output with no source twin left on the built file; the workspace diagnostic thrown when resolution yields nothing (a branch with zero execution anywhere before this); and `skipSelf: true` plus verbatim forwarding of the hook's own `kind`/`isEntry` options.

New `describe("plugin attachment")` re-imports the real `vitest.config.ts` (with `vi.resetModules()`, since the config reads the variable at module scope) and asserts every project carries `workglow:workspace-source` under the default target and none does under `dist`. **Both directions stub `WORKGLOW_TEST_TARGET` explicitly and `vi.unstubAllEnvs()` after** — `test-vitest-dist` runs this file with that variable ambient, so a test reading the ambient value would pass in one CI job and fail in the other.

## 2. The blocking bundle check was tier-shaped; two entries had no check at all

`test-vitest-dist` runs `test:vitest:unit` only, while the source rewrite applies to every vitest job. The integration/rag/provider suites used to load the bundles and now load src, so a bundle reachable only from an `.integration.test.ts` file lost its blocking check. Two lost **every** check — `@workglow/openrouter/ai-runtime` and `@workglow/huggingface-inference/ai-runtime`, imported only from provider-api integration files whose section the nightly Bun parity run also excludes. A `bun build` change dropping `registerOpenRouterInline` from `providers/openrouter/dist/ai-runtime.js` would leave the file in place, satisfy the dist-must-exist requirement, pass all of CI, and break consumers only after publish.

New `packages/test/src/test/util/PublishedEntryImports.test.ts` makes the check **total** instead of tier-shaped: it enumerates every workspace manifest's `exports`, resolves each subpath under the Node conditions only (walked in declaration order the way Node does, so `types`/`browser`/`bun` are stepped over rather than entered), and `it.each` dynamically imports each resulting specifier, asserting the module is non-empty. Under `WORKGLOW_TEST_TARGET=dist` that one unit-tier file loads every published bundle; under the default target it costs nothing, since it loads the same source the rest of the suite already does.

Adding `"workglow": "workspace:*"` to `packages/test`'s devDependencies is the larger half — it brings the meta-package's own 28 entries and, transitively, the provider bundles those re-export. Total swept today: **98 entries across 38 packages, 97 imported** (`@workglow/cli` exempt).

The review suggested generating this from `stubSpecsFor(manifest)`. That does not work: it returns dist **targets**, not import specifiers, and `packages/test` is a `composite` project rooted at `./src`, so importing from `scripts/lib/` would put those files in its program and break `build-types`. The enumeration is therefore local.

Anti-vacuity assertions (over 60 entries across over 20 packages, every target matching `^\./dist/.+\.js$`) keep a mis-typed walk from passing as a short list, and both exemption maps are staleness-checked against the enumeration. Two exemptions, each with its reason:

| entry | kind | reason |
| --- | --- | --- |
| `@workglow/cli` | UNCHECKABLE | an example app `packages/test` does not depend on — under isolated linking the specifier does not resolve from here at all |
| `workglow/auto-bootstrap` | SIDE_EFFECT_ONLY | still imported; only the non-empty assertion is lifted, since it registers providers as a side effect and exports nothing by design |

New packages default to checked.

## 3. Docs

The `.claude/CLAUDE.md` paragraph this branch adds now says **why** the unit-tier dist job suffices — naming `PublishedEntryImports.test.ts` and the tier-shaped gap it closes — and documents the `resolveId`/attachment tests alongside it.

## Verification

- **Full `WORKGLOW_TEST_TARGET=dist bun run test:vitest:unit` against a real `bun run build`: 534 files passed / 3 skipped, 6152 tests passed / 71 skipped, exit 0.** No OOM; the sweep adds ~11s. That run is what proves all 97 entries load as *bundles*, not just as source.
- **Go-red on the review's exact scenario**: replacing `providers/openrouter/dist/ai-runtime.js` with an export-less module (file still present) fails `@workglow/openrouter/ai-runtime loads` **and** `workglow/openrouter/runtime loads`, and nothing else — `AssertionError: expected 0 to be greater than 0`. Before this PR no CI job imported either.
- `bun scripts/test.ts scripts vitest` — 4 files, 38 passed.
- Go-red on finding 1: hoisting `plugins` to the root `defineConfig` fails "attaches the source rewrite to every project" and nothing else.
- Typechecked `scripts/lib/workspaceSource.ts` against the installed vite typings (`scripts/` is in no CI tsconfig, and `vite` does not resolve from the root, so the branch's existing `import type { Plugin } from "vite"` is effectively `any` there — pinned with a temporary `paths` mapping instead of trusting that).
- Full `bun run build` — 84/84 tasks, so adding `workglow` to `packages/test` introduces no turbo cycle and `build-types` still passes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)