### PR TITLE
fix(triggers): explicit installer, duplicate/running-trigger guards, per-binding pending count

### DIFF
--- a/packages/test/src/test/trigger/TriggerInstall.test.ts
+++ b/packages/test/src/test/trigger/TriggerInstall.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Workflow } from "@workglow/task-graph";
+import {
+  bindWorkflowTrigger,
+  getWorkflowTriggers,
+  installWorkflowTriggers,
+  IntervalTrigger,
+  listenWorkflow,
+  stopWorkflowListening,
+} from "@workglow/triggers";
+import { describe, expect, test } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+const triggersSource = (relative: string): string =>
+  readFileSync(resolve(repoRoot, "packages/triggers/src", relative), "utf8");
+
+/**
+ * The barrel must stay PURE. `workglow` re-exports it, and `workglow`'s manifest
+ * declares only `./dist/auto-bootstrap.js` side-effectful — an allow-list that
+ * is only honest while importing `@workglow/triggers` installs nothing. If the
+ * import-time `Workflow.prototype` patch ever comes back, a bundler must keep
+ * the whole barrel, and with it `@workglow/duckdb`, `postgres`, `sqlite` and
+ * `mcp`, none of which declare `sideEffects` at all.
+ */
+describe("installWorkflowTriggers", () => {
+  // FIRST, before anything in this file installs: the behavioral guard.
+  test("importing the package leaves Workflow.prototype unpatched", () => {
+    expect(Object.prototype.hasOwnProperty.call(Workflow.prototype, "trigger")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(Workflow.prototype, "listen")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(Workflow.prototype, "stopListening")).toBe(false);
+    expect(new Workflow().trigger).toBeUndefined();
+  });
+
+  /**
+   * The backstop for the case above. That test depends on this file being the
+   * first to touch `Workflow.prototype` in its process — true under vitest's
+   * per-file isolation, but not a property the source itself carries. This one
+   * reads the source and holds no matter what ran first.
+   */
+  test("no module body patches Workflow.prototype outside the installer", () => {
+    const common = triggersSource("common.ts");
+    expect(common).not.toMatch(/^\s*import\s+["']\.\/workflow\/WorkflowTriggers["']/m);
+
+    const module = triggersSource("workflow/WorkflowTriggers.ts");
+    const assignments = module.match(/^Workflow\.prototype\.\w+\s*=/gm) ?? [];
+    // Every assignment is indented, i.e. inside installWorkflowTriggers().
+    expect(assignments).toEqual([]);
+    expect(module).toMatch(/export function installWorkflowTriggers\(\): void \{/);
+  });
+
+  test("the free functions work with no install at all", async () => {
+    const workflow = new Workflow();
+    const trigger = new IntervalTrigger({ intervalMs: 60_000, unrefTimer: true });
+
+    expect(bindWorkflowTrigger(workflow, trigger)).toBe(workflow);
+    expect(getWorkflowTriggers(workflow)).toEqual([trigger]);
+
+    const handle = await listenWorkflow(workflow);
+    expect(handle.triggers).toEqual([trigger]);
+    expect(trigger.running).toBe(true);
+
+    await stopWorkflowListening(workflow);
+    expect(trigger.running).toBe(false);
+  });
+
+  test("installs the fluent methods, and is idempotent", () => {
+    installWorkflowTriggers();
+
+    const installed = Workflow.prototype.trigger;
+    expect(typeof installed).toBe("function");
+    expect(typeof Workflow.prototype.listen).toBe("function");
+    expect(typeof Workflow.prototype.stopListening).toBe("function");
+
+    // A second call must not re-wrap: a consumer calling it defensively at every
+    // entry point would otherwise build a chain of delegating closures.
+    installWorkflowTriggers();
+    expect(Workflow.prototype.trigger).toBe(installed);
+  });
+
+  test("the installed methods delegate to the free functions", async () => {
+    installWorkflowTriggers();
+
+    const workflow = new Workflow();
+    const trigger = new IntervalTrigger({ intervalMs: 60_000, unrefTimer: true });
+
+    expect(workflow.trigger(trigger)).toBe(workflow);
+    expect(getWorkflowTriggers(workflow)).toEqual([trigger]);
+
+    const handle = await workflow.listen();
+    expect(handle.triggers).toEqual([trigger]);
+
+    await workflow.stopListening();
+    expect(trigger.running).toBe(false);
+  });
+});

--- a/packages/test/src/test/trigger/WorkflowTriggers.test.ts
+++ b/packages/test/src/test/trigger/WorkflowTriggers.test.ts
@@ -387,6 +387,86 @@ describe("Workflow trigger bindings", () => {
     await handle.stop();
   });
 
+  test("one binding's backlog is not charged against another binding's limit", async () => {
+    // The counter used to be workflow-global while the limit came from the
+    // arriving fire's binding. The fast trigger filled the shared count to 5,
+    // and the slow trigger's FIRST fire was then dropped with a message reading
+    // "5 fire(s) are already waiting ... (maxPendingFires: 1)" — quoting a
+    // limit belonging to a trigger that had never queued anything.
+    const workflow = createWorkflow();
+    const fast = new IntervalTrigger({ intervalMs: PERIOD, id: "fast", overlap: "concurrent" });
+    // Fires once, well after the fast trigger has filled its own backlog.
+    const slow = new IntervalTrigger({ intervalMs: PERIOD * 4, id: "slow", overlap: "concurrent" });
+
+    const errors: Error[] = [];
+    fast.on("error", (error) => errors.push(error));
+    slow.on("error", (error) => errors.push(error));
+
+    workflow.trigger(fast, {
+      input: (context) => ({ label: `fast@${context.scheduledAt - START}` }),
+      maxPendingFires: 5,
+    });
+    // Default (1): its own first fire queues, and must not see the fast
+    // trigger's backlog at all.
+    workflow.trigger(slow, { input: () => ({ label: "slow" }) });
+
+    const gate = createGate();
+    holdGate = gate;
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD * 4);
+
+    // The fast trigger queued 3 fires behind the running one, under its own
+    // limit of 5, and the slow trigger's single fire queued under its own 1.
+    expect(executions).toEqual(["fast@100"]);
+    expect(
+      errors.map((error) => error.message).filter((message) => message.includes("slow"))
+    ).toEqual([]);
+    expect(errors).toEqual([]);
+
+    holdGate = undefined;
+    gate.open();
+    await drainUntil(() => completed.length >= 5);
+
+    expect(completed).toContain("slow");
+    expect(errors).toEqual([]);
+
+    await handle.stop();
+  });
+
+  test("a dropped fire names the trigger it came from", async () => {
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({
+      intervalMs: PERIOD,
+      id: "chatty",
+      overlap: "concurrent",
+    });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+    workflow.trigger(trigger, {
+      input: (context) => ({ label: `fire@${context.scheduledAt - START}` }),
+      maxPendingFires: 1,
+    });
+
+    const gate = createGate();
+    holdGate = gate;
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD * 3);
+
+    expect(errors).toHaveLength(1);
+    // Trigger and count in one message, so the quoted limit can never belong to
+    // a different trigger than the backlog.
+    expect(errors[0]?.message).toContain('trigger "chatty"');
+    expect(errors[0]?.message).toContain("1 fire(s) from that trigger");
+    expect(errors[0]?.message).toContain("maxPendingFires: 1");
+
+    holdGate = undefined;
+    gate.open();
+    await drainUntil(() => completed.length >= 2);
+    await handle.stop();
+  });
+
   test("stopListening() halts further runs", async () => {
     const workflow = createWorkflow();
     workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }), {

--- a/packages/test/src/test/trigger/WorkflowTriggers.test.ts
+++ b/packages/test/src/test/trigger/WorkflowTriggers.test.ts
@@ -479,6 +479,77 @@ describe("Workflow trigger bindings", () => {
     expect(() => workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }))).not.toThrow();
   });
 
+  test("binding the same trigger twice to one workflow throws", () => {
+    // Not catchable by a `running` check: neither binding is running yet. One
+    // `ITrigger` holds one handler, so the second `start()` is a no-op and the
+    // second binding's `input` mapper would never run.
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD, id: "shared" });
+    workflow.trigger(trigger);
+
+    expect(() => workflow.trigger(trigger, { input: () => ({ label: "never" }) })).toThrow(
+      WorkflowTriggerError
+    );
+    expect(() => workflow.trigger(trigger)).toThrow(/shared/);
+    // The rejected binding was not recorded.
+    expect(getWorkflowTriggers(workflow)).toEqual([trigger]);
+  });
+
+  test("listen() with a trigger already running for another workflow throws", async () => {
+    const a = createWorkflow();
+    const b = createWorkflow();
+    const shared = new IntervalTrigger({ intervalMs: PERIOD, id: "shared" });
+    a.trigger(shared, { input: () => ({ label: "a" }) });
+    b.trigger(shared, { input: () => ({ label: "b" }) });
+
+    const handleA = await a.listen();
+    await expect(b.listen()).rejects.toBeInstanceOf(WorkflowTriggerError);
+
+    // Rejected BEFORE any state was touched, so b is unchanged and still
+    // bindable — the point of checking ahead of the handle registration.
+    expect(() => b.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "other" }))).not.toThrow();
+
+    await handleA.stop();
+  });
+
+  test("a rejected listen() leaves the other workflow's schedule intact", async () => {
+    // Previously b.listen() resolved with a handle listing the shared trigger
+    // while the handler stayed a's — and `b.stopListening()` then killed a's
+    // schedule, from a workflow that had never run once.
+    const a = createWorkflow();
+    const b = createWorkflow();
+    const shared = new IntervalTrigger({ intervalMs: PERIOD, id: "shared" });
+    a.trigger(shared, { input: () => ({ label: "a" }) });
+    b.trigger(shared, { input: () => ({ label: "b" }) });
+
+    const handleA = await a.listen();
+    await expect(b.listen()).rejects.toBeInstanceOf(WorkflowTriggerError);
+
+    await b.stopListening();
+    expect(shared.running).toBe(true);
+
+    await advanceFakeTimers(PERIOD * 2);
+    expect(executions).toEqual(["a", "a"]);
+
+    await handleA.stop();
+  });
+
+  test("a trigger is bindable again once the workflow using it has stopped", async () => {
+    const a = createWorkflow();
+    const b = createWorkflow();
+    const shared = new IntervalTrigger({ intervalMs: PERIOD, id: "shared" });
+    a.trigger(shared, { input: () => ({ label: "a" }) });
+    b.trigger(shared, { input: () => ({ label: "b" }) });
+
+    await (await a.listen()).stop();
+    const handleB = await b.listen();
+
+    await advanceFakeTimers(PERIOD);
+    expect(executions).toEqual(["b"]);
+
+    await handleB.stop();
+  });
+
   test("a caller signal passed to listen() stops every trigger", async () => {
     const workflow = createWorkflow();
     const trigger = new IntervalTrigger({ intervalMs: PERIOD });

--- a/packages/test/src/test/trigger/WorkflowTriggers.test.ts
+++ b/packages/test/src/test/trigger/WorkflowTriggers.test.ts
@@ -17,6 +17,7 @@ import {
   CronTrigger,
   CronUnsatisfiableError,
   getWorkflowTriggers,
+  installWorkflowTriggers,
   IntervalTrigger,
   PollingTrigger,
   WorkflowTriggerError,
@@ -200,6 +201,10 @@ async function drainUntil(predicate: () => boolean): Promise<void> {
   }
 }
 
+// The fluent methods this suite exercises are opt-in: importing the package
+// installs nothing (see TriggerInstall.test.ts). Install once for the file.
+installWorkflowTriggers();
+
 describe("Workflow trigger bindings", () => {
   beforeEach(() => {
     executions.length = 0;
@@ -217,7 +222,7 @@ describe("Workflow trigger bindings", () => {
     vi.useRealTimers();
   });
 
-  test("augments the Workflow prototype with lifecycle methods", () => {
+  test("installWorkflowTriggers() adds the lifecycle methods to the prototype", () => {
     expect(typeof Workflow.prototype.trigger).toBe("function");
     expect(typeof Workflow.prototype.listen).toBe("function");
     expect(typeof Workflow.prototype.stopListening).toBe("function");

--- a/packages/test/src/test/util/PackageSideEffects.test.ts
+++ b/packages/test/src/test/util/PackageSideEffects.test.ts
@@ -75,29 +75,61 @@ const workspaces = readWorkspaces();
  * patch, a registry entry — must be listed, or the bundler is entitled to elide
  * the import chain that would have run it.
  *
- * `workglow` got this wrong: it listed only `./dist/auto-bootstrap.js` while its
- * `.` entry re-exports `@workglow/triggers`, whose module body patches
- * `Workflow.prototype.trigger`. `@workglow/triggers` deliberately omits
- * `sideEffects: false` to protect that patch, but webpack re-routes
- * `import { Workflow } from "workglow"` straight to `@workglow/task-graph` and
- * never consults the intermediary's own dependencies — so the patch was dropped
- * in production bundles while dev and Node kept working.
+ * The fixture below is deliberately EXACT and fails in both directions, because
+ * both directions are silent bugs:
  *
- * Omitting the field entirely (the conservative default every other package here
- * relies on) is what this asserts back to: an entry point a consumer imports
- * from must either be listed, or the package must not make the claim at all.
+ * - an entry point that gained a side effect but was not listed is dropped from
+ *   production bundles while dev and Node keep working; and
+ * - a listed entry point that no longer has one (or, worse, whose dist file was
+ *   renamed) leaves a stale path in the allow-list. The stale entry protects
+ *   nothing — it names a file the bundler never sees — so the real entry point
+ *   silently reverts to "safe to drop". That is why the second test requires
+ *   every listed path to be a real runtime target of the same `exports` map.
+ *
+ * `workglow` carries the only interesting entry: `./dist/auto-bootstrap.js`, the
+ * one module in the meta-package whose body runs anything (it bootstraps the
+ * global registry and calls `installWorkflowTriggers()`). Its barrel must stay
+ * ELIDABLE — it re-exports `@workglow/duckdb`, `postgres`, `sqlite` and `mcp`
+ * among others, none of which declare `sideEffects` at all, so a bundler that
+ * cannot drop the barrel must keep every one of them. That is what
+ * `@workglow/triggers` giving up its import-time `Workflow.prototype` patch
+ * bought.
  */
+const EXPECTED_SIDE_EFFECTS: Readonly<Record<string, readonly string[]>> = {
+  workglow: ["./dist/auto-bootstrap.js"],
+  "@workglow/javascript": ["./dist/task.js"],
+};
+
 describe("package sideEffects declarations", () => {
-  it("cover every exported entry point of the packages that declare them", () => {
-    const uncovered = workspaces.flatMap(({ name, manifest }) => {
+  it("are declared by exactly the packages that need them, with exactly these entries", () => {
+    const declared = Object.fromEntries(
+      workspaces
+        .filter(({ manifest }) => Array.isArray(manifest.sideEffects))
+        .map(({ name, manifest }) => [name, manifest.sideEffects as readonly string[]])
+    );
+    expect(declared).toEqual(EXPECTED_SIDE_EFFECTS);
+  });
+
+  it("list only real runtime export targets, so a renamed dist file cannot leave a stale entry", () => {
+    const stale = workspaces.flatMap(({ name, manifest }) => {
       const { sideEffects } = manifest;
       if (!Array.isArray(sideEffects)) return [];
       const targets = collectRuntimeTargets(manifest.exports, new Set<string>());
-      return [...targets]
-        .filter((target) => !sideEffects.includes(target))
-        .map((target) => `${name} ${target}`);
+      return sideEffects
+        .filter((entry: unknown) => typeof entry !== "string" || !targets.has(entry))
+        .map((entry: unknown) => `${name} ${String(entry)}`);
     });
-    expect(uncovered).toEqual([]);
+    expect(stale).toEqual([]);
+  });
+
+  it("are the only allow-lists: every other package claims purity or stays silent", () => {
+    const unexpected = workspaces
+      .filter(({ name }) => !(name in EXPECTED_SIDE_EFFECTS))
+      .filter(
+        ({ manifest }) => manifest.sideEffects !== undefined && manifest.sideEffects !== false
+      )
+      .map(({ name, manifest }) => `${name}: ${JSON.stringify(manifest.sideEffects)}`);
+    expect(unexpected).toEqual([]);
   });
 
   it("scans every workspace, so an empty result cannot pass vacuously", () => {

--- a/packages/triggers/README.md
+++ b/packages/triggers/README.md
@@ -31,19 +31,47 @@ await trigger.stop();
 
 ## Driving a workflow
 
+Two forms, same behavior. The free functions always work; the fluent methods
+exist only after `installWorkflowTriggers()`.
+
 ```ts
-import { IntervalTrigger, PollingTrigger } from "@workglow/triggers"; // also patches Workflow.prototype
+import { bindWorkflowTrigger, IntervalTrigger, listenWorkflow, PollingTrigger } from "@workglow/triggers";
 import { Workflow } from "@workglow/task-graph";
 
 const workflow = new Workflow().addTask(MyTask);
 
-workflow.trigger(new IntervalTrigger({ intervalMs: 60_000 }));
-workflow.trigger(new PollingTrigger({ intervalMs: 5_000, poll: () => fetchPendingIds() }), {
+bindWorkflowTrigger(workflow, new IntervalTrigger({ intervalMs: 60_000 }));
+bindWorkflowTrigger(workflow, new PollingTrigger({ intervalMs: 5_000, poll: () => fetchPendingIds() }), {
   input: (context) => ({ ids: context.payload }),
 });
 
+await using handle = await listenWorkflow(workflow);
+```
+
+**Importing this package installs nothing.** A module body that patched
+`Workflow.prototype` would make every barrel re-exporting it side-effectful —
+including `workglow`'s, which also reaches `@workglow/duckdb`, `postgres`,
+`sqlite` and `mcp`, none of which declare `sideEffects`, so a bundler would have
+to keep all of them in the app's bundle. Ask for the patch instead:
+
+```ts
+import { installWorkflowTriggers } from "@workglow/triggers";
+
+installWorkflowTriggers(); // once, at startup; idempotent
+
+workflow.trigger(new IntervalTrigger({ intervalMs: 60_000 }));
 await using handle = await workflow.listen();
 ```
+
+`import "workglow/auto-bootstrap"` already calls it, so the batteries-included
+path keeps the fluent API. Anything else that bootstraps by hand — including
+`bootstrapWorkglow()` from `workglow/bootstrap` — does not: `workflow.trigger`
+is `undefined` there until you install it, and TypeScript will not warn you,
+because the method declaration is a module augmentation with no way to say
+"after install".
+
+`stopWorkflowListening(workflow)` is the free-function form of
+`workflow.stopListening()`.
 
 `listen()` **resolves as soon as the triggers are scheduled — it does not block
 until the process is interrupted.** It does not, however, leave the process free

--- a/packages/triggers/src/common.ts
+++ b/packages/triggers/src/common.ts
@@ -4,25 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// organize-imports-ignore
-
-// Load first: this module patches Workflow.prototype, so importing it before
-// the value exports guarantees `.trigger()` / `.listen()` exist on any Workflow
-// a consumer touches after importing this package. The package deliberately
-// does NOT declare `"sideEffects": false` — a bundler that believed it would
-// drop this patch and leave those methods undefined at runtime. Nor may a
-// package that re-exports this one: webpack re-routes an
-// `import { Workflow } from "workglow"` straight to `@workglow/task-graph` and
-// never consults this package's flag, so the barrel has to claim side effects
-// on its own behalf (i.e. by not declaring the field at all).
-import "./workflow/WorkflowTriggers";
+// This barrel is PURE: nothing here patches `Workflow.prototype`, so a bundler
+// may elide any of it. `installWorkflowTriggers()` is what installs the fluent
+// `.trigger()` / `.listen()` methods, and a consumer calls it (or uses the free
+// functions instead). Do not re-add a bare `import "./workflow/WorkflowTriggers"`:
+// it would make this module side-effectful, and every package re-exporting it —
+// `workglow`'s barrel most of all — would be pinned into consumer bundles along
+// with duckdb, postgres, sqlite and mcp, none of which declare `sideEffects`.
 
 export * from "./cron/CronSchedule";
 export * from "./trigger/BaseTrigger";
 export * from "./trigger/CronTrigger";
-export * from "./trigger/ITrigger";
 export * from "./trigger/fixedInterval";
 export * from "./trigger/IntervalTrigger";
+export * from "./trigger/ITrigger";
 export * from "./trigger/PollingTrigger";
 export * from "./trigger/TriggerError";
 export * from "./workflow/WorkflowTriggers";

--- a/packages/triggers/src/workflow/WorkflowTriggers.ts
+++ b/packages/triggers/src/workflow/WorkflowTriggers.ts
@@ -25,14 +25,20 @@ export interface WorkflowTriggerOptions {
   /** Run configuration forwarded to {@link Workflow.run} on every fire. */
   readonly runConfig?: WorkflowRunConfig | undefined;
   /**
-   * How many fires may wait for the workflow's current run before one is
-   * dropped. Defaults to `1`.
+   * How many of THIS binding's fires may wait for the workflow's current run
+   * before one is dropped. Defaults to `1`.
    *
    * One `Workflow` owns one task graph, which can only be running once, so
    * fires against a workflow are run one at a time no matter what overlap
    * policy the trigger uses. This is the bound on that backlog: a fire arriving
    * past it is dropped and reported on the trigger's `error` event rather than
    * queued forever behind a handler that cannot keep up.
+   *
+   * Counted per binding, matching where the option lives. A workflow-global
+   * count would let a fast trigger's backlog drop a slow trigger's first-ever
+   * fire against a ceiling the slow trigger never approached — so two bindings
+   * on one workflow do not share this budget, and the aggregate backlog is
+   * bounded by the sum rather than by any single binding's value.
    */
   readonly maxPendingFires?: number | undefined;
 }
@@ -82,6 +88,16 @@ export interface ITriggerListenerHandle extends AsyncDisposable {
 interface TriggerBinding {
   readonly trigger: ITrigger;
   readonly options: WorkflowTriggerOptions;
+  /**
+   * How many of THIS binding's fires are waiting on the workflow's run chain.
+   *
+   * Deliberately mutable, and deliberately on the binding rather than in a
+   * workflow-keyed map: `maxPendingFires` is a per-binding option, so charging
+   * every binding's backlog against one workflow-global counter let a fast
+   * trigger's queue drop a slow trigger's first-ever fire — and quote the slow
+   * trigger's limit while doing it.
+   */
+  pending: number;
 }
 
 /** Backlog bound applied when a binding does not set {@link WorkflowTriggerOptions.maxPendingFires}. */
@@ -92,11 +108,12 @@ const DEFAULT_MAX_PENDING_FIRES = 1;
 const workflowBindings = new WeakMap<Workflow, TriggerBinding[]>();
 const workflowHandles = new WeakMap<Workflow, ITriggerListenerHandle>();
 /**
- * Tail of the serialized run chain per workflow, and the number of fires
- * waiting on it. See {@link runWorkflowForFire}.
+ * Tail of the serialized run chain per workflow. Fires against one workflow are
+ * serialized no matter which binding they came from — one `Workflow` owns one
+ * task graph — but the BACKLOG on that chain is counted per binding
+ * ({@link TriggerBinding.pending}). See {@link runWorkflowForFire}.
  */
 const workflowRunChains = new WeakMap<Workflow, Promise<void>>();
-const workflowPendingFires = new WeakMap<Workflow, number>();
 
 /**
  * Resolves what `settling` resolved to, or `undefined` once `timeoutMs` passes.
@@ -206,7 +223,7 @@ export function bindWorkflowTrigger<W extends Workflow>(
         `binding: bind a second trigger instance instead of re-binding this one.`
     );
   }
-  bindings.push({ trigger, options });
+  bindings.push({ trigger, options, pending: 0 });
   workflowBindings.set(workflow, bindings);
   return workflow;
 }
@@ -429,18 +446,23 @@ async function runWorkflowForFire(
 
   if (predecessor !== undefined) {
     const limit = binding.options.maxPendingFires ?? DEFAULT_MAX_PENDING_FIRES;
-    const waiting = workflowPendingFires.get(workflow) ?? 0;
+    // This binding's own backlog. The limit and the count must come from the
+    // same binding or the message is a lie: a workflow-global count charged a
+    // fast binding's queue against a slow binding's ceiling and then reported
+    // "5 fire(s) are already waiting ... (maxPendingFires: 1)" for a trigger
+    // that had never queued a fire.
+    const waiting = binding.pending;
     if (waiting >= limit) {
       // Thrown rather than dropped in silence: this is the one place the old
       // "Graph is already running" failure was observable, and a backlog the
       // workflow cannot work off is worth reporting on the `error` event.
       throw new WorkflowTriggerError(
-        `Dropped a trigger fire scheduled for ${new Date(context.scheduledAt).toISOString()}: ` +
-          `${waiting} fire(s) are already waiting for this workflow's run to finish ` +
-          `(maxPendingFires: ${limit}).`
+        `Dropped a fire from trigger "${binding.trigger.id}" scheduled for ` +
+          `${new Date(context.scheduledAt).toISOString()}: ${waiting} fire(s) from that trigger ` +
+          `are already waiting for this workflow's run to finish (maxPendingFires: ${limit}).`
       );
     }
-    workflowPendingFires.set(workflow, waiting + 1);
+    binding.pending = waiting + 1;
   }
 
   const chain = (async (): Promise<void> => {
@@ -448,7 +470,7 @@ async function runWorkflowForFire(
       // `catch`, not a bare await: a fire whose run rejected must not take the
       // fires queued behind it down with it.
       await predecessor.catch(() => {});
-      workflowPendingFires.set(workflow, (workflowPendingFires.get(workflow) ?? 1) - 1);
+      binding.pending -= 1;
       // The wait can outlast the trigger. A fire that queued behind a slow run
       // must not start a new one after `stop()`.
       if (context.signal.aborted) return;

--- a/packages/triggers/src/workflow/WorkflowTriggers.ts
+++ b/packages/triggers/src/workflow/WorkflowTriggers.ts
@@ -124,6 +124,15 @@ export function getWorkflowTriggers(workflow: Workflow): readonly ITrigger[] {
   return (workflowBindings.get(workflow) ?? []).map((binding) => binding.trigger);
 }
 
+/**
+ * These three methods exist only after {@link installWorkflowTriggers} has run
+ * — importing this package no longer patches the prototype. TypeScript cannot
+ * express that, so the augmentation declares them unconditionally and an app
+ * that never installs them gets a `TypeError` the compiler did not warn about.
+ * `workglow/auto-bootstrap` installs them; the free functions
+ * ({@link bindWorkflowTrigger}, {@link listenWorkflow},
+ * {@link stopWorkflowListening}) need no install at all.
+ */
 declare module "@workglow/task-graph" {
   interface Workflow {
     /**
@@ -159,24 +168,36 @@ declare module "@workglow/task-graph" {
   }
 }
 
-Workflow.prototype.trigger = function (
-  this: Workflow,
+/**
+ * Binds `trigger` to `workflow`. The free-function form of
+ * {@link Workflow.trigger}, and the one that always exists: the method is only
+ * present after {@link installWorkflowTriggers}.
+ *
+ * Returns the workflow it was given, generically, so a chain preserves
+ * `Workflow<Input, Output>` rather than collapsing to the defaults.
+ */
+export function bindWorkflowTrigger<W extends Workflow>(
+  workflow: W,
   trigger: ITrigger,
   options: WorkflowTriggerOptions = {}
-): Workflow {
-  if (workflowHandles.has(this)) {
+): W {
+  if (workflowHandles.has(workflow)) {
     throw new WorkflowTriggerError(
       "Cannot bind a trigger while the workflow is listening. Call stopListening() first."
     );
   }
-  const bindings = workflowBindings.get(this) ?? [];
+  const bindings = workflowBindings.get(workflow) ?? [];
   bindings.push({ trigger, options });
-  workflowBindings.set(this, bindings);
-  return this;
-};
+  workflowBindings.set(workflow, bindings);
+  return workflow;
+}
 
-Workflow.prototype.listen = async function (
-  this: Workflow,
+/**
+ * Starts every trigger bound to `workflow`. The free-function form of
+ * {@link Workflow.listen}; see that declaration for the semantics.
+ */
+export async function listenWorkflow(
+  workflow: Workflow,
   options: WorkflowListenOptions = {}
 ): Promise<ITriggerListenerHandle> {
   // FIRST, before the handle lookup and before any state is touched. An
@@ -186,10 +207,10 @@ Workflow.prototype.listen = async function (
   // looked successful and was inert.
   options.signal?.throwIfAborted();
 
-  const existing = workflowHandles.get(this);
+  const existing = workflowHandles.get(workflow);
   if (existing) return existing;
 
-  const bindings = workflowBindings.get(this) ?? [];
+  const bindings = workflowBindings.get(workflow) ?? [];
   if (bindings.length === 0) {
     throw new WorkflowTriggerError(
       "listen() requires at least one trigger. Bind one with workflow.trigger(...) first."
@@ -202,7 +223,7 @@ Workflow.prototype.listen = async function (
   const releaseHandle = (): void => {
     detachAbort?.();
     detachAbort = undefined;
-    if (workflowHandles.get(this) === handle) workflowHandles.delete(this);
+    if (workflowHandles.get(workflow) === handle) workflowHandles.delete(workflow);
   };
 
   const stop = async (stopOptions: TriggerStopOptions = {}): Promise<void> => {
@@ -256,7 +277,7 @@ Workflow.prototype.listen = async function (
 
   // Registered BEFORE the triggers start, so the rollback path below (and a
   // caller-signal abort) can always find the handle to release.
-  workflowHandles.set(this, handle);
+  workflowHandles.set(workflow, handle);
 
   if (options.signal) {
     const signal = options.signal;
@@ -274,7 +295,7 @@ Workflow.prototype.listen = async function (
   try {
     for (const binding of bindings) {
       binding.trigger.start(
-        (context) => runWorkflowForFire(this, binding, context),
+        (context) => runWorkflowForFire(workflow, binding, context),
         options.signal ? { signal: options.signal } : {}
       );
       started.push(binding.trigger);
@@ -289,11 +310,61 @@ Workflow.prototype.listen = async function (
   }
 
   return handle;
-};
+}
 
-Workflow.prototype.stopListening = async function (this: Workflow): Promise<void> {
-  await workflowHandles.get(this)?.stop();
-};
+/**
+ * Stops every trigger {@link listenWorkflow} started for `workflow`. The
+ * free-function form of {@link Workflow.stopListening}; a no-op when the
+ * workflow is not listening.
+ */
+export async function stopWorkflowListening(workflow: Workflow): Promise<void> {
+  await workflowHandles.get(workflow)?.stop();
+}
+
+/**
+ * Installs `trigger()` / `listen()` / `stopListening()` on `Workflow.prototype`,
+ * so the fluent form in this package's README works.
+ *
+ * **Importing this package does not call it.** A module body that patched a
+ * foreign prototype would make every entry point re-exporting it side-effectful,
+ * and the meta-package `workglow` re-exports it from a barrel that also reaches
+ * `@workglow/duckdb`, `postgres`, `sqlite`, `mcp`, `storage`, `task-graph` and
+ * `util` — none of which declare `sideEffects` at all, so a bundler must keep
+ * every one of them once the barrel cannot be elided. Naming the barrel in
+ * `sideEffects` does not help: the flag is consulted per package, and those
+ * dependencies have already forfeited the claim. The patch therefore has to be
+ * something a consumer asks for.
+ *
+ * `workglow/auto-bootstrap` calls it, so the batteries-included path is
+ * unchanged. Everyone else either calls this once at startup, or uses
+ * {@link bindWorkflowTrigger} / {@link listenWorkflow} /
+ * {@link stopWorkflowListening} directly and never patches anything.
+ *
+ * Idempotent, and cheap to call defensively: it returns early once the methods
+ * are own properties of the prototype.
+ */
+export function installWorkflowTriggers(): void {
+  if (Object.prototype.hasOwnProperty.call(Workflow.prototype, "trigger")) return;
+
+  Workflow.prototype.trigger = function (
+    this: Workflow,
+    trigger: ITrigger,
+    options?: WorkflowTriggerOptions
+  ): Workflow {
+    return bindWorkflowTrigger(this, trigger, options);
+  };
+
+  Workflow.prototype.listen = function (
+    this: Workflow,
+    options?: WorkflowListenOptions
+  ): Promise<ITriggerListenerHandle> {
+    return listenWorkflow(this, options);
+  };
+
+  Workflow.prototype.stopListening = function (this: Workflow): Promise<void> {
+    return stopWorkflowListening(this);
+  };
+}
 
 /**
  * Runs the workflow for one fire, serialized against every other fire on the

--- a/packages/triggers/src/workflow/WorkflowTriggers.ts
+++ b/packages/triggers/src/workflow/WorkflowTriggers.ts
@@ -142,6 +142,10 @@ declare module "@workglow/task-graph" {
      * Returns `this`, not `Workflow`: a declared return type would collapse a
      * `Workflow<Input, Output>` to the default `Workflow<DataPorts, DataPorts>`
      * on the first chained call and lose both port types.
+     *
+     * @throws {@link WorkflowTriggerError} when this workflow is already
+     *   listening, or when `trigger` is already bound to it — the second
+     *   binding's options would never be used.
      */
     trigger(trigger: ITrigger, options?: WorkflowTriggerOptions): this;
 
@@ -157,6 +161,10 @@ declare module "@workglow/task-graph" {
      * @throws the signal's abort reason when `options.signal` is already
      *   aborted — checked before any state is touched, so the workflow is left
      *   exactly as it was and stays free to bind and listen later.
+     * @throws {@link WorkflowTriggerError} when a bound trigger is already
+     *   running (it is driving another workflow, and a trigger holds one
+     *   handler). Checked before any state is touched too, so a rejected
+     *   `listen()` leaves BOTH workflows exactly as they were.
      */
     listen(options?: WorkflowListenOptions): Promise<ITriggerListenerHandle>;
 
@@ -187,6 +195,17 @@ export function bindWorkflowTrigger<W extends Workflow>(
     );
   }
   const bindings = workflowBindings.get(workflow) ?? [];
+  // Rejected HERE rather than at listen(): neither binding is running yet, so a
+  // `trigger.running` check cannot see this. `wf.trigger(t).trigger(t, {input})`
+  // used to be accepted and then silently honour only the first binding's
+  // options — one `ITrigger` holds one handler, so the second `start()` is a
+  // no-op and that input mapper never runs.
+  if (bindings.some((binding) => binding.trigger === trigger)) {
+    throw new WorkflowTriggerError(
+      `Trigger "${trigger.id}" is already bound to this workflow. One trigger drives one ` +
+        `binding: bind a second trigger instance instead of re-binding this one.`
+    );
+  }
   bindings.push({ trigger, options });
   workflowBindings.set(workflow, bindings);
   return workflow;
@@ -214,6 +233,27 @@ export async function listenWorkflow(
   if (bindings.length === 0) {
     throw new WorkflowTriggerError(
       "listen() requires at least one trigger. Bind one with workflow.trigger(...) first."
+    );
+  }
+
+  // Also before any state is touched, for the same reason the abort check is:
+  // `BaseTrigger.start` is a silent no-op on a running trigger, so a trigger
+  // already listening for ANOTHER workflow would be reported in this handle's
+  // `triggers` while its handler stayed the other workflow's — a listen() that
+  // looks successful and never fires. Worse, this handle's `stop()` would then
+  // stop the other workflow's schedule.
+  //
+  // There is deliberately no ownership map (`WeakMap<ITrigger, Workflow>`): the
+  // trigger is the long-lived object and the workflow the disposable one, so
+  // that mapping is a strong reference from a trigger to every workflow it was
+  // ever bound to. `running` is the property that actually matters, and it is
+  // already on the interface.
+  const running = bindings.filter((binding) => binding.trigger.running);
+  if (running.length > 0) {
+    throw new WorkflowTriggerError(
+      `Cannot listen: trigger(s) ${running.map((binding) => `"${binding.trigger.id}"`).join(", ")} ` +
+        `are already running. A trigger holds one handler, so it drives one workflow at a time — ` +
+        `stop the workflow already listening on it, or bind a separate trigger instance.`
     );
   }
 

--- a/packages/workglow/package.json
+++ b/packages/workglow/package.json
@@ -193,6 +193,9 @@
     "dist",
     "src/**/*.md"
   ],
+  "sideEffects": [
+    "./dist/auto-bootstrap.js"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workglow/src/auto-bootstrap.ts
+++ b/packages/workglow/src/auto-bootstrap.ts
@@ -6,11 +6,13 @@
 
 /**
  * Convenience subpath that bootstraps the global Workglow runtime with the
- * tslog-backed logger. Equivalent to:
+ * tslog-backed logger and installs the fluent `Workflow` trigger methods.
+ * Equivalent to:
  *
  * ```ts
- * import { bootstrapWorkglow, TsLogLogger } from "workglow";
+ * import { bootstrapWorkglow, installWorkflowTriggers, TsLogLogger } from "workglow";
  * bootstrapWorkglow({ logger: new TsLogLogger() });
+ * installWorkflowTriggers();
  * ```
  *
  * Use it for "import workglow and go" ergonomics:
@@ -21,10 +23,21 @@
  *
  * For library code, multi-tenant servers, tests, or any case needing a
  * configurable or isolated registry, prefer `bootstrapWorkglow()` /
- * `createOrchestrationContext()` from `workglow/bootstrap`.
+ * `createOrchestrationContext()` from `workglow/bootstrap` — and call
+ * `installWorkflowTriggers()` yourself if you want `workflow.trigger(...)`
+ * rather than the free functions `bindWorkflowTrigger` / `listenWorkflow` /
+ * `stopWorkflowListening`.
+ *
+ * This module is the ONLY side-effectful entry point of the package, which is
+ * what `"sideEffects": ["./dist/auto-bootstrap.js"]` in the manifest says: the
+ * barrel stays elidable, so an app importing `{ Workflow } from "workglow"`
+ * does not drag duckdb, postgres, sqlite and mcp into its bundle.
  */
+
+import { installWorkflowTriggers } from "@workglow/triggers";
 
 import { bootstrapWorkglow } from "./bootstrap";
 import { TsLogLogger } from "./logging";
 
 bootstrapWorkglow({ logger: new TsLogLogger() });
+installWorkflowTriggers();

--- a/packages/workglow/src/common.ts
+++ b/packages/workglow/src/common.ts
@@ -16,9 +16,9 @@ export * from "@workglow/postgres/job-queue";
 export * from "@workglow/duckdb/storage";
 export * from "@workglow/storage";
 export * from "@workglow/task-graph";
-// After task-graph: this package patches `Workflow.prototype` with
-// `.trigger()` / `.listen()`, so the meta-package must pull it in for a
-// consumer importing only `workglow` to get those methods at all.
+// A pure re-export: the triggers package installs nothing on import. It exports
+// `installWorkflowTriggers()`, which `workglow/auto-bootstrap` calls; a consumer
+// bootstrapping manually calls it too, or uses the free functions.
 export * from "@workglow/triggers";
 export * from "@workglow/browser-control/task";
 export * from "@workglow/javascript/task";


### PR DESCRIPTION
Three MEDIUM defects from review of the `@workglow/triggers` PR. Commit order is `A3 → A1 → A2` deliberately: A3 changes the package's public shape, so A1 and A2's tests are written once against the final shape.

Targets `claude/libs-issues-triage-prs-mh6x2o-237`, not `main`.

---

## 1. `installWorkflowTriggers()` replaces the import-time prototype patch

**The problem.** `@workglow/triggers` patched `Workflow.prototype` in a module body, so its barrel was side-effectful and `workglow`'s barrel — which re-exports it — had to be too. The fix that shipped for that deleted `"sideEffects": ["./dist/auto-bootstrap.js"]` from `packages/workglow` entirely, which flips **every** file in the meta-package from pure to side-effectful, not just the barrel.

**Why the middle ground does not exist.** Listing the barrel targets in `sideEffects` was the obvious alternative. It does not work, and this was verified against the manifests rather than assumed: `sideEffects` is consulted **per package**, and `@workglow/duckdb`, `postgres`, `sqlite`, `mcp`, `storage`, `task-graph` and `util` all **omit** the field. A barrel a bundler cannot elide pins every one of them into the app's bundle regardless of what `workglow` claims. A browser app doing `import { Workflow } from "workglow"` was paying for duckdb, postgres, sqlite and mcp.

**So the patch becomes something a consumer asks for:**

- `bindWorkflowTrigger` / `listenWorkflow` / `stopWorkflowListening` — named exported free functions, the whole API, nothing patched;
- `installWorkflowTriggers()` — installs the fluent methods, guarding on `hasOwnProperty(Workflow.prototype, "trigger")` so it is idempotent and never re-wraps;
- `common.ts` drops the bare `import "./workflow/WorkflowTriggers"`;
- `packages/workglow` gets its `sideEffects` allow-list back, and `auto-bootstrap` calls the installer.

### The real cost of this choice

**An app that imports `workglow` (not `workglow/auto-bootstrap`) and calls `bootstrapWorkglow()` by hand now gets a `TypeError` on `workflow.trigger(...)` while TypeScript says it is fine.** The methods come from a module augmentation, and there is no way to express "declared, but only after an install call" — so the compiler keeps reporting them as present. `import "workglow/auto-bootstrap"` is unchanged; every other bootstrap path must call `installWorkflowTriggers()` once, or use the free functions.

The cost lands on nobody **today**, and both halves of that were verified rather than asserted: `@workglow/triggers` is absent from `origin/main`, and `npm view @workglow/triggers` is a 404. The README and the augmentation's docblock both state the trap.

**Tests.** `PackageSideEffects.test.ts` becomes an exact per-package fixture (`workglow` → auto-bootstrap, `@workglow/javascript` → its task entry) plus a rule that every listed path is a real runtime export target of the same `exports` map — a renamed dist file otherwise leaves a stale entry that protects nothing while the real entry point silently reverts to droppable. `TriggerInstall.test.ts` leads with the behavioral guard (importing the package leaves `Workflow.prototype.trigger` undefined); since that depends on the file being first to touch the prototype in its process, a source-shape assertion backs it up isolation-independently.

---

## 2. Reusing one trigger across workflows bound nothing, and the wrong `stop()` won

`listen()` called `start()` on every binding, and `BaseTrigger.start` is a silent no-op when already running.

```ts
wfA.trigger(t); await wfA.listen();
wfB.trigger(t); await wfB.listen();   // resolves, listing t, and never fires
```

`wfB.listen()` handed back a handle whose `triggers` contained `t` — reporting success — while `t`'s handler was still `wfA`'s. Then `wfB.stopListening()` called `t.stop()` and killed `wfA`'s schedule, from a workflow that had never run once.

Two separate checks, because neither can see what the other catches:

- **`bindWorkflowTrigger`** rejects a trigger already in this workflow's bindings. `wf.trigger(t).trigger(t, { input })` is exactly the case a running-check cannot reach — neither binding is running yet — and its symptom is the second binding's `input` mapper silently never running.
- **`listenWorkflow`** rejects a bound trigger whose `running` is already true.

Both fire **before any state is touched**, so a rejected `listen()` leaves both workflows exactly as they were. A test pins that `wfB.stopListening()` no longer kills `wfA`.

Deliberately **no** `WeakMap<ITrigger, Workflow>` ownership map: the trigger is the long-lived object and the workflow the disposable one, so that mapping is a strong reference from a trigger to every workflow it was ever bound to. `running` is already on the interface.

---

## 3. `maxPendingFires` was a per-binding option enforced against a workflow-global counter

The limit came from the arriving fire's binding while the count came from a workflow-keyed `WeakMap` shared by all of them. Bind a fast `IntervalTrigger` with `maxPendingFires: 5` beside one with the default `1`: the fast one fills the shared counter, and the second trigger's **first ever** fire is dropped — reported as `5 fire(s) are already waiting ... (maxPendingFires: 1)`, a sentence in which the count and the limit belong to different triggers.

The counter moves onto `TriggerBinding` as a mutable `pending` field (the documented exception to `readonly` by default — genuinely mutable state, living where the option it enforces already lives). The message now names the trigger and scopes the count to it, so it can never quote a limit belonging to a different one.

**Consequence worth stating:** two bindings on one workflow no longer share this budget, so the aggregate backlog is bounded by the *sum* of their limits rather than by any single value. That is what a per-binding option means; the docblock says so.

---

## Verification

- `bun scripts/test.ts trigger vitest` — 6 files, **174 passed** (was 168 before this branch).
- `bun scripts/test.ts util vitest` — 54 files, **762 passed / 10 skipped**.
- `npx tsc -b packages/triggers packages/workglow packages/test` — clean.
- Each fix confirmed **red before, green after**, by reverting the guard and re-running: the duplicate/running guards fail 3 cases without them; the per-binding counter reproduces the exact reported message (`Dropped a fire from trigger "slow" ... 2 fire(s) ... (maxPendingFires: 1)`) when swapped back to a global count.
- `sideEffects` omission verified across all 39 workspace manifests; `@workglow/triggers` absence from `origin/main` and from npm verified directly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKvKnyVeQQQCm6FhtaLyMa)_