### PR TITLE
fix(bootstrap): pin the registered set, correct the overwrite claim, regenerate bun.lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -181,7 +181,7 @@
     },
     "packages/bootstrap": {
       "name": "@workglow/bootstrap",
-      "version": "0.3.38",
+      "version": "0.3.39",
       "devDependencies": {
         "@workglow/ai": "workspace:*",
         "@workglow/knowledge-base": "workspace:*",

--- a/packages/bootstrap/CHANGELOG.md
+++ b/packages/bootstrap/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.38
+## 0.3.39
 
 ### Features
 

--- a/packages/bootstrap/README.md
+++ b/packages/bootstrap/README.md
@@ -45,9 +45,39 @@ import { TsLogLogger } from "workglow";
 bootstrapWorkglow({ logger: new TsLogLogger() });
 ```
 
-`bootstrapWorkglow()` is idempotent — defaults register with `registerIfAbsent`,
-so an earlier explicit registration (a custom storage backend, say) is never
-overwritten, and repeat calls are harmless.
+`bootstrapWorkglow()` is idempotent — repeat calls are harmless.
+
+**Two halves, two behaviors, and the difference decides where your own
+registrations go.**
+
+The **factory tokens** (logger, telemetry, worker manager, credential store,
+model repository, AI provider registry, knowledge-base and MCP maps, tabular
+repositories, task constructors, transform defs) register with
+`registry.registerIfAbsent`. An earlier explicit registration — a custom storage
+backend, say — survives, so those may be installed **before**
+`bootstrapWorkglow()`.
+
+The **input resolvers and compactors** do not. `registerInputResolver` /
+`registerInputCompactor` are an unconditional `resolvers.set(formatPrefix, fn)`:
+last writer wins. Nine of the fourteen registrars call them, covering the
+`credential`, `image`, `knowledge-base`, `mcp-server`, `model`,
+`storage:tabular` and `tasks` prefixes. A custom resolver installed **before**
+`bootstrapWorkglow()` is silently replaced by the built-in one, with no warning
+and nothing in the registry to inspect:
+
+```typescript
+// WRONG — bootstrapWorkglow() overwrites this during startup, and every
+// `format: "model"` input then resolves from the built-in MODEL_REPOSITORY.
+registerInputResolver("model", myCatalogResolver);
+bootstrapWorkglow();
+
+// RIGHT — install custom resolvers AFTER the defaults are in place.
+bootstrapWorkglow();
+registerInputResolver("model", myCatalogResolver);
+```
+
+The same ordering applies to `registerAllDefaults(registry)` and
+`createOrchestrationContext()`.
 
 ### Isolated context
 

--- a/packages/bootstrap/src/bootstrap/registerAllDefaults.ts
+++ b/packages/bootstrap/src/bootstrap/registerAllDefaults.ts
@@ -24,9 +24,18 @@ import { registerWorkerManagerDefaults } from "@workglow/util/worker";
  * Registers every default factory and input resolver/compactor from the
  * core Workglow packages onto the given registry.
  *
- * Idempotent — safe to call multiple times. `registerIfAbsent` ensures
- * earlier explicit registrations (e.g. a custom storage backend) are not
- * overwritten.
+ * Idempotent — safe to call multiple times.
+ *
+ * The two halves behave differently, and only one of them is safe to pre-empt:
+ *
+ * - **Factory tokens** go through `registry.registerIfAbsent`, so an earlier
+ *   explicit registration (a custom storage backend, say) is not overwritten.
+ * - **Input resolvers and compactors** do not. `registerInputResolver` /
+ *   `registerInputCompactor` are an unconditional `Map.set` — last writer
+ *   wins — and nine of the fourteen calls below register one of each. A custom
+ *   resolver installed BEFORE this function is silently replaced by the
+ *   built-in one, so install custom resolvers AFTER `bootstrapWorkglow()` /
+ *   `registerAllDefaults()`.
  *
  * The registry is required, never defaulted: this mutates whichever container
  * it is handed, so the target is always stated at the call site. Pass

--- a/packages/test/src/test/util/RegisterAllDefaults.test.ts
+++ b/packages/test/src/test/util/RegisterAllDefaults.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pins the set `registerAllDefaults()` produces, against an ISOLATED registry.
+ *
+ * The global registry cannot express this assertion. Every `register*Defaults`
+ * module ALSO self-registers on the global registry at module scope
+ * (`registerLoggerDefaults();` at the bottom of `LoggerRegistry.ts`, and
+ * thirteen siblings), and `registerAllDefaults.ts` imports all of them — so
+ * deleting a call from the function body leaves the global path fully
+ * populated by import side effect and the whole suite green. The bug only
+ * surfaces on `createOrchestrationContext()`, whose registry gets nothing it
+ * was not explicitly handed: a `format: "storage:tabular"` input then resolves
+ * to the raw id string instead of the repository. No error, wrong value.
+ *
+ * So the fixtures below are deliberately EXACT and fail in both directions —
+ * a dropped registration and an undeclared new one are both worth a failing
+ * test. Update the fixture in the same commit that changes the set.
+ */
+
+import { registerAllDefaults } from "@workglow/bootstrap";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { AI_PROVIDER_REGISTRY, MODEL_REPOSITORY } from "@workglow/ai";
+import { KNOWLEDGE_BASE_REPOSITORY, KNOWLEDGE_BASES } from "@workglow/knowledge-base";
+import { MCP_SERVER_REPOSITORY, MCP_SERVERS } from "@workglow/mcp/util";
+import { TABULAR_REPOSITORIES } from "@workglow/storage";
+import { TASK_CONSTRUCTORS, TRANSFORM_DEFS } from "@workglow/task-graph";
+import type { ServiceToken } from "@workglow/util";
+import {
+  Container,
+  CREDENTIAL_STORE,
+  getInputCompactors,
+  getInputResolvers,
+  INPUT_COMPACTORS,
+  INPUT_RESOLVERS,
+  LOGGER,
+  ServiceRegistry,
+  TELEMETRY_PROVIDER,
+  WORKER_MANAGER,
+} from "@workglow/util";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+const SOURCE_PATH = join(REPO_ROOT, "packages/bootstrap/src/bootstrap/registerAllDefaults.ts");
+
+/**
+ * Every factory token `registerAllDefaults` installs, named so a failure says
+ * which registrar went missing rather than only that a count moved.
+ */
+const EXPECTED_TOKENS: ReadonlyArray<readonly [string, ServiceToken<unknown>]> = [
+  ["INPUT_RESOLVERS", INPUT_RESOLVERS as ServiceToken<unknown>],
+  ["INPUT_COMPACTORS", INPUT_COMPACTORS as ServiceToken<unknown>],
+  ["LOGGER", LOGGER as ServiceToken<unknown>],
+  ["TELEMETRY_PROVIDER", TELEMETRY_PROVIDER as ServiceToken<unknown>],
+  ["WORKER_MANAGER", WORKER_MANAGER as ServiceToken<unknown>],
+  ["CREDENTIAL_STORE", CREDENTIAL_STORE as ServiceToken<unknown>],
+  ["MODEL_REPOSITORY", MODEL_REPOSITORY as ServiceToken<unknown>],
+  ["AI_PROVIDER_REGISTRY", AI_PROVIDER_REGISTRY as ServiceToken<unknown>],
+  ["KNOWLEDGE_BASES", KNOWLEDGE_BASES as ServiceToken<unknown>],
+  ["KNOWLEDGE_BASE_REPOSITORY", KNOWLEDGE_BASE_REPOSITORY as ServiceToken<unknown>],
+  ["MCP_SERVERS", MCP_SERVERS as ServiceToken<unknown>],
+  ["MCP_SERVER_REPOSITORY", MCP_SERVER_REPOSITORY as ServiceToken<unknown>],
+  ["TABULAR_REPOSITORIES", TABULAR_REPOSITORIES as ServiceToken<unknown>],
+  ["TASK_CONSTRUCTORS", TASK_CONSTRUCTORS as ServiceToken<unknown>],
+  ["TRANSFORM_DEFS", TRANSFORM_DEFS as ServiceToken<unknown>],
+];
+
+/**
+ * Format prefixes `Task` matches an input's `format` annotation against. A
+ * missing entry is the silent failure: the raw id string reaches the task.
+ */
+const EXPECTED_RESOLVER_PREFIXES = [
+  "credential",
+  "image",
+  "knowledge-base",
+  "mcp-server",
+  "model",
+  "storage:tabular",
+  "tasks",
+] as const;
+
+/**
+ * One fewer than the resolvers: `image` resolves a data URI it cannot
+ * round-trip back to an id, so it registers no compactor.
+ */
+const EXPECTED_COMPACTOR_PREFIXES = [
+  "credential",
+  "knowledge-base",
+  "mcp-server",
+  "model",
+  "storage:tabular",
+  "tasks",
+] as const;
+
+const bareRegistry = (): ServiceRegistry => new ServiceRegistry(new Container());
+
+const presentTokens = (registry: ServiceRegistry): string[] =>
+  EXPECTED_TOKENS.filter(([, token]) => registry.has(token)).map(([name]) => name);
+
+describe("registerAllDefaults", () => {
+  // FIRST: without this, every assertion below could pass on a registry that
+  // was already populated, and the suite would prove nothing.
+  it("a bare registry has none of the defaults before the call", () => {
+    const registry = bareRegistry();
+    expect(presentTokens(registry)).toEqual([]);
+  });
+
+  it("registers exactly these factory tokens on an isolated registry", () => {
+    const registry = bareRegistry();
+    registerAllDefaults(registry);
+    expect(presentTokens(registry)).toEqual(EXPECTED_TOKENS.map(([name]) => name));
+  });
+
+  it("registers exactly these input-resolver prefixes", () => {
+    const registry = bareRegistry();
+    registerAllDefaults(registry);
+    expect([...getInputResolvers(registry).keys()].sort()).toEqual([...EXPECTED_RESOLVER_PREFIXES]);
+  });
+
+  it("registers exactly these input-compactor prefixes", () => {
+    const registry = bareRegistry();
+    registerAllDefaults(registry);
+    expect([...getInputCompactors(registry).keys()].sort()).toEqual([
+      ...EXPECTED_COMPACTOR_PREFIXES,
+    ]);
+  });
+
+  it("is idempotent — a second call changes nothing", () => {
+    const registry = bareRegistry();
+    registerAllDefaults(registry);
+    const resolvers = getInputResolvers(registry);
+    const firstModelResolver = resolvers.get("model");
+
+    registerAllDefaults(registry);
+
+    expect(presentTokens(registry)).toEqual(EXPECTED_TOKENS.map(([name]) => name));
+    expect([...getInputResolvers(registry).keys()].sort()).toEqual([...EXPECTED_RESOLVER_PREFIXES]);
+    expect(getInputResolvers(registry).get("model")).toBe(firstModelResolver);
+  });
+
+  /**
+   * Ordering is invisible at runtime and cannot be asserted by calling the
+   * function. `getInputResolvers` SELF-HEALS: handed a registry with no
+   * `INPUT_RESOLVERS` map it calls `registerInputResolverDefaults` and carries
+   * on, so moving `registerInputResolverDefaults` after its nine consumers
+   * produces an identical registry and a green suite — until a resolver map is
+   * pre-registered by a caller and the healed one silently replaces it. The
+   * source text is the only place the ordering is stated, so it is the only
+   * place it can be checked.
+   */
+  it("registers the primitive containers before their consumers", () => {
+    const source = readFileSync(SOURCE_PATH, "utf8");
+    const body = source.slice(source.indexOf("export function registerAllDefaults"));
+    const callOrder = [...body.matchAll(/^ {2}(register\w+)\(registry\);$/gm)].map(
+      (match) => match[1]!
+    );
+
+    // Anti-vacuity: the regex must actually have found the call list.
+    expect(callOrder.length).toBe(14);
+
+    const primitives = [
+      "registerInputResolverDefaults",
+      "registerInputCompactorDefaults",
+      "registerLoggerDefaults",
+      "registerTelemetryDefaults",
+      "registerWorkerManagerDefaults",
+    ];
+    // The primitives are the FIRST five calls, in that order.
+    expect(callOrder.slice(0, primitives.length)).toEqual(primitives);
+
+    // And every consumer that stores into a primitive's map comes after them.
+    const consumers = [
+      "registerImageDefaults",
+      "registerCredentialDefaults",
+      "registerModelDefaults",
+      "registerKnowledgeBaseDefaults",
+      "registerMcpServerDefaults",
+      "registerTabularStorageDefaults",
+      "registerTaskDefaults",
+    ];
+    const lastPrimitive = Math.max(...primitives.map((name) => callOrder.indexOf(name)));
+    for (const consumer of consumers) {
+      expect(callOrder.indexOf(consumer), consumer).toBeGreaterThan(lastPrimitive);
+    }
+  });
+});

--- a/packages/test/src/test/util/RegisterAllDefaults.test.ts
+++ b/packages/test/src/test/util/RegisterAllDefaults.test.ts
@@ -32,15 +32,18 @@ import { KNOWLEDGE_BASE_REPOSITORY, KNOWLEDGE_BASES } from "@workglow/knowledge-
 import { MCP_SERVER_REPOSITORY, MCP_SERVERS } from "@workglow/mcp/util";
 import { TABULAR_REPOSITORIES } from "@workglow/storage";
 import { TASK_CONSTRUCTORS, TRANSFORM_DEFS } from "@workglow/task-graph";
-import type { ServiceToken } from "@workglow/util";
+import type { InputCompactorFn, InputResolverFn, ServiceToken } from "@workglow/util";
 import {
   Container,
   CREDENTIAL_STORE,
   getInputCompactors,
   getInputResolvers,
+  InMemoryCredentialStore,
   INPUT_COMPACTORS,
   INPUT_RESOLVERS,
   LOGGER,
+  registerInputCompactor,
+  registerInputResolver,
   ServiceRegistry,
   TELEMETRY_PROVIDER,
   WORKER_MANAGER,
@@ -143,6 +146,65 @@ describe("registerAllDefaults", () => {
     expect(presentTokens(registry)).toEqual(EXPECTED_TOKENS.map(([name]) => name));
     expect([...getInputResolvers(registry).keys()].sort()).toEqual([...EXPECTED_RESOLVER_PREFIXES]);
     expect(getInputResolvers(registry).get("model")).toBe(firstModelResolver);
+  });
+
+  /**
+   * The executable half of the README's "two halves, two behaviors" section.
+   *
+   * The claim that used to stand — "defaults register with `registerIfAbsent`,
+   * so an earlier explicit registration is never overwritten" — held for the
+   * factory tokens and not for the resolver/compactor maps, whose registrars
+   * are an unconditional `Map.set`. That half-truth was worse than a plain
+   * error, because the example the README picked (a custom storage backend) is
+   * exactly the case that DOES survive.
+   */
+  describe("what an earlier registration survives", () => {
+    it("keeps a pre-registered factory token — registerIfAbsent", () => {
+      const registry = bareRegistry();
+      const custom = new InMemoryCredentialStore();
+      registry.registerInstance(CREDENTIAL_STORE, custom);
+
+      registerAllDefaults(registry);
+
+      expect(registry.get(CREDENTIAL_STORE)).toBe(custom);
+    });
+
+    it("OVERWRITES a pre-registered input resolver — last writer wins", () => {
+      const registry = bareRegistry();
+      const customResolver: InputResolverFn = () => "from-my-catalog";
+      registerInputResolver("model", customResolver, registry);
+
+      registerAllDefaults(registry);
+
+      // Silent: no warning, and nothing in the registry records the loss.
+      expect(getInputResolvers(registry).get("model")).not.toBe(customResolver);
+    });
+
+    it("keeps a resolver installed in the documented order — after the defaults", () => {
+      const registry = bareRegistry();
+      const customResolver: InputResolverFn = () => "from-my-catalog";
+
+      registerAllDefaults(registry);
+      registerInputResolver("model", customResolver, registry);
+
+      expect(getInputResolvers(registry).get("model")).toBe(customResolver);
+      // And it did not disturb its neighbours.
+      expect([...getInputResolvers(registry).keys()].sort()).toEqual([
+        ...EXPECTED_RESOLVER_PREFIXES,
+      ]);
+    });
+
+    it("overwrites a pre-registered input compactor too", () => {
+      const registry = bareRegistry();
+      const customCompactor: InputCompactorFn = () => "my-id";
+      registerInputCompactor("model", customCompactor, registry);
+
+      registerAllDefaults(registry);
+      expect(getInputCompactors(registry).get("model")).not.toBe(customCompactor);
+
+      registerInputCompactor("model", customCompactor, registry);
+      expect(getInputCompactors(registry).get("model")).toBe(customCompactor);
+    });
   });
 
   /**

--- a/packages/test/src/test/util/WorkspaceVersions.test.ts
+++ b/packages/test/src/test/util/WorkspaceVersions.test.ts
@@ -90,4 +90,54 @@ describe("workspace versions", () => {
     }));
     expect(byVersion.length, JSON.stringify(byVersion, null, 2)).toBe(1);
   });
+
+  /**
+   * The manifests agreeing with each other is not enough: `bun.lock` records a
+   * `version` per workspace of its own, and a version bump committed without a
+   * regenerated lockfile leaves the two out of step. That is what happened to
+   * `packages/bootstrap` — manifest at 0.3.39, lockfile still at 0.3.38, 41 of
+   * 42 lock entries correct — and it is invisible to the check above, which
+   * reads manifests only.
+   *
+   * The consequence is not cosmetic: `bun install --frozen-lockfile` (any
+   * consumer CI, any reproducible install) fails outright, while a plain
+   * `bun i` succeeds and rewrites `bun.lock`, so every developer gets an
+   * unexplained dirty lockfile on first install and repo CI never reports it.
+   */
+  const lockWorkspaceVersions = (root: string): ManifestVersion[] => {
+    // bun.lock is JSONC: comment-free in practice, but trailing commas
+    // everywhere. Strip those before parsing rather than pulling in a parser.
+    const text = readFileSync(join(root, "bun.lock"), "utf8");
+    const lock = JSON.parse(text.replace(/,(\s*[}\]])/g, "$1")) as {
+      workspaces?: Record<string, { version?: unknown }>;
+    };
+    return Object.entries(lock.workspaces ?? {})
+      .filter(([relative]) => relative !== "")
+      .filter(
+        (entry): entry is [string, { version: string }] => typeof entry[1].version === "string"
+      )
+      .map(([relative, entry]) => ({
+        manifest: `${relative}/package.json`,
+        version: entry.version,
+      }));
+  };
+
+  it("records the same version for every workspace in bun.lock", () => {
+    const locked = lockWorkspaceVersions(root);
+
+    // Anti-vacuity: a degraded parse (or a `workspaces` key that moved) must
+    // fail loudly rather than compare an empty set and pass.
+    expect(locked.length).toBeGreaterThan(40);
+
+    const byManifest = new Map(versions.map((v) => [v.manifest, v.version]));
+    const mismatched = locked
+      .filter(({ manifest, version }) => byManifest.get(manifest) !== version)
+      .map(
+        ({ manifest, version }) =>
+          `${manifest}: bun.lock ${version} vs manifest ${byManifest.get(manifest) ?? "(absent)"}`
+      );
+    // Named, so a failure says which entry is stale — the fix is `bun install`,
+    // never a hand-edit of the lockfile.
+    expect(mismatched, mismatched.join("\n")).toEqual([]);
+  });
 });


### PR DESCRIPTION
Three MEDIUM defects from review of the `@workglow/bootstrap` extraction PR. Commit order `B1 → B2 → B3`, lockfile last.

Targets `claude/libs-issues-triage-prs-mh6x2o-574`, not `main`.

---

## 1. Nothing pinned the registered set, and self-registration masks a dropped line

The extraction preserved all 14 calls, but no test asserted the resulting set — and on this code base **the obvious test cannot fail**. Every `register*Defaults` module *also* self-registers on the **global** registry at module scope (`registerLoggerDefaults();` at the bottom of `LoggerRegistry.ts`, and thirteen siblings), and `registerAllDefaults.ts` imports all of them. Delete `registerTabularStorageDefaults(registry);` from the body and `bootstrapWorkglow()` still yields a fully populated global registry by import side effect; the whole suite passes.

The damage lands on `createOrchestrationContext()`, whose registry gets nothing it was not explicitly handed: a task run with `{ registry: ctx.registry }` and a `format: "storage:tabular"` input then receives the raw id string instead of the repository. No error, wrong value.

So the fixtures are asserted against a bare `new ServiceRegistry(new Container())` — the only place the assertion means anything — and the **anti-vacuity case comes first**: a bare registry has none of the 15 tokens before the call, so nothing below can pass on an already-populated one. Exact fixtures for the tokens, the 7 resolver prefixes and the 6 compactor prefixes, failing in both directions. (The sets were enumerated from the source rather than taken from the review: `image` registers a resolver but no compactor, which is why the two lists differ by one.)

**Ordering gets a source-text guard**, because the runtime cannot see it: `getInputResolvers` **self-heals** — handed a registry with no `INPUT_RESOLVERS` map it registers one and carries on — so moving a primitive container after its nine consumers produces an identical registry and a green suite, until a pre-registered map is silently replaced by the healed one.

Both directions verified by hand:

| mutation | this file | the three existing bootstrap tests |
| --- | --- | --- |
| delete `registerTabularStorageDefaults(registry);` | **5 of 6 fail** | all pass |
| move `registerInputResolverDefaults` to the end | **only the ordering case fails** | all pass |

---

## 2. The README promised earlier registrations survive; for the resolver half they do not

Both the README and the `registerAllDefaults` JSDoc said defaults register with `registerIfAbsent`, so an earlier explicit registration "is never overwritten". That holds for the `registry.registerIfAbsent(TOKEN, ...)` half and **not** for the other: `registerInputResolver` / `registerInputCompactor` are an unconditional `resolvers.set(formatPrefix, fn)` — last writer wins — and nine of the fourteen calls register one of each.

The half-truth is worse than a plain error would have been, **because the example the README picked to illustrate it — a custom storage backend, a factory token — is exactly the case that does survive.** A consumer following it registers `registerInputResolver("model", myCatalogResolver)` during plugin init, calls `bootstrapWorkglow()` at startup, and every `format: "model"` input silently resolves from the built-in `MODEL_REPOSITORY` instead of their catalog. No warning, nothing in the registry to inspect.

Both documents now state the split and the rule it implies — **custom resolvers go in AFTER `bootstrapWorkglow()`** — and the README shows the wrong order and the right one side by side.

The **executable half**, four cases: a pre-registered factory token survives; a pre-registered resolver is overwritten; a pre-registered compactor is overwritten; the documented order keeps the custom resolver without disturbing its neighbours.

---

## 3. `packages/bootstrap` was the only workspace whose lockfile version was not updated

`bun.lock` recorded `0.3.38` for that workspace while the other 41 read `0.3.39`, and `packages/bootstrap/CHANGELOG.md` was still headed `## 0.3.38`. `bun install --frozen-lockfile` — any consumer CI, any reproducible install — fails outright on that; a plain `bun i` succeeds and rewrites `bun.lock`, so every developer gets an unexplained dirty lockfile on first install and repo CI (bare `bun i`) never reports it.

`bun install` touched **exactly the one line**, which is the whole lockfile diff here — no hand-editing, and no extra churn to report. `bun install --frozen-lockfile` now exits 0.

`WorkspaceVersions.test.ts` gains the cross-check that would have caught it: it read manifests only, so the straggler it was added for slipped past. It now parses `bun.lock` (JSONC — trailing commas stripped) and compares the version recorded per workspace against that workspace's manifest, naming any entry that disagrees. It asserts more than 40 entries **first**, so a degraded parse or a moved `workspaces` key fails loudly instead of comparing an empty set and passing vacuously. Verified red against the stale lockfile — it printed `packages/bootstrap/package.json: bun.lock 0.3.38 vs manifest 0.3.39`.

---

## Verification

- `bun scripts/test.ts util vitest` — 57 files, **778 passed / 10 skipped**.
- `bun install --frozen-lockfile` — exits 0 (`Checked 1022 installs across 1098 packages (no changes)`).
- `npx tsc -b packages/test` — clean.
- Each guard confirmed red against the defect it closes, and green after.

The LOW finding about the stale `vitest.setup.ts` comment was outside this task's scope and is untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKvKnyVeQQQCm6FhtaLyMa)_