### PR TITLE
Remove readonly modifier from effort_options arrays

### DIFF
--- a/packages/ai/src/model/ModelSchema.ts
+++ b/packages/ai/src/model/ModelSchema.ts
@@ -151,7 +151,7 @@ export type ModelConfig = {
   metadata?: { [x: string]: unknown } | undefined;
   pricing?: ModelPricing | undefined;
   effort?: ModelEffort | undefined;
-  effort_options?: readonly ModelEffort[] | undefined;
+  effort_options?: ModelEffort[] | undefined;
   provider: string;
   provider_config: {
     [x: string]: unknown;
@@ -167,7 +167,7 @@ export type ModelRecord = {
   capabilities: string[];
   pricing?: ModelPricing | undefined;
   effort?: ModelEffort | undefined;
-  effort_options?: readonly ModelEffort[] | undefined;
+  effort_options?: ModelEffort[] | undefined;
   provider: string;
   provider_config: {
     [x: string]: unknown;


### PR DESCRIPTION
## Summary

Drop `readonly` from `effort_options` on `ModelConfig` and `ModelRecord`.

`readonly` stays on `ModelEffortPolicy.supported`, where it is correct — that is a shared provider-level constant, and it is the one place the immutability means something.

## Why

This is not about mutating the list — `readonly` is a compile-time annotation with no runtime effect, and nothing writes to `effort_options` in place. It is about the declaration contradicting its own writer.

`stampEffortOptions` is the function that puts this field on a record:

```ts
export function stampEffortOptions<T extends object>(
  record: T,
  policy: ModelEffortPolicy | undefined
): T & { effort_options?: ModelEffort[] } {            // mutable
  return { ...record, effort_options: [...policy.supported] };  // copies out of the readonly policy
}
```

It deliberately spreads the readonly policy array into a fresh mutable one *specifically* to stamp it onto a record — then `ModelRecord` declared that same field `readonly`. `readEffortOptions` and `sanitizeEffortOptions` also return `ModelEffort[]`. So every function written for this field types it mutable, while the type itself said otherwise.

It was also the only `readonly` array in `ModelRecord` — the sibling `capabilities` is `string[]`. The field was introduced in ae6cc44 and was never mutable, so this looks like `readonly` carried across from `ModelEffortPolicy.supported` (right there) onto the record field (wrong there) rather than a deliberate choice.

## What it unblocks

A consumer deriving its record type from `ModelRecordSchema` gets a **mutable** array from `FromSchema`, so a `readonly` declaration here is unsatisfiable by the derived type and forces an `Omit`-and-rebind at every such site. This currently breaks builder's typecheck:

```
addSuggestedModel.ts(24,9): error TS2322
  Types of property 'effort_options' are incompatible.
    Type 'readonly ModelEffort[]' is 'readonly' and cannot be assigned to
    the mutable type 'ModelEffort[]'.
```

Fixing it here removes the mismatch at the source instead of adding a per-consumer workaround.

## Compatibility

`readonly T[]` → `T[]` narrows what the property accepts, so it is worth stating that nothing is affected: every producer goes through `stampEffortOptions`' spread copy, and no caller assigns a readonly array to the field. `effort_options` does not appear in the source of any downstream consumer checked (builder, sec, embarc-data) — builder touches it only implicitly, through a spread.

## Verification

- `bun run build:types` — 41/41 packages clean
- ai package tests — 36 files, 332 tests pass