### PR TITLE
fix(providers): restore the runtime-agnostic exports the browser barrels dropped

### DIFF
--- a/packages/test/src/test/util/ExportBarrelParity.test.ts
+++ b/packages/test/src/test/util/ExportBarrelParity.test.ts
@@ -1,0 +1,316 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * A provider whose `src/ai/index.ts` and `src/ai/index.browser.ts` are two
+ * hand-maintained barrels over ONE set of modules must export the same surface
+ * from both, except where the difference is deliberate and stated here.
+ *
+ * `ExportTypesPairing.test.ts` proves the manifest routes a browser consumer to
+ * the browser declarations. That is what turns a barrel omission from invisible
+ * into a hard `TS2305`: before it, a `customConditions: ["browser"]` consumer
+ * was type-checked against the NODE barrel, so a symbol missing from the
+ * browser one still compiled and still autocompleted. Five providers had such
+ * omissions — every one a module with no platform-specific code, already
+ * compiled into the browser bundle through the runtime entry, missing only its
+ * `export *` line.
+ *
+ * This guard is deliberately source-only: it reads the two barrels as text, so
+ * it runs under `use-source` and needs no `dist`.
+ */
+
+/** The exported names of one top-level statement, as a stable comparable key. */
+type SurfaceEntry = string;
+
+interface ParsedBarrel {
+  readonly surface: ReadonlySet<SurfaceEntry>;
+  /**
+   * Statements this parser could not classify. Reported rather than skipped:
+   * the parser is regex-based, and a shape it silently dropped is exactly where
+   * a real asymmetry would hide. (`buildEntryViolations` in the sibling file
+   * makes the same call for an underivable dist stem.)
+   */
+  readonly unparseable: readonly string[];
+}
+
+/** Strip block and whole-line comments so they cannot be read as statements. */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+/**
+ * Whether every `{` in the text is closed, ignoring braces inside strings.
+ *
+ * This is what lets a statement span lines: the closing brace of a multi-line
+ * `export { a, b } from "x";` sits at column 0, so a column-0 boundary on its
+ * own cuts the statement in half and reports `export {` as an unparseable line.
+ */
+function bracesBalanced(text: string): boolean {
+  const withoutStrings = text.replace(
+    /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`/g,
+    '""'
+  );
+  let depth = 0;
+  for (const char of withoutStrings) {
+    if (char === "{") depth++;
+    else if (char === "}") depth--;
+  }
+  return depth === 0;
+}
+
+/**
+ * Every top-level statement beginning with `export`.
+ *
+ * A statement starts at a line beginning with `export` and runs to the first
+ * column-0 boundary at which its braces are balanced, so both multi-line forms
+ * these barrels use — the named re-export list and the `_testOnly` object
+ * literal, each closing at column 0 — arrive whole.
+ */
+function topLevelExportStatements(text: string): string[] {
+  const stripped = stripComments(text);
+  const starts = [...stripped.matchAll(/^\S/gm)].map((match) => match.index);
+  const statements: string[] = [];
+  let pending = "";
+  for (let i = 0; i < starts.length; i++) {
+    const chunk = stripped.slice(starts[i], starts[i + 1] ?? stripped.length);
+    if (pending === "" && !chunk.startsWith("export")) continue;
+    pending += chunk;
+    if (!bracesBalanced(pending)) continue;
+    statements.push(pending.trim());
+    pending = "";
+  }
+  // An unterminated statement is handed back rather than dropped; the caller
+  // classifies it as unparseable.
+  if (pending !== "") statements.push(pending.trim());
+  return statements;
+}
+
+/** `{ a, b as c, type D }` -> the names a consumer can import: `a`, `c`, `D`. */
+function memberNames(clause: string): string[] {
+  return clause
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map((part) => {
+      const aliased = /\bas\s+([A-Za-z_$][\w$]*)$/.exec(part);
+      if (aliased !== null) return aliased[1] as string;
+      return part.replace(/^type\s+/, "").trim();
+    });
+}
+
+/**
+ * The surface one barrel exports, as one entry per importable name.
+ *
+ * A `export * from "x"` cannot be expanded without resolving `x`, so it is kept
+ * whole and compared as a unit — two barrels that both star-export the same
+ * specifier export the same names by construction, and one that does not is the
+ * difference worth reporting.
+ */
+function parseBarrel(text: string): ParsedBarrel {
+  const surface = new Set<SurfaceEntry>();
+  const unparseable: string[] = [];
+  for (const statement of topLevelExportStatements(text)) {
+    const star = /^export\s+(?:type\s+)?\*\s+from\s+"([^"]+)"/.exec(statement);
+    if (star !== null) {
+      surface.add(`* from "${star[1]}"`);
+      continue;
+    }
+    const named = /^export\s+(?:type\s+)?\{([\s\S]*?)\}\s*(?:from\s+"([^"]+)")?/.exec(statement);
+    if (named !== null) {
+      const from = named[2] === undefined ? "" : ` from "${named[2]}"`;
+      for (const name of memberNames(named[1] as string)) surface.add(`${name}${from}`);
+      continue;
+    }
+    const declared =
+      /^export\s+(?:declare\s+)?(?:async\s+)?(?:const|let|var|function|class|type|interface|enum)\s+([A-Za-z_$][\w$]*)/.exec(
+        statement
+      );
+    if (declared !== null) {
+      surface.add(declared[1] as string);
+      continue;
+    }
+    unparseable.push(statement.split("\n")[0] as string);
+  }
+  return { surface, unparseable };
+}
+
+/**
+ * Names the node barrel exports and the browser barrel deliberately does not.
+ *
+ * `_testOnly` is `@internal` — a bag of run-fn specs, queued providers and
+ * client-injection hooks that exists for `@workglow/test` alone, never for a
+ * consumer. It stays node-only because that is where the tests importing it
+ * run; `packages/ai` has already moved the equivalent surface behind a
+ * dedicated `./test` entry, which is where these belong too. Until then, its
+ * absence from the browser barrel is intent, not drift.
+ *
+ * Anything else appearing here is a real asymmetry: the modules behind these
+ * barrels carry no `node:` imports, and each omitted module was already in the
+ * browser bundle via the runtime entry — only its `export *` was missing.
+ */
+const INTENTIONAL_NODE_ONLY: ReadonlyMap<string, readonly string[]> = new Map([
+  ["providers/deepseek", ["_testOnly"]],
+  ["providers/ollama", ["_testOnly"]],
+  ["providers/openai", ["_testOnly"]],
+  ["providers/openrouter", ["_testOnly"]],
+  ["providers/xai", ["_testOnly"]],
+]);
+
+interface BarrelPair {
+  readonly packageDir: string;
+  readonly nodePath: string;
+  readonly browserPath: string;
+  readonly node: ParsedBarrel;
+  readonly browser: ParsedBarrel;
+}
+
+function repoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 10; i++) {
+    const candidate = join(dir, "package.json");
+    if (existsSync(candidate)) {
+      const pkg = JSON.parse(readFileSync(candidate, "utf8")) as { workspaces?: unknown };
+      if (Array.isArray(pkg.workspaces)) return dir;
+    }
+    dir = dirname(dir);
+  }
+  throw new Error("could not locate the workspace root from " + import.meta.url);
+}
+
+function barrelPairs(root: string): BarrelPair[] {
+  const pairs: BarrelPair[] = [];
+  const providersDir = join(root, "providers");
+  for (const entry of readdirSync(providersDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const packageDir = `providers/${entry.name}`;
+    const nodePath = `${packageDir}/src/ai/index.ts`;
+    const browserPath = `${packageDir}/src/ai/index.browser.ts`;
+    if (!existsSync(join(root, nodePath)) || !existsSync(join(root, browserPath))) continue;
+    pairs.push({
+      packageDir,
+      nodePath,
+      browserPath,
+      node: parseBarrel(readFileSync(join(root, nodePath), "utf8")),
+      browser: parseBarrel(readFileSync(join(root, browserPath), "utf8")),
+    });
+  }
+  return pairs;
+}
+
+/** Sorted so a failure message is stable across runs. */
+function nodeOnly(pair: BarrelPair): string[] {
+  return [...pair.node.surface].filter((name) => !pair.browser.surface.has(name)).sort();
+}
+
+describe("provider ai barrels", () => {
+  const root = repoRoot();
+  const pairs = barrelPairs(root);
+
+  it("finds the barrel pairs to check", () => {
+    // Vacuous-pass guard: the scan keying on a path that no longer exists would
+    // otherwise turn this whole file into a no-op.
+    expect(pairs.map((pair) => pair.packageDir).sort()).toEqual([...INTENTIONAL_NODE_ONLY.keys()]);
+  });
+
+  it("parses every top-level export in both barrels", () => {
+    const unparseable = pairs.flatMap((pair) => [
+      ...pair.node.unparseable.map((line) => `${pair.nodePath}: ${line}`),
+      ...pair.browser.unparseable.map((line) => `${pair.browserPath}: ${line}`),
+    ]);
+    expect(unparseable).toEqual([]);
+  });
+
+  it("exports the same surface from both barrels apart from the pinned node-only names", () => {
+    const drift: string[] = [];
+    for (const pair of pairs) {
+      const expected = [...(INTENTIONAL_NODE_ONLY.get(pair.packageDir) ?? [])].sort();
+      const actual = nodeOnly(pair);
+      const extra = actual.filter((name) => !expected.includes(name));
+      if (extra.length === 0) continue;
+      drift.push(
+        `${pair.packageDir}: ${pair.nodePath} exports ${extra.join(", ")} but ` +
+          `${pair.browserPath} does not`
+      );
+    }
+    expect(drift).toEqual([]);
+  });
+
+  it("keeps the node-only pins free of names that no longer differ", () => {
+    // Staleness, mirroring `ALLOWED_MISMATCHES` in `ExportTypesPairing.test.ts`:
+    // a pin that stops describing a real difference is an exemption nobody
+    // asked for, and hides the next omission behind an entry that reads as
+    // deliberate.
+    const stale: string[] = [];
+    for (const [packageDir, names] of INTENTIONAL_NODE_ONLY) {
+      const pair = pairs.find((candidate) => candidate.packageDir === packageDir);
+      expect(pair, `${packageDir} is pinned but has no barrel pair`).toBeDefined();
+      if (pair === undefined) continue;
+      const actual = nodeOnly(pair);
+      for (const name of names) {
+        if (actual.includes(name)) continue;
+        stale.push(`${packageDir}: "${name}" is pinned node-only but both barrels export it`);
+      }
+    }
+    expect(stale).toEqual([]);
+  });
+});
+
+/**
+ * The parser. Its behavior on the shapes these barrels really use is what the
+ * guard above is worth, so it is exercised directly rather than only through
+ * the tree.
+ */
+describe("barrel parsing", () => {
+  it("reads star, named, aliased and locally declared exports", () => {
+    const { surface, unparseable } = parseBarrel(
+      [
+        "/**\n * @license\n */",
+        "",
+        "// organize-imports-ignore",
+        "",
+        'export * from "./common/Constants";',
+        "export {",
+        "  ALLOWED_HOSTS,",
+        "  resolveMaxTokens as resolveTokens,",
+        "  type Options,",
+        '} from "./common/Client";',
+        'import { thing } from "./common/Thing";',
+        "export const _testOnly = {",
+        "  thing,",
+        "} as const;",
+        "",
+      ].join("\n")
+    );
+    expect(unparseable).toEqual([]);
+    expect([...surface].sort()).toEqual([
+      '* from "./common/Constants"',
+      'ALLOWED_HOSTS from "./common/Client"',
+      'Options from "./common/Client"',
+      "_testOnly",
+      'resolveTokens from "./common/Client"',
+    ]);
+  });
+
+  it("reports a statement it cannot classify rather than dropping it", () => {
+    // Regex-based, so an unrecognized shape must be loud. Silently skipping it
+    // would let a real asymmetry ride in on a form nobody taught the parser.
+    const { surface, unparseable } = parseBarrel("export default registerThing;\n");
+    expect(surface.size).toBe(0);
+    expect(unparseable).toEqual(["export default registerThing;"]);
+  });
+
+  it("does not read a re-export inside a comment as a statement", () => {
+    const { surface } = parseBarrel(
+      ['// export * from "./common/Gone";', 'export * from "./common/Here";'].join("\n")
+    );
+    expect([...surface]).toEqual(['* from "./common/Here"']);
+  });
+});

--- a/packages/test/src/test/util/ExportTypesPairing.test.ts
+++ b/packages/test/src/test/util/ExportTypesPairing.test.ts
@@ -257,6 +257,35 @@ function implementationsIn(node: unknown, out: string[]): void {
 }
 
 /**
+ * The `browser` block of one subpath, wherever it is nested.
+ *
+ * A top-level `value.browser` lookup finds only the flat shape. Its sibling
+ * {@link nodeImportTarget} recurses, so the two disagreed about the same
+ * manifest: `{ "import": { "browser": {…}, "default": … } }` resolves its node
+ * target through the recursion while the browser block sat one level down,
+ * invisible — every rule keyed on `branch` then behaved as if the subpath
+ * declared no `browser` condition at all, which is the "reports a built browser
+ * entry that no condition routes to" message pointed at a manifest that does
+ * route to one.
+ *
+ * The first block found wins: resolution stops at the first matching condition,
+ * so a second `browser` deeper in a sibling branch is unreachable anyway.
+ */
+function findBrowserBlock(node: unknown): unknown {
+  if (typeof node !== "object" || node === null || Array.isArray(node)) return undefined;
+  const entry = node as Record<string, unknown>;
+  if ("browser" in entry) return entry.browser;
+  for (const [key, value] of Object.entries(entry)) {
+    // `types` is TypeScript's, never a runtime's, so a `browser` under it would
+    // not be entered by the bundler this rule is about.
+    if (key === "types") continue;
+    const found = findBrowserBlock(value);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+/**
  * Subpaths that have a browser source entry beside them but do not route
  * browser consumers to it.
  *
@@ -293,7 +322,7 @@ function browserSplitViolations(
     const nodeTarget = nodeImportTarget(value);
     if (nodeTarget === undefined) continue;
     const at = `${manifest} exports["${subpath}"]`;
-    const branch = (value as Record<string, unknown> | undefined)?.browser;
+    const branch = findBrowserBlock(value);
 
     if (branch !== undefined) {
       const declared: string[] = [];
@@ -335,6 +364,86 @@ function browserSplitViolations(
           `${browserEntry[0]} exists (expected "${expected}")`
       );
     }
+  }
+  return out;
+}
+
+/**
+ * One `src/<stem>.browser.ts` and the `src/<stem>.ts` beside it, as text.
+ *
+ * Injected rather than read inside the rule so the fixtures below can state
+ * both halves, the same way {@link browserSplitViolations} takes its probe.
+ */
+interface EntryPair {
+  readonly browserPath: string;
+  readonly nodePath: string;
+  readonly browserText: string;
+  readonly nodeText: string;
+}
+
+/**
+ * The part of an entry file that decides what it exports. Block comments (the
+ * license header), whole-line `//` comments (`organize-imports-ignore`, and any
+ * prose explaining the entry) and whitespace are boilerplate every entry
+ * carries, so two entries differing only in those are the same module — and a
+ * comment alone can never talk this rule out of a real duplicate.
+ */
+function entryBody(text: string): string {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[ \t]*\/\/.*$/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Every module specifier the entry names, in source order. */
+function specifiersIn(text: string): string[] {
+  return [...text.matchAll(/from\s+"([^"]+)"/g)].map((match) => match[1] as string);
+}
+
+/**
+ * Browser entries that are a copy of the node entry beside them AND name only
+ * relative specifiers.
+ *
+ * **The relative/bare distinction is the entire rule.** Two identical entry
+ * files mean opposite things depending on what they import:
+ *
+ * - A **relative** specifier (`"./ai/index"`) is resolved once, by the file's
+ *   own path, and nothing in this toolchain substitutes `X.browser.ts` for
+ *   `X.ts` on one (`--target=browser` changes the compile target, not the
+ *   resolver; the `browser` field in a manifest applies to BARE specifiers).
+ *   So both entries pull in the same module graph and the declaration split is
+ *   nominal — two `.d.ts` files that must be hand-kept in sync, with nothing
+ *   but diligence stopping them drifting. `providers/llamacpp-server` and
+ *   `providers/stable-diffusion-server` were exactly this. The fix is for the
+ *   browser entry to `export * from "./ai"`, which cannot drift.
+ *
+ * - A **bare** specifier (`"@workglow/openai/ai"`) is re-resolved at every hop
+ *   under the CONSUMER's conditions, so the two identical files land on
+ *   different modules: the split really happens one layer down, in the
+ *   provider's own exports map. The nine `packages/workglow/src/*.browser.ts`
+ *   shims are this shape, and their being byte-identical IS the mechanism —
+ *   collapsing one into `export * from "./openai"` would pin browser consumers
+ *   to whatever the shim's own condition resolved and destroy the split. They
+ *   must stay identical; this rule must never report them.
+ *
+ * A pair with no specifiers at all is not reported: there is no import graph to
+ * reason about, so "the two resolve the same graph" says nothing.
+ */
+function duplicateBrowserEntryViolations(pairs: readonly EntryPair[]): string[] {
+  const out: string[] = [];
+  for (const pair of pairs) {
+    const browserBody = entryBody(pair.browserText);
+    if (browserBody !== entryBody(pair.nodeText)) continue;
+    const specifiers = specifiersIn(browserBody);
+    if (specifiers.length === 0) continue;
+    if (!specifiers.every((specifier) => specifier.startsWith("."))) continue;
+    out.push(
+      `${pair.browserPath} is identical to ${pair.nodePath} and names only relative ` +
+        `specifiers (${specifiers.map((specifier) => `"${specifier}"`).join(", ")}), so both ` +
+        `entries resolve the same module graph and the declaration split is nominal — ` +
+        `re-export the node entry from it instead of duplicating it`
+    );
   }
   return out;
 }
@@ -695,6 +804,35 @@ describe("workspace exports maps", () => {
         .filter((program) => existsSync(join(root.dir, dirname(relative), program)));
       expect(programs, `${relative} runs no repo-local build program`).not.toEqual([]);
     }
+  });
+
+  it("re-exports rather than duplicates a browser entry that has no split", () => {
+    // Collected from `src/*.browser.ts` — the ENTRY layer, which is what the
+    // manifests above name. A `.browser.ts` with no `.ts` beside it (e.g.
+    // `packages/tasks/src/codec.browser.ts`) is not an entry pair and has
+    // nothing to be a duplicate of.
+    const pairs: EntryPair[] = [];
+    for (const manifest of manifests) {
+      const srcDir = join(root.dir, dirname(manifest.relative), "src");
+      if (!existsSync(srcDir)) continue;
+      for (const file of readdirSync(srcDir)) {
+        const stem = /^(.+)\.browser\.(tsx?)$/.exec(file);
+        if (stem === null) continue;
+        const nodeFile = `${stem[1]}.${stem[2]}`;
+        if (!existsSync(join(srcDir, nodeFile))) continue;
+        pairs.push({
+          browserPath: `${dirname(manifest.relative)}/src/${file}`,
+          nodePath: `${dirname(manifest.relative)}/src/${nodeFile}`,
+          browserText: readFileSync(join(srcDir, file), "utf8"),
+          nodeText: readFileSync(join(srcDir, nodeFile), "utf8"),
+        });
+      }
+    }
+    // The nine `packages/workglow` shims are pairs, and correctly identical —
+    // they are the negative case the rule has to keep passing, so a scan that
+    // found nothing would prove nothing.
+    expect(pairs.length).toBeGreaterThan(9);
+    expect(duplicateBrowserEntryViolations(pairs)).toEqual([]);
   });
 
   it("keeps the allowlist free of entries that no longer mismatch", () => {
@@ -1083,6 +1221,34 @@ describe("exports map violation detection", () => {
       ).toEqual([]);
     });
 
+    /**
+     * `{ import: { browser: …, default: … } }`. `nodeImportTarget` recurses
+     * into `import` and resolves the node target, so the subpath IS checked —
+     * but the browser block was looked up flatly on `value`, found nothing, and
+     * every rule keyed on it behaved as though no `browser` condition existed.
+     */
+    it("finds a browser block nested inside another condition", () => {
+      expect(
+        browserSplitViolations(
+          "providers/openai/package.json",
+          {
+            "./ai": {
+              import: {
+                browser: { types: "./dist/ai.browser.d.ts" },
+                types: "./dist/ai.d.ts",
+                default: "./dist/ai.js",
+              },
+            },
+          },
+          always
+        )
+      ).toEqual([
+        'providers/openai/package.json exports["./ai"] [browser]: the "browser" condition ' +
+          "declares no implementation, so a browser bundler enters it, matches nothing, and " +
+          'falls through to the node target "./dist/ai.js"',
+      ]);
+    });
+
     it("leaves the packages/* browser/node layout alone", () => {
       // Stem `node`, so the probe asks for `src/node.browser.ts` and finds
       // nothing — the split here is expressed as two peer entries, not a
@@ -1250,6 +1416,96 @@ describe("exports map violation detection", () => {
       expect(
         buildEntryViolations("p/package.json", { "./types": { types: "./dist/x.d.ts" } }, {})
       ).toEqual([]);
+    });
+  });
+
+  /**
+   * The duplicate-entry rule. No pair in the tree violates it after
+   * `providers/llamacpp-server` and `providers/stable-diffusion-server` were
+   * collapsed onto `export * from "./ai"`, so both branches need fixtures.
+   */
+  describe("duplicate browser entries", () => {
+    const license =
+      "/**\n * @license\n * Copyright 2026 Steven Roussey <sroussey@gmail.com>\n" +
+      " * SPDX-License-Identifier: Apache-2.0\n */\n\n// organize-imports-ignore\n\n";
+
+    it("reports a browser entry that duplicates the node entry through a relative specifier", () => {
+      // `providers/llamacpp-server` as it stood: two files, one module graph.
+      // Nothing substitutes `./ai/index.browser` for `./ai/index` on a relative
+      // specifier, so `dist/ai.browser.d.ts` and `dist/ai.d.ts` describe the
+      // same exports and stay equal only by hand.
+      expect(
+        duplicateBrowserEntryViolations([
+          {
+            browserPath: "providers/llamacpp-server/src/ai.browser.ts",
+            nodePath: "providers/llamacpp-server/src/ai.ts",
+            browserText: `${license}export * from "./ai/index";\n`,
+            nodeText: `${license}export * from "./ai/index";\n`,
+          },
+        ])
+      ).toEqual([
+        "providers/llamacpp-server/src/ai.browser.ts is identical to " +
+          'providers/llamacpp-server/src/ai.ts and names only relative specifiers ("./ai/index"), ' +
+          "so both entries resolve the same module graph and the declaration split is nominal — " +
+          "re-export the node entry from it instead of duplicating it",
+      ]);
+    });
+
+    it("says nothing about identical shims that re-export a bare specifier", () => {
+      // The `packages/workglow` shape, and the reason this rule tests the
+      // SPECIFIERS rather than just the text. A bare specifier is re-resolved
+      // under the consumer's own conditions at every hop, so these two files
+      // land on `@workglow/openai`'s browser and node bundles respectively —
+      // the split happens one layer down, in that package's exports map. Their
+      // being byte-identical is the mechanism, not a defect: collapsing the
+      // browser shim onto `export * from "./openai"` would resolve the bare
+      // specifier once, under the shim's own condition, and destroy the split.
+      expect(
+        duplicateBrowserEntryViolations([
+          {
+            browserPath: "packages/workglow/src/openai.browser.ts",
+            nodePath: "packages/workglow/src/openai.ts",
+            browserText: `${license}export * from "@workglow/openai/ai";\n`,
+            nodeText: `${license}export * from "@workglow/openai/ai";\n`,
+          },
+        ])
+      ).toEqual([]);
+    });
+
+    it("says nothing about a browser entry with a genuinely different graph", () => {
+      // `providers/deepseek`: the browser entry names its own barrel, so the
+      // two declarations describe different modules and cannot drift together.
+      expect(
+        duplicateBrowserEntryViolations([
+          {
+            browserPath: "providers/deepseek/src/ai.browser.ts",
+            nodePath: "providers/deepseek/src/ai.ts",
+            browserText: `${license}export * from "./ai/index.browser";\n`,
+            nodeText: `${license}export * from "./ai/index";\n`,
+          },
+        ])
+      ).toEqual([]);
+    });
+
+    it("ignores the license header and comments when comparing", () => {
+      // A differing copyright year, or prose added above the export, does not
+      // make two entries different modules — and must not be a way to silence
+      // the rule.
+      expect(
+        duplicateBrowserEntryViolations([
+          {
+            browserPath: "p/src/ai.browser.ts",
+            nodePath: "p/src/ai.ts",
+            browserText: `${license}// browser build\nexport * from "./ai/index";\n`,
+            nodeText:
+              '/**\n * @license\n * Copyright 2025 Someone\n */\n\nexport * from "./ai/index";\n',
+          },
+        ])
+      ).toEqual([
+        "p/src/ai.browser.ts is identical to p/src/ai.ts and names only relative specifiers " +
+          '("./ai/index"), so both entries resolve the same module graph and the declaration ' +
+          "split is nominal — re-export the node entry from it instead of duplicating it",
+      ]);
     });
   });
 

--- a/providers/deepseek/src/ai/index.browser.ts
+++ b/providers/deepseek/src/ai/index.browser.ts
@@ -6,7 +6,19 @@
 
 // organize-imports-ignore
 
-export { DEEPSEEK_ALLOWED_HOSTS, DEEPSEEK_DEFAULT_BASE_URL } from "./common/DeepSeek_Client";
+export {
+  assertNotTruncatedByReasoning,
+  DEEPSEEK_ALLOWED_HOSTS,
+  DEEPSEEK_DEFAULT_BASE_URL,
+  DEEPSEEK_DEFAULT_REASONING_ALLOWANCE,
+  resolveMaxTokens,
+} from "./common/DeepSeek_Client";
 export * from "./common/DeepSeek_Constants";
 export * from "./common/DeepSeek_ModelSchema";
+export * from "./common/DeepSeek_ModelSearch";
+export {
+  DeepSeekToolChoiceNotHonoredError,
+  assertToolChoiceHonored,
+  isForcingToolChoice,
+} from "./common/DeepSeek_ToolCalling";
 export * from "./registerDeepSeek";

--- a/providers/llamacpp-server/src/ai-runtime.browser.ts
+++ b/providers/llamacpp-server/src/ai-runtime.browser.ts
@@ -6,4 +6,7 @@
 
 // organize-imports-ignore
 
-export * from "./ai/runtime";
+// See `ai.browser.ts`: no platform-specific source here either, so the browser
+// entry re-exports the node one rather than duplicating it. Relative specifier,
+// resolved identically under both conditions.
+export * from "./ai-runtime";

--- a/providers/llamacpp-server/src/ai.browser.ts
+++ b/providers/llamacpp-server/src/ai.browser.ts
@@ -6,4 +6,10 @@
 
 // organize-imports-ignore
 
-export * from "./ai/index";
+// This package has no platform-specific source: the browser bundle is the same
+// graph compiled `--target=browser`. Re-exporting the node entry is what stops
+// the two declarations drifting apart. Safe because the specifier is RELATIVE —
+// resolved once, identically under either condition. A future toolchain plugin
+// that substituted `X.browser.ts` for `X.ts` on relative specifiers would make
+// this a cycle.
+export * from "./ai";

--- a/providers/openai/src/ai/index.browser.ts
+++ b/providers/openai/src/ai/index.browser.ts
@@ -8,5 +8,7 @@
 
 export { OPENAI_ALLOWED_HOSTS } from "./common/OpenAI_Client";
 export * from "./common/OpenAI_Constants";
+export * from "./common/OpenAI_ImageValidation";
 export * from "./common/OpenAI_ModelSchema";
+export * from "./common/OpenAI_ModelSearch";
 export * from "./registerOpenAi";

--- a/providers/openrouter/src/ai/index.browser.ts
+++ b/providers/openrouter/src/ai/index.browser.ts
@@ -8,5 +8,7 @@
 
 export { OPENROUTER_ALLOWED_HOSTS } from "./common/OpenRouter_Client";
 export * from "./common/OpenRouter_Constants";
+export * from "./common/OpenRouter_Capabilities";
 export * from "./common/OpenRouter_ModelSchema";
+export * from "./common/OpenRouter_ModelSearch";
 export * from "./registerOpenRouter";

--- a/providers/stable-diffusion-server/src/ai-runtime.browser.ts
+++ b/providers/stable-diffusion-server/src/ai-runtime.browser.ts
@@ -6,4 +6,7 @@
 
 // organize-imports-ignore
 
-export * from "./ai/runtime";
+// See `ai.browser.ts`: no platform-specific source here either, so the browser
+// entry re-exports the node one rather than duplicating it. Relative specifier,
+// resolved identically under both conditions.
+export * from "./ai-runtime";

--- a/providers/stable-diffusion-server/src/ai.browser.ts
+++ b/providers/stable-diffusion-server/src/ai.browser.ts
@@ -6,4 +6,10 @@
 
 // organize-imports-ignore
 
-export * from "./ai/index";
+// This package has no platform-specific source: the browser bundle is the same
+// graph compiled `--target=browser`. Re-exporting the node entry is what stops
+// the two declarations drifting apart. Safe because the specifier is RELATIVE —
+// resolved once, identically under either condition. A future toolchain plugin
+// that substituted `X.browser.ts` for `X.ts` on relative specifiers would make
+// this a cycle.
+export * from "./ai";

--- a/providers/xai/src/ai/index.browser.ts
+++ b/providers/xai/src/ai/index.browser.ts
@@ -9,4 +9,5 @@
 export { XAI_ALLOWED_HOSTS, XAI_DEFAULT_BASE_URL } from "./common/Xai_Client";
 export * from "./common/Xai_Constants";
 export * from "./common/Xai_ModelSchema";
+export * from "./common/Xai_ModelSearch";
 export * from "./registerXai";


### PR DESCRIPTION
Stacked on #717 (`claude/wonderful-turing-rjtcnx-ai-types`), not on `main`.

#717's 24 manifest edits are correct and are not touched here. What they do is turn an
**invisible** gap into a **hard error**: once a `customConditions: ["browser"]` consumer is
type-checked against the browser declarations, every symbol a browser barrel forgot to
re-export becomes `TS2305`. Four providers have such omissions. This PR closes them, removes
the one class of nominal browser entry that has no split at all, and adds the guards that
would have caught both.

## Why this is stacked on #717 rather than a follow-up

Shipping them apart means one released version in which `assertToolChoiceHonored`,
`DeepSeek_ModelSearch_Stream`, `registerOpenAiImageValidator`, `OpenAI_ModelSearch_Stream`,
`Xai_ModelSearch_Stream` and OpenRouter's whole capability/model-search surface are
**uncompilable in the browser with no substitute** — #717 makes the routing correct, and the
barrels are what the correct routing then points at. In-repo consumers already break:
`packages/test/src/test/ai-provider-api/DeepSeek_ToolCalling.test.ts:9-11`,
`OpenAI_ImageValidation.test.ts:8`, and `ai-provider/provider-model-search.test.ts:10-16`
import these symbols from `@workglow/<p>/ai`.

## M1(b) — the omitted exports, per provider

The evidence these omissions are accidental is stronger than "no `node:` imports" (also true —
`grep 'from "node:"' over all five `src` trees returns zero): **every omitted module is already
compiled into that provider's browser bundle via the runtime entry.** E.g.
`providers/openai/src/ai/registerOpenAi.ts:10` imports `registerOpenAiImageValidator`, and
`registerOpenAi` IS in `index.browser.ts` — so it is in `dist/ai.browser.js` today and only its
`export *` was missing.

| provider | module restored | symbols |
| --- | --- | --- |
| deepseek | `common/DeepSeek_Client` (widened from 2 names to the node barrel's 5) | `assertNotTruncatedByReasoning`, `DEEPSEEK_DEFAULT_REASONING_ALLOWANCE`, `resolveMaxTokens` (plus the 2 already there) |
| deepseek | `common/DeepSeek_ModelSearch` | `DeepSeek_ModelSearch_Stream` |
| deepseek | `common/DeepSeek_ToolCalling` (named form) | `DeepSeekToolChoiceNotHonoredError`, `assertToolChoiceHonored`, `isForcingToolChoice` |
| openai | `common/OpenAI_ImageValidation` | `registerOpenAiImageValidator` |
| openai | `common/OpenAI_ModelSearch` | `OpenAI_ModelSearch_Stream` |
| xai | `common/Xai_ModelSearch` | `Xai_ModelSearch_Stream` |
| openrouter | `common/OpenRouter_Capabilities` | `OPENROUTER_RUN_FN_SPECS`, `openRouterWorkerRunFnSpecs`, `deriveCapabilitiesFromMeta`, `inferOpenRouterCapabilities` |
| openrouter | `common/OpenRouter_ModelSearch` | `OpenRouterRawModel`, `OPENROUTER_FALLBACK_MODELS`, `fetchOpenRouterModels`, `mapOpenRouterModels`, `OpenRouter_ModelSearch_Stream` |

`DeepSeek_ToolCalling` keeps the **named** form the node barrel uses rather than a `export *`.
That is what holds `DeepSeek_ToolCalling_Stream` out of the main-thread barrel on both
platforms — matching `index.ts` exactly.

`_testOnly` is deliberately **not** added anywhere. It is `@internal`, exists for
`@workglow/test` alone, and belongs behind a `./test` entry the way `packages/ai` already did
it. After this PR it is the only symbol a browser consumer loses.

## Two claims from the original review, refuted — please don't "fix" these

1. **ollama has no gap.** The "every `*_ModelSearch` is missing from the browser barrel" claim
   does not hold here: `providers/ollama/src/ai/common/Ollama_ModelSearch.ts` exists but is
   exported by **neither** barrel (it is consumed internally by `Ollama_JobRunFns` /
   `Ollama_JobRunFns.browser`, which register `Ollama_ModelSearch_Stream` as a run-fn). The two
   barrels already agree; ollama's only delta is `_testOnly`. **No change made.**
   `providers/ollama/src/ai-runtime` is also untouched — its `runtime.ts` vs
   `runtime.browser.ts` split is genuine (`import("ollama")` vs `import("ollama/browser")`),
   cactus-class.

2. **The nine `packages/workglow` shims are correctly identical.** They contain
   `export * from "@workglow/openai/ai"` — a **bare** specifier, re-resolved under the
   consumer's conditions at every hop, so the split really happens one layer down in the
   provider's exports map. The two files being identical **is** the mechanism. Collapsing the
   browser shim onto `export * from "./openai"` would resolve the bare specifier once, under
   the shim's own condition, and destroy the split. Left alone, and the new guard has a
   dedicated negative fixture documenting this.

## M2(i) — the four genuinely nominal browser entries

`providers/llamacpp-server` and `providers/stable-diffusion-server` each had a
`src/ai.browser.ts` byte-identical to `src/ai.ts` and a `src/ai-runtime.browser.ts`
byte-identical to `src/ai-runtime.ts`, all four naming **relative** specifiers
(`./ai/index`, `./ai/runtime`). A relative specifier is resolved once, by the importing file's
own path — `--target=browser` changes the compile target, not the resolver, and a manifest's
`browser` field applies to bare specifiers only. So both entries already pulled in the same
graph and the declaration split was nominal: two `.d.ts` files kept equal by hand.

Each `.browser.ts` now re-exports its node peer. Cycle safety was checked: under
`moduleResolution: "bundler"` a file (`./ai.ts`) beats a directory (`./ai/index.ts`), bun
agrees, `ai.ts` re-exports `./ai/index` and never `./ai.browser`, and nothing in the toolchain
(`examples/web/vite.config.ts`, `bunfig.toml`, bun's `--target=browser`) substitutes
`X.browser.ts` for `X.ts` on a relative specifier. Each file keeps a one-line comment saying a
future `.browser.ts` resolver plugin would break this.

The `browser` **condition** is kept for both packages — `--target=browser` still produces a
genuinely different bundle, so the entry earns its keep. Confirmed by build: all four bundles
are **byte-identical** before and after (see table below).

## Bundle-size cost — measured, and the plan's prediction was wrong in an interesting way

`bun run build:packages` at the base commit vs. after, `dist/ai.browser.js`:

| provider | before | after | Δ raw | gzip before | gzip after | Δ gzip |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| deepseek | 7,842 | 13,028 | **+5,186** | 2,680 | 4,155 | +1,475 |
| openai | 10,300 | 12,941 | **+2,641** | 3,400 | 4,054 | +654 |
| xai | 6,319 | 8,427 | **+2,108** | 2,256 | 2,803 | +547 |
| openrouter | 8,786 | 11,358 | **+2,572** | 2,694 | 3,333 | +639 |
| llamacpp-server | 28,270 | 28,270 | **0** | 5,855 | 5,839 | −16 |
| stable-diffusion-server | 15,368 | 15,368 | **0** | 3,560 | 3,536 | −24 |

Corrections to what the plan predicted:

- **The SDK was already there.** `grep -o 'import("[^"]*")'` finds `import("openai")` in the
  **baseline** `ai.browser.js` of all four providers, reached through `registerDeepSeek` /
  `registerOpenAi` / `registerXai` / `registerOpenRouter`. `getClient` is not pulled in by
  this change — it was already in every browser bundle.
- **No code-splitting happens, and none is needed.** bun emits no lazy chunk (`ls dist/*.js`
  is unchanged: `ai.js`, `ai.browser.js`, `ai-runtime.js`, `ai-runtime.browser.js` and nothing
  else). Under `--packages=external` the `await import("openai")` stays a literal dynamic
  import of a bare specifier, which the downstream bundler defers — so the SDK never
  contributes eager weight either way.
- **The whole delta is the restored modules' own source**, and it is eager. Isolated by
  rebuilding openai with only `OpenAI_ImageValidation` added: 10,300 → **10,331** (+31 bytes,
  effectively the plan's "literal zero"); adding `OpenAI_ModelSearch` on top accounts for the
  remaining +2,610.
- **OpenRouter is not free.** The plan predicted "adds nothing (uses global `fetch`, no SDK)".
  It adds +2,572 raw / +639 gzip — its own capability-inference and model-mapping code,
  including the `OPENROUTER_FALLBACK_MODELS` literal. Correct, but not zero.

Worst case is deepseek at +1.5 KB gzipped, for symbols a browser consumer currently cannot
import at all.

## M2(ii) + M1(b)'s regression net

- **`duplicateBrowserEntryViolations`** (`ExportTypesPairing.test.ts`, beside
  `browserSplitViolations`): reports a `src/*.browser.ts` identical to its `src/<stem>.ts`
  peer whose specifiers are **all relative**. The relative/bare distinction is the entire rule
  and is documented in full in the doc comment, including why the `packages/workglow` shims
  are correctly identical. No violation survives after M2(i), so both branches carry fixtures:
  a positive pair (`export * from "./ai/index"` on both → one violation), a **negative** pair
  (`export * from "@workglow/openai/ai"` on both → zero violations, commented with the
  refutation), a differing-graph pair, and one proving a comment cannot silence the rule.

- **`packages/test/src/test/util/ExportBarrelParity.test.ts`** (new): parses each provider's
  `src/ai/index.ts` + `src/ai/index.browser.ts` into a surface set and asserts
  `node \ browser` equals a pinned `INTENTIONAL_NODE_ONLY` fixture (each of the five providers
  → `["_testOnly"]`), with a comment explaining why `_testOnly` is node-only and pointing at
  the `./test` migration. Includes a staleness check (a pin that no longer describes a real
  difference fails), mirroring `ALLOWED_MISMATCHES`. Source-only — no build, works under
  `use-source`. The parser is regex-based, so an unclassifiable statement is **reported**, not
  skipped, matching how `buildEntryViolations` reports an underivable dist stem.

- **LOW, `findBrowserBlock`**: `browserSplitViolations` did a top-level `?.browser` lookup
  while its sibling `nodeImportTarget` recurses, so a nested
  `{ import: { browser: {…}, default: … } }` was invisible — every rule keyed on the branch
  behaved as if no `browser` condition existed. Replaced with a walker; fixture added for the
  no-implementation case reached that way.

- **SKIPPED, as planned**: hardening `buildEntryViolations`' regex against glob/variable-driven
  entry lists. Fixing it properly means executing the build, and it is already fenced by
  `GLOB_BUILT_PACKAGES`.

## Verification

```
$ bun scripts/test.ts util vitest
 Test Files  55 passed (55)
      Tests  810 passed | 10 skipped (820)
   Duration  177.72s
exit=0

$ bun scripts/test.ts provider-api provider vitest
 Test Files  3 failed | 87 passed | 3 skipped (93)
      Tests  10 failed | 1021 passed | 61 skipped (1093)
```

All 10 failures are **live** OpenAI integration tests
(`OpenAI_Generic.integration.test.ts`, `OpenAI_ImageGeneration.integration.test.ts`,
`OpenAI_UsageAccounting.integration.test.ts`) failing on billing, unrelated to this change:

```
Error: OpenAI Responses 429: {"message":"You have no credits remaining. ...",
  "type":"insufficient_quota","code":"credit_balance_exhausted"}
```

The three consumer tests this PR unblocks pass:

```
$ bunx vitest run --project test src/test/ai-provider-api/DeepSeek_ToolCalling.test.ts \
    src/test/ai-provider-api/OpenAI_ImageValidation.test.ts
 Test Files  2 passed (2)      Tests  11 passed (11)

$ bunx vitest run --project test src/test/ai-provider/provider-model-search.test.ts
 Test Files  1 passed (1)      Tests  10 passed (10)
```

Lint (the repo has no root `lint` script; each package carries one) — clean, no output, on
every changed package:

```
$ for p in providers/{deepseek,openai,xai,openrouter,llamacpp-server,stable-diffusion-server} packages/test; do (cd $p && bun run lint); done
$ eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0   # x7, all silent
```

Build:

```
$ bun run build:packages
 Tasks:    81 successful, 81 total
  Time:    49.415s
exit=0
```

### The guards actually guard

Deleting the one added `Xai_ModelSearch` line:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+ [
+   "providers/xai: providers/xai/src/ai/index.ts exports * from \"./common/Xai_ModelSearch\"
+    but providers/xai/src/ai/index.browser.ts does not",
+ ]
```

Restoring `providers/llamacpp-server/src/ai.browser.ts` to its duplicated form:

```
FAIL  workspace exports maps > re-exports rather than duplicates a browser entry that has no split
+ [
+   "providers/llamacpp-server/src/ai.browser.ts is identical to providers/llamacpp-server/src/ai.ts
+    and names only relative specifiers (\"./ai/index\"), so both entries resolve the same module
+    graph and the declaration split is nominal — re-export the node entry from it instead of
+    duplicating it",
+ ]
```

Both restored afterwards.

### tsgo probe — #717's own methodology, reproduced

A throwaway file (not committed) importing the two symbols, compiled twice under
`moduleResolution: "bundler"`, once with `customConditions: ["browser"]` and once without:

```ts
import { assertToolChoiceHonored, DeepSeek_ModelSearch_Stream } from "@workglow/deepseek/ai";
void assertToolChoiceHonored;
void DeepSeek_ModelSearch_Stream;
```

**Before M1(b)** (deepseek's browser barrel reverted, rebuilt):

```
=== BEFORE M1(b): NODE ===
exit=0
=== BEFORE M1(b): BROWSER ===
probe.ts(1,10): error TS2305: Module '"@workglow/deepseek/ai"' has no exported member 'assertToolChoiceHonored'.
probe.ts(1,35): error TS2724: '"@workglow/deepseek/ai"' has no exported member named 'DeepSeek_ModelSearch_Stream'. Did you mean 'DeepSeekModelSchema'?
exit=1
```

**After M1(b)**:

```
=== NODE (no customConditions) ===
exit=0
=== BROWSER (customConditions: ["browser"]) ===
exit=0
```

No `tsgo`-spawning vitest test was added — it needs a built `dist`, is slow, and has no
precedent in the repo.

## Release metadata

The repo uses **bunset**, not changesets (there is no `.changeset/`), and `CHANGELOG.md` files
are generated from conventional-commit subjects — none were hand-edited. Once M1(b) lands, the
only symbols leaving the browser type surface are `_testOnly` (internal) and ollama's genuine
platform split, so a **patch** bump is honest and the normal `bunset --patch --all` path
applies. The three commit subjects are the changelog entries:

- `fix(providers): restore the runtime-agnostic exports the browser barrels dropped`
- `refactor(providers): re-export the node entry from the browser entry where no split exists`
- `test(exports): flag a duplicate browser entry and pin browser barrel parity`

## Suggested description fix for #717

Not edited by this PR — for the author to apply:

- It says **25 branches**; the actual count in the diff is **24**.
- It says **"10 in workglow including `./worker`"**; there are **9** `packages/workglow`
  shims (`anthropic`, `deepseek`, `google-gemini`, `hf-inference`, `hf-transformers`,
  `ollama`, `openai`, `openrouter`, `xai`). `./worker` was already correct on `main` and is
  untouched by #717.
- It says **"Three assertions"**; `ExportTypesPairing.test.ts` as merged carries **8** tests
  in its `workspace exports maps` suite (finds branches, pairs types, source entries, types
  ordering, browser split, condition ordering, build entries, glob exemption) plus the
  fixture suites.
- Worth adding: once this parity fix lands, a `customConditions: ["browser"]` consumer loses
  only `_testOnly` relative to the node surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UW1Qr5mxetAQr61YKEY9nz)_