### PR TITLE
fix(tasks): repair the streaming fetch's length check, body release, and payload guard (stacked on #790)

### DIFF
--- a/packages/tasks/CHANGELOG.md
+++ b/packages/tasks/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## 0.3.44
 
+### Breaking Changes
+
+- **feat(tasks)**: `FetchUrlTask` / `FetchUrlJob` require `response_type`, and no longer infer it
+
+  `response_type` was optional and, when absent, the response format was guessed from the
+  `Content-Type` header. Both are gone: the input schema now lists `response_type` in
+  `required`, it declares no default, and there is no Content-Type inference left — so a
+  caller that stated nothing no longer gets whichever format the sniffing would have picked.
+
+  Two caveats on how loudly that lands. A directly constructed `FetchUrlTask` still runs
+  without one: `Task`'s constructor seeds its defaults from the input schema and synthesizes
+  an `enum` property as its first member, which here is `"stream"`. A **persisted job
+  payload** with no `response_type` now fails with `INVALID_RESPONSE_TYPE` before the request
+  is issued, where it previously streamed and completed successfully with no value.
+
+  Migration — state what the consumer actually reads:
+
+  - `"stream"` reproduces the previous byte-level behaviour exactly. The bytes still reach
+    the `body` port and the output cache, `metadata.contentType` reports what they are, and
+    nothing is buffered into memory.
+  - `"json"`, `"text"`, `"blob"`, `"arraybuffer"` additionally populate the matching derived
+    port, replacing whatever the Content-Type sniffing used to pick.
+
+  Re-enqueue any job enqueued before this change with an explicit `response_type`.
+
+### Bug Fixes
+
+#### tasks
+
+- stop asserting `Content-Length` against a transparently decompressed body. `Content-Length`
+  states the ENCODED size while the read loop counts DECODED bytes, so every gzip/br response
+  failed `CONTENT_LENGTH_MISMATCH` — a permanent, non-retryable error raised after the correct
+  body had already reached the consumer and the cache sink. A response carrying a
+  content-coding now reports no progress and asserts no total, exactly like a chunked one.
+- release the response body on a non-2xx fetch. The server transport holds an undici `Agent`
+  (and its socket) open until the passthrough pipe carrying the body settles, and an
+  unread `TransformStream` readable never lets it; an HTTP error abandoned the body without
+  cancelling, leaking an Agent per attempt — ten per job on the queued path's `maxAttempts`.
+- fail a queued fetch whose persisted payload carries no `response_type` instead of streaming
+  and returning an output with no value. `JobQueueWorker` runs a persisted input with no schema
+  validation, so the task layer's `required` never sees it; the job now asserts it before
+  issuing the request.
+- copy a retained body chunk rather than aliasing the view handed to the stream transport, which
+  `Job`'s contract lets the carrier transfer (and so detach). Only runs that materialize a
+  derived port pay the copy.
+
 ## 0.3.43
 
 ## 0.3.42

--- a/packages/tasks/README.md
+++ b/packages/tasks/README.md
@@ -77,7 +77,7 @@ Makes HTTP requests with built-in retry logic, progress tracking, and multiple r
 - `method` (string, optional): HTTP method ("GET", "POST", "PUT", "DELETE", "PATCH"). Default: "GET"
 - `headers` (object, optional): Headers to send with the request
 - `body` (string, optional): Request body for POST/PUT requests
-- `response_type` (string, optional): Response format ("json", "text", "blob", "arraybuffer"). Default: "json"
+- `response_type` (string, **required**): What to materialize from the response — `"stream"`, `"json"`, `"text"`, `"blob"`, or `"arraybuffer"`. `"stream"` materializes nothing: the bytes still reach the `body` port and the output cache, and `metadata.contentType` says what they are. The other values additionally populate the matching derived port. The schema declares no default and there is no Content-Type inference — whether a caller wants the body buffered into memory is theirs to state. (A directly constructed task that states nothing falls back to `"stream"`, because `Task` synthesizes an enum's first member as its default; a queued job payload carrying no `response_type` is rejected outright.)
 - `timeout` (number, optional): Request timeout in milliseconds
 - `queue` (boolean|string, optional): Queue handling (`false` runs inline when possible, `true` uses the task's default queue, strings target a specific registered queue). Default: `true`
 
@@ -156,7 +156,7 @@ await new DebugLogTask(
 
 // In workflow with data flow
 const workflow = new Workflow()
-  .fetch({ url: "https://api.example.com/data" })
+  .fetch({ url: "https://api.example.com/data", response_type: "json" })
   .debugLog(undefined, { log_level: "dir" }) // Logs the fetched data
   .delay(undefined, { delay: 1000 });
 ```
@@ -199,7 +199,7 @@ console.log(result); // { message: "Data preserved through delay" }
 
 // In workflow
 const workflow = new Workflow()
-  .fetch({ url: "https://api.example.com/data" })
+  .fetch({ url: "https://api.example.com/data", response_type: "json" })
   .delay(undefined, { delay: 2000 }) // 2 second delay
   .debugLog(undefined, { log_level: "info" });
 ```
@@ -247,7 +247,7 @@ console.log(processed.output); // { sum: 15, average: 3, count: 5 }
 
 // In workflow
 const workflow = new Workflow()
-  .fetch({ url: "https://api.example.com/data" })
+  .fetch({ url: "https://api.example.com/data", response_type: "json" })
   .javaScript({
     code: `
       const data = input.json;
@@ -628,6 +628,7 @@ Tasks support various configuration options:
 const fetchTask = new FetchUrlTask(
   {
     url: "https://api.example.com/data",
+    response_type: "json",
   },
   {
     queue: "api-requests",

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -186,9 +186,42 @@ export function parseContentLength(header: string | null, url: string): number |
 }
 
 /**
+ * True when the bytes this response hands out have already been decoded from
+ * the encoding its headers still advertise.
+ *
+ * `Content-Length` counts the ENCODED body (RFC 9110 §8.6), but a transport
+ * that negotiates `accept-encoding` on the caller's behalf — undici does, and
+ * so does every browser — decodes transparently while passing the origin's
+ * header list through verbatim. The stated length then describes bytes nobody
+ * ever sees: a live gzip response measured `content-length: 9819` against
+ * 33235 decoded bytes.
+ *
+ * Absent header means no content coding was applied. Otherwise any token that
+ * is neither empty nor `identity` means one was, so the stated size cannot be
+ * compared against what the reader counts.
+ */
+function bodyWasTransparentlyDecoded(response: Response): boolean {
+  const encoding = response.headers.get("content-encoding");
+  if (encoding === null) return false;
+  return encoding
+    .split(",")
+    .map((token) => token.trim().toLowerCase())
+    .some((token) => token !== "" && token !== "identity");
+}
+
+/**
  * Issues the request and yields the body in arrival order, reporting progress
  * against `Content-Length` when the origin states one, and asserting the
  * advertised size at end of stream.
+ *
+ * `Content-Length` states the ENCODED size, while this loop counts DECODED
+ * bytes. The two are the same number only when no content coding was applied,
+ * so a transparently-decompressed response (see
+ * {@link bodyWasTransparentlyDecoded}) states no size this loop can use: it
+ * reports no progress and asserts no total, exactly like a chunked response
+ * that sent no `Content-Length` at all. `undefined` here means "no stated
+ * decoded size", and both the progress denominator and the end-of-stream
+ * assertion are gated on it.
  *
  * There is no wrapper stream: the previous implementation rebuilt a second
  * ReadableStream (and a second Response around it) solely so a byte counter
@@ -215,7 +248,9 @@ async function* streamResponseBody(
     // Parsed inside the try (reader already acquired) so an invalid/conflicting
     // header cancels the body via the finally below instead of leaking an
     // undrained response.
-    totalBytes = parseContentLength(response.headers.get("content-length"), url);
+    totalBytes = bodyWasTransparentlyDecoded(response)
+      ? undefined
+      : parseContentLength(response.headers.get("content-length"), url);
     while (true) {
       if (signal.aborted) throw createFetchUrlAbortedError();
       const { done, value } = await reader.read();
@@ -332,6 +367,67 @@ function buildHttpError(url: string, response: Response): Error {
 }
 
 /**
+ * Releases a response this task is about to abandon without reading.
+ *
+ * The server transport hands back a passthrough whose source pipe holds the
+ * connection's undici `Agent` open until that pipe settles, and a
+ * `TransformStream` readable nobody reads never lets it settle. Cancelling is
+ * what settles it, so an abandoned response that is not cancelled leaks an
+ * Agent and its socket for the lifetime of the process — once per attempt, and
+ * the queued path sends `maxAttempts: 10`.
+ *
+ * Every abandoning path calls this, including ones whose status cannot carry a
+ * body: `response.body?.` already covers that, and a mechanical rule is worth
+ * more than per-status reasoning that a future edit has to redo correctly.
+ * Errors are swallowed — the response is being discarded, and the caller is
+ * already on its way to throwing the real failure.
+ */
+async function discardResponseBody(response: Response): Promise<void> {
+  await response.body?.cancel().catch(() => {});
+}
+
+/**
+ * The `response_type` values that name a derived port. `"stream"` is
+ * deliberately absent: it materializes nothing, so it is handled before this
+ * set is ever consulted.
+ */
+const DERIVED_RESPONSE_TYPES: ReadonlySet<string> = new Set([
+  "text",
+  "json",
+  "blob",
+  "arraybuffer",
+]);
+
+/**
+ * Fails closed on a `response_type` the schema would have rejected.
+ *
+ * The task layer validates its input, but `JobQueueWorker` calls
+ * `job.execute()` on a *persisted* payload with no validation at all — so a job
+ * enqueued before `response_type` became required, drained by a worker running
+ * the code that requires it, arrives here carrying `undefined`. Treating that
+ * as `"stream"` would let it complete successfully with neither `text` nor
+ * `json` in its output: a caller that asked for a value gets a silent success
+ * with no value, which is worse than any failure.
+ */
+function assertResponseType(
+  value: FetchUrlResponseType | undefined,
+  url: string
+): asserts value is FetchUrlResponseType {
+  if (value === "stream" || (typeof value === "string" && DERIVED_RESPONSE_TYPES.has(value))) {
+    return;
+  }
+  throw createFetchUrlJobError(
+    FetchUrlErrorCode.INVALID_RESPONSE_TYPE,
+    value === undefined
+      ? `Fetch of ${url} carries no response_type. It is required and has no default; a job ` +
+          `enqueued before it became required cannot be run — re-enqueue it with an explicit ` +
+          `response_type ('stream' reproduces the previous byte-level behaviour).`
+      : `Invalid response type: ${String(value)} for ${url}`,
+    { url }
+  );
+}
+
+/**
  * Builds the derived port `response_type` named from the collected bytes.
  * `Response.text()` is an unconditional UTF-8 decode per the Fetch standard —
  * it ignores the Content-Type charset — so decoding here is byte-identical to
@@ -340,8 +436,11 @@ function buildHttpError(url: string, response: Response): Error {
  * `responseType` is typed as possibly `undefined` (rather than trusting the
  * schema's `required` + enum) because `JobQueueWorker` calls `job.execute()`
  * on a *persisted* input with no schema validation — a queued job can carry
- * any string here. Fails closed: an unrecognized value throws
- * `INVALID_RESPONSE_TYPE` instead of falling through to `JSON.parse`.
+ * any string here. Fails closed via {@link assertResponseType}, so an
+ * unrecognized value throws `INVALID_RESPONSE_TYPE` instead of falling through
+ * to `JSON.parse`, and merges no bytes for a type it is about to reject.
+ * `executeStream` asserts the same thing before issuing the request; this stays
+ * independently fail-closed because it is reachable from any future caller.
  */
 function materializeDerivedPort(
   responseType: FetchUrlResponseType | undefined,
@@ -349,7 +448,8 @@ function materializeDerivedPort(
   metadata: FetchUrlMetadata,
   url: string
 ): Record<string, unknown> {
-  if (responseType === "stream" || responseType === undefined) return {};
+  if (responseType === "stream") return {};
+  assertResponseType(responseType, url);
   let total = 0;
   for (const c of chunks) total += c.byteLength;
   const merged = new Uint8Array(total);
@@ -458,6 +558,11 @@ export class FetchUrlJob<
     input: Input,
     context: IJobExecuteContext
   ): AsyncIterable<StreamEvent<Output>> {
+    // Before the request, not after: a payload this job cannot produce a result
+    // for should not spend a network call, and failing ahead of the first delta
+    // keeps the retry rule in `classifyBodyFailure` out of it entirely.
+    assertResponseType(input.response_type, input.url!);
+
     const response = await this.issueRequest(input, context);
     const metadata = buildMetadata(response);
 
@@ -465,12 +570,17 @@ export class FetchUrlJob<
       // No body, no derived port, no delta — so no router opens and no cache
       // ref is minted. The caller reads metadata.notModified and keeps
       // whatever artifact it already had.
+      await discardResponseBody(response);
       await this.emitStreamEnd(metadata, context);
       yield { type: "finish", data: { metadata } } as StreamEvent<Output>;
       return;
     }
 
     if (!response.ok) {
+      // A non-2xx carries a body like any other response, and abandoning it
+      // unread parks the transport's passthrough pipe forever — see
+      // {@link discardResponseBody}.
+      await discardResponseBody(response);
       throw buildHttpError(input.url!, response);
     }
 
@@ -488,7 +598,16 @@ export class FetchUrlJob<
         context.signal,
         async (p) => await context.updateProgress(p)
       )) {
-        if (wantsValue) chunks.push(chunk);
+        // Copied on the RETAIN side. `Job`'s contract is that an emitted
+        // binary delta belongs to the transport, which may transfer (and so
+        // detach) its buffer — retaining the same view would leave
+        // `materializeDerivedPort` merging zero-length arrays. Copying at the
+        // emit point instead would tax every chunk of every run, including
+        // `"stream"` runs that retain nothing; copying here taxes only runs
+        // that already hold the body twice at peak (`chunks` plus `merged`),
+        // so nothing's asymptotic cost changes. The emitted view stays the
+        // transport's to transfer, which is what the contract intends.
+        if (wantsValue) chunks.push(chunk.slice());
         // Latched before the emit rather than after it: from the moment a
         // chunk is handed to the consumer this attempt is unrepeatable, and a
         // failure raised during the emit itself is on the far side of that
@@ -843,10 +962,21 @@ export class FetchUrlTask<
    * followed by a `finish`. Credential resolution is handled by the input
    * resolver system — credential_key arrives already resolved to the secret.
    *
-   * Invariant: a resolved secret never leaves this method. Job queues persist
-   * their payloads durably (SQLite/Postgres/SQS), so the secret is only ever
-   * placed on the in-process request headers of the inline path, and the
-   * queued path refuses to run at all when a credential is present.
+   * Invariant, scoped to PERSISTENCE: a resolved secret is never written to
+   * durable storage. Job queues persist their payloads (SQLite/Postgres/SQS),
+   * so the secret is only ever placed on the in-process request headers of the
+   * inline path, and the queued path refuses to run at all when a credential is
+   * present.
+   *
+   * It is NOT an invariant about where the secret is sent. `safeFetch` follows
+   * redirects itself and replays the same header list on every hop, so a
+   * credential placed here is replayed to a cross-origin redirect target — a
+   * compromised or misconfigured upstream can therefore harvest it with a
+   * `Location` pointing at a host it controls. Closing that needs the transport
+   * to know which headers are sensitive (a `sensitiveHeaders` option threaded
+   * through both the server and browser implementations) so it can drop them
+   * when the hop changes origin; it is not something this method can do on its
+   * own, and it ships separately.
    */
   // No `override`: `executeStream` is an optional member of ITask, not a
   // declared member of Task, so marking it override fails TS4113.

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -22,6 +22,7 @@ import {
   JobTaskFailedError,
   setTaskQueueRegistry,
   TaskConfigurationError,
+  TaskInvalidInputError,
 } from "@workglow/task-graph";
 import { InMemoryTaskOutputRepository } from "@workglow/task-graph/test";
 import type { FetchUrlTaskInput, FetchUrlTaskOutput } from "@workglow/tasks";
@@ -694,6 +695,188 @@ describe("FetchUrlTask", () => {
         response_type: "stream",
       }).catch((e) => e);
       expect(String(error)).toMatch(/content-length/i);
+    });
+
+    // -----------------------------------------------------------------------
+    // Regression (C1): `Content-Length` states the ENCODED size, but every
+    // transport that negotiates `accept-encoding` for us — undici on the
+    // server path, the browser's fetch — decodes transparently and passes the
+    // origin's header list through verbatim. So the read loop counts decoded
+    // bytes while the header describes compressed ones, and comparing them
+    // failed EVERY gzip/br response with a permanent, non-retryable
+    // CONTENT_LENGTH_MISMATCH — raised only after the correct body had already
+    // reached the consumer and the cache sink. This mock is the exact
+    // post-decode shape (a real measurement: content-length 9819 against 33235
+    // decoded bytes).
+    //
+    // The transport-level proof that undici really does this lives in
+    // SafeFetchServerTransport.test.ts; every test in THIS file mocks
+    // safeFetch, so none of them can see a real decompression.
+    // -----------------------------------------------------------------------
+    test("a decoded body is not measured against the encoded Content-Length", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(new Blob([new Uint8Array(8192)]), {
+            status: 200,
+            headers: { "content-encoding": "gzip", "content-length": "1024" },
+          })
+        )
+      );
+      const result = await fetchUrl({
+        url: "https://example.com/compressed.bin",
+        response_type: "stream",
+      });
+      expect(result.metadata?.status).toBe(200);
+    });
+
+    // The two guards that stop the skip above from widening into "we no longer
+    // check Content-Length at all". `identity` is a content-coding token that
+    // means no coding was applied, so the stated size is still the decoded
+    // size and the assertion must still run. (The absent-header half is the
+    // "a Content-Length mismatch throws" test above — it sets no
+    // content-encoding.)
+    test("content-encoding: identity still asserts the Content-Length", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(new Blob([new Uint8Array([1, 2])]), {
+            status: 200,
+            headers: { "content-encoding": "identity", "content-length": "9" },
+          })
+        )
+      );
+      const error = await fetchUrl({
+        url: "https://example.com/identity.bin",
+        response_type: "stream",
+      }).catch((e) => e);
+      expect(String(error)).toMatch(/content-length/i);
+    });
+
+    test("no content-encoding still asserts the Content-Length", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(new Blob([new Uint8Array([1, 2])]), {
+            status: 200,
+            headers: { "content-length": "9" },
+          })
+        )
+      );
+      const error = await fetchUrl({
+        url: "https://example.com/plain.bin",
+        response_type: "stream",
+      }).catch((e) => e);
+      expect(String(error)).toMatch(/content-length/i);
+    });
+
+    // -----------------------------------------------------------------------
+    // Regression (H1): the server transport hands back a passthrough whose
+    // source pipe holds the connection's undici Agent open until that pipe
+    // settles — and an unread TransformStream readable never lets it, because
+    // its readable HWM is 0. Cancelling is what settles it. Abandoning a
+    // non-2xx body without cancelling therefore leaked an Agent and a socket
+    // per attempt, ten per job on the queued path's maxAttempts.
+    //
+    // The socket-level proof is in SafeFetchServerTransport.test.ts; this one
+    // is carrier-independent and pins the INTENT (the body gets cancelled)
+    // rather than the symptom, so it keeps holding if the transport changes.
+    // -----------------------------------------------------------------------
+    test("an HTTP error cancels the response body instead of abandoning it", async () => {
+      let cancelled = false;
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([1, 2, 3]));
+              },
+              cancel() {
+                cancelled = true;
+              },
+            }),
+            { status: 500, statusText: "Internal Server Error" }
+          )
+        )
+      );
+
+      await expect(
+        fetchUrl({ url: "https://example.com/boom", response_type: "stream" })
+      ).rejects.toThrow();
+      expect(cancelled).toBe(true);
+    });
+
+    // -----------------------------------------------------------------------
+    // What "required" actually buys at the TASK layer, pinned in both
+    // directions because the two halves disagree and the disagreement is easy
+    // to mis-remember.
+    //
+    // The schema does list `response_type` in `required`, and `validateInput`
+    // rejects a payload without it. But `run()` never presents such a payload:
+    // `Task`'s constructor seeds `defaults` from the input schema via
+    // `getData(..., { addOptionalProps: true })`, and json-schema-library
+    // synthesizes an `enum` property as its FIRST member — which here is
+    // "stream". So `new FetchUrlTask().run({ url })` does not throw; it fetches
+    // with response_type "stream".
+    //
+    // That is a gap in the breaking change, not a property to rely on: the
+    // stated rationale ("a default would silently pick one for a caller who
+    // never considered the question") is met for a persisted job payload — see
+    // the FetchUrlJob test below, which is the case that used to complete
+    // successfully with no value — and not met for a directly constructed
+    // task. Closing it means suppressing the base class's synthesized default,
+    // which is a further behaviour change and belongs to its own review. Both
+    // assertions are here so that change cannot land unnoticed in either
+    // direction.
+    // -----------------------------------------------------------------------
+    test("validateInput rejects a payload with no response_type", async () => {
+      const task = new FetchUrlTask();
+      await expect(
+        task.validateInput({ url: "https://example.com/no-type" } as FetchUrlTaskInput)
+      ).rejects.toThrow(TaskInvalidInputError);
+    });
+
+    test("run() with no response_type still fetches, defaulted to 'stream' by the base class", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response("defaulted", { status: 200 }))
+      );
+      const task = new FetchUrlTask();
+      const result = (await task.run({
+        url: "https://example.com/no-type",
+      } as FetchUrlTaskInput)) as FetchUrlTaskOutput;
+
+      expect(task.runInputData.response_type).toBe("stream");
+      // "stream" materializes nothing, so no derived port is populated.
+      expect(result.text).toBeUndefined();
+      expect(result.json).toBeUndefined();
+      expect(result.metadata?.status).toBe(200);
+    });
+
+    // -----------------------------------------------------------------------
+    // Regression (M1): the task layer validates its input, but JobQueueWorker
+    // calls job.execute() on a PERSISTED payload with no validation at all. A
+    // job enqueued before response_type became required, drained after the
+    // deploy that requires it, therefore reaches the job carrying `undefined`
+    // — and grouping that with "stream" let it stream, complete, and return
+    // `{ metadata }` with no text and no json: a caller that asked for a value
+    // got a silent success with no value. This has to go through FetchUrlJob
+    // directly; the task layer would reject it first, so only the job
+    // reproduces the queued-payload case.
+    // -----------------------------------------------------------------------
+    test("a persisted job payload with no response_type fails before fetching", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response("never reached", { status: 200 }))
+      );
+      const input = { url: "https://example.com/legacy-payload" } as FetchUrlTaskInput;
+      const job = new FetchUrlJob<FetchUrlTaskInput, FetchUrlTaskOutput>({ input });
+
+      const error = await job
+        .execute(input, { signal: new AbortController().signal, updateProgress: async () => {} })
+        .catch((e: unknown) => e);
+
+      expect(isFetchUrlJobError(error)).toBe(true);
+      expect((error as { code?: string }).code).toBe(FetchUrlErrorCode.INVALID_RESPONSE_TYPE);
+      // Before the request, not after: a payload that cannot produce a result
+      // should not spend a network call, and failing ahead of the first delta
+      // keeps classifyBodyFailure's retry rule out of it entirely.
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     test("a combined Content-Length with equal duplicates is accepted", async () => {

--- a/packages/test/src/test/task/FetchTaskQueuedStream.test.ts
+++ b/packages/test/src/test/task/FetchTaskQueuedStream.test.ts
@@ -750,6 +750,78 @@ describe("queued fetch retry safety", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Regression (M2): `Job`'s contract says an emitted binary delta belongs to the
+// transport, which may TRANSFER its buffer — and a transferred ArrayBuffer is
+// detached, so every view onto it becomes zero-length. FetchUrlJob pushed the
+// same Uint8Array it emitted onto the retain list, so on such a carrier
+// materializeDerivedPort would merge detached views and hand back an empty
+// `text` alongside a successful `metadata`: silent data loss, not an error.
+//
+// No SHIPPED carrier transfers today (the in-process one hands the view over
+// untouched, the cross-process one serializes rows), so this is a latent
+// violation of a documented invariant rather than a live bug — which is
+// exactly why it needs a test that synthesizes the transferring carrier
+// instead of waiting for one to exist. `structuredClone` with `transfer` is
+// what a postMessage-based host does, and it is verified to detach in Node.
+//
+// The assertion is on the FINISH payload only. The generator's own yielded
+// views are detached too — that is the contract working as intended, not the
+// thing under test.
+// ---------------------------------------------------------------------------
+describe("retained body chunks survive a transferring stream carrier", () => {
+  setLogger(getTestingLogger());
+  let prevSafeFetch: SafeFetchFn;
+
+  beforeAll(async () => {
+    prevSafeFetch = registerSafeFetch(mockSafeFetch);
+  });
+
+  afterAll(() => {
+    registerSafeFetch(prevSafeFetch);
+  });
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    responder = singleChunkResponder;
+  });
+
+  test("a derived port is built from the bytes, not from detached views", async () => {
+    const text = "the quick brown fox jumps over the lazy dog";
+    const encoded = new TextEncoder().encode(text);
+    // Several chunks, so a partial detach cannot pass by accident.
+    const chunks = [encoded.slice(0, 10), encoded.slice(10, 25), encoded.slice(25)];
+    responder = () => Promise.resolve(chunkedResponse(chunks));
+
+    const input: FetchUrlTaskInput = {
+      url: "https://example.com/transferred.txt",
+      response_type: "text",
+    };
+    const job = new FetchUrlJob<FetchUrlTaskInput, FetchUrlTaskOutput>({ input });
+
+    const detached: number[] = [];
+    let finish: FetchUrlTaskOutput | undefined;
+    for await (const event of job.executeStream(input, {
+      signal: new AbortController().signal,
+      updateProgress: async () => {},
+      emitStreamEvent: async (e) => {
+        if (e.type !== "binary-delta") return;
+        const delta = (e as unknown as { binaryDelta: Uint8Array }).binaryDelta;
+        // What a postMessage-based carrier does: hand the bytes across and
+        // detach the sender's buffer.
+        structuredClone(delta, { transfer: [delta.buffer] });
+        detached.push(delta.byteLength);
+      },
+    })) {
+      if (event.type === "finish") finish = event.data as FetchUrlTaskOutput;
+    }
+
+    // The premise: the emitted views really were detached by the transfer.
+    expect(detached).toEqual([0, 0, 0]);
+    expect(finish?.text).toBe(text);
+  });
+});
+
 describe("queued fetch stream adapter", () => {
   setLogger(getTestingLogger());
   let prevSafeFetch: SafeFetchFn;

--- a/packages/test/src/test/task/FetchUrlSsrf.test.ts
+++ b/packages/test/src/test/task/FetchUrlSsrf.test.ts
@@ -474,7 +474,14 @@ describe("FetchUrlJob threads privateResourceScopes from declared entitlement sc
   test("private URL input passes privateResourceScopes matching urlResourcePattern", async () => {
     const url = "http://localhost:3000/api";
     const task = new FetchUrlTask({ queue: false });
-    await task.run({ url });
+    // `response_type` is listed in the schema's `required`. Omitting it does
+    // not currently fail here — `Task`'s constructor synthesizes an enum
+    // property as its first member, so the run silently becomes "stream" — but
+    // relying on that leaves the assertion below reading as if the request
+    // shape were incidental. State it: "stream" materializes nothing, so the
+    // mocked body is never decoded and these assertions stay about the options
+    // handed to safeFetch rather than about what came back.
+    await task.run({ url, response_type: "stream" });
     expect(capturedOptions?.allowPrivate).toBe(true);
     expect(capturedOptions?.privateResourceScopes).toEqual([urlResourcePattern(url)]);
     expect(capturedOptions?.privateResourceScopes).toEqual(["http://localhost:3000/*"]);
@@ -482,7 +489,7 @@ describe("FetchUrlJob threads privateResourceScopes from declared entitlement sc
 
   test("public URL input does not pass privateResourceScopes", async () => {
     const task = new FetchUrlTask({ queue: false });
-    await task.run({ url: "https://example.com/" });
+    await task.run({ url: "https://example.com/", response_type: "stream" });
     expect(capturedOptions?.allowPrivate).toBe(false);
     expect(capturedOptions?.privateResourceScopes).toBeUndefined();
   });
@@ -559,7 +566,19 @@ describe("FetchUrlTask end-to-end entitlement enforcement", () => {
 
   function makeGraphForUrl(url: string): TaskGraph {
     const graph = new TaskGraph();
-    graph.addTask(new FetchUrlTask({ id: "fetch-node", queue: false, defaults: { url } }));
+    // `response_type: "stream"` stated explicitly: these tests are about the
+    // entitlement outcome, not the response value, and "stream" materializes
+    // nothing so the mocked body is never decoded. The DENY cases would not
+    // reach input validation at all (the graph-level entitlement preflight
+    // throws first), so stating it keeps the allow and deny halves of this
+    // suite identical apart from the policy under test.
+    graph.addTask(
+      new FetchUrlTask({
+        id: "fetch-node",
+        queue: false,
+        defaults: { url, response_type: "stream" },
+      })
+    );
     return graph;
   }
 

--- a/packages/test/src/test/task/SafeFetchServerTransport.test.ts
+++ b/packages/test/src/test/task/SafeFetchServerTransport.test.ts
@@ -17,6 +17,7 @@
 import { FetchUrlTask, getSafeFetchImpl, safeFetch } from "@workglow/tasks";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
+import zlib from "node:zlib";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 interface TestServer {
@@ -205,4 +206,81 @@ describe("SafeFetch server transport (real node:http, no mocks)", () => {
     await drainRejections();
     expect(unhandled).toEqual([]);
   });
+
+  // -------------------------------------------------------------------------
+  // Regression (C1): this is the one test in the repo that can see undici
+  // actually decompress. Every other fetch suite installs a mock through
+  // registerSafeFetch, so none of them exercise the `accept-encoding` undici
+  // appends on the caller's behalf, nor the passthrough that hands the origin's
+  // header list back verbatim alongside the DECODED bytes.
+  //
+  // `Content-Length` counts encoded bytes; FetchUrlTask's read loop counts
+  // decoded ones. Comparing them made every compressed response fail with
+  // CONTENT_LENGTH_MISMATCH — a PermanentJobError, so no retry — raised only
+  // after the correct body had already reached the consumer and the cache
+  // sink. Here 50_000 bytes compress to a few dozen, so the numbers are as far
+  // apart as they can get and the assertion is on the whole payload rather
+  // than on the absence of an error.
+  // -------------------------------------------------------------------------
+  test("a gzipped body is delivered whole, not measured against the encoded length", async () => {
+    const payload = "x".repeat(50_000);
+    const gzipped = zlib.gzipSync(payload);
+    expect(gzipped.byteLength).toBeLessThan(payload.length);
+
+    const { origin } = await withServer((_req, res) => {
+      res.writeHead(200, {
+        "content-type": "text/plain",
+        "content-encoding": "gzip",
+        // The encoded length, which is what a real origin states.
+        "content-length": String(gzipped.byteLength),
+      });
+      res.end(gzipped);
+    });
+
+    const result = await new FetchUrlTask().run({ url: `${origin}/`, response_type: "text" });
+    expect(result.text).toBe(payload);
+
+    await drainRejections();
+    expect(unhandled).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression (H1): a non-2xx carries a body like any other response, and the
+  // passthrough this transport returns parks until that body is read or
+  // cancelled — `new TransformStream()` has a readable HWM of 0, so `pipeTo`
+  // never settles on its own. The `.finally(closeAgent)` hanging off it
+  // therefore never ran for a response the task threw on, leaking an undici
+  // Agent and its socket per attempt (the queued path sends maxAttempts: 10).
+  //
+  // Connection count is the observable: a leaked Agent keeps its keep-alive
+  // socket open, so `getConnections` never reaches 0. Both statuses are
+  // covered because they fail differently — a 404 is permanent, a 500 is the
+  // retryable one a long-lived worker hits over and over.
+  //
+  // `keepAliveTimeout` is raised off its 5s default deliberately. At the
+  // default the SERVER reaps the idle socket at almost exactly the deadline
+  // below, so the count reaches 0 whether or not the client ever released the
+  // Agent — the test passes on the broken code and measures nothing. Holding
+  // the server side open makes the client's release the only thing that can
+  // drop the connection.
+  // -------------------------------------------------------------------------
+  for (const status of [404, 500] as const) {
+    test(`a ${status} with a body still frees the connection`, async () => {
+      const { origin, server } = await withServer((_req, res) => {
+        res.writeHead(status, { "content-type": "text/plain" });
+        res.end("error body");
+      });
+      server.keepAliveTimeout = 120_000;
+      server.headersTimeout = 125_000;
+
+      await expect(
+        new FetchUrlTask().run({ url: `${origin}/`, response_type: "text" })
+      ).rejects.toThrow();
+
+      expect(await waitForNoConnections(server, 5000)).toBe(0);
+
+      await drainRejections();
+      expect(unhandled).toEqual([]);
+    });
+  }
 });


### PR DESCRIPTION
**Stacked PR.** Base is `claude/fetchurltask-streaming-cache-ey52fj` (#790), not `main`. Review #790 first; this only shows its own three commits.

Four defects in the streaming `FetchUrlTask` path introduced or left open by #790, plus the changelog and README entries the branch was missing.

---

## C1 — every transparently-compressed response failed `CONTENT_LENGTH_MISMATCH`

`Content-Length` states the **encoded** body size (RFC 9110 §8.6). `SafeFetch.server.ts` calls undici with only the caller's `fetchInit`, so undici appends its own `accept-encoding` and decodes; the passthrough is then rebuilt with `headers: response.headers` — the origin's list verbatim. `streamResponseBody` counts **decoded** bytes and compared the two.

Measured live: `content-encoding=gzip content-length=9819 decoded bytes=33235`.

Every gzip/br response therefore threw `CONTENT_LENGTH_MISMATCH` — a `PermanentJobError`, so no retry — **after** the correct body had already reached the consumer and the cache sink. On `origin/main` the value was only a progress denominator, so this is new on the branch.

A new `bodyWasTransparentlyDecoded(response)` makes `totalBytes` `undefined` when any content-coding token is neither empty nor `identity`. Both uses were already gated on `undefined`, so a compressed response now reports no progress and asserts no total — exactly like a chunked response that sent no `Content-Length`. The absent-header case is unchanged (it was already correct).

## H1 — non-2xx responses leaked an undici Agent + socket per attempt

Both halves reproduce:

- the passthrough parks — `new TransformStream()` has readable HWM 0, so `pipeTo` never settles unless the readable is read or cancelled (measured: `pipeTo settled without reading readable? false`), and the `.finally(() => closeAgent(dispatcher))` hanging off it never ran;
- a non-2xx **does** carry a body (local 404: `body null? false, cl 5`).

The queued path sends `maxAttempts: 10`, so one job could leak ten Agents and ten sockets.

New `discardResponseBody(response)` — `await response.body?.cancel().catch(() => {})` — is called before `buildHttpError` throws.

**The 304 early return does NOT leak, and was not missed.** undici nulls a 304 body, so `closeAgent` had already run, and a spec-compliant `Response` cannot carry a body on a null-body status. The cancel is added there anyway as a mechanical rule: `response.body?.` already covers the no-body case, and per-status reasoning is what a future edit gets wrong. Every other early exit was enumerated and none leak — they are covered by the reader `finally`, since `for await` abrupt completion calls `.return()`.

## M1 — a persisted job payload with no `response_type` completed successfully with no value

`JobQueueWorker` calls `job.execute()` on a persisted input with **no schema validation**. `materializeDerivedPort` grouped `undefined` with `"stream"`, so a job enqueued before `response_type` became required, drained after the deploy that requires it, streamed, completed, and returned `{ metadata }` with no `text` and no `json`. A persisted `null` already threw; only absent was silent.

`assertResponseType` now runs as the **first statement** of `FetchUrlJob.executeStream`, before `issueRequest`: a payload that cannot produce a result spends no network call, and failing ahead of the first delta keeps `classifyBodyFailure`'s retry rule out of it entirely. `materializeDerivedPort` asserts the same thing so it stays independently fail-closed; the trailing `throw` remains as the exhaustiveness guard.

## M2 — retained buffers violated the `Job.ts:26-27` contract (latent)

`executeStream` pushed the exact `Uint8Array` it emitted onto the retain list. `Job`'s contract lets the transport transfer that buffer, and a transferred `ArrayBuffer` is detached — `materializeDerivedPort` would then merge zero-length views and hand back an empty `text` beside a successful `metadata`. No **shipped** carrier detaches today (the in-process path hands the view over untouched, the cross-process path serializes rows), so this is latent — but it is a documented invariant, it is one token, and `WorkerServerBase.postStreamChunk` already transfers on the path a future queue host would use.

Fixed on the **retain** side (`chunks.push(chunk.slice())`). Copying at the emit point would tax every chunk of every run including `"stream"` runs that retain nothing; copying here taxes only runs that already hold the body twice at peak (`chunks` + `merged`), so no asymptote changes, and the emitted view stays the transport's to transfer.

## M3 — credential/redirect comment corrected (docs only)

The "a resolved secret never leaves this method" comment is about *persistence* but reads as absolute. Credentials **are** replayed to cross-origin redirect targets — `safeFetch` follows redirects itself and replays the same header list on every hop. The comment is now scoped to persistence and names the gap explicitly.

**No behaviour change here.** `SafeFetch*.ts` is byte-identical to `main` (pre-existing), and a complete fix needs a new `SafeFetchOptions.sensitiveHeaders` threaded through both implementations. That ships as a separate PR against `main`.

---

## Why `response_type` stays required

Not softened to accept `null` as "infer". It is an already-declared breaking change (`4c10a25e`); accepting `null` would resurrect the deleted Content-Type sniffing as a second path to maintain, force `null` into the enum, and degrade the `FromSchema<typeof inputSchema>` narrowing that `FetchUrlResponseType` and the dynamic `outputSchema()` depend on. The genuinely silent case was the queued one, which M1 fixes by throwing rather than guessing.

### One finding that came out differently than expected

The plan predicted four `FetchUrlSsrf.test.ts` call sites would break on the now-required `response_type`. **They do not** — that file passes unmodified, 60/60, verified by stashing the edits and re-running.

The reason: `Task`'s constructor seeds `defaults` via `getDefaultInputsFromStaticInputDefinitions()` → `getData(undefined, { addOptionalProps: true })`, and json-schema-library synthesizes an `enum` property as its **first member** — which for `response_type` is `"stream"`. So `new FetchUrlTask().run({ url })` does not throw; it fetches with `response_type: "stream"`.

That is a gap in the breaking change: the stated rationale ("a default would silently pick one for a caller who never considered the question") holds for a persisted job payload and not for a directly constructed task. **Nothing here closes it** — suppressing the base class's synthesized default is a further behaviour change and belongs to its own review. Instead it is pinned in both directions (`validateInput` *does* reject such a payload; `run()` never presents one) so it cannot change unnoticed, and the changelog and README say so plainly. The four SSRF call sites now state `response_type: "stream"` anyway, since the assertions read better when the request shape is not incidental.

---

## Tests

Comments in the tests say what each failure catches.

- **C1(b)** in `SafeFetchServerTransport.test.ts` is the load-bearing one: every other fetch suite mocks `registerSafeFetch`, so none can see undici actually decompress. A loopback server serves `zlib.gzipSync("x".repeat(50_000))` under the **compressed** `content-length`; the task must return the full 50k.
- **C1(a)** in `FetchTask.test.ts` mocks the exact post-decode shape, plus two guards so the skip cannot widen (`identity` and no `content-encoding` both still assert).
- **H1** asserts zero server connections after a 404 and after a 500 (the retryable one a long-lived worker hits repeatedly), plus a carrier-independent companion in `FetchTask.test.ts` that pins the intent — a `Response(bodyStream, { status: 500 })` whose `cancel()` flips a flag.

  Note for reviewers: those two tests raise `keepAliveTimeout` off its 5s default **deliberately**. At the default the *server* reaps the idle socket at almost exactly the 5s deadline, so the count reached 0 whether or not the client ever released the Agent — the test passed on the broken code and measured nothing.
- **M1** goes through `FetchUrlJob` directly; the task layer would reject first, so only the job reproduces the queued-payload case.
- **M2** synthesizes the transferring carrier no shipped carrier is yet: `structuredClone(delta, { transfer: [delta.buffer] })` (verified to detach in Node) on each `binary-delta`, then asserts the **finish payload** equals the input. The generator's own yielded views are detached too — expected, and not what this pins.

All five new source-behaviour tests were confirmed to **fail** on the branch with the source fix reverted, and pass with it.

## Verification

```
npx vitest run --config vitest.config.ts --project test \
  packages/test/src/test/task/{FetchTask,FetchUrlSsrf,FetchTaskQueuedStream,SafeFetchServerTransport}.test.ts
  → Test Files  4 passed (4)      Tests  174 passed (174)

bun scripts/test.ts task vitest
  → Test Files  66 passed (66)    Tests  1001 passed | 24 skipped (1025)

eslint + prettier --check on every changed file  → clean
turbo run build-types --filter=@workglow/tasks... --filter=@workglow/test...  → clean
```

(There is no root `lint` script; eslint and prettier were run directly over the changed files.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UW1Qr5mxetAQr61YKEY9nz)_