### PR TITLE
fix(ai): report the tokens a fully-failed structured generation billed

### DIFF
--- a/packages/ai/src/task/StructuredGenerationTask.ts
+++ b/packages/ai/src/task/StructuredGenerationTask.ts
@@ -119,7 +119,14 @@ export interface StructuredOutputValidationAttempt {
 export class StructuredOutputValidationError extends TaskError {
   public static override readonly type: string = "StructuredOutputValidationError";
   public readonly attempts: ReadonlyArray<StructuredOutputValidationAttempt>;
-  constructor(attempts: ReadonlyArray<StructuredOutputValidationAttempt>) {
+  /**
+   * Tokens billed across every failed attempt, or `undefined` when no attempt
+   * reported any. Every attempt was a real request, so this outcome is the most
+   * expensive one the task has — a caller that only reads usage off a
+   * successful result would price a schema-flaky model as free.
+   */
+  public readonly usage: Usage | undefined;
+  constructor(attempts: ReadonlyArray<StructuredOutputValidationAttempt>, usage?: Usage) {
     const last = attempts[attempts.length - 1];
     const summary = last?.errors.map((e) => `${e.path || "/"}: ${e.message}`).join("; ") ?? "";
     super(
@@ -127,6 +134,7 @@ export class StructuredOutputValidationError extends TaskError {
         `Last errors: ${summary}`
     );
     this.attempts = attempts;
+    this.usage = usage;
   }
 }
 
@@ -178,7 +186,9 @@ export class StructuredGenerationTask extends StreamingAiTask<
    *
    * Throws:
    * - `TaskConfigurationError` if `input.outputSchema` isn't a compilable JSON Schema.
-   * - `StructuredOutputValidationError` if every attempt fails validation.
+   * - `StructuredOutputValidationError` if every attempt fails validation. The
+   *   tokens those attempts billed ride on the error's `usage` and are emitted
+   *   as a final `usage` snapshot before it is thrown.
    */
   override async *executeStream(
     input: StructuredGenerationTaskInput,
@@ -275,7 +285,22 @@ export class StructuredGenerationTask extends StreamingAiTask<
       }
     }
 
-    const err = new StructuredOutputValidationError(attempts);
+    // Every attempt failed, so no `finish` reaches the consumer — and a `finish`
+    // is the only thing that settles a call's tokens. Without this the run that
+    // burned the most requests is the one reporting no spend at all. A `usage`
+    // snapshot carries the total instead: it is the cumulative running figure
+    // for this task by definition (each attempt's own finish was swallowed by
+    // the loop above), so the consumer's replace-never-merge rule lands on
+    // exactly the sum, and it is emitted before the throw so the run's usage
+    // sinks see it while the stream is still open.
+    if (attemptsUsage) {
+      yield {
+        type: "usage",
+        usage: attemptsUsage,
+      } as StreamEvent<StructuredGenerationTaskOutput>;
+    }
+
+    const err = new StructuredOutputValidationError(attempts, attemptsUsage);
     err.taskType = this.type;
     err.taskId = this.id;
     throw err;

--- a/packages/ai/src/task/__tests__/StructuredGenerationTask.test.ts
+++ b/packages/ai/src/task/__tests__/StructuredGenerationTask.test.ts
@@ -510,6 +510,104 @@ describe("StructuredGenerationTask — usage aggregation", () => {
     }
   });
 
+  it("reports the tokens every failed attempt billed on the thrown error", async () => {
+    // The all-attempts-failed path is the most expensive outcome the task has:
+    // three billed requests and no result. Reporting nothing for it would make
+    // a schema-flaky model look cheaper than one that answers correctly.
+    const { unregister } = registerUsageProvider([
+      { payload: { name: "Alice", age: "thirty" }, usage: mkUsage({ input: 50, output: 8 }) },
+      { payload: { name: "Alice", age: "forty" }, usage: mkUsage({ input: 60, output: 9 }) },
+      { payload: { name: "Alice", age: "fifty" }, usage: mkUsage({ input: 70, output: 10 }) },
+    ]);
+    try {
+      const input = {
+        model: mkModel(),
+        prompt: "Give me a person",
+        outputSchema: PERSON_SCHEMA,
+        maxRetries: 2, // 3 total attempts, all failing
+      };
+      const task = new StructuredGenerationTask({ defaults: input } as any);
+      let caught: unknown;
+      try {
+        await drain(task.executeStream(input as any, mkContext()));
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(StructuredOutputValidationError);
+      const err = caught as StructuredOutputValidationError;
+      expect(err.attempts).toHaveLength(3);
+      expect(err.usage).toEqual(mkUsage({ input: 180, output: 27 }));
+    } finally {
+      unregister();
+    }
+  });
+
+  it("emits the failed run's total as a usage snapshot before throwing", async () => {
+    // No `finish` reaches the consumer on this path, so the snapshot is the
+    // only thing that puts the spend in front of the run's usage sinks.
+    const { unregister } = registerUsageProvider([
+      { payload: { name: "Alice", age: "thirty" }, usage: mkUsage({ input: 50, output: 8 }) },
+      { payload: { name: "Alice", age: "forty" }, usage: mkUsage({ input: 60, output: 9 }) },
+    ]);
+    try {
+      const input = {
+        model: mkModel(),
+        prompt: "Give me a person",
+        outputSchema: PERSON_SCHEMA,
+        maxRetries: 1, // 2 total attempts, both failing
+      };
+      const task = new StructuredGenerationTask({ defaults: input } as any);
+      const seen: Array<{ type: string; usage?: Usage }> = [];
+      await expect(
+        (async () => {
+          for await (const event of task.executeStream(input as any, mkContext())) {
+            seen.push(event as { type: string; usage?: Usage });
+          }
+        })()
+      ).rejects.toBeInstanceOf(StructuredOutputValidationError);
+
+      expect(seen.some((e) => e.type === "finish")).toBe(false);
+      const snapshots = seen.filter((e) => e.type === "usage");
+      expect(snapshots).toHaveLength(1);
+      // Cumulative, not per-attempt: the consumer replaces on each snapshot.
+      expect(snapshots[0].usage).toEqual(mkUsage({ input: 110, output: 17 }));
+      expect(seen[seen.length - 1]).toBe(snapshots[0]);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("emits no usage snapshot when a failed run reported no tokens", async () => {
+    // `undefined` means "not reported" — a zeroed snapshot would state that the
+    // failed attempts were free.
+    const { unregister } = registerUsageProvider([
+      { payload: { name: "Alice", age: "thirty" }, usage: undefined },
+    ]);
+    try {
+      const input = {
+        model: mkModel(),
+        prompt: "Give me a person",
+        outputSchema: PERSON_SCHEMA,
+        maxRetries: 0,
+      };
+      const task = new StructuredGenerationTask({ defaults: input } as any);
+      const seen: Array<{ type: string }> = [];
+      let caught: unknown;
+      try {
+        for await (const event of task.executeStream(input as any, mkContext())) {
+          seen.push(event as { type: string });
+        }
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(StructuredOutputValidationError);
+      expect((caught as StructuredOutputValidationError).usage).toBeUndefined();
+      expect(seen.some((e) => e.type === "usage")).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+
   it("leaves no usage key when the provider reported none", async () => {
     const { unregister } = registerUsageProvider([
       { payload: { name: "Alice", age: 30 }, usage: undefined },


### PR DESCRIPTION
Closes the "known gap" left open at the bottom of #624:

> `StructuredOutputValidationError` drops the accumulated usage when *every* validation attempt fails — the most expensive outcome reports nothing. Fixing it requires an error-shape change.

## The gap

`StructuredGenerationTask` already sums usage across validation retries — a rejected attempt is still a billed request — and folds the total onto the `finish` it yields on success. But when every attempt fails it throws instead, and `finish` is the only event that settles a call's tokens:

- each attempt's own `finish` is consumed by the retry loop and never forwarded, so nothing reaches `StreamProcessor`;
- the task never produces an output, so `USAGE_OUTPUT_KEY` never rides one;
- `StructuredOutputValidationError` carried only `attempts`.

So three billed requests that produce no result reported **zero spend**, which prices a schema-flaky model below one that answers correctly. (Anthropic and Gemini partly escaped this by emitting mid-stream `usage` snapshots that pass straight through; every provider whose counts arrive only on the terminal frame — OpenAI, xAI, DeepSeek, OpenRouter, llama.cpp-server — lost the lot.)

## The fix

The accumulated total now reaches both audiences it has.

**As a `usage` snapshot, yielded before the throw** — the stream is still open at that point, so `StreamProcessor` publishes it (`task.runUsage`, the `usage` event) and it lands in the run rollup through `RunScheduler`'s `task_usage` bridge and any owned-child usage sink. The value is cumulative by construction, since each attempt's finish was swallowed by the loop above it, which is exactly what the consumer's replace-never-merge rule for snapshots expects.

**On `StructuredOutputValidationError.usage`** — the error-shape change the issue anticipated, for the caller that catches the error rather than watching the stream. Added as an optional second constructor parameter, so out-of-tree constructions keep compiling.

`undefined` still means "not reported". A run whose attempts reported no tokens emits **no** snapshot and leaves `usage` undefined rather than stating a zero, which would claim the failed attempts were free.

## Not changed

Per-attempt OTel telemetry was never lost here — `StreamingAiTask.executeStream` records each attempt's usage from a `finally`, precisely because this retry loop closes its generator early. This PR is about the task-level total that feeds run accounting and cost reporting.

One adjacent nuance is deliberately left alone: while a retry is in flight, a provider's own pass-through `usage` snapshots restate only *that* attempt's tokens, so a live counter dips before the terminal event corrects it. That is display-only — settled accounting comes from `finish` (success) or the new snapshot (failure) — and rebasing every pass-through snapshot onto the completed attempts' total is a wider change than this gap needs.

## Tests

Three cases added to `packages/ai/src/task/__tests__/StructuredGenerationTask.test.ts`, alongside the existing usage-aggregation suite:

- the thrown error carries the sum over three failed attempts (180 in / 27 out);
- a failed run emits exactly one `usage` snapshot, cumulative, as its last event, with no `finish` anywhere in the stream;
- a failed run that reported no tokens emits no snapshot and leaves `usage` undefined.

The first two fail on `main` and pass here; the third is a guard against a future zeroed total.

## Verification

```
$ bunx vitest run --config vitest.config.ts --project ai \
    packages/ai/src/task/__tests__/StructuredGenerationTask.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)

$ bun scripts/test.ts ai vitest unit
 Test Files  44 passed (44)
      Tests  361 passed (361)

$ bun run build:types
 Tasks:    41 successful, 41 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2VpL7ukd3JrupQKy1iMcA

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2VpL7ukd3JrupQKy1iMcA)_