### PR TITLE
fix(util): correct TurboQuant's 1-bit cosine estimator and document the shrinkage

### DIFF
--- a/packages/test/src/test/util/TurboQuantize.test.ts
+++ b/packages/test/src/test/util/TurboQuantize.test.ts
@@ -617,14 +617,26 @@ describe("TurboQuantize", () => {
       // under test.
       //
       // Measured RMSE, shipped grid vs a fixed 3-sigma one:
-      //   shipped 0.0273 0.0130 0.0070 0.0049 0.0032 0.0013 0.0010 0.0005
-      //   3-sigma 0.0273 0.0210 0.0107 0.0058 0.0024 0.0015 0.0008 0.0012
+      //   shipped 0.0356 0.0130 0.0070 0.0049 0.0032 0.0013 0.0010 0.0005
+      //   3-sigma 0.0356 0.0210 0.0107 0.0058 0.0024 0.0015 0.0008 0.0012
       // The ceilings pass the first row with >=21% headroom and reject the second at 2, 3
       // and 8 bits. The two rows agree exactly at 1 bit because a 2-level grid is +/-a:
       // the codes carry only sign, and the cosine is invariant to the scale of `a`.
+      //
+      // THE 1-BIT CEILING IS A TRADE, not headroom. It was 0.033 against a measured
+      // 0.0273 while the 1-bit estimator returned the raw sign-agreement statistic
+      // `1 - 2*theta/pi`. Inverting that to recover the cosine removed a bias of up to
+      // 0.21 on correlated pairs (see the signed-bias case below) and cost variance:
+      // d/dr of cos(pi*(1 - r)/2) peaks at ~1.57 near theta = pi/2, which is exactly
+      // where i.i.d. uniform pairs at d=1024 land, so THIS test's regime pays the
+      // amplification in full and gets none of the bias correction. Measured RMSE went
+      // 0.0273 -> 0.0356; the ceiling follows to 0.050. Unbiased-but-noisier is the right
+      // side of that trade — the noise is symmetric and averages out over a candidate
+      // set, and it is worst precisely where the answer is "unrelated" either way, while
+      // the bias moved every absolute threshold in one direction.
       const d = 1024;
       const pairs = 24;
-      const ceilings = [0.033, 0.016, 0.0085, 0.006, 0.004, 0.0017, 0.0013, 0.0007];
+      const ceilings = [0.05, 0.016, 0.0085, 0.006, 0.004, 0.0017, 0.0013, 0.0007];
 
       for (let bits = 1; bits <= 8; bits++) {
         const rnd = makeRandom(2048 + bits);
@@ -707,6 +719,56 @@ describe("TurboQuantize", () => {
      * and `quantizedCosine` inverts it — which is why the 1-bit row sits at
      * zero while the 2-bit row, four times finer, is the worst in the table.
      */
+    /**
+     * The angle correction lives in `quantizedCosine`, so it reaches
+     * `turboQuantizedCosineSimilarity` and `turboQuantizedInnerProduct` and NOTHING ELSE.
+     * Decoding with `turboDequantize` and running plain `cosineSimilarity` over the
+     * results is a different number at 1 bit — lower, by the sign-statistic shrinkage the
+     * correction exists to undo.
+     *
+     * That asymmetry is worth pinning rather than leaving to be discovered: the two
+     * routes look interchangeable at every other bit width, and a caller who decodes once
+     * and compares many times (the natural optimisation) would silently drop back to the
+     * biased estimator at exactly the bit width where the bias is largest.
+     */
+    test("turboDequantize + plain cosineSimilarity is NOT angle-corrected at 1 bit", () => {
+      const d = 1024;
+      const rnd = makeRandom(31337);
+      const a = new Float32Array(d);
+      const noise = new Float32Array(d);
+      for (let i = 0; i < d; i++) {
+        a[i] = rnd() - 0.5;
+        noise[i] = rnd() - 0.5;
+      }
+      const t = 0.8;
+      const k = Math.sqrt(1 - t * t);
+      const b = new Float32Array(d);
+      for (let i = 0; i < d; i++) b[i] = t * a[i]! + k * noise[i]!;
+
+      const exact = cosineSimilarity(a, b);
+      const qa = turboQuantize(a, { bits: 1, seed: 42 });
+      const qb = turboQuantize(b, { bits: 1, seed: 42 });
+
+      const corrected = turboQuantizedCosineSimilarity(qa, qb);
+      const viaDecode = cosineSimilarity(turboDequantize(qa), turboDequantize(qb));
+
+      // The corrected estimator tracks the exact cosine.
+      expect(Math.abs(corrected - exact)).toBeLessThan(0.05);
+      // The decode route does not — it is the raw sign statistic, biased low.
+      expect(viaDecode).toBeLessThan(exact - 0.1);
+      expect(corrected).toBeGreaterThan(viaDecode + 0.1);
+
+      // At 4 bits there is no correction, so the two routes agree closely.
+      const wa = turboQuantize(a, { bits: 4, seed: 42 });
+      const wb = turboQuantize(b, { bits: 4, seed: 42 });
+      expect(
+        Math.abs(
+          turboQuantizedCosineSimilarity(wa, wb) -
+            cosineSimilarity(turboDequantize(wa), turboDequantize(wb))
+        )
+      ).toBeLessThan(0.01);
+    });
+
     test("should have a per-bit-width, per-correlation signed bias within measured bands", () => {
       const d = 1024;
       const pairs = 32;

--- a/packages/test/src/test/util/TurboQuantize.test.ts
+++ b/packages/test/src/test/util/TurboQuantize.test.ts
@@ -670,6 +670,96 @@ describe("TurboQuantize", () => {
         }
       }
     });
+
+    /**
+     * MEAN SIGNED error on CORRELATED pairs, per (bit width, correlation) cell.
+     *
+     * Both halves of that sentence are the point.
+     *
+     * Signed, not RMSE, because RMSE is what every other accuracy case here
+     * already measures — and RMSE is exactly what hides a one-directional
+     * shrinkage. An estimator that reads every similar pair 0.08 low and an
+     * estimator with 0.08 of symmetric noise score the same RMSE; only one of
+     * them silently moves a threshold.
+     *
+     * Correlated, because the existing cases draw both vectors i.i.d. uniform
+     * at d=1024, where the true cosine concentrates at 0 ± ~0.03 — the one
+     * regime where this bias vanishes. `b = t*a + sqrt(1-t^2)*noise` puts the
+     * pair at a chosen similarity instead.
+     *
+     * The reference is `cosineSimilarity(a, b)` on the UNQUANTIZED inputs,
+     * never `t`: `t` is what the construction aims at, and the realized cosine
+     * of a finite sample differs from it by ~1/sqrt(d). Scoring against `t`
+     * would fold that sampling error into the measured bias.
+     *
+     * Bands are the MEASURED value ±30%, floored at ±0.005 so a cell whose bias
+     * is genuinely at the noise level is not pinned to a number that is itself
+     * noise. They are two-sided: an estimator that stopped under-reporting
+     * would fail these, which is the intent — this is a record of behavior, not
+     * a ceiling. Re-measure and re-record when the estimator changes.
+     *
+     * What the table shows: shrinkage grows as the bit width falls, and it is
+     * an ordinary quantization effect at 2-8 bits (clipping and rounding shrink
+     * the reconstructed dot product relative to each side's codeNorm). At 1 bit
+     * it is not: a 2-level grid is exactly ±scale, so the estimator degenerates
+     * to the sign-agreement statistic 1 - 2*theta/pi, which is a different
+     * function of the angle rather than a noisy cosine. That one is invertible,
+     * and `quantizedCosine` inverts it — which is why the 1-bit row sits at
+     * zero while the 2-bit row, four times finer, is the worst in the table.
+     */
+    test("should have a per-bit-width, per-correlation signed bias within measured bands", () => {
+      const d = 1024;
+      const pairs = 32;
+      const correlations = [0.5, 0.8, 0.95] as const;
+
+      /** Measured mean signed error, indexed [bits - 1][correlation]. */
+      const measured: readonly (readonly number[])[] = [
+        [0.0015, 0.0014, -0.0001],
+        [-0.0561, -0.0799, -0.075],
+        [-0.0171, -0.0271, -0.028],
+        [-0.0055, -0.0075, -0.0094],
+        [-0.0019, -0.003, -0.003],
+        [-0.0001, -0.001, -0.0009],
+        [-0.0001, -0.0003, -0.0003],
+        [0.0, -0.0001, -0.0001],
+      ];
+
+      for (let bits = 1; bits <= 8; bits++) {
+        for (let c = 0; c < correlations.length; c++) {
+          const t = correlations[c]!;
+          const rnd = makeRandom(9000 + bits * 31 + Math.round(t * 100));
+          const k = Math.sqrt(1 - t * t);
+          let signedError = 0;
+
+          for (let p = 0; p < pairs; p++) {
+            const a = new Float32Array(d);
+            const noise = new Float32Array(d);
+            for (let i = 0; i < d; i++) {
+              a[i] = rnd() - 0.5;
+              noise[i] = rnd() - 0.5;
+            }
+            const b = new Float32Array(d);
+            for (let i = 0; i < d; i++) b[i] = t * a[i]! + k * noise[i]!;
+
+            signedError +=
+              turboQuantizedCosineSimilarity(
+                turboQuantize(a, { bits, seed: 42 }),
+                turboQuantize(b, { bits, seed: 42 })
+              ) - cosineSimilarity(a, b);
+          }
+
+          const mean = signedError / pairs;
+          const expected = measured[bits - 1]![c]!;
+          const tolerance = Math.max(Math.abs(expected) * 0.3, 0.005);
+          expect(mean, `bits=${bits} t=${t} mean=${mean.toFixed(5)}`).toBeGreaterThan(
+            expected - tolerance
+          );
+          expect(mean, `bits=${bits} t=${t} mean=${mean.toFixed(5)}`).toBeLessThan(
+            expected + tolerance
+          );
+        }
+      }
+    });
   });
 
   describe("sign table cache", () => {

--- a/packages/util/src/vector/TurboQuantize.ts
+++ b/packages/util/src/vector/TurboQuantize.ts
@@ -7,8 +7,11 @@
 /**
  * Vector quantization by randomized rotation plus uniform scalar quantization.
  *
+ * THE NAME REFERS TO THE BORROWED ROTATION STRATEGY, not to the paper's quantizer or its
+ * distortion bound — what ships here is a classical construction that predates the paper.
+ *
  * Inspired by "TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate"
- * by Zandieh, Daliri, Hadian, and Mirrokni (2025).
+ * by Zandieh, Daliri, Hadian, and Mirrokni (2025), arXiv:2504.19874.
  *
  * Why rotate: a random orthogonal rotation spreads a vector's energy evenly over its
  * coordinates, so no coordinate dominates and every coordinate ends up with the same
@@ -18,16 +21,48 @@
  * What this module implements: the randomized Hadamard rotation, plus a UNIFORM scalar
  * quantizer whose clipping range is the MSE-optimal loading factor for a unit-variance
  * Gaussian at the given bit width. Reconstruction is renormalized back to the recorded
- * L2 norm, which keeps reconstructed magnitude and the similarity estimates unbiased.
+ * L2 norm, which keeps reconstructed MAGNITUDE unbiased.
  *
  * What it does NOT implement: the paper's non-uniform, distribution-fitted (Beta) level
- * placement. Distortion here is that of an optimal *uniform* quantizer, which is coarser
- * than the paper's near-optimal one.
+ * placement — the contribution that buys the near-optimal distortion rate. Distortion here
+ * is that of an optimal *uniform* quantizer, which is coarser.
+ *
+ * ## Similarity is biased LOW at low bit widths
+ *
+ * Magnitude is unbiased; similarity is not. Clipping and rounding shrink the reconstructed
+ * dot product relative to each side's `codeNorm`, so
+ * {@link turboQuantizedCosineSimilarity} — and {@link turboQuantizedInnerProduct}, which
+ * is that times the two norms — systematically UNDER-report similar pairs. Mean signed
+ * error against the exact cosine, 32 correlated pairs per cell, d=1024, seeded:
+ *
+ * | bits | true 0.50 | true 0.80 | true 0.95 |
+ * | ---- | --------- | --------- | --------- |
+ * | 1    |  +0.002   |  +0.001   |  -0.000   |
+ * | 2    |  -0.056   |  -0.080   |  -0.075   |
+ * | 3    |  -0.017   |  -0.027   |  -0.028   |
+ * | 4    |  -0.005   |  -0.007   |  -0.009   |
+ * | 5    |  -0.002   |  -0.003   |  -0.003   |
+ * | 6    |  -0.000   |  -0.001   |  -0.001   |
+ * | 7    |  -0.000   |  -0.000   |  -0.000   |
+ * | 8    |  -0.000   |  -0.000   |  -0.000   |
+ *
+ * The 1-bit row is zero because that case alone HAS a closed form and is corrected: a
+ * 2-level grid is exactly ±scale, so the estimator degenerates to the sign-agreement
+ * statistic `1 - 2*theta/pi`, which `quantizedCosine` inverts. At 2-8 bits there is no
+ * closed form, and a fitted gain would be tuned at one dimensionality and wrong at the
+ * next — so the bias is documented rather than papered over. That is why 2 bits, four
+ * times finer than 1, is the worst row in the table.
+ *
+ * RANKING SURVIVES this — the shrinkage is monotone in the true cosine, so ordering a
+ * candidate set is unaffected. ABSOLUTE THRESHOLDS AND CALIBRATION DO NOT. At 2 bits a
+ * `cos > 0.8` cut (an ordinary RAG threshold) drops pairs whose real cosine is 0.87. Use
+ * 4 bits or more when a stored threshold has to mean what it says, or re-tune the
+ * threshold against the table above.
  *
  * Properties:
  * - Data-oblivious: no training or codebook construction needed
  * - Per-vector: each vector quantized independently (streaming-friendly)
- * - Preserves inner products and cosine similarity for similarity search
+ * - Preserves the RANKING induced by inner products and cosine similarity
  */
 
 import { TensorType } from "./Tensor";
@@ -896,6 +931,29 @@ function assertComparablePair(a: TurboQuantizeResult, b: TurboQuantizeResult): v
  * makes the result an actual cosine: Cauchy-Schwarz then bounds it to [-1, 1] by
  * construction and a record compared with itself scores exactly 1. The clamp only absorbs
  * floating-point rounding at the endpoints.
+ *
+ * At 1 BIT that ratio is not an estimate of the cosine at all, and the last line corrects
+ * for it. A 2-level grid is exactly ±scale, so both reconstructions are constant-magnitude
+ * sign vectors: the normalized dot product reduces to the fraction of coordinates whose
+ * signs agree, mapped to [-1, 1]. For a random rotation that statistic converges to
+ * `1 - 2*theta/pi` (Goemans-Williamson), a DIFFERENT function of the angle rather than a
+ * noisy cosine — it reads a true 0.80 as 0.59 and a true 0.95 as 0.79. It is also exactly
+ * invertible, and the inversion costs one `Math.cos` per comparison, changes no stored
+ * bytes, and needs no version bump: `theta = pi*(1 - ratio)/2`, so `cos(theta)` recovers
+ * the cosine.
+ *
+ * The inversion is NOT extended to 2-8 bits, where the shrinkage is ordinary quantization
+ * error (clipping and rounding shrink the reconstructed dot product relative to each
+ * side's `codeNorm`) with no closed form to invert. A fitted per-bit gain would be a
+ * constant tuned at one dimensionality, and the shrinkage varies with d — so it would
+ * correct one corpus and skew the next. That residual bias is documented in the module
+ * header instead, with the measured per-bit table.
+ *
+ * The trade at 1 bit is real: the derivative of `cos(pi*(1 - r)/2)` peaks at ~pi/2 ≈ 1.57
+ * near theta = pi/2, so whatever noise the sign statistic carries is amplified by up to
+ * ~1.57x for near-orthogonal pairs. Measured on i.i.d. uniform inputs at d=1024, RMSE
+ * against the exact cosine rises from 0.027 to 0.036 — paid to remove a bias of up to
+ * 0.21, and paid in the regime where the answer is "these are unrelated" either way.
  */
 function quantizedCosine(a: TurboQuantizeResult, b: TurboQuantizeResult): number {
   const { values: valuesA, codeNorm: codeNormA } = reconstructRotatedCodes(a);
@@ -906,7 +964,11 @@ function quantizedCosine(a: TurboQuantizeResult, b: TurboQuantizeResult): number
   for (let i = 0; i < valuesA.length; i++) {
     dot += valuesA[i] * valuesB[i];
   }
-  return Math.max(-1, Math.min(1, dot / (codeNormA * codeNormB)));
+  const cosine = Math.max(-1, Math.min(1, dot / (codeNormA * codeNormB)));
+  // After the clamp, so the argument is a valid angle even when rounding pushed the
+  // ratio a hair past ±1.
+  if (a.bits === 1) return Math.cos((Math.PI * (1 - cosine)) / 2);
+  return cosine;
 }
 
 /**


### PR DESCRIPTION
One MEDIUM correctness defect plus the header claims it rests on, from review of the TurboQuant PR. Two commits: the measurement (red), then the fix.

Targets `claude/integrate-arxiv-paper-VF55c`, not `main`.

---

## The defect

The module header claimed renormalization "keeps reconstructed magnitude and the similarity estimates unbiased". Magnitude is unbiased; **similarity is not**. Clipping and rounding shrink the reconstructed dot product relative to each side's `codeNorm`, so `turboQuantizedCosineSimilarity` — and `turboQuantizedInnerProduct`, which is that times the two norms — systematically under-report similar pairs.

Every accuracy test drew both vectors i.i.d. uniform at d=1024, where the true cosine concentrates at 0 ± ~0.03 — **exactly the regime where the bias vanishes** — so the committed RMSE ceilings could not detect it.

## Commit 1 — the measurement, deliberately red

A correlated-pair case (`b = t*a + sqrt(1-t²)*noise`, t ∈ {0.5, 0.8, 0.95}, d=1024, 32 seeded pairs per cell) measuring **mean signed error** per (bits, t) cell.

Signed rather than RMSE on purpose: RMSE is what every other accuracy case here already measures, and it scores a uniform 0.08 under-report and 0.08 of symmetric noise identically — only the first silently moves a threshold. The reference is `cosineSimilarity(a, b)` on the **unquantized** inputs, never `t`; the realized cosine of a finite sample differs from `t` by ~1/√d, and scoring against `t` would fold that sampling error into the measured bias.

Cells were measured, not guessed. Bands are the measured value ±30%, floored at ±0.005, and **two-sided** — an estimator that stopped under-reporting would fail these too, because this is a record of behavior rather than a ceiling.

**Measured mean signed error (post-fix, which is what the test asserts):**

| bits | true 0.50 | true 0.80 | true 0.95 |
| ---- | --------- | --------- | --------- |
| 1 | +0.0015 | +0.0014 | −0.0001 |
| 2 | −0.0561 | −0.0799 | −0.0750 |
| 3 | −0.0171 | −0.0271 | −0.0280 |
| 4 | −0.0055 | −0.0075 | −0.0094 |
| 5 | −0.0019 | −0.0030 | −0.0030 |
| 6 | −0.0001 | −0.0010 | −0.0009 |
| 7 | −0.0001 | −0.0003 | −0.0003 |
| 8 | −0.0000 | −0.0001 | −0.0001 |

The pre-fix 1-bit row, which is what makes this commit red: **−0.1657 / −0.2078 / −0.1521**.

A caller storing 2-bit codes for the advertised 16× compression and keeping hits above `cos > 0.8` (an ordinary RAG cut) drops matches whose real cosine is 0.87.

## Commit 2 — the fix, 1 bit only

At 1 bit the grid is exactly ±scale, so both reconstructions are constant-magnitude sign vectors and the normalized dot product reduces to the fraction of coordinates whose signs agree. Under a random rotation that converges to `1 − 2θ/π` — a **different function of the angle**, not a noisy cosine. It is exactly invertible, so `quantizedCosine` inverts it after the clamp (so the argument is always a valid angle):

```ts
if (a.bits === 1) return Math.cos((Math.PI * (1 - cosine)) / 2);
```

One `Math.cos` per comparison, **no change to any stored byte**, no version bump — the golden encodings are untouched.

**Deliberately not extended to 2–8 bits.** The shrinkage there is ordinary quantization error with no closed form, and a fitted per-bit gain would be a constant tuned at one dimensionality while the shrinkage varies with d — it would correct one corpus and skew the next. The header documents it instead, with the table above, and states plainly that **ranking survives** the bias (it is monotone) while **absolute thresholds and calibration do not**. That is also why 2 bits, four times finer than 1, is now the worst row in the table.

### The honest trade

The inversion amplifies whatever noise the sign statistic carries by up to **~1.57×** near θ = π/2, and the existing "should track the exact cosine within a per-bit-width RMSE ceiling" case draws i.i.d. uniform pairs at d=1024 — which land exactly there. It pays the amplification in full and collects none of the bias correction. **Its 1-bit RMSE went 0.0273 → 0.0356, so the existing 0.033 ceiling fails**; it is re-measured and raised to 0.050, with the reasoning written into the test rather than the number quietly moved.

Unbiased-but-noisier is the right side of that trade: the noise is symmetric and averages out over a candidate set, and it is worst precisely where the answer is "unrelated" either way, while the bias moved every absolute threshold in one direction.

### Header corrections

- "unbiased" scoped to magnitude — the similarity claim was false;
- citation gains **arXiv:2504.19874**;
- a one-line note **at the top**, not fifteen lines down: the name refers to the borrowed rotation strategy, not the paper's quantizer or its distortion bound.

### The asymmetry, pinned

The correction lives in `quantizedCosine`, so it reaches the two estimator exports and nothing else. A new test pins that `turboDequantize` + plain `cosineSimilarity` is **not** angle-corrected at 1 bit (and that the two routes agree within 0.01 at 4 bits, where there is no correction). The two look interchangeable at every other bit width, and a caller who decodes once to compare many times — the natural optimisation — would otherwise silently fall back to the biased estimator at the bit width where the bias is largest.

---

## Verification

- `bun scripts/test.ts util vitest` — 54 files, **829 passed / 10 skipped**. `TurboQuantize.test.ts` alone: 72 passed.
- `npx tsc -b packages/util packages/test` — clean.
- Commit 1 confirmed red at the intended cell before commit 2 (`bits=1 t=0.5 mean=-0.16573`); green after.
- No other consumer of `turboQuantizedCosineSimilarity` / `turboQuantizedInnerProduct` exists in the repo, so the behavior change is contained to these two exports.

The four LOW findings (engine-dependent int8/int16 grid scale, the overstated 0.35% solver cross-check, the missing hoisted-query seam) were outside this task's scope and are untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKvKnyVeQQQCm6FhtaLyMa)_