### PR TITLE
fix(tasks): stop replaying credentials to cross-origin redirect targets

### DIFF
--- a/packages/tasks/CHANGELOG.md
+++ b/packages/tasks/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @workglow/tasks
 
+## Unreleased
+
+### Security
+
+#### tasks
+
+- stop replaying credentials to cross-origin redirect targets in `safeFetch`.
+  Both redirect loops (`SafeFetch.ts` and `SafeFetch.server.ts`) now drop
+  `authorization`, `proxy-authorization`, and `cookie` on any hop whose target
+  origin differs from the current one — origin comparison, so a differing scheme
+  or port also counts. `SafeFetchOptions.sensitiveHeaders` names additional
+  headers to drop, which `FetchUrlTask` supplies for
+  `credential_scheme: "header"` (the secret sits on a caller-named header such
+  as `X-Api-Key` that `safeFetch` cannot otherwise recognize). Once a header is
+  stripped it stays stripped for the remainder of the chain, so a
+  `vendor -> attacker -> vendor` redirect cannot launder it back.
+
 ## 0.3.44
 
 ## 0.3.43

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -27,7 +27,12 @@ import {
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { safeFetch } from "../util/SafeFetch";
 import { classifyUrl, urlResourcePattern } from "../util/UrlClassifier";
-import { applyCredentialToHeaders } from "./FetchUrlCredentials";
+import {
+  applyCredentialToHeaders,
+  credentialHeaderName,
+  CredentialSchemes,
+  DEFAULT_CREDENTIAL_SCHEME,
+} from "./FetchUrlCredentials";
 import {
   createFetchUrlAbortedError,
   createFetchUrlHttpError,
@@ -149,6 +154,7 @@ async function fetchWithProgress(
   options: RequestInit & {
     allowPrivate?: boolean;
     privateResourceScopes?: readonly string[];
+    sensitiveHeaders?: readonly string[];
   } = {},
   onProgress?: (progress: number) => Promise<void>
 ): Promise<Response> {
@@ -229,6 +235,21 @@ export class FetchUrlJob<
   Output = FetchUrlTaskOutput,
 > extends Job<Input, Output> {
   static readonly type: string = "FetchUrlJob";
+
+  /**
+   * Header names holding a resolved credential, so safeFetch can drop them on a
+   * cross-origin redirect. `Authorization` is covered by safeFetch's own
+   * strip-set; this exists for `credential_scheme: "header"`, whose header name
+   * is caller-chosen and is stripped from the job input before the request is
+   * issued — nothing downstream could otherwise know which header is secret.
+   *
+   * Set by {@link FetchUrlTask} on the inline path only. It is deliberately not
+   * a data port: job inputs are persisted durably by the queued path, and this
+   * names a credential header. The queued path refuses credentials outright, so
+   * there is nothing for it to carry.
+   */
+  public sensitiveHeaders: readonly string[] | undefined = undefined;
+
   override async execute(input: Input, context: IJobExecuteContext): Promise<Output> {
     const classification = classifyUrl(input.url!);
     if (classification.kind === "invalid") {
@@ -265,6 +286,7 @@ export class FetchUrlJob<
           signal: context.signal,
           allowPrivate: isPrivate,
           privateResourceScopes: isPrivate ? [urlResourcePattern(input.url!)] : undefined,
+          sensitiveHeaders: this.sensitiveHeaders,
         },
         async (progress: number) => await context.updateProgress(progress)
       );
@@ -549,11 +571,21 @@ export class FetchUrlTask<
     });
     const jobInput: FetchUrlTaskInput = headers ? { ...rest, headers } : rest;
 
+    // The header the credential landed on, so safeFetch can drop it when a
+    // redirect crosses origins. Only the `header` scheme needs telling: the
+    // others write Authorization, which is always stripped cross-origin.
+    const credentialScheme = input.credential_scheme ?? DEFAULT_CREDENTIAL_SCHEME;
+    const sensitiveHeaders =
+      credential && credentialScheme !== CredentialSchemes.NONE
+        ? [credentialHeaderName(credentialScheme, input.credential_header)]
+        : undefined;
+
     let cleanup: () => void = () => {};
 
     try {
       if (queuePref === false) {
         const job = new FetchUrlJob<FetchUrlTaskInput, Output>({ input: jobInput });
+        job.sensitiveHeaders = sensitiveHeaders;
         cleanup = job.onJobProgress(
           (progress: number, message: string, details: Record<string, any> | null) => {
             executeContext.updateProgress(progress, message, details);

--- a/packages/tasks/src/util/SafeFetch.server.ts
+++ b/packages/tasks/src/util/SafeFetch.server.ts
@@ -26,7 +26,12 @@ import {
   FetchUrlErrorCode,
   isFetchUrlJobError,
 } from "../task/FetchUrlJobError";
-import { registerSafeFetch, type SafeFetchFn, type SafeFetchOptions } from "./SafeFetch";
+import {
+  applyCrossOriginHeaderStrip,
+  registerSafeFetch,
+  type SafeFetchFn,
+  type SafeFetchOptions,
+} from "./SafeFetch";
 import { classifyIpLiteral, classifyUrl, urlMatchesScope } from "./UrlClassifier";
 
 const MAX_REDIRECT_HOPS = SECURITY_LIMITS.safeFetchMaxRedirectHops;
@@ -85,6 +90,12 @@ function isRedirectStatus(status: number): boolean {
   return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }
 
+/** The request init actually handed to undici, once SafeFetch-only fields are removed. */
+type HopInit = Omit<
+  SafeFetchOptions,
+  "allowPrivate" | "privateResourceScopes" | "sensitiveHeaders" | "redirect"
+>;
+
 /**
  * Resolve a single hop: classify URL, DNS-resolve if needed, pin connection,
  * execute the request with redirect:manual, and return the raw response.
@@ -93,7 +104,7 @@ function isRedirectStatus(status: number): boolean {
 async function fetchOneHop(
   url: string,
   opts: SafeFetchOptions,
-  fetchInit: Omit<SafeFetchOptions, "allowPrivate" | "privateResourceScopes" | "redirect">
+  fetchInit: HopInit
 ): Promise<{ response: Response; dispatcher: Agent }> {
   const classification = classifyUrl(url);
   if (classification.kind === "invalid") {
@@ -188,11 +199,13 @@ export const serverSafeFetch: SafeFetchFn = async (url, options) => {
   const {
     allowPrivate: _allowPrivate,
     privateResourceScopes: _privateResourceScopes,
+    sensitiveHeaders,
     redirect: _redirect,
-    ...fetchInit
+    ...initialFetchInit
   } = opts;
 
   let currentUrl = url;
+  let fetchInit: HopInit = initialFetchInit;
   let prevDispatcher: Agent | undefined;
 
   for (let hops = 0; hops <= MAX_REDIRECT_HOPS; hops += 1) {
@@ -255,7 +268,11 @@ export const serverSafeFetch: SafeFetchFn = async (url, options) => {
     }
 
     prevDispatcher = dispatcher;
-    currentUrl = new URL(location, currentUrl).toString();
+    const nextUrl = new URL(location, currentUrl).toString();
+    // Credential-bearing headers never survive an origin change; the strip is
+    // carried forward, so it is never undone by a later same-origin hop.
+    fetchInit = applyCrossOriginHeaderStrip(fetchInit, currentUrl, nextUrl, sensitiveHeaders);
+    currentUrl = nextUrl;
   }
 
   throw createFetchUrlJobError(

--- a/packages/tasks/src/util/SafeFetch.ts
+++ b/packages/tasks/src/util/SafeFetch.ts
@@ -44,6 +44,89 @@ export interface SafeFetchOptions extends RequestInit {
    * port the task was never authorized to reach.
    */
   readonly privateResourceScopes?: readonly string[];
+  /**
+   * Extra request-header names that carry a secret and must be dropped when a
+   * redirect crosses to a different origin. {@link CROSS_ORIGIN_STRIPPED_HEADERS}
+   * is always dropped regardless of this field; this list exists for schemes
+   * that place a credential on a caller-named header (e.g. `X-Api-Key`), which
+   * safeFetch cannot recognize on its own. Matched case-insensitively.
+   */
+  readonly sensitiveHeaders?: readonly string[];
+}
+
+/**
+ * Request headers always dropped on a cross-origin redirect hop. Following a
+ * redirect must not replay ambient authority to a host the caller never chose:
+ * the redirect target is named by the previous server, which may itself be
+ * compromised or attacker-influenced.
+ */
+export const CROSS_ORIGIN_STRIPPED_HEADERS: readonly string[] = [
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+];
+
+/** Origin comparison, so a differing scheme or port also counts as cross-origin. */
+function isCrossOrigin(fromUrl: string, toUrl: string): boolean {
+  try {
+    return new URL(fromUrl).origin !== new URL(toUrl).origin;
+  } catch {
+    // Unparseable on either side: fail closed and strip.
+    return true;
+  }
+}
+
+/**
+ * Returns a copy of `headers` with the credential-bearing entries removed,
+ * preserving the caller's `HeadersInit` shape (`Headers`, entry pairs, or a
+ * plain record). Never mutates its argument.
+ */
+export function stripSensitiveHeaders(
+  headers: HeadersInit | undefined,
+  sensitiveHeaders: readonly string[] | undefined
+): HeadersInit | undefined {
+  if (headers === undefined) return undefined;
+  const extra = new Set((sensitiveHeaders ?? []).map((name) => name.toLowerCase()));
+  const drop = (name: string): boolean => {
+    const lower = name.toLowerCase();
+    return CROSS_ORIGIN_STRIPPED_HEADERS.includes(lower) || extra.has(lower);
+  };
+
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    const next = new Headers();
+    headers.forEach((value, key) => {
+      if (!drop(key)) next.append(key, value);
+    });
+    return next;
+  }
+  if (Array.isArray(headers)) {
+    return headers.filter((entry) => !drop(entry[0] ?? ""));
+  }
+  const next: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers as Record<string, string>)) {
+    if (!drop(key)) next[key] = value;
+  }
+  return next;
+}
+
+/**
+ * Applies {@link stripSensitiveHeaders} to a request init when the next hop is
+ * cross-origin; returns `init` unchanged otherwise.
+ *
+ * Callers thread the result forward as the init for every remaining hop, so a
+ * header stripped once stays stripped for the rest of the chain even if a later
+ * Location returns to the original origin. That is deliberate: restoring it
+ * would let a `vendor -> attacker -> vendor` chain launder the credential back
+ * into a request whose path the attacker chose.
+ */
+export function applyCrossOriginHeaderStrip<T extends { headers?: HeadersInit | undefined }>(
+  init: T,
+  fromUrl: string,
+  toUrl: string,
+  sensitiveHeaders: readonly string[] | undefined
+): T {
+  if (!isCrossOrigin(fromUrl, toUrl)) return init;
+  return { ...init, headers: stripSensitiveHeaders(init.headers, sensitiveHeaders) };
 }
 
 export type SafeFetchFn = (url: string, options: SafeFetchOptions) => Promise<Response>;
@@ -98,9 +181,19 @@ function isRedirectStatus(status: number): boolean {
  */
 async function defaultSafeFetch(url: string, options: SafeFetchOptions): Promise<Response> {
   const requestedRedirectMode = options.redirect ?? "follow";
-  const { allowPrivate, privateResourceScopes, redirect: _redirect, ...fetchOptions } = options;
+  const {
+    allowPrivate,
+    privateResourceScopes,
+    sensitiveHeaders,
+    redirect: _redirect,
+    ...initialFetchOptions
+  } = options;
 
   let currentUrl = url;
+  let fetchOptions: Omit<
+    SafeFetchOptions,
+    "allowPrivate" | "privateResourceScopes" | "sensitiveHeaders" | "redirect"
+  > = initialFetchOptions;
   for (let hops = 0; hops <= MAX_REDIRECT_HOPS; hops += 1) {
     assertAllowedUrl(currentUrl, allowPrivate, privateResourceScopes);
 
@@ -132,7 +225,11 @@ async function defaultSafeFetch(url: string, options: SafeFetchOptions): Promise
       );
     }
 
-    currentUrl = new URL(location, currentUrl).toString();
+    const nextUrl = new URL(location, currentUrl).toString();
+    // Credential-bearing headers never survive an origin change; the strip is
+    // carried forward, so it is never undone by a later same-origin hop.
+    fetchOptions = applyCrossOriginHeaderStrip(fetchOptions, currentUrl, nextUrl, sensitiveHeaders);
+    currentUrl = nextUrl;
   }
 
   throw createFetchUrlJobError(

--- a/packages/test/src/test/task/FetchUrlSsrf.test.ts
+++ b/packages/test/src/test/task/FetchUrlSsrf.test.ts
@@ -32,7 +32,14 @@ import {
   type SafeFetchFn,
   type SafeFetchOptions,
 } from "@workglow/tasks";
-import { Container, ServiceRegistry, setLogger } from "@workglow/util";
+import {
+  Container,
+  InMemoryCredentialStore,
+  registerCredentialDefaults,
+  ServiceRegistry,
+  setGlobalCredentialStore,
+  setLogger,
+} from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -449,6 +456,253 @@ describe("SafeFetch redirect scope enforcement (real redirect loop)", () => {
     });
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("defaultSafeFetch cross-origin redirect header strip", () => {
+  // The browser implementation is a second, independent redirect loop: a fix in
+  // SafeFetch.server.ts is not a fix here. These exercise the real
+  // defaultSafeFetch by resetting to it and mocking globalThis.fetch, and all of
+  // them use PUBLIC origins — `privateResourceScopes` never applies there, so
+  // the header strip is the only thing standing between a compromised vendor
+  // and the caller's credential.
+
+  const redirect = (location: string, status = 302): Response =>
+    new Response(null, { status, headers: { location } });
+
+  let prevSafeFetch: SafeFetchFn;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let realFetch: typeof globalThis.fetch;
+
+  /** Headers the mock received on call `index` (0-based), keyed lower-case. */
+  const headersOnCall = (index: number): Record<string, string> => {
+    const init = fetchMock.mock.calls[index]?.[1] as { headers?: Record<string, string> };
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(init?.headers ?? {})) {
+      out[key.toLowerCase()] = value;
+    }
+    return out;
+  };
+
+  beforeEach(() => {
+    prevSafeFetch = getSafeFetchImpl();
+    resetSafeFetch();
+    realFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    registerSafeFetch(prevSafeFetch);
+  });
+
+  test("cross-origin 302 drops Authorization and keeps unrelated headers", async () => {
+    // The finding itself: without the strip the attacker origin receives the
+    // bearer token. The surviving X-Trace-Id proves the strip is targeted.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://attacker.example/"))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      headers: { Authorization: "Bearer super-secret-token", "X-Trace-Id": "trace-1" },
+    });
+
+    expect(headersOnCall(0).authorization).toBe("Bearer super-secret-token");
+    expect(headersOnCall(1).authorization).toBeUndefined();
+    expect(headersOnCall(1)["x-trace-id"]).toBe("trace-1");
+  });
+
+  test("same-origin 302 keeps Authorization", async () => {
+    // Guards the opposite failure: an unconditional strip would break every
+    // authenticated API that redirects within its own origin.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://api.vendor.example/x/v2"))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      headers: { Authorization: "Bearer super-secret-token" },
+    });
+
+    expect(headersOnCall(1).authorization).toBe("Bearer super-secret-token");
+  });
+
+  test("a sensitiveHeaders-named custom header is dropped cross-origin", async () => {
+    // credential_scheme "header" puts the secret on a caller-chosen header that
+    // safeFetch cannot recognize on its own.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://attacker.example/"))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      headers: { "X-Api-Key": "sk-secret", "X-Trace-Id": "trace-1" },
+      sensitiveHeaders: ["x-api-key"],
+    });
+
+    expect(headersOnCall(1)["x-api-key"]).toBeUndefined();
+    expect(headersOnCall(1)["x-trace-id"]).toBe("trace-1");
+  });
+
+  test("a differing port on the same host counts as cross-origin", async () => {
+    // A hostname comparison would call these same-origin and replay the token.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://api.vendor.example:8443/x"))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      headers: { Authorization: "Bearer super-secret-token" },
+    });
+
+    expect(headersOnCall(1).authorization).toBeUndefined();
+  });
+
+  test("a differing scheme on the same host counts as cross-origin", async () => {
+    // https -> http is a downgrade onto the wire; the token must not follow.
+    fetchMock
+      .mockResolvedValueOnce(redirect("http://api.vendor.example/x"))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      headers: { Authorization: "Bearer super-secret-token" },
+    });
+
+    expect(headersOnCall(1).authorization).toBeUndefined();
+  });
+
+  test("cookie and proxy-authorization are dropped with no sensitiveHeaders supplied", async () => {
+    // The fixed strip-set must not depend on the caller opting in.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://attacker.example/"))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      headers: { Cookie: "session=abc123", "Proxy-Authorization": "Basic cHJveHk6cHc=" },
+    });
+
+    expect(headersOnCall(1).cookie).toBeUndefined();
+    expect(headersOnCall(1)["proxy-authorization"]).toBeUndefined();
+  });
+
+  test("a Headers instance is stripped too, not just a plain record", async () => {
+    // Direct callers may pass any HeadersInit shape; a record-only strip would
+    // pass a Headers object straight through to the attacker origin.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://attacker.example/"))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      headers: new Headers({ Authorization: "Bearer super-secret-token", Accept: "text/plain" }),
+    });
+
+    const sent = fetchMock.mock.calls[1]?.[1] as { headers?: Headers };
+    expect(sent?.headers).toBeInstanceOf(Headers);
+    expect(sent!.headers!.get("authorization")).toBeNull();
+    expect(sent!.headers!.get("accept")).toBe("text/plain");
+  });
+
+  test("once stripped the header stays stripped when the chain returns home", async () => {
+    // Laundering guard: vendor -> attacker -> vendor must not restore the token
+    // on the final hop merely because that origin matches the original.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://attacker.example/bounce"))
+      .mockResolvedValueOnce(redirect("https://api.vendor.example/final"))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      headers: { Authorization: "Bearer super-secret-token" },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("https://api.vendor.example/final");
+    expect(headersOnCall(2).authorization).toBeUndefined();
+  });
+});
+
+describe("FetchUrlTask end-to-end: a resolved credential never reaches a redirect target", () => {
+  // The whole path is real here — credential resolution, header placement,
+  // FetchUrlJob, and the defaultSafeFetch redirect loop — with only the socket
+  // mocked. Public origins are used deliberately: the private-scope guard does
+  // not apply to them, so nothing but the header strip protects the secret.
+  const SECRET = "sk-super-secret-value-1234567890";
+  const CREDENTIAL_KEY = "vendor-api-credential";
+
+  const redirect = (location: string): Response =>
+    new Response(null, { status: 302, headers: { location } });
+
+  let prevSafeFetch: SafeFetchFn;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let realFetch: typeof globalThis.fetch;
+
+  const createCredentialRegistry = async (): Promise<ServiceRegistry> => {
+    const credentialRegistry = new ServiceRegistry(new Container());
+    registerCredentialDefaults(credentialRegistry);
+    const store = new InMemoryCredentialStore();
+    await store.put(CREDENTIAL_KEY, SECRET);
+    setGlobalCredentialStore(store, credentialRegistry);
+    return credentialRegistry;
+  };
+
+  /** Every header value the mock ever received, flattened for a secret scan. */
+  const allSentHeaderValues = (): string[] =>
+    fetchMock.mock.calls.flatMap((call) => {
+      const init = call[1] as { headers?: Record<string, string> };
+      return Object.values(init?.headers ?? {});
+    });
+
+  beforeEach(() => {
+    prevSafeFetch = getSafeFetchImpl();
+    resetSafeFetch();
+    realFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    registerSafeFetch(prevSafeFetch);
+  });
+
+  test("a bearer credential is not replayed to a cross-origin redirect target", async () => {
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://attacker.example/"))
+      .mockResolvedValueOnce(ok());
+
+    const credentialRegistry = await createCredentialRegistry();
+    await new FetchUrlTask().run(
+      { url: "https://api.vendor.example/x", credential_key: CREDENTIAL_KEY },
+      { registry: credentialRegistry }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("https://attacker.example/");
+    const attackerInit = fetchMock.mock.calls[1]?.[1] as { headers?: Record<string, string> };
+    expect(JSON.stringify(attackerInit?.headers ?? {})).not.toContain(SECRET);
+    // The vendor origin did receive it — otherwise this would pass on a
+    // credential that was never applied to the request in the first place.
+    expect(JSON.stringify(fetchMock.mock.calls[0]?.[1])).toContain(SECRET);
+  });
+
+  test("a credential_scheme 'header' secret is not replayed either", async () => {
+    // This is the case that forced the SafeFetchOptions API change: the secret
+    // sits on X-Api-Key, a name the redirect loop cannot infer from the request.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://attacker.example/"))
+      .mockResolvedValueOnce(ok());
+
+    const credentialRegistry = await createCredentialRegistry();
+    await new FetchUrlTask().run(
+      {
+        url: "https://api.vendor.example/x",
+        credential_key: CREDENTIAL_KEY,
+        credential_scheme: "header",
+        credential_header: "X-Api-Key",
+      },
+      { registry: credentialRegistry }
+    );
+
+    const attackerInit = fetchMock.mock.calls[1]?.[1] as { headers?: Record<string, string> };
+    expect(attackerInit?.headers?.["X-Api-Key"]).toBeUndefined();
+    expect(allSentHeaderValues().filter((value) => value.includes(SECRET))).toHaveLength(1);
   });
 });
 

--- a/packages/test/src/test/task/SafeFetchServerTransport.test.ts
+++ b/packages/test/src/test/task/SafeFetchServerTransport.test.ts
@@ -24,6 +24,9 @@ interface TestServer {
   readonly server: http.Server;
 }
 
+/** Headers of every request a test server received, in arrival order. */
+type RequestLog = Array<Readonly<Record<string, string | string[] | undefined>>>;
+
 const servers: http.Server[] = [];
 const timers: NodeJS.Timeout[] = [];
 
@@ -204,5 +207,183 @@ describe("SafeFetch server transport (real node:http, no mocks)", () => {
 
     await drainRejections();
     expect(unhandled).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cross-origin redirect credential strip.
+  //
+  // Two loopback servers on different ephemeral ports give a genuine
+  // cross-origin redirect over the real undici transport, so the second server
+  // reports exactly what bytes reached it. `privateResourceScopes` is left
+  // undefined throughout (the legacy direct-caller mode), because a scope would
+  // reject the cross-origin hop before the header strip is ever reached — these
+  // tests must fail when the strip is removed, not pass because of a different
+  // guard.
+  // ---------------------------------------------------------------------------
+  describe("cross-origin redirect header strip", () => {
+    /** Records every inbound request's headers and answers 200 with "landed". */
+    async function recordingServer(): Promise<{ target: TestServer; seen: RequestLog }> {
+      const seen: RequestLog = [];
+      const target = await withServer((req, res) => {
+        seen.push({ ...req.headers });
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("landed");
+      });
+      return { target, seen };
+    }
+
+    /** Answers every request with a 302 to `location`. */
+    async function redirectingServer(location: string): Promise<TestServer> {
+      return withServer((_req, res) => {
+        res.writeHead(302, { location });
+        res.end();
+      });
+    }
+
+    test("a cross-origin 302 drops Authorization before the second hop", async () => {
+      // The finding itself: a vendor that answers 302 to an attacker origin
+      // would otherwise receive the bearer token verbatim.
+      const { target, seen } = await recordingServer();
+      const hop = await redirectingServer(`${target.origin}/landed`);
+
+      const response = await safeFetch(`${hop.origin}/start`, {
+        allowPrivate: true,
+        headers: { Authorization: "Bearer super-secret-token", Accept: "text/plain" },
+      });
+
+      expect(await response.text()).toBe("landed");
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!.authorization).toBeUndefined();
+      // Targeted, not a blanket wipe: an ordinary header still crosses.
+      expect(seen[0]!.accept).toBe("text/plain");
+    });
+
+    test("a same-origin 302 keeps Authorization", async () => {
+      // Guards the opposite failure: a strip that fires on every redirect would
+      // silently break authenticated APIs that redirect within their own origin.
+      const seen: RequestLog = [];
+      const { origin } = await withServer((req, res) => {
+        seen.push({ ...req.headers });
+        if (req.url === "/start") {
+          res.writeHead(302, { location: "/landed" });
+          res.end();
+          return;
+        }
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("landed");
+      });
+
+      const response = await safeFetch(`${origin}/start`, {
+        allowPrivate: true,
+        headers: { Authorization: "Bearer super-secret-token" },
+      });
+
+      expect(await response.text()).toBe("landed");
+      expect(seen).toHaveLength(2);
+      expect(seen[1]!.authorization).toBe("Bearer super-secret-token");
+    });
+
+    test("a caller-named credential header passed via sensitiveHeaders is dropped", async () => {
+      // `credential_scheme: "header"` puts the secret on an arbitrary header,
+      // which safeFetch cannot recognize; without the option it would replay.
+      const { target, seen } = await recordingServer();
+      const hop = await redirectingServer(`${target.origin}/landed`);
+
+      await safeFetch(`${hop.origin}/start`, {
+        allowPrivate: true,
+        headers: { "X-Api-Key": "sk-secret", "X-Trace-Id": "trace-1" },
+        sensitiveHeaders: ["x-api-key"],
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!["x-api-key"]).toBeUndefined();
+      expect(seen[0]!["x-trace-id"]).toBe("trace-1");
+    });
+
+    test("sensitiveHeaders matching is case-insensitive against the sent header", async () => {
+      // HTTP header names are case-insensitive; a case-sensitive compare would
+      // leak whenever the configured name and the sent name differ in case.
+      const { target, seen } = await recordingServer();
+      const hop = await redirectingServer(`${target.origin}/landed`);
+
+      await safeFetch(`${hop.origin}/start`, {
+        allowPrivate: true,
+        headers: { "x-api-key": "sk-secret" },
+        sensitiveHeaders: ["X-Api-Key"],
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!["x-api-key"]).toBeUndefined();
+    });
+
+    test("a differing port on the same host counts as cross-origin and strips", async () => {
+      // A hostname comparison would call these same-origin and replay the token.
+      // Both servers are 127.0.0.1; only the ephemeral ports differ.
+      const { target, seen } = await recordingServer();
+      const hop = await redirectingServer(`${target.origin}/landed`);
+      expect(new URL(hop.origin).hostname).toBe(new URL(target.origin).hostname);
+
+      await safeFetch(`${hop.origin}/start`, {
+        allowPrivate: true,
+        headers: { Authorization: "Bearer super-secret-token" },
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!.authorization).toBeUndefined();
+    });
+
+    test("cookie and proxy-authorization are dropped without any sensitiveHeaders", async () => {
+      // The fixed strip-set must not depend on the caller opting in.
+      const { target, seen } = await recordingServer();
+      const hop = await redirectingServer(`${target.origin}/landed`);
+
+      await safeFetch(`${hop.origin}/start`, {
+        allowPrivate: true,
+        headers: {
+          Cookie: "session=abc123",
+          "Proxy-Authorization": "Basic cHJveHk6cHc=",
+          "X-Trace-Id": "trace-1",
+        },
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!.cookie).toBeUndefined();
+      expect(seen[0]!["proxy-authorization"]).toBeUndefined();
+      expect(seen[0]!["x-trace-id"]).toBe("trace-1");
+    });
+
+    test("a header stripped on one hop stays stripped when the chain returns home", async () => {
+      // Laundering guard: A -> B -> A must not restore the token on the final
+      // hop just because the last URL happens to share the first URL's origin.
+      const seen: RequestLog = [];
+      // Assigned once the away server has a port; the handler only reads it at
+      // request time, which is after both servers are listening.
+      let awayLocation = "";
+      const home = await withServer((req, res) => {
+        seen.push({ ...req.headers, "x-path": req.url ?? "" });
+        if (req.url === "/start") {
+          res.writeHead(302, { location: awayLocation });
+          res.end();
+          return;
+        }
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("home-again");
+      });
+      const away = await withServer((_req, res) => {
+        res.writeHead(302, { location: `${home.origin}/final` });
+        res.end();
+      });
+      awayLocation = `${away.origin}/away`;
+
+      const response = await safeFetch(`${home.origin}/start`, {
+        allowPrivate: true,
+        headers: { Authorization: "Bearer super-secret-token" },
+      });
+
+      expect(await response.text()).toBe("home-again");
+      const finalHop = seen.find((headers) => headers["x-path"] === "/final");
+      expect(finalHop).toBeDefined();
+      expect(finalHop!.authorization).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## The problem

`safeFetch` follows redirects itself (`redirect: "manual"` per hop, then a loop), and both implementations built the request init **once** and reused the same object for every hop while only the URL advanced — `serverSafeFetch` destructured `fetchInit` before the loop and passed it to every `fetchOneHop`; `defaultSafeFetch` did the same with `fetchOptions`. `FetchUrlTask` never sets `redirect`, so the default `"follow"` applies and the loop runs.

The result: every header the caller supplied is replayed verbatim to whatever origin the previous server's `Location` header names.

**Concrete scenario.** A `FetchUrlTask` is configured with `credential_key` against `https://api.vendor.example/x`. `FetchUrlTask.execute` resolves the secret and places it on `Authorization: Bearer …`. The vendor — or anyone who can influence its responses — answers:

```
HTTP/1.1 302 Found
Location: https://attacker.example/
```

`safeFetch` follows it and sends the bearer token to `attacker.example`. `privateResourceScopes` does not help: it only gates **private** destinations (`SafeFetch.server.ts` classification branch), so this public → public pivot was entirely unguarded. This is pre-existing on `main`, not introduced by any open PR.

## Why this needed an API change rather than a one-liner

Stripping `Authorization` unconditionally would have covered `credential_scheme` `bearer` and `basic`, but **not `header`** — the API-key style, where the secret is placed on an arbitrary caller-named header such as `X-Api-Key` (`FetchUrlCredentials.credentialHeaderName`). `safeFetch` cannot infer which header that is: `FetchUrlTask.execute` strips `credential_scheme` and `credential_header` from the job input before the request is ever issued, precisely so they cannot survive as data ports. Nothing downstream knows which of the request's headers is the secret.

So the fix threads that knowledge down:

- `SafeFetchOptions.sensitiveHeaders?: readonly string[]` — extra header names to drop cross-origin.
- `FetchUrlTask.execute` computes the header the credential actually landed on and sets it on the inline `FetchUrlJob` (`job.sensitiveHeaders`), which passes it through `fetchWithProgress` into `safeFetch`. It is deliberately **not** a data port: job inputs are persisted durably on the queued path, and this names a credential header. The queued path already refuses credentials outright, so there is nothing for it to carry.

## The strip-set and the rules

Always dropped on a cross-origin hop, regardless of `sensitiveHeaders` (`CROSS_ORIGIN_STRIPPED_HEADERS`):

- `authorization`
- `proxy-authorization`
- `cookie`

Plus anything named in `sensitiveHeaders`. Rules:

- **Origin comparison, not hostname.** `new URL(...).origin`, so a differing **port** (`https://a.example` → `https://a.example:8443`) or **scheme** (`https://a.example` → `http://a.example`) counts as cross-origin and strips. An unparseable URL on either side fails closed and strips.
- **Case-insensitive matching**, on both the sent header name and the configured one — HTTP header names are case-insensitive, and a case-sensitive compare would leak whenever the two differ in case.
- **Once stripped, stays stripped.** The stripped init is threaded forward as the init for every remaining hop, so the header is never restored even if a later `Location` returns to the original origin. This is the conservative reading and it blocks the laundering chain `vendor → attacker → vendor`, where the final request's origin matches the original but the attacker chose the path. Stated in the source comment and covered by a test in both suites.
- **All three `HeadersInit` shapes** are handled — `Headers` instance, `string[][]` entry pairs, and a plain record. `FetchUrlTask` passes a record, but direct callers of `safeFetch` may pass any of them, and a record-only strip would pass a `Headers` object straight through. There is a test for the `Headers` case.

Both loops were fixed. `SafeFetch.ts` (`defaultSafeFetch`, browser) and `SafeFetch.server.ts` (`serverSafeFetch`, undici/DNS-pinned) are independent implementations and each has its own test coverage; they share the `applyCrossOriginHeaderStrip` helper so the two cannot drift.

## The 303 question — left out, deliberately, with one thing noted

Recommendation is to **not** handle it here, and that is what this PR does.

The loop does mishandle 303 today: it replays the original `method` and `body` on every redirect status, so a `303` is not downgraded to `GET`-with-no-body, and neither is the `301`/`302`-after-`POST` conversion browsers perform. That is a spec-conformance defect, is not a credential leak, and changing request methods mid-chain has a much wider blast radius than dropping three header names — it belongs in its own PR with its own tests.

One interaction is worth recording rather than leaving implicit: because the body **is** replayed, a cross-origin redirect still delivers the original request body to the redirect target. This fix stops the credential leak, not a body leak. If a caller puts a secret in a POST body against an untrusted endpoint, that is a separate exposure and the 303/method-downgrade work is where it gets closed. It does not weaken the header strip and the two fixes do not conflict.

## Doc comment

`FetchUrlTask.ts` carries an invariant comment claiming "a resolved secret never leaves this method". With this strip landed that claim is closer to true. It is deliberately **not** edited here — a separate branch (stacked on #790) is already rewording it, and touching it here would conflict. Both branches will want a final pass over that wording once they have landed, since the accurate statement after this change is narrower than "never leaves": the secret leaves on the first hop's headers by design, and what this change guarantees is that it does not follow a cross-origin redirect.

## Changelog / breaking marker

Added under a new `## Unreleased` → `### Security` → `#### tasks` section in `packages/tasks/CHANGELOG.md` (`## Unreleased` has precedent in this repo — `packages/ai`, `packages/storage`, `packages/indexeddb`, `packages/task-graph`). Note that this changelog is normally generated from commit messages at release time, so a release run may reorganize it.

**Recommendation: no `!` breaking marker.** It is a behavior change — headers that used to reach a cross-origin redirect target no longer do — but the only caller it can break is one depending on a credential being replayed to an origin chosen by a third party, which is the vulnerability itself rather than a contract. Nothing in the type surface changes incompatibly (`sensitiveHeaders` is optional and additive), same-origin redirects are untouched, and non-credential headers still cross. Marking it breaking would push a major bump onto every consumer to protect a behavior no one should be relying on. It is worth a prominent Security entry, which it has.

## Tests

Every case below was confirmed to **fail without the fix** (verified by disabling the strip in each implementation separately: 6 failures in the server suite, 9 in the default-impl suite).

`packages/test/src/test/task/SafeFetchServerTransport.test.ts` — real undici transport, two loopback `node:http` servers on different ephemeral ports for a genuine cross-origin redirect. `privateResourceScopes` is left undefined throughout, since a scope would reject the cross-origin hop before the strip is reached — these must fail when the strip is removed, not pass because of a different guard:

- cross-origin 302 drops `Authorization`, second server observes no such header (and still observes `Accept`)
- same-origin 302 keeps `Authorization`
- a `sensitiveHeaders`-named `X-Api-Key` is dropped cross-origin
- `sensitiveHeaders` matching is case-insensitive against the sent header
- a differing **port** on the same host counts as cross-origin (asserts both hostnames are identical first)
- `cookie` and `proxy-authorization` dropped with no `sensitiveHeaders` supplied
- once stripped, stays stripped when the chain returns home

`packages/test/src/test/task/FetchUrlSsrf.test.ts` — this is where `defaultSafeFetch` is currently tested (the file already resets to the browser impl and mocks `globalThis.fetch`). All new cases use **public** origins, where `privateResourceScopes` does not apply and the strip is the only guard: the same seven cases, plus a differing-**scheme** case and a `Headers`-instance case.

Also in that file, the required **end-to-end through `FetchUrlTask`** with a real `credential_key` (real credential store, real resolution, real header placement, real `FetchUrlJob`, real redirect loop, only the socket mocked):

- a bearer credential is not replayed to `https://attacker.example/` — and the vendor hop **is** asserted to have received it, so the test cannot pass on a credential that was never applied
- a `credential_scheme: "header"` / `X-Api-Key` secret is likewise not replayed, asserting the secret appears in exactly one request's headers across the whole chain

Note for reviewers: an e2e over **loopback** could not have proven the strip. `FetchUrlJob` passes `privateResourceScopes: [urlResourcePattern(url)]` for private URLs, and a scope-passing target is same-origin by construction — so on a private host every cross-origin redirect is already scope-rejected before the strip runs. The public-origin path is the one this fix actually protects, which is why the e2e uses it.

## Verification

```
$ npx vitest run --config vitest.config.ts --project test packages/test/src/test/task/SafeFetchServerTransport.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)

$ bun scripts/test.ts task vitest
Running all tests in sections [task] — 65 file(s)
 Test Files  65 passed (65)
      Tests  979 passed | 24 skipped (1003)

$ npx vitest run ... FetchUrlSsrf.test.ts   (the defaultSafeFetch suite)
 Test Files  1 passed (1)
      Tests  70 passed (70)
```

There is no `lint` script in this repo's root `package.json` (`format` is the ESLint+Prettier entry point). Ran the equivalents directly: `npx eslint` over all five changed files reported no findings, and `npx prettier --check` passes (two files needed `--write`, applied). `npx tsc --noEmit -p packages/tasks/tsconfig.json` reports **1532 lines before and after** the change — the errors are pre-existing source-mode/`dist` noise in this checkout and none of them reference the new code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UW1Qr5mxetAQr61YKEY9nz)_