### PR TITLE
perf(task-graph): delete a run's private cache rows by name, not by scanning the folder

### DIFF
--- a/packages/task-graph/README.md
+++ b/packages/task-graph/README.md
@@ -823,8 +823,8 @@ If the registered `private` slot is present and the graph contains any task whos
 
 #### Cleanup
 
-- On `succeeded`, the runner awaits `privateRepo.clearRun()` before resolving so that a restart with the same `runId` cannot accidentally hit stale entries from the previous attempt. The wrapper already knows its `runId`, so the method takes no arguments.
-- On crash (no terminal status reached), nothing happens at the cache layer — the entries stay on disk so the restart can find them.
+- On `succeeded`, the runner awaits `privateRepo.clearRun()` before resolving so that a restart with the same `runId` cannot accidentally hit stale entries from the previous attempt. The wrapper already knows its `runId`, so the method takes no arguments. It also knows which rows it wrote, so cleanup deletes exactly those rather than searching the store for them — see [EXECUTION_MODEL.md](./src/EXECUTION_MODEL.md#lifecycle-of-cache-rows).
+- On crash (no terminal status reached), nothing happens at the cache layer — the entries stay on disk so the restart can find them. A resumed run's `clearRun()` does not remove the previous attempt's rows (it never wrote them); the `CacheJanitor` below is what reclaims those.
 - For abandoned runs (crashed and never restarted), schedule the `CacheJanitor`:
 
 ```typescript

--- a/packages/task-graph/src/EXECUTION_MODEL.md
+++ b/packages/task-graph/src/EXECUTION_MODEL.md
@@ -282,6 +282,10 @@ key = sha256(taskType + getCacheVersion() + fingerprint(inputs))
 
 Failed tasks are never cached — only `Ok` results reach `saveOutput`. `saveOutput` is upsert by primary key (last writer wins) — the underlying `TaskOutputTabularRepository` calls `put()` on its tabular storage, so a same-key write replaces the existing row.
 
+**`clearRun()` costs what the run wrote, not what the store holds.** It fires after every successful run, so it must not scale with the cache. A backing with a runId-leading primary key (`RunPrivateTaskOutputRepository`) answers with one indexed `deleteSearch({ runId })`. A backing that can only find a run's rows by scanning — `FsFolderTaskOutputRepository`, whose rows are keyed `(taskType, fingerprint)` one file each — is instead handed the rows to delete: `RunPrivateCacheRepo` mediates every private row write, so it records each `(taskType, key)` it wrote and passes that write-set to `deleteRunEntries(runId, entries)`. Cleanup is then one unlink per row plus one readdir of the blobs directory, and a run that wrote nothing does essentially nothing (previously: a full read-and-parse of every row file in the folder, per run, including unrelated runs' cached values).
+
+The write-set covers the current process only. Rows left under the same `runId` by a previous attempt (a crash-resume) are not in it and survive `clearRun()`; the age sweep (`CacheJanitor` / `clearOlderThan` → `deleteRunOlderThan`) reclaims those and **still scans**, because it is reached with no knowledge of what the run wrote. A backing declaring neither `deleteRunEntries` nor `keyFromInputs`, and any run whose write-set could not be recorded in full, fall back to the exhaustive `deleteRun`.
+
 ### Binary cache stream-out (refs on the read path)
 
 Binary output ports whose bytes were piped into a stream-capable cache carry a branded `CacheRef` in the cached row. On a **cache hit**, the runner mirrors the fresh-run event contract, driven by two graph-computed consumer hints (`IRunConfig.hasStreamingConsumers` / `hasMaterializingConsumers`):

--- a/packages/task-graph/src/cache/RunPrivateCacheRepo.ts
+++ b/packages/task-graph/src/cache/RunPrivateCacheRepo.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { RunCacheEntryKey } from "../storage/TaskOutputRepository";
 import { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { TaskInput, TaskOutput } from "../task/TaskTypes";
 
@@ -52,10 +53,45 @@ export class RunPrivateCacheRepo extends TaskOutputRepository {
   private readonly runId: string;
   private observedFallback: boolean = false;
 
+  /**
+   * Rows this wrapper has written, so {@link clearRun} can delete exactly them
+   * instead of asking the backing to go find them. Keyed by `taskType` + row
+   * key so a task re-saving the same entry records one row, which is also all
+   * that exists on the backing: the set is bounded by the run's DISTINCT cache
+   * entries, not by its write count. Long-lived runs (a `while` loop writing a
+   * fresh entry per iteration) still grow it linearly — it holds two short
+   * strings per entry and no values, but it is not free.
+   *
+   * Every private row write is mediated by {@link saveOutput}, so this is the
+   * complete set for the current process. It cannot cover rows written under
+   * this `runId` by a PREVIOUS process (a crash-resume): those are reclaimed by
+   * the age sweep {@link clearOlderThan} / `CacheJanitor`, which still scans.
+   */
+  private writeSet = new Map<string, RunCacheEntryKey>();
+
+  /**
+   * False once anything could have been written without being recorded, which
+   * makes {@link writeSet} an incomplete answer and sends {@link clearRun} back
+   * to the backing's exhaustive `deleteRun`. Leaving a private row behind is
+   * worse than paying for one scan.
+   */
+  private writeSetComplete: boolean = true;
+
+  /**
+   * Whether the backing can act on a write-set at all. It has to expose both
+   * halves — the key derivation its own writes use, and the targeted delete —
+   * so the keys recorded here and the keys deleted later are the same function
+   * by construction. A backing whose `deleteRun` is already an indexed delete
+   * declares neither, and tracking would be pure overhead.
+   */
+  private readonly tracksWrites: boolean;
+
   constructor({ backing, runId }: RunPrivateCacheRepoOptions) {
     super({ outputCompression: backing.outputCompression });
     this._backing = backing;
     this.runId = runId;
+    this.tracksWrites =
+      typeof backing.deleteRunEntries === "function" && typeof backing.keyFromInputs === "function";
 
     // Streaming is a per-backing capability: only backings with a sidecar
     // (today `FsFolderTaskOutputRepository`) implement the run-scoped stream
@@ -128,7 +164,35 @@ export class RunPrivateCacheRepo extends TaskOutputRepository {
     output: TaskOutput,
     createdAt?: Date
   ): Promise<void> {
-    await this._backing.saveOutputForRun(this.runId, cacheIdentity, inputs, output, createdAt);
+    const save = this._backing.saveOutputForRun(
+      this.runId,
+      cacheIdentity,
+      inputs,
+      output,
+      createdAt
+    );
+    if (!this.tracksWrites) {
+      await save;
+      return;
+    }
+    // Derive the key alongside the write rather than after it: the two are
+    // independent, and the recording must not add a round-trip to the hot path.
+    // Record even when the write then fails — a targeted delete of a row that
+    // does not exist is a no-op, whereas failing to record a row that DID land
+    // leaks it. A key derivation that itself fails is the one case nothing can
+    // be recorded from, so it downgrades the whole run to the scanning path.
+    const record = this._backing.keyFromInputs!(inputs).then(
+      (key) => {
+        // NUL joins the two halves: it cannot occur in a fingerprint key, so no
+        // taskType can spell another entry's composite and displace it from the
+        // set — which would silently leave that row behind on cleanup.
+        this.writeSet.set(`${cacheIdentity}\u0000${key}`, { taskType: cacheIdentity, key });
+      },
+      () => {
+        this.writeSetComplete = false;
+      }
+    );
+    await Promise.all([save, record]);
   }
 
   public async getOutput(
@@ -149,11 +213,31 @@ export class RunPrivateCacheRepo extends TaskOutputRepository {
 
   /**
    * Delete every entry written through this wrapper's `runId`. Called by the
-   * graph runner after a successful run. An indexed `deleteSearch({ runId })`
-   * on the backing's runId-leading primary key — not a table scan.
+   * graph runner after every successful run, so its cost has to scale with what
+   * the run wrote, not with what the store holds.
+   *
+   * A backing with a runId-leading primary key answers that with an indexed
+   * `deleteSearch({ runId })` and this delegates straight to `deleteRun`. A
+   * backing that can only find a run's rows by scanning gets handed the
+   * write-set instead: the rows are named, so a run that wrote nothing does
+   * essentially nothing and a run that wrote three rows deletes three rows —
+   * where the scan cost a full read of every row in the store, on every run.
+   *
+   * The write-set only covers THIS process. Rows left by a previous attempt at
+   * the same `runId` (a crash-resume) are not in it and survive here; the age
+   * sweep (`CacheJanitor` / {@link clearOlderThan}) is what reclaims those, and
+   * it still scans precisely because it cannot be told what to delete.
    */
   public async clearRun(): Promise<void> {
-    await this._backing.deleteRun(this.runId);
+    if (!this.tracksWrites || !this.writeSetComplete) {
+      await this._backing.deleteRun(this.runId);
+      return;
+    }
+    const entries = [...this.writeSet.values()];
+    await this._backing.deleteRunEntries!(this.runId, entries);
+    // Cleared only after the delete settles: a throw leaves the set intact so a
+    // retry still knows what to remove.
+    this.writeSet.clear();
   }
 
   /**

--- a/packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts
@@ -13,7 +13,9 @@ import type { CacheRef } from "../cache/CacheRef";
 import { makeCacheRef, makeRefPattern, mintRefKey } from "../cache/CacheRef";
 import type { StreamMode } from "../task/StreamTypes";
 import type { TaskInput, TaskOutput } from "../task/TaskTypes";
+import type { TaskOutputRowPrimaryKey } from "./ITaskOutputStorage";
 import { tabularTaskOutputStorage } from "./TabularTaskOutputStorage";
+import type { RunCacheEntryKey } from "./TaskOutputRepository";
 import {
   TaskOutputPrimaryKeyNames,
   TaskOutputSchema,
@@ -52,6 +54,34 @@ function runScopePrefix(runId: string): string {
   let hex = "";
   for (const byte of bytes) hex += byte.toString(16).padStart(2, "0");
   return `__run.${hex}.`;
+}
+
+/**
+ * How many row deletions are in flight at once. Each is a separate `unlink`, so
+ * issuing them one after the other makes cleanup latency the row count times a
+ * syscall round-trip; issuing all of them at once would hand a run that wrote
+ * thousands of rows an unbounded fan-out of open file operations.
+ */
+const ROW_DELETE_CONCURRENCY = 16;
+
+/** Delete rows with at most {@link ROW_DELETE_CONCURRENCY} unlinks in flight. */
+async function deleteRowsBounded(
+  keys: readonly TaskOutputRowPrimaryKey[],
+  deleteOne: (key: TaskOutputRowPrimaryKey) => Promise<void>
+): Promise<void> {
+  let next = 0;
+  const workers: Promise<void>[] = [];
+  const width = Math.min(ROW_DELETE_CONCURRENCY, keys.length);
+  for (let i = 0; i < width; i++) {
+    workers.push(
+      (async () => {
+        while (next < keys.length) {
+          await deleteOne(keys[next++]);
+        }
+      })()
+    );
+  }
+  await Promise.all(workers);
 }
 
 /**
@@ -171,13 +201,24 @@ export class FsFolderTaskOutputRepository extends TaskOutputTabularRepository {
     );
   }
 
+  /**
+   * Exhaustive run cleanup. Rows are keyed `(taskType, key)` with the key a
+   * fingerprint hash, so a run's rows are not recoverable from the filenames
+   * and finding them means reading every row in the folder. That cost is the
+   * reason {@link deleteRunEntries} exists for the common case; this method
+   * stays the honest primitive for a caller that cannot enumerate what a run
+   * wrote (a resumed run reclaiming a previous process's rows, an operator
+   * clearing a run id by hand).
+   */
   override async deleteRun(runId: string): Promise<void> {
     const nsPrefix = runScopePrefix(runId);
+    const doomed: TaskOutputRowPrimaryKey[] = [];
     for await (const row of this.storage.records()) {
       if (typeof row.taskType === "string" && row.taskType.startsWith(nsPrefix)) {
-        await this.storage.delete({ key: row.key, taskType: row.taskType });
+        doomed.push({ key: row.key, taskType: row.taskType });
       }
     }
+    await deleteRowsBounded(doomed, (key) => this.storage.delete(key));
     this.emit("output_pruned");
     // Blob names lead with `sanitize(taskType)` and `sanitize` is the identity
     // on the hex run-scope prefix, so `nsPrefix` itself is the shared prefix of
@@ -185,16 +226,47 @@ export class FsFolderTaskOutputRepository extends TaskOutputTabularRepository {
     await this.deleteBlobsByPrefix(nsPrefix);
   }
 
+  /**
+   * Delete the listed rows of `runId` and sweep the run's sidecar blobs.
+   *
+   * The scan {@link deleteRun} performs is what this avoids: the caller states
+   * which rows it wrote, so cleanup costs one unlink per row plus one readdir
+   * of the blobs directory, independent of how much unrelated data the folder
+   * holds. Rows of `runId` that the caller did not list are LEFT IN PLACE —
+   * {@link deleteRunOlderThan} reclaims those.
+   */
+  override async deleteRunEntries(
+    runId: string,
+    entries: readonly RunCacheEntryKey[]
+  ): Promise<void> {
+    const nsPrefix = runScopePrefix(runId);
+    const doomed = entries.map((entry) => ({
+      key: entry.key,
+      taskType: `${nsPrefix}${entry.taskType}`,
+    }));
+    await deleteRowsBounded(doomed, (key) => this.storage.delete(key));
+    this.emit("output_pruned");
+    await this.deleteBlobsByPrefix(nsPrefix);
+  }
+
+  /**
+   * Age-bounded run cleanup — the crash-recovery reclaim path, and deliberately
+   * still a full scan. It is reached with no knowledge of what the run wrote
+   * (that is exactly the state a crashed or abandoned run leaves behind), so
+   * the rows have to be found rather than named.
+   */
   override async deleteRunOlderThan(runId: string, olderThanInMs: number): Promise<void> {
     const cutoff = Date.now() - olderThanInMs;
     const nsPrefix = runScopePrefix(runId);
+    const doomed: TaskOutputRowPrimaryKey[] = [];
     for await (const row of this.storage.records()) {
       if (typeof row.taskType !== "string" || !row.taskType.startsWith(nsPrefix)) continue;
       const ts = typeof row.createdAt === "string" ? new Date(row.createdAt).getTime() : NaN;
       if (!isNaN(ts) && ts < cutoff) {
-        await this.storage.delete({ key: row.key, taskType: row.taskType });
+        doomed.push({ key: row.key, taskType: row.taskType });
       }
     }
+    await deleteRowsBounded(doomed, (key) => this.storage.delete(key));
     this.emit("output_pruned");
     await this.deleteBlobsByPrefix(nsPrefix, cutoff);
   }

--- a/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
@@ -53,7 +53,7 @@ export class RunPrivateTaskOutputRepository extends TaskOutputRepository {
     await this.storage.setupDatabase?.();
   }
 
-  public async keyFromInputs(inputs: TaskInput): Promise<string> {
+  public override async keyFromInputs(inputs: TaskInput): Promise<string> {
     return await makeFingerprint(inputs);
   }
 

--- a/packages/task-graph/src/storage/TaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/TaskOutputRepository.ts
@@ -32,6 +32,20 @@ export type TaskOutputEventParameters<Event extends TaskOutputEvents> = EventPar
 >;
 
 /**
+ * Primary key of a single cached row, as a repository addresses it: the
+ * `taskType` axis value the writer passed and the row `key` the repository
+ * derived from the inputs via {@link TaskOutputRepository.keyFromInputs}.
+ *
+ * Run scoping is NOT baked into `taskType` here — a run-scoped delete takes the
+ * `runId` separately and applies whatever namespacing it uses internally, so a
+ * caller holding these pairs never has to know how a backing scopes runs.
+ */
+export interface RunCacheEntryKey {
+  readonly taskType: string;
+  readonly key: string;
+}
+
+/**
  * Abstract class for managing task outputs in a repository
  * Provides methods for saving, retrieving, and clearing task outputs
  */
@@ -223,6 +237,33 @@ export abstract class TaskOutputRepository {
   async deleteRun(_runId: string): Promise<void> {
     throw new Error(`${this.constructor.name}: deleteRun is not supported by this repository.`);
   }
+
+  /**
+   * OPTIONAL targeted counterpart of {@link deleteRun}: delete exactly the
+   * listed rows of `runId`, plus whatever run-scoped side storage the backing
+   * reclaims wholesale (e.g. sidecar blobs selected by a name prefix).
+   *
+   * Declared only by backings whose {@link deleteRun} cannot select a run's
+   * rows without scanning — the win is skipping that scan, so a backing with an
+   * indexed run-scoped delete should NOT declare this. `entries` are the raw
+   * (unscoped) `taskType` and row `key` pairs; the backing applies its own run
+   * namespacing.
+   *
+   * The caller is responsible for the list being COMPLETE: any row of `runId`
+   * not listed survives, and is reclaimed later by {@link deleteRunOlderThan}.
+   * {@link RunPrivateCacheRepo} therefore falls back to {@link deleteRun}
+   * whenever it cannot vouch for its recorded write-set.
+   */
+  deleteRunEntries?(runId: string, entries: readonly RunCacheEntryKey[]): Promise<void>;
+
+  /**
+   * OPTIONAL derivation of a row `key` from a task's cache-key inputs — the
+   * same function the backing's own write path uses. Exposed so a wrapper can
+   * record the exact key a write landed under (see {@link deleteRunEntries})
+   * instead of re-deriving it from an assumed hash, which would silently stop
+   * matching if a backing changed its keying.
+   */
+  keyFromInputs?(inputs: TaskInput): Promise<string>;
 
   /**
    * Delete entries for `runId` created more than `olderThanMs` ago. Used by

--- a/packages/task-graph/src/storage/TaskOutputTabularRepository.ts
+++ b/packages/task-graph/src/storage/TaskOutputTabularRepository.ts
@@ -42,7 +42,7 @@ export class TaskOutputTabularRepository extends TaskOutputRepository {
     await this.storage.setupDatabase?.();
   }
 
-  public async keyFromInputs(inputs: TaskInput): Promise<string> {
+  public override async keyFromInputs(inputs: TaskInput): Promise<string> {
     return await makeFingerprint(inputs);
   }
 

--- a/packages/test/src/test/task-graph-cache/RunPrivateClearRunCost.test.ts
+++ b/packages/test/src/test/task-graph-cache/RunPrivateClearRunCost.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * `clearRun()` runs after EVERY successful graph run, so its cost must scale
+ * with what the run wrote rather than with what the cache folder holds.
+ *
+ * `FsFolderTaskOutputRepository` keys rows `(taskType, fingerprint)` and stores
+ * one file per row, so finding a run's rows by their run-scope prefix means
+ * reading and parsing every row file in the folder — including the large cached
+ * values of runs that have nothing to do with this one. The tests below assert
+ * the scan itself is gone from the happy path (not merely that the right rows
+ * end up deleted), and that it is still there on the age-based reclaim path
+ * that has no write-set to work from.
+ */
+
+import type { RunCacheEntryKey, TaskInput, TaskOutput } from "@workglow/task-graph";
+import {
+  FsFolderTaskOutputRepository,
+  RunPrivateCacheRepo,
+  TaskOutputRepository,
+} from "@workglow/task-graph";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Row-level storage calls made by a repository, counted per method. */
+interface StorageCalls {
+  readonly records: () => number;
+  readonly get: () => number;
+  readonly delete: () => number;
+}
+
+function countStorageCalls(repo: FsFolderTaskOutputRepository): StorageCalls {
+  const storage = repo.storage;
+  const records = vi.spyOn(storage, "records");
+  const get = vi.spyOn(storage, "get");
+  const del = vi.spyOn(storage, "delete");
+  return {
+    records: () => records.mock.calls.length,
+    get: () => get.mock.calls.length,
+    delete: () => del.mock.calls.length,
+  };
+}
+
+/**
+ * Minimal backing declaring both halves of the write-set contract, so the
+ * wrapper's choice between the targeted delete and the exhaustive one is
+ * observable without depending on how any real backing derives its keys.
+ */
+class FakeTrackingBacking extends TaskOutputRepository {
+  public keyDerivationFails = false;
+  public readonly deleteRunCalls: string[] = [];
+  public readonly deleteRunEntriesCalls: RunCacheEntryKey[][] = [];
+
+  constructor() {
+    super({ outputCompression: false });
+  }
+
+  public override async keyFromInputs(inputs: TaskInput): Promise<string> {
+    if (this.keyDerivationFails) throw new Error("key derivation unavailable");
+    return JSON.stringify(inputs);
+  }
+
+  public override async saveOutputForRun(): Promise<void> {}
+
+  public override async deleteRun(runId: string): Promise<void> {
+    this.deleteRunCalls.push(runId);
+  }
+
+  public override async deleteRunEntries(
+    _runId: string,
+    entries: readonly RunCacheEntryKey[]
+  ): Promise<void> {
+    this.deleteRunEntriesCalls.push([...entries]);
+  }
+
+  public async saveOutput(): Promise<void> {}
+  public async getOutput(): Promise<TaskOutput | undefined> {
+    return undefined;
+  }
+  public async clear(): Promise<void> {}
+  public async size(): Promise<number> {
+    return 0;
+  }
+  public async clearOlderThan(): Promise<void> {}
+  public isDurable(): boolean {
+    return true;
+  }
+}
+
+describe("run-private clearRun write-set fallbacks", () => {
+  it("names the rows it wrote when the write-set is trustworthy", async () => {
+    const backing = new FakeTrackingBacking();
+    const repo = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+    await repo.saveOutput("T", { p: 1 }, { ok: 1 });
+
+    await repo.clearRun();
+
+    expect(backing.deleteRunCalls).toEqual([]);
+    expect(backing.deleteRunEntriesCalls).toEqual([
+      [{ taskType: "T", key: JSON.stringify({ p: 1 }) }],
+    ]);
+  });
+
+  it("reverts to the exhaustive delete when a write could not be recorded", async () => {
+    const backing = new FakeTrackingBacking();
+    const repo = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+    backing.keyDerivationFails = true;
+    await repo.saveOutput("T", { p: 1 }, { ok: 1 });
+    backing.keyDerivationFails = false;
+    // A later recordable write must not restore confidence in the set: the
+    // unrecorded row is still out there.
+    await repo.saveOutput("T", { p: 2 }, { ok: 2 });
+
+    await repo.clearRun();
+
+    expect(backing.deleteRunEntriesCalls).toEqual([]);
+    expect(backing.deleteRunCalls).toEqual(["run-A"]);
+  });
+});
+
+describe("run-private clearRun cost over an FsFolder backing", () => {
+  let folder: string;
+  let backing: FsFolderTaskOutputRepository;
+
+  beforeEach(async () => {
+    folder = mkdtempSync(join(tmpdir(), "runprivate-clearrun-"));
+    backing = new FsFolderTaskOutputRepository(folder);
+    // Unrelated neighbours: deterministic-tier rows plus another run's private
+    // rows. A scan would read and parse every one of them.
+    const other = new RunPrivateCacheRepo({ backing, runId: "run-other" });
+    for (let i = 0; i < 12; i++) {
+      await backing.saveOutput("DeterministicTask", { i }, { payload: "x".repeat(2048) });
+      await other.saveOutput("OtherRunTask", { i }, { payload: "y".repeat(2048) });
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(folder, { recursive: true, force: true });
+  });
+
+  it("deletes only the rows the run wrote, without scanning the folder", async () => {
+    const repo = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+    await repo.saveOutput("T", { p: 1 }, { ok: "A" });
+    await repo.saveOutput("T", { p: 2 }, { ok: "A2" });
+
+    const calls = countStorageCalls(backing);
+    await repo.clearRun();
+
+    // The scan is the cost being removed: `records()` walks every row file.
+    expect(calls.records()).toBe(0);
+    expect(calls.get()).toBe(0);
+    // Exactly the two rows this run wrote.
+    expect(calls.delete()).toBe(2);
+
+    expect(await repo.getOutput("T", { p: 1 })).toBeUndefined();
+    expect(await repo.getOutput("T", { p: 2 })).toBeUndefined();
+    // Neighbours untouched.
+    expect(await backing.getOutput("DeterministicTask", { i: 0 })).toBeDefined();
+    const other = new RunPrivateCacheRepo({ backing, runId: "run-other" });
+    expect(await other.getOutput("OtherRunTask", { i: 0 })).toBeDefined();
+  });
+
+  it("re-saving the same entry records one row, not one per write", async () => {
+    const repo = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+    await repo.saveOutput("T", { p: 1 }, { ok: 1 });
+    await repo.saveOutput("T", { p: 1 }, { ok: 2 });
+    await repo.saveOutput("T", { p: 1 }, { ok: 3 });
+
+    const calls = countStorageCalls(backing);
+    await repo.clearRun();
+
+    expect(calls.delete()).toBe(1);
+    expect(await repo.getOutput("T", { p: 1 })).toBeUndefined();
+  });
+
+  it("a run that wrote nothing touches no rows at all", async () => {
+    const repo = new RunPrivateCacheRepo({ backing, runId: "run-empty" });
+
+    const calls = countStorageCalls(backing);
+    await repo.clearRun();
+
+    expect(calls.records()).toBe(0);
+    expect(calls.delete()).toBe(0);
+    expect(await backing.getOutput("DeterministicTask", { i: 0 })).toBeDefined();
+  });
+
+  it("a backing without the targeted delete still gets a correct (scanning) cleanup", async () => {
+    const noTargetedDelete = new FsFolderTaskOutputRepository(folder);
+    // Shadow the prototype method: this is what a backing that never declared
+    // `deleteRunEntries` looks like to the wrapper.
+    (noTargetedDelete as { deleteRunEntries?: unknown }).deleteRunEntries = undefined;
+    const repo = new RunPrivateCacheRepo({ backing: noTargetedDelete, runId: "run-A" });
+    await repo.saveOutput("T", { p: 1 }, { ok: "A" });
+
+    const calls = countStorageCalls(noTargetedDelete);
+    await repo.clearRun();
+
+    expect(calls.records()).toBeGreaterThan(0);
+    expect(await repo.getOutput("T", { p: 1 })).toBeUndefined();
+    expect(await backing.getOutput("DeterministicTask", { i: 0 })).toBeDefined();
+  });
+
+  it("the age sweep still scans, so a previous attempt's rows are reclaimed", async () => {
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600_000);
+    // Pre-crash attempt: rows exist under this runId with no live write-set.
+    const crashed = new RunPrivateCacheRepo({ backing, runId: "run-resumed" });
+    await crashed.saveOutput("T", { p: "before" }, { ok: "pre-crash" }, tenDaysAgo);
+
+    // The resumed run knows only its own writes, so clearRun leaves the older
+    // row in place rather than paying for a scan to find it.
+    const resumed = new RunPrivateCacheRepo({ backing, runId: "run-resumed" });
+    await resumed.saveOutput("T", { p: "after" }, { ok: "post-crash" });
+    await resumed.clearRun();
+
+    expect(await resumed.getOutput("T", { p: "after" })).toBeUndefined();
+    expect(await resumed.getOutput("T", { p: "before" })).toEqual({ ok: "pre-crash" });
+
+    // The janitor's age sweep is what reclaims it, and it does scan.
+    const calls = countStorageCalls(backing);
+    await resumed.clearOlderThan(24 * 3600_000);
+
+    expect(calls.records()).toBeGreaterThan(0);
+    expect(await resumed.getOutput("T", { p: "before" })).toBeUndefined();
+    expect(await backing.getOutput("DeterministicTask", { i: 0 })).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #690

## What changed

`RunPrivateCacheRepo.clearRun()` fires after **every** successful graph run whenever a `runId` and a private cache slot are configured. On an `FsFolderTaskOutputRepository` backing it delegated to `deleteRun(runId)`, which walks `storage.records()` to prefix-match the run's namespaced `taskType`. Because the row PK is composite and `FsFolderTabularStorage.query()` throws, `BaseTabularStorage.runPage` falls back to `getAll()` — reading and JSON-parsing **every row file's full contents**, including other runs' large cached values, re-executed per 100-row page — just to find a taskType the filenames (fingerprint hashes) cannot carry. The matches were then deleted with sequential awaits.

The wrapper mediates every private row write, so it now records what it wrote and deletes exactly that.

| file | change |
| --- | --- |
| `packages/task-graph/src/storage/TaskOutputRepository.ts` | new exported `RunCacheEntryKey` (`{taskType, key}`); two new OPTIONAL methods on the base — `deleteRunEntries(runId, entries)` (targeted counterpart of `deleteRun`) and `keyFromInputs(inputs)` (the backing's own row-key derivation, already concrete on both tabular repos) |
| `packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts` | implements `deleteRunEntries`: unlink the named rows, then the existing `deleteBlobsByPrefix(nsPrefix)` sweep. `deleteRun` / `deleteRunOlderThan` / `deleteRunEntries` all delete at bounded concurrency (`ROW_DELETE_CONCURRENCY = 16`) instead of sequential awaits |
| `packages/task-graph/src/cache/RunPrivateCacheRepo.ts` | records each write's `(taskType, key)` in a per-run `Map`; `clearRun()` hands that write-set to `deleteRunEntries`, falling back to `deleteRun` when the backing lacks the pair of methods or when a write could not be recorded |
| `packages/task-graph/src/storage/{TaskOutputTabularRepository,RunPrivateTaskOutputRepository}.ts` | `keyFromInputs` gains `override` (it now overrides an optional base member) |
| `packages/task-graph/src/EXECUTION_MODEL.md`, `packages/task-graph/README.md` | document the new cleanup cost model and the retained scan |
| `packages/test/src/test/task-graph-cache/RunPrivateClearRunCost.test.ts` | new regression test (below) |

## Before / after I/O

| scenario (private cache folder holding N rows) | before | after |
| --- | --- | --- |
| successful run that wrote 0 rows | read + JSON-parse all N row files | 1 `readdir` of `blobs/` |
| successful run that wrote k rows | read + JSON-parse all N row files, then k sequential unlinks | k unlinks (≤16 in flight) + 1 `readdir` |
| age sweep / janitor | full scan | **unchanged — full scan** |

Cleanup cost stops being `O(runs × folder-bytes)` and becomes `O(rows the run actually wrote)`.

## `deleteRunOlderThan` keeps its full scan — deliberately

`deleteRunOlderThan` (and therefore `CacheJanitor.sweepStaleRunPrivate` / `clearOlderThan`) is **not** optimized here and still scans. It is the crash-recovery reclaim path and is reached with no knowledge of what the run wrote — that is precisely the state a crashed or abandoned run leaves behind, so the rows have to be found rather than named.

This is the one behavioral trade the change makes: a same-`runId` crash-resume's **pre-crash** rows are no longer removed by the resumed run's `clearRun()` (the fresh wrapper never wrote them), so the janitor reclaims them instead. Both halves are asserted by the new test and written into `EXECUTION_MODEL.md`.

## Correctness of the write-set

Every row that reaches the private tier passes through `RunPrivateCacheRepo.saveOutput` — `CacheCoordinator.save()` is the only production row write to that slot (`outputCache.saveOutput(...)`), and it is reached for streaming and non-streaming tasks alike. Post-#767's streaming writers (`saveOutputStreamPort` / `saveOutputStreamPortForRun`) write **blobs**, which the retained `deleteBlobsByPrefix` sweep reclaims wholesale; the row carrying the resulting `CacheRef` still lands via `save()`. So no row-write path bypasses the write-set.

Guards on top of that:

- the recorded key comes from the **backing's own** `keyFromInputs`, so the key recorded and the key deleted are the same function by construction;
- tracking engages only when the backing declares **both** `deleteRunEntries` and `keyFromInputs` — a backing with an indexed run-scoped delete (`RunPrivateTaskOutputRepository`, one `deleteSearch({runId})`) declares neither and is untouched;
- if a key derivation ever fails, the wrapper marks the write-set untrustworthy for the rest of the run and `clearRun()` reverts to the exhaustive `deleteRun` — leaving a private row behind is worse than paying for one scan;
- the write-set is per-wrapper and a wrapper's `runId` is immutable (`TaskGraphRunner` mints one per run), so it can never name another run's rows. Keys, not values, are stored, deduped per distinct cache entry; the growth characteristic for long-lived runs is noted in the field's doc comment.

Out of scope by design: application code writing through the *backing* directly (`backing.saveOutputForRun(runId, …)`, bypassing the wrapper) is not recorded — the janitor covers it, same as before.

## How to test

```sh
bun scripts/test.ts graph task-graph vitest
npx vitest run --config vitest.config.ts --project test \
  packages/test/src/test/task-graph-cache/RunPrivateClearRunCost.test.ts
```

The regression test asserts the **absence of the scan**, not just the right rows being gone: it seeds the folder with 24 unrelated rows (deterministic-tier + another run's private rows), spies on `storage.records` / `get` / `delete`, and requires `records() === 0` with exactly one `delete` per row the run wrote. Reverting only `clearRun()`'s branch back to `deleteRun` fails 4 of the 7 tests:

```
 Test Files  1 failed (1)
      Tests  4 failed | 3 passed (7)
```

(including `the age sweep still scans, so a previous attempt's rows are reclaimed`, which pins the crash-resume contract in both directions).

## Verification

```
$ bun run build:types
 Tasks:    41 successful, 41 total
 Cached:   10 cached, 41 total

$ npx tsc -b packages/test
tsc-exit=0

$ npx vitest run ... RunPrivateClearRunCost.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ bun scripts/test.ts graph task-graph vitest
Running all tests in sections [graph+task-graph] — 149 file(s)
 Test Files  149 passed (149)
      Tests  1407 passed (1407)

$ bun scripts/test.ts --check-sections
Every test file is discovered and reachable by section+kind selection.

$ bun scripts/test.ts --changed
 Tasks:    88 successful, 89 total
 Failed:   @workglow/test#test
   └─ @workglow/test:  Test Files  1 failed | 302 passed | 1 skipped (304)
                            Tests  4 failed | 3616 passed | 62 skipped (3682)
      the 4 failures are all ai-provider/TFMP_GenaiHelpers.test.ts
      ("@mediapipe/tasks-{genai,vision,text,audio} pin matches the installed
      version") — @mediapipe/* is not installed in this container.

$ npx prettier --check <changed files>   # clean
$ npx eslint <changed files>             # clean (no output)
```

`bun scripts/test.ts storage task vitest` additionally reports 8 failures, all in `packages/test/src/test/task/FetchTask.test.ts` (undici / socket-error classification). Verified **pre-existing**: `git stash -u` back to clean `origin/main`, rebuild, re-run — the same 8 failures.

Environment note: this container only has **Node v22.22.2**; the repo asks for Node 24+. Everything above ran under 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SS3QiufMDGbfmamoQgY7J
