### PR TITLE
feat(task-graph): stream N binary output ports to cache on the unflagged path

### DIFF
--- a/packages/task-graph/src/EXECUTION_MODEL.md
+++ b/packages/task-graph/src/EXECUTION_MODEL.md
@@ -296,9 +296,9 @@ Binary output ports whose bytes were piped into a stream-capable cache carry a b
 
 **Rows store the wire form**: the cached row always carries the `CacheRef`, never inline bytes — JSON-row backings would destroy an inline `Blob`/`ArrayBuffer` (`JSON.stringify(Blob)` is `{}`). Below-threshold hydration to inline bytes applies to the value **returned to the caller**, identically on fresh runs and cache hits.
 
-**Single binary port**: outside the per-port path below the runner drives a single binary sink, so this path supports exactly one binary output port. Tasks with multiple binary ports take the accumulation path (enforced in both `StreamPump.canStreamBinaryToCache` and `CacheCoordinator.getBinaryRefSinksByPolicy`) — unless the run opts into the per-port sink path below, which has no such limit.
+**Binary-only, any number of ports**: this path takes one _or more_ binary output ports — each gets its own sink and its own `CacheRef`, and `mintRefKey(taskType, fingerprint, port)` keeps the blobs distinct. What it does not take is a **mix**: a task whose streaming ports are not all binary falls back to accumulation (enforced in both `StreamPump.canStreamBinaryToCache` and `CacheCoordinator.getBinaryRefSinksByPolicy`), because only the binary ports get sinks here, so an `append` / `object` port alongside them would have neither a sink nor — with accumulation skipped — an accumulator, and its deltas would be dropped into an empty finish payload. Such mixed tasks stream every port only under the per-port path below.
 
-**One writer, two gating rules**: a backing declares exactly one streaming writer, `saveOutputStreamPort(taskType, inputs, port, mode, chunks, metadata)`, probed by `supportsStreaming()`. The single-binary case is that writer called with the task's one binary port and `mode: "binary"`; `CacheCoordinator.getBinaryRefSinksByPolicy` adapts it there, since that is the one place the port id is already known. What still differs between the two paths is when the runner _uses_ the writer, not what a backing has to implement: a single binary port streams to the cache unconditionally, while `append` / `object` ports stream only under `noAccumulation`.
+**One writer, two gating rules**: a backing declares exactly one streaming writer, `saveOutputStreamPort(taskType, inputs, port, mode, chunks, metadata)`, probed by `supportsStreaming()`. The binary case is that writer called per binary port with `mode: "binary"`; `CacheCoordinator.getBinaryRefSinksByPolicy` selects those ports and shares one writer closure with the all-mode builder, so the two paths differ in which ports they select, never in how a port's bytes are written. What still differs is when the runner _uses_ the writer, not what a backing has to implement: binary ports stream to the cache unconditionally, while `append` / `object` ports stream only under `noAccumulation`.
 
 **Self-healing dangling refs**: when a ref needed for replay or hydration no longer resolves (blob evicted, cache cleared), the hit converts into a **miss** — the task re-executes and rewrites both the row and the bytes. No events are emitted before all refs are validated.
 
@@ -346,7 +346,7 @@ The **SQL** backings share one implementation. `TabularBlobChunkStore` persists 
 
 ### Per-port stream sinks and the no-accumulation passthrough
 
-Everything above generalizes from "one binary port" to **every delta stream mode**
+Everything above generalizes from "binary ports only" to **every delta stream mode**
 (`append`, `object`, `binary`) behind an opt-in run flag,
 `TaskGraphRunConfig.noAccumulation` (default off — off is byte-identical to the
 accumulation path).

--- a/packages/task-graph/src/task-graph/StreamPump.ts
+++ b/packages/task-graph/src/task-graph/StreamPump.ts
@@ -404,10 +404,10 @@ export class StreamPump {
   ): boolean {
     if (outputCache) {
       // Relaxation: when the cache can ingest a byte stream, the task streams
-      // ONLY binary, and no downstream edge needs the materialized value, the
-      // bytes are piped straight to the cache sink instead of being buffered
-      // into an enriched finish event. This is the memory win for large binary
-      // outputs (e.g. file/image producers).
+      // ONLY binary (any number of such ports), and no downstream edge needs
+      // the materialized value, the bytes are piped straight to one cache sink
+      // per port instead of being buffered into an enriched finish event. This
+      // is the memory win for large binary outputs (e.g. file/image producers).
       if (StreamPump.canStreamBinaryToCache(this.graph, task, outputCache)) return false;
       // No-accumulation passthrough: under the opt-in flag, a cacheable task
       // whose streamable ports can each be sunk per-port (and no consumer needs
@@ -454,7 +454,9 @@ export class StreamPump {
    *    `RunPrivateCacheRepo` may expose a concrete writer while its
    *    `supportsStreaming()` reflects the BACKING repo, so the duck-type would
    *    falsely report `true` over a non-streaming backing store).
-   * 2. The task's only streaming output port(s) are binary.
+   * 2. The task's streaming output ports are ALL binary — one or many. Each
+   *    gets its own sink and its own {@link CacheRef}, so a two-artifact
+   *    producer is not pushed back onto full in-memory accumulation.
    * 3. No downstream dataflow edge needs the materialized value (every consumer
    *    accepts the raw binary stream, or there are no consumers).
    *
@@ -479,12 +481,16 @@ export class StreamPump {
 
     const outSchema = task.outputSchema();
     const streamingPorts = getStreamingPorts(outSchema);
-    // Exactly ONE binary port: outside the no-accumulation path the runner
-    // drives a single binary sink, so only one port can pipe to the cache.
-    // With accumulation skipped, any additional binary port would have neither
-    // a sink nor an accumulator and its chunks would be silently dropped —
-    // multi-port tasks must take the accumulation path instead.
-    if (streamingPorts.length !== 1 || streamingPorts[0].mode !== "binary") return false;
+    // At least one streaming port, and EVERY one of them binary. The count is
+    // free (each binary port gets its own sink and its own CacheRef), but the
+    // binary-only half is load-bearing: `getBinaryRefSinksByPolicy` builds
+    // sinks for binary ports only, so an `append`/`object` port alongside them
+    // would have neither a sink nor — with accumulation skipped — an
+    // accumulator, and its deltas would be silently dropped. Such mixed tasks
+    // take the accumulation path unless the caller opts into `noAccumulation`,
+    // where `canStreamAllPortsToCache` sinks every delta-mode port.
+    if (streamingPorts.length === 0) return false;
+    if (!streamingPorts.every((p) => p.mode === "binary")) return false;
 
     return !StreamPump.anyConsumerNeedsMaterialized(graph, task);
   }
@@ -492,8 +498,8 @@ export class StreamPump {
   /**
    * All-mode analogue of {@link canStreamBinaryToCache} for the opt-in
    * no-accumulation path. The two share a capability probe but NOT a gating
-   * rule: a single binary port streams to the cache unconditionally, while
-   * append / object ports only do so under the flag. True when the flag is on,
+   * rule: binary ports stream to the cache unconditionally, while append /
+   * object ports only do so under the flag. True when the flag is on,
    * the task is cacheable, the cache reports `supportsStreaming()`, every streaming
    * output port is a delta mode (`append` / `object` / `binary`), and no
    * downstream edge needs a materialized value. Then each port is sunk

--- a/packages/task-graph/src/task-graph/__tests__/MultiBinaryPortCacheStream.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/MultiBinaryPortCacheStream.test.ts
@@ -1,0 +1,366 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Binary output ports stream straight to the cache on the UNFLAGGED path — for
+ * any number of them, not just one. The memory win of piping bytes to a sink
+ * instead of buffering them scales with how many large artifacts a task
+ * produces, so a two-artifact producer is exactly the task that should not be
+ * forced back onto full in-memory accumulation.
+ *
+ * What is pinned here:
+ *
+ * - the decision (`canStreamBinaryToCache`) for one, two and three binary ports;
+ * - that binary-ONLY is still required — a task mixing a binary port with an
+ *   `append` port keeps accumulating, because only binary ports get sinks and
+ *   the append port would otherwise have neither sink nor accumulator;
+ * - the live run: one distinct blob per port, `CacheRef`s each naming their own
+ *   port, and both values correct on a replayed cache hit;
+ * - the all-or-nothing ref invariant, extended to the multi-binary case this
+ *   widening makes reachable without the `noAccumulation` flag.
+ */
+
+import type { CacheRef, StreamEvent } from "@workglow/task-graph";
+import {
+  Dataflow,
+  isCacheRef,
+  StreamPump,
+  Task,
+  TaskGraph,
+  TaskGraphRunner,
+} from "@workglow/task-graph";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { beforeEach, describe, expect, it } from "vitest";
+import { StreamingMemoryRepo } from "../../testing/StreamingMemoryRepo";
+
+type TwoBinaryOut = { a: Blob | ArrayBuffer; b: Blob | ArrayBuffer };
+
+const A_BYTES = [1, 2, 3];
+const B_BYTES = [9, 8, 7, 6];
+
+let twoPortRuns = 0;
+
+/** Cacheable leaf streaming two independent binary artifacts in one run. */
+class TwoBinaryPortSource extends Task<Record<string, never>, TwoBinaryOut> {
+  public static override type = "MultiBinaryPortCacheStream_TwoPort";
+  public static override category = "Test";
+  public static override cacheable = true;
+  public static override inputSchema(): DataPortSchema {
+    return { type: "object", properties: {}, additionalProperties: false } as const;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        a: { type: "object", format: "blob", "x-stream": "binary" },
+        b: { type: "object", format: "blob", "x-stream": "binary" },
+      },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+  async *executeStream(): AsyncIterable<StreamEvent<TwoBinaryOut>> {
+    twoPortRuns++;
+    yield { type: "binary-delta", port: "a", binaryDelta: new Uint8Array(A_BYTES) };
+    yield { type: "binary-delta", port: "b", binaryDelta: new Uint8Array(B_BYTES) };
+    yield { type: "finish", data: {} as TwoBinaryOut };
+  }
+}
+
+type ThreeBinaryOut = { a: Blob | ArrayBuffer; b: Blob | ArrayBuffer; c: Blob | ArrayBuffer };
+
+/** Three binary ports — the old cap was `=== 1`, so two must not be a special case. */
+class ThreeBinaryPortSource extends Task<Record<string, never>, ThreeBinaryOut> {
+  public static override type = "MultiBinaryPortCacheStream_ThreePort";
+  public static override category = "Test";
+  public static override cacheable = true;
+  public static override inputSchema(): DataPortSchema {
+    return { type: "object", properties: {}, additionalProperties: false } as const;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        a: { type: "object", format: "blob", "x-stream": "binary" },
+        b: { type: "object", format: "blob", "x-stream": "binary" },
+        c: { type: "object", format: "blob", "x-stream": "binary" },
+      },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+  async *executeStream(): AsyncIterable<StreamEvent<ThreeBinaryOut>> {
+    yield { type: "binary-delta", port: "a", binaryDelta: new Uint8Array([1]) };
+    yield { type: "binary-delta", port: "b", binaryDelta: new Uint8Array([2]) };
+    yield { type: "binary-delta", port: "c", binaryDelta: new Uint8Array([3]) };
+    yield { type: "finish", data: {} as ThreeBinaryOut };
+  }
+}
+
+type OneBinaryOut = { bytes: Blob | ArrayBuffer };
+
+/** The common case, pinned so the widening cannot disturb it. */
+class OneBinaryPortSource extends Task<Record<string, never>, OneBinaryOut> {
+  public static override type = "MultiBinaryPortCacheStream_OnePort";
+  public static override category = "Test";
+  public static override cacheable = true;
+  public static override inputSchema(): DataPortSchema {
+    return { type: "object", properties: {}, additionalProperties: false } as const;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { bytes: { type: "object", format: "blob", "x-stream": "binary" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+  async *executeStream(): AsyncIterable<StreamEvent<OneBinaryOut>> {
+    yield { type: "binary-delta", port: "bytes", binaryDelta: new Uint8Array([4, 5]) };
+    yield { type: "finish", data: {} as OneBinaryOut };
+  }
+}
+
+type MixedOut = { a: Blob | ArrayBuffer; t: string };
+
+/**
+ * Binary + `append`: the append port gets no binary sink, so skipping
+ * accumulation would leave its deltas with nowhere to go.
+ */
+class MixedModeSource extends Task<Record<string, never>, MixedOut> {
+  public static override type = "MultiBinaryPortCacheStream_Mixed";
+  public static override category = "Test";
+  public static override cacheable = true;
+  public static override inputSchema(): DataPortSchema {
+    return { type: "object", properties: {}, additionalProperties: false } as const;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        a: { type: "object", format: "blob", "x-stream": "binary" },
+        t: { type: "string", "x-stream": "append" },
+      },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+  async *executeStream(): AsyncIterable<StreamEvent<MixedOut>> {
+    yield { type: "binary-delta", port: "a", binaryDelta: new Uint8Array([1, 2]) };
+    yield { type: "text-delta", port: "t", textDelta: "hello" };
+    yield { type: "finish", data: {} as MixedOut };
+  }
+}
+
+type BinarySinkOut = { size: number };
+
+/**
+ * Materializing consumer: its `bytes` input port declares no `x-stream`, so the
+ * edge needs the settled value. Used to engage the cache-hit replay path, which
+ * is where the all-or-nothing ref invariant is enforced.
+ */
+class BinarySink extends Task<{ bytes: Blob | ArrayBuffer }, BinarySinkOut> {
+  public static override type = "MultiBinaryPortCacheStream_Sink";
+  public static override category = "Test";
+  public static override cacheable = false;
+  public static override inputSchema(): DataPortSchema {
+    // No `type` constraint (accepts the materialized Blob at runtime) and NO
+    // `x-stream` ⇒ a non-streaming consumer that needs the value at the edge.
+    return {
+      type: "object",
+      properties: { bytes: { title: "Bytes", description: "materialized binary" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { size: { type: "number" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+  async execute(input: { bytes: Blob | ArrayBuffer }): Promise<BinarySinkOut> {
+    const blob = input.bytes as Blob;
+    return { size: (await blob.arrayBuffer()).byteLength };
+  }
+}
+
+/** Two binary ports, each feeding a materializing consumer. */
+function consumedGraph(): TaskGraph {
+  const source = new TwoBinaryPortSource({ id: "source" });
+  source.runConfig = { ...source.runConfig, referenceThresholdBytes: 0 };
+  const graph = new TaskGraph();
+  graph.addTasks([source, new BinarySink({ id: "sinkA" }), new BinarySink({ id: "sinkB" })]);
+  graph.addDataflow(new Dataflow("source", "a", "sinkA", "bytes"));
+  graph.addDataflow(new Dataflow("source", "b", "sinkB", "bytes"));
+  return graph;
+}
+
+function sinkSizes(results: Array<{ id: unknown; data: unknown }>): [number, number] {
+  const a = (results.find((r) => r.id === "sinkA")!.data as BinarySinkOut).size;
+  const b = (results.find((r) => r.id === "sinkB")!.data as BinarySinkOut).size;
+  return [a, b];
+}
+
+/** Single-task graph, optionally forcing every ref to survive (`threshold: 0`). */
+function leafGraph(task: Task<any, any>, thresholdBytes?: number | undefined): TaskGraph {
+  if (thresholdBytes !== undefined) {
+    task.runConfig = { ...task.runConfig, referenceThresholdBytes: thresholdBytes };
+  }
+  const graph = new TaskGraph();
+  graph.addTask(task);
+  return graph;
+}
+
+function decisionFor(task: Task<any, any>): boolean {
+  return StreamPump.canStreamBinaryToCache(leafGraph(task), task, new StreamingMemoryRepo({}));
+}
+
+async function blobBytes(value: unknown): Promise<number[]> {
+  expect(value).toBeInstanceOf(Blob);
+  return Array.from(new Uint8Array(await (value as Blob).arrayBuffer()));
+}
+
+async function refBytes(cache: StreamingMemoryRepo, ref: unknown): Promise<number[]> {
+  expect(isCacheRef(ref)).toBe(true);
+  const blob = await cache.getOutputByRef(ref as CacheRef);
+  expect(blob).toBeInstanceOf(Blob);
+  return Array.from(new Uint8Array(await blob!.arrayBuffer()));
+}
+
+function sourceData(results: Array<{ id: unknown; data: unknown }>): Record<string, unknown> {
+  return results.find((r) => r.id === "source")!.data as Record<string, unknown>;
+}
+
+describe("canStreamBinaryToCache — one or more binary ports", () => {
+  it("accepts a single binary port (unchanged common case)", () => {
+    expect(decisionFor(new OneBinaryPortSource({ id: "source" }))).toBe(true);
+  });
+
+  it("accepts two binary ports", () => {
+    expect(decisionFor(new TwoBinaryPortSource({ id: "source" }))).toBe(true);
+  });
+
+  it("accepts three binary ports", () => {
+    expect(decisionFor(new ThreeBinaryPortSource({ id: "source" }))).toBe(true);
+  });
+
+  it("still rejects a binary port mixed with a non-binary streaming port", () => {
+    expect(decisionFor(new MixedModeSource({ id: "source" }))).toBe(false);
+  });
+});
+
+describe("multi-binary-port cache streaming (no noAccumulation flag)", () => {
+  let cache: StreamingMemoryRepo;
+
+  beforeEach(() => {
+    cache = new StreamingMemoryRepo({});
+    twoPortRuns = 0;
+  });
+
+  it("writes one distinct blob and one port-bearing ref per binary port", async () => {
+    const results = await new TaskGraphRunner(
+      leafGraph(new TwoBinaryPortSource({ id: "source" }), 0)
+    ).runGraph({}, { outputCache: cache });
+
+    expect(cache.streamed.size).toBe(2);
+
+    const data = sourceData(results);
+    expect(isCacheRef(data.a)).toBe(true);
+    expect(isCacheRef(data.b)).toBe(true);
+    const refA = data.a as CacheRef;
+    const refB = data.b as CacheRef;
+    // Distinct blobs, each self-describing its port (the ref key carries it).
+    expect(refA.$ref).not.toBe(refB.$ref);
+    expect(refA.port).toBe("a");
+    expect(refB.port).toBe("b");
+
+    expect(await refBytes(cache, refA)).toEqual(A_BYTES);
+    expect(await refBytes(cache, refB)).toEqual(B_BYTES);
+  });
+
+  it("streams three binary ports to three distinct blobs", async () => {
+    const results = await new TaskGraphRunner(
+      leafGraph(new ThreeBinaryPortSource({ id: "source" }), 0)
+    ).runGraph({}, { outputCache: cache });
+
+    expect(cache.streamed.size).toBe(3);
+    const data = sourceData(results);
+    expect(await refBytes(cache, data.a)).toEqual([1]);
+    expect(await refBytes(cache, data.b)).toEqual([2]);
+    expect(await refBytes(cache, data.c)).toEqual([3]);
+  });
+
+  it("rehydrates both ports below the threshold and replays them on a cache hit", async () => {
+    const first = await new TaskGraphRunner(
+      leafGraph(new TwoBinaryPortSource({ id: "source" }))
+    ).runGraph({}, { outputCache: cache });
+    expect(twoPortRuns).toBe(1);
+    expect(cache.streamed.size).toBe(2);
+    const firstData = first.find((r) => r.id === "source")!.data as TwoBinaryOut;
+    expect(await blobBytes(firstData.a)).toEqual(A_BYTES);
+    expect(await blobBytes(firstData.b)).toEqual(B_BYTES);
+
+    const second = await new TaskGraphRunner(
+      leafGraph(new TwoBinaryPortSource({ id: "source" }))
+    ).runGraph({}, { outputCache: cache });
+    expect(twoPortRuns).toBe(1); // served from cache
+    const secondData = second.find((r) => r.id === "source")!.data as TwoBinaryOut;
+    expect(await blobBytes(secondData.a)).toEqual(A_BYTES);
+    expect(await blobBytes(secondData.b)).toEqual(B_BYTES);
+  });
+
+  it("tees to both sinks: materializing consumers still get one blob per port", async () => {
+    const results = await new TaskGraphRunner(consumedGraph()).runGraph({}, { outputCache: cache });
+
+    // A materializing consumer gates SKIPPING accumulation, not writing to
+    // cache — both ports are still written, one blob each.
+    expect(cache.streamed.size).toBe(2);
+    expect(sinkSizes(results)).toEqual([A_BYTES.length, B_BYTES.length]);
+  });
+
+  it("treats one evicted binary blob of two as a whole-entry miss", async () => {
+    await new TaskGraphRunner(consumedGraph()).runGraph({}, { outputCache: cache });
+    expect(twoPortRuns).toBe(1);
+    expect(cache.streamed.size).toBe(2);
+
+    // Drop only port b's bytes; the row keeps BOTH refs.
+    const bKey = [...cache.streamed.keys()].find((k) => k.endsWith("#b"))!;
+    expect(cache.streamed.delete(bKey)).toBe(true);
+
+    const results = await new TaskGraphRunner(consumedGraph()).runGraph({}, { outputCache: cache });
+
+    // Recomputed rather than replaying a hole at b alongside a stale value at a.
+    expect(twoPortRuns).toBe(2);
+    expect(sinkSizes(results)).toEqual([A_BYTES.length, B_BYTES.length]);
+  });
+
+  it("replays both ports to their consumers on a full multi-binary hit", async () => {
+    await new TaskGraphRunner(consumedGraph()).runGraph({}, { outputCache: cache });
+    expect(twoPortRuns).toBe(1);
+
+    const hit = await new TaskGraphRunner(consumedGraph()).runGraph({}, { outputCache: cache });
+    expect(twoPortRuns).toBe(1); // served entirely from cache
+    expect(sinkSizes(hit)).toEqual([A_BYTES.length, B_BYTES.length]);
+  });
+
+  it("keeps accumulating when a non-binary streaming port is present", async () => {
+    const results = await new TaskGraphRunner(
+      leafGraph(new MixedModeSource({ id: "source" }))
+    ).runGraph({}, { outputCache: cache });
+
+    const data = sourceData(results);
+    // The append port keeps its accumulated value — no silently dropped deltas.
+    expect(data.t).toBe("hello");
+    expect(await blobBytes(data.a)).toEqual([1, 2]);
+  });
+
+  it("leaves the single-binary-port path byte-identical", async () => {
+    const results = await new TaskGraphRunner(
+      leafGraph(new OneBinaryPortSource({ id: "source" }))
+    ).runGraph({}, { outputCache: cache });
+
+    expect(cache.streamed.size).toBe(1);
+    const data = sourceData(results);
+    expect(await blobBytes(data.bytes)).toEqual([4, 5]);
+  });
+});

--- a/packages/task-graph/src/task-graph/__tests__/MultiBinaryPortCacheStream.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/MultiBinaryPortCacheStream.test.ts
@@ -187,7 +187,7 @@ class BinarySink extends Task<{ bytes: Blob | ArrayBuffer }, BinarySinkOut> {
       additionalProperties: false,
     } as const satisfies DataPortSchema;
   }
-  async execute(input: { bytes: Blob | ArrayBuffer }): Promise<BinarySinkOut> {
+  override async execute(input: { bytes: Blob | ArrayBuffer }): Promise<BinarySinkOut> {
     const blob = input.bytes as Blob;
     return { size: (await blob.arrayBuffer()).byteLength };
   }

--- a/packages/task-graph/src/task-graph/__tests__/MultiBinaryPortCacheStream.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/MultiBinaryPortCacheStream.test.ts
@@ -151,6 +151,15 @@ class MixedModeSource extends Task<Record<string, never>, MixedOut> {
   }
 }
 
+/**
+ * Same two binary ports, but NOT cacheable — so no sink is ever built for
+ * either port and accumulation must stay on.
+ */
+class UncacheableTwoBinaryPortSource extends TwoBinaryPortSource {
+  public static override type = "MultiBinaryPortCacheStream_TwoPortUncacheable";
+  public static override cacheable = false;
+}
+
 type BinarySinkOut = { size: number };
 
 /**
@@ -246,6 +255,18 @@ describe("canStreamBinaryToCache — one or more binary ports", () => {
 
   it("still rejects a binary port mixed with a non-binary streaming port", () => {
     expect(decisionFor(new MixedModeSource({ id: "source" }))).toBe(false);
+  });
+
+  it("still rejects a non-cacheable task, whatever its binary port count", () => {
+    // No sinks are built for a non-cacheable task, so every port must keep its
+    // accumulator — the "neither sink nor accumulator" hole this guards.
+    expect(decisionFor(new UncacheableTwoBinaryPortSource({ id: "source" }))).toBe(false);
+  });
+
+  it("still rejects a cache that cannot report supportsStreaming()", () => {
+    const source = new TwoBinaryPortSource({ id: "source" });
+    const partial = {} as unknown as Parameters<typeof StreamPump.canStreamBinaryToCache>[2];
+    expect(StreamPump.canStreamBinaryToCache(leafGraph(source), source, partial)).toBe(false);
   });
 });
 
@@ -352,6 +373,17 @@ describe("multi-binary-port cache streaming (no noAccumulation flag)", () => {
     // The append port keeps its accumulated value — no silently dropped deltas.
     expect(data.t).toBe("hello");
     expect(await blobBytes(data.a)).toEqual([1, 2]);
+  });
+
+  it("keeps every port's bytes when the task is not cacheable (no sinks at all)", async () => {
+    const results = await new TaskGraphRunner(
+      leafGraph(new UncacheableTwoBinaryPortSource({ id: "source" }))
+    ).runGraph({}, { outputCache: cache });
+
+    expect(cache.streamed.size).toBe(0);
+    const data = sourceData(results);
+    expect(await blobBytes(data.a)).toEqual(A_BYTES);
+    expect(await blobBytes(data.b)).toEqual(B_BYTES);
   });
 
   it("leaves the single-binary-port path byte-identical", async () => {

--- a/packages/task-graph/src/task/CacheCoordinator.ts
+++ b/packages/task-graph/src/task/CacheCoordinator.ts
@@ -17,7 +17,7 @@ import { getStreamPortCodec } from "../cache/streamCodec";
 import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ITask } from "./ITask";
 import type { BinaryRefSink, StreamSink } from "./StreamProcessor";
-import type { StreamEvent } from "./StreamTypes";
+import type { StreamEvent, StreamMode } from "./StreamTypes";
 import {
   assertBinaryFormat,
   CACHE_HIT_USAGE,
@@ -474,8 +474,9 @@ export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput
    * Returns `undefined` when any of the conditions for the ref path are not
    * met: no cache is configured by policy, the cache does not implement
    * `saveOutputStreamPort`, the task is not cacheable, or the output schema has
-   * no `x-stream: "binary"` port. This path supports single-binary-port tasks
-   * only; tasks with multiple binary ports fall back to the accumulation path.
+   * no `x-stream: "binary"` port. Every binary port gets its own sink and its
+   * own {@link CacheRef}; non-binary streaming ports (`append` / `object`) are
+   * excluded here and stay flag-gated on {@link getRefSinksByPolicy}.
    *
    * The threshold ({@link IRunConfig.referenceThresholdBytes}) controls
    * whether the ref *survives* in the final Output, not whether the sink
@@ -493,36 +494,36 @@ export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput
     if (!this.task.cacheable) return undefined;
     const cache = this.repoFor(registry, policy);
     if (!cache || !cache.supportsStreaming()) return undefined;
-    // Without the no-accumulation flag the runner drives at most one sink per
-    // task, so a second binary port would have neither a sink nor an
-    // accumulator. Enforce the single-binary-port restriction here as well as
-    // in the accumulation decision (StreamPump.canStreamBinaryToCache) —
-    // multi-port tasks fall back to pure accumulation.
     const binaryPorts = getStreamingPorts(outputSchema).filter((p) => p.mode === "binary");
-    if (binaryPorts.length !== 1) return undefined;
-    const port = binaryPorts[0].port;
+    if (binaryPorts.length === 0) return undefined;
+    const sinks = new Map<string, BinaryRefSink>();
+    for (const { port } of binaryPorts) {
+      sinks.set(port, this.makeStreamWriter(cache, keyInputs, port, "binary"));
+    }
+    return sinks;
+  }
+
+  /**
+   * One port's writer closure: hand the encoded bytes to the port-aware backing
+   * and normalize what comes back.
+   *
+   * Re-wraps the backing's `CacheRef` so an implementation that pre-dates the
+   * `kind` brand still produces a discriminator-bearing ref; branded refs pass
+   * through unchanged (preserving size/mime hints). Shared by the binary and
+   * all-mode sink builders so the two paths differ only in which ports they
+   * select, never in how a port's bytes are written.
+   */
+  private makeStreamWriter(
+    cache: TaskOutputRepository,
+    keyInputs: Input,
+    port: string,
+    mode: StreamMode
+  ): BinaryRefSink {
     const taskType = this.task.type;
-    // The single-binary case IS the port-aware writer with one binary port, so
-    // it adapts here rather than in the repository: this is the one call site
-    // that has to synthesize nothing (the port id is already in hand), and a
-    // base-class shim would have to invent a port name for a portless
-    // signature — reintroducing the second writer this collapsed away.
-    //
-    // Re-wrap the backing's CacheRef so an implementation that pre-dates the
-    // `kind` brand still produces a discriminator-bearing ref. Branded refs
-    // pass through unchanged (preserving size/mime hints).
-    const sink: BinaryRefSink = async (chunks) => {
-      const raw = await cache.saveOutputStreamPort!(
-        taskType,
-        keyInputs,
-        port,
-        "binary",
-        chunks,
-        {}
-      );
+    return async (chunks) => {
+      const raw = await cache.saveOutputStreamPort!(taskType, keyInputs, port, mode, chunks, {});
       return isCacheRef(raw) ? raw : makeCacheRef(raw);
     };
-    return new Map([[port, sink]]);
   }
 
   /**
@@ -552,23 +553,9 @@ export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput
       (p) => p.mode === "append" || p.mode === "object" || p.mode === "binary"
     );
     if (ports.length === 0) return undefined;
-    const taskType = this.task.type;
     const sinks = new Map<string, StreamSink>();
     for (const { port, mode } of ports) {
-      sinks.set(port, {
-        mode,
-        write: async (chunks) => {
-          const raw = await cache.saveOutputStreamPort!(
-            taskType,
-            keyInputs,
-            port,
-            mode,
-            chunks,
-            {}
-          );
-          return isCacheRef(raw) ? raw : makeCacheRef(raw);
-        },
-      });
+      sinks.set(port, { mode, write: this.makeStreamWriter(cache, keyInputs, port, mode) });
     }
     return sinks;
   }

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -98,9 +98,9 @@ function isOwnTrackable(i: unknown): i is object {
 }
 
 /**
- * Adapts the legacy single-binary-port sink map to the unified per-port
- * {@link StreamSink} shape: a binary-mode sink is exactly a
- * {@link BinaryRefSink} with its mode named.
+ * Adapts the binary-only sink map to the unified per-port {@link StreamSink}
+ * shape: a binary-mode sink is exactly a {@link BinaryRefSink} with its mode
+ * named.
  */
 function wrapBinarySinks(
   sinks: ReadonlyMap<string, BinaryRefSink> | undefined
@@ -397,10 +397,10 @@ export class TaskRunner<
         if (outputs === undefined) {
           // Under the no-accumulation opt-in, build per-port sinks for EVERY
           // streamable mode (append/object/binary) via the port-aware backing;
-          // otherwise fall back to the legacy single-binary-port sink (adapted
-          // to the same StreamSink shape). Both run memory-bounded; the runtime
-          // threshold controls whether the resulting CacheRef survives in
-          // Output or is rehydrated inline below.
+          // otherwise build them for the binary ports only (adapted to the same
+          // StreamSink shape) — that mode streams to cache unflagged. Both run
+          // memory-bounded; the runtime threshold controls whether the
+          // resulting CacheRef survives in Output or is rehydrated inline below.
           const portSinks =
             isStreamable && this.noAccumulation === true
               ? this.cacheCoordinator.getRefSinksByPolicy(

--- a/packages/test/src/test/task-graph/BinaryCacheIntegrity.test.ts
+++ b/packages/test/src/test/task-graph/BinaryCacheIntegrity.test.ts
@@ -113,27 +113,30 @@ describe("binary cache integrity", () => {
     expect(await blobBytes(out2.bytes)).toEqual([1, 2, 3, 4, 5]);
   });
 
-  it("multi-binary-port tasks fall back to accumulation — no port is dropped", async () => {
+  it("multi-binary-port tasks stream every port — no port is dropped", async () => {
     const repo = new StreamingMemoryRepo({});
 
     const graph = new TaskGraph();
     const source = new TwoPortBinarySource({ id: "source" });
     graph.addTask(source);
     // Legacy direct-cache config: this is the path where taskNeedsAccumulation
-    // consults canStreamBinaryToCache and may skip accumulation entirely.
+    // consults canStreamBinaryToCache and skips accumulation entirely.
     const results = await new TaskGraphRunner(graph).runGraph({}, { outputCache: repo });
 
+    // One blob per port, and both values still reach the caller — under the
+    // default threshold each small ref is rehydrated back to an inline Blob.
+    expect(repo.streamed.size).toBe(2);
     const data = results.find((r) => r.id === "source")!.data as TwoPortOut;
     expect(await blobBytes(data.a)).toEqual([1, 2]);
     expect(await blobBytes(data.b)).toEqual([9, 8, 7]);
   });
 
-  it("canStreamBinaryToCache rejects tasks with more than one binary port", () => {
+  it("canStreamBinaryToCache accepts tasks with more than one binary port", () => {
     const graph = new TaskGraph();
     const source = new TwoPortBinarySource({ id: "source" });
     graph.addTask(source);
     expect(StreamPump.canStreamBinaryToCache(graph, source, new StreamingMemoryRepo({}))).toBe(
-      false
+      true
     );
   });
 });


### PR DESCRIPTION
Closes #785 — items 1–3. Item 4 (splitting `anyConsumerNeedsMaterialized` per-port) is **deferred** with reasoning below.

## What changed

A single binary output port streamed straight to a cache sink; two or more silently fell back to full in-memory accumulation unless the caller opted into `noAccumulation` — precisely the memory behavior the unconditional binary path exists to avoid, and worst for the tasks producing the most bytes.

The cap was originally a *contract* limitation: the portless writer keyed bytes by `(taskType, inputs)` with no port axis, so one entry genuinely could not name two blobs. `saveOutputStreamPort` removed that, leaving only a limitation of which builder the unflagged path called.

| file | change |
| --- | --- |
| `task/CacheCoordinator.ts` | `getBinaryRefSinksByPolicy` widens `!== 1` → `=== 0` and builds one sink per binary port. Extracted `makeStreamWriter(cache, keyInputs, port, mode)` — the writer closure now **shared** with `getRefSinksByPolicy`, which loses its duplicated inline copy. The two builders differ in which ports they select, never in how a port's bytes are written. |
| `task-graph/StreamPump.ts` | `canStreamBinaryToCache` widens to any all-binary port set. The two conditions the old one-liner fused are now stated separately: `length === 0` → false, and `every(mode === "binary")` → false. |
| `task/TaskRunner.ts` | Comments only — the "legacy single-binary-port sink" framing was no longer true. |
| `src/EXECUTION_MODEL.md` | "Single binary port" → "Binary-only, any number of ports"; "One writer, two gating rules" restated. The deliberate asymmetry is preserved and still documented. |
| `task-graph/__tests__/MultiBinaryPortCacheStream.test.ts` | New, 15 tests. |
| `test/.../BinaryCacheIntegrity.test.ts` | Two tests pinned the old cap; inverted and strengthened. |

`append` / `object` remain flag-gated. **Binary-only is still load-bearing** and is now its own condition rather than riding on the count: only binary ports get sinks here, so an `append`/`object` port alongside them would have neither a sink nor — with accumulation skipped — an accumulator, and its deltas would drop into an empty finish payload.

## How I confirmed the harness was live (not stale `dist`)

Tests resolve `@workglow/task-graph` to `dist/`, so a source edit is invisible without `use-source`. I ran `bun run use-source`, then proved reachability **twice** before trusting any result:

1. **`task-graph` project** — changed the guard's constant to `!== 99`; `StreamBinaryPump.test.ts` went 15 passed → `1 failed | 14 passed`, failing at the exact `canStreamBinaryToCache` assertion. Reverted.
2. **`test` project** (separate workspace, consumes the package) — inserted `throw new Error("MUTANT-PROOF")` at the top of `canStreamBinaryToCache`; `BinaryCacheIntegrity.test.ts` went to `2 failed | 4 passed` with the throw in the stack. Reverted.

And after the change, mutating the *real* edit back to the old cap (`binaryPorts.length !== 1`) turned 12 passed → `5 failed | 7 passed`. Restored with `bun run use-dist`; `git status` is clean of stubs.

## Proof the new tests fail against pre-change code

Stashed the three source files and re-ran the new suite:

```
❯ MultiBinaryPortCacheStream.test.ts (12 tests | 7 failed)
  × accepts two binary ports
  × accepts three binary ports
  × writes one distinct blob and one port-bearing ref per binary port
  × streams three binary ports to three distinct blobs
  × rehydrates both ports below the threshold and replays them on a cache hit
  × tees to both sinks: materializing consumers still get one blob per port
  × treats one evicted binary blob of two as a whole-entry miss
  Tests  7 failed | 5 passed (12)
```

The 5 that passed pre-change are the invariants that must **not** move: single binary port, mixed binary+append, and a full multi-binary cache-hit replay. Post-change all 15 pass.

## Does the multi-binary case genuinely work end to end?

Yes. `cache.streamed.size === 2` (and `=== 3`), distinct `$ref`s, `ref.port` equal to `"a"`/`"b"`, bytes read back per port, and correct values on a replayed hit — with two and three ports, at `referenceThresholdBytes: 0` (refs survive) and at the default threshold (refs rehydrate to inline `Blob`s).

**The teeing claim in the issue was verified against the code, not assumed.** `StreamProcessor` keys routers per port and installs sinks independently of `ctx.shouldAccumulate`; the finish handler emits accumulated bytes to edge consumers while overlaying router refs onto `finalOutput`. The `tees to both sinks` test exercises exactly that: two materializing consumers, and **both** blobs are still written.

## Invariants held

- **All-or-nothing multi-port refs** (`CacheHitPartialRefMiss.test.ts`) still passes, and is **extended** to the newly-reachable multi-binary case: evicting one of two binary blobs re-executes the task rather than serving a hole.
  - Worth recording: that invariant is **consumer-gated** — `replayStreamRefs` returns early when neither consumer hint is set, so a *consumerless leaf* passes a dangling ref through unchecked. I probed this and confirmed it is **pre-existing and identical for a single binary port**, i.e. orthogonal to this change (it is the documented "No consumers" row in `EXECUTION_MODEL.md`). The eviction test is therefore shaped with consumers, matching `CacheHitPartialRefMiss`.
- **Every ref carries `port`** (`CacheRefPortGuarantee.test.ts`) — passes; additionally asserted per-port in the new suite.
- **No port without sink *or* accumulator.** The sink map is all-or-nothing (`getBinaryRefSinksByPolicy` builds sinks for every binary port or returns `undefined`) and `canStreamBinaryToCache` requires all-binary, so either every port has a sink or accumulation stays on. Pinned for both absence routes: non-cacheable task (decision *and* end-to-end, where both ports' bytes still reach the caller with nothing written to cache) and a cache that cannot report `supportsStreaming()`.
- **Single-binary-port behavior unchanged** — pinned explicitly, and the 5 pre-change-passing tests are the evidence it did not move.

## Item 4 deferred — why

The issue's own framing is right (materializing consumers gate *skipping accumulation*, not *writing to cache*), and I confirmed the tee empirically. But splitting the predicate per-port is not a local edit, because the value it feeds is scalar the whole way down:

- `anyConsumerNeedsMaterialized` → `canStreamBinaryToCache` → `taskNeedsAccumulation` → **`ctx.shouldAccumulate`, a single `boolean` on the public `IExecuteContext` / `TaskRunContext`** (and `IRunConfig.shouldAccumulate`).
- `StreamProcessor` creates all three accumulator maps from that one boolean, and derives `hasEnrichment` and the whole finish-merge branch from it.
- `TaskRunner`'s "no sink resolved → force accumulation" safety net sets it task-wide.
- The cache-**hit** side has the same fusion in `replayStreamRefs`'s task-level `needBytes`, which would need splitting too for the two paths to agree.

So it means changing a public context field's semantics plus the accumulator lifecycle, and the risk lands on the single-binary-port common case this PR is required not to regress. That is a different change with a different risk profile, and half-doing it (per-port decision feeding a scalar flag) would be worse than not doing it. Items 1–3 stand on their own and are useful without it: N binary ports stream today.

## Verification

```
bun run build:types            41 successful, 41 total
npx tsc -b packages/test       exit 0

bun scripts/test.ts task-graph graph vitest   152 files, 1452 passed
bun scripts/test.ts task vitest                65 files,  962 passed | 24 skipped
bun scripts/test.ts storage vitest             68 passed | 1 skipped, 1946 passed
bun scripts/test.ts queue vitest               15 files,  424 passed | 26 skipped
bun scripts/test.ts --check-sections           Every test file is discovered and reachable

npx prettier --check <changed files>           All matched files use Prettier code style!
npx eslint <changed files>                     exit 0
```

No unrelated files touched (the known ~12-file `bun run format` drift on main was avoided — `prettier --write` was scoped to changed files only). Node 22.22.2 was the only runtime available in this container; the repo asks for Node 24+, so the native-dependency caveat in `CLAUDE.md` applies, though nothing in the run suggested it bit here.

Known pre-existing failures in this container (`TFMP_GenaiHelpers.test.ts`, `task/FetchTask.test.ts`) were not attributed to this change; the `task` section in fact ran fully green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SS3QiufMDGbfmamoQgY7J

---
_Generated by [Claude Code](https://claude.ai/code/session_016SS3QiufMDGbfmamoQgY7J)_