### PR TITLE
feat(util): declare x-ui-placeholder and x-ui-disabled

### DIFF
--- a/packages/util/src/json-schema/JsonSchema.ts
+++ b/packages/util/src/json-schema/JsonSchema.ts
@@ -20,6 +20,8 @@ export type JsonSchemaCustomProps = {
   "x-ui-group-priority"?: number;
   "x-ui-group-open"?: boolean;
   "x-ui-enum-labels"?: Record<string, string>; // Map of enum value -> display label
+  "x-ui-placeholder"?: string; // placeholder shown by the editor while the field holds no value
+  "x-ui-disabled"?: boolean; // renders the field read-only (the value is shown but cannot be edited)
   "x-ui-manual"?: boolean; // marks a property as manually added by the user
   "x-ui"?: unknown;
   "x-ui-iteration"?: boolean; // marks property as iteration-injected (hidden from parent, read-only in subgraph)


### PR DESCRIPTION
Adds two editor-hint keys to `JsonSchemaCustomProps`. Needed by builder's model-effort-policy work (workglow-dev/builder#399), which is currently red without them.

## Why here and not in the consumer

`JsonSchemaCustomProps` (`packages/util/src/json-schema/JsonSchema.ts`) is the canonical registry for `x-ui-*` keys — it is what `DataPortSchemaObject` and `ExtendedJSONSchema` resolve through. A key absent from it cannot be read off a schema at all:

```
error TS7053: Element implicitly has an 'any' type because expression of type
'"x-ui-disabled"' can't be used to index type
'ExtendedJSONSchema<JsonSchemaCustomProps> & …'
```

builder declared both keys in its own local property type, which covers the code paths typed as that local type but not the ones typed as `DataPortSchemaObject` — 7 errors in builder, all from the second group. Declaring the vocabulary in one place is what keeps the two from diverging.

## The keys

- **`x-ui-placeholder`** — text an editor shows while the field holds no value. The motivating case is a class default the provider applies on its own, so the field reads `Default: medium` rather than empty or `Not set`.
- **`x-ui-disabled`** — render the field read-only, so a value can be shown without being editable.

Both sit alongside the existing hints (`x-ui-editor`, `x-ui-enum-labels`, `x-ui-hidden`, …) and are optional, so no existing schema changes shape.

## Verification

- `bun run build-types` in `packages/util` — clean.
- Purely additive optional properties on an existing type; nothing else in the repo reads or writes these keys yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYF1YwiEtVDtsoXKRFKgiZ)_