### PR TITLE
fix(task-graph): re-resolve credential inputs on a re-run instead of blanking them

### DIFF
--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -215,6 +215,46 @@ export class TaskRunner<
   private readonly ownedUsageUnsubs = new Map<object, () => void>();
 
   /**
+   * What {@link resolveSchemas} rewrote on `task.runInputData` last run, per
+   * port: the value it wrote and the value it read.
+   *
+   * Input resolution writes back **in place** — the resolved value replaces the
+   * reference id on the very port it was read from — and `run()` *merges*
+   * overrides into `runInputData` rather than resetting it (`Task.setInput`
+   * skips `undefined` and leaves absent keys untouched; nothing in
+   * `run()`/`runPreview()` calls `resetInputData`). So a second standalone run
+   * of the same instance re-resolves whatever the first run left behind.
+   *
+   * That is harmless for every resolver but one, because they are idempotent:
+   * `model` / `mcp-server` / storage resolvers turn a string id into an object
+   * and ignore a non-string on the next pass. `format: "credential"` is the
+   * lossy exception — it resolves string → string, and a store miss yields
+   * `undefined` rather than the id (deliberately: echoing the id would send a
+   * credential's *name* as its *value*). Re-resolving a secret therefore looks
+   * the secret up as if it were a key, misses, and blanks the port — a
+   * fail-closed task then throws on run 2, and `FetchUrlTask` silently sends
+   * the request with no `Authorization` header at all.
+   *
+   * The config path escapes this by re-resolving from the frozen
+   * `originalConfig` snapshot. Inputs have no frozen original — direct
+   * `task.runInputData = {...}` assignment and `copyInputFromEdgesToNode` both
+   * write it between runs — so instead of restoring a whole snapshot, each
+   * rewritten port remembers its source and is reverted **only when it still
+   * holds exactly the value this runner put there** (`Object.is`). A graph run
+   * (whose `resetGraph` → `resetTask` → `resetInputData` already put the raw id
+   * back), an override supplied to `run()`, and a caller's own assignment all
+   * fail that identity check and are left alone.
+   *
+   * A store miss is memoized too (`{ resolved: undefined, original: "key" }`),
+   * so a store that was locked during run 1 and unlocked before run 2 resolves
+   * on run 2 instead of failing identically forever.
+   */
+  private readonly resolvedInputOrigins = new Map<
+    string,
+    { resolved: unknown; original: unknown }
+  >();
+
+  /**
    * True when `this.resourceScope` was auto-created by `run()` (caller did not
    * pass one in `config`). The flag is used by `own()` so that an auto-owned
    * scope is not stamped into a child task's long-lived `runConfig` — that
@@ -1143,7 +1183,9 @@ export class TaskRunner<
    * Resolves config and input schema annotations (e.g. mcp-server references)
    * by mutating task.config and task.runInputData. Always resolves config from
    * originalConfig so re-runs use the original string IDs, not previously resolved
-   * objects. Shared between run() and runPreview() to avoid duplication.
+   * objects; inputs get the same guarantee from the per-port revert memo in
+   * {@link resolvedInputOrigins}. Shared between run() and runPreview() to avoid
+   * duplication.
    */
   private async resolveSchemas(): Promise<void> {
     const configSchema = (this.task.constructor as typeof Task).configSchema();
@@ -1162,11 +1204,26 @@ export class TaskRunner<
     // the instance; the static schema has no format annotations and would skip hydration.
     const ctor = this.task.constructor as typeof Task;
     const schema = ctor.hasDynamicSchemas ? this.task.inputSchema() : ctor.inputSchema();
-    this.task.runInputData = (await resolveSchemaInputs(
-      this.task.runInputData as Record<string, unknown>,
-      schema,
-      { registry: this.registry }
-    )) as Input;
+
+    // Revert the ports this runner rewrote last time, but only where they still
+    // hold exactly the value it put there — see {@link resolvedInputOrigins}.
+    const source = { ...(this.task.runInputData as Record<string, unknown>) };
+    for (const [port, memo] of this.resolvedInputOrigins) {
+      if (Object.is(source[port], memo.resolved)) source[port] = memo.original;
+    }
+
+    const resolved = (await resolveSchemaInputs(source, schema, {
+      registry: this.registry,
+    })) as Record<string, unknown>;
+
+    this.resolvedInputOrigins.clear();
+    for (const port of Object.keys(source)) {
+      if (!Object.is(resolved[port], source[port])) {
+        this.resolvedInputOrigins.set(port, { resolved: resolved[port], original: source[port] });
+      }
+    }
+
+    this.task.runInputData = resolved as Input;
   }
 
   /**

--- a/packages/test/src/test/task-graph/TaskRunnerRerunResolution.test.ts
+++ b/packages/test/src/test/task-graph/TaskRunnerRerunResolution.test.ts
@@ -1,0 +1,303 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ModelConfig, ModelRecord } from "@workglow/ai";
+import { getGlobalModelRepository, ModelConfigSchema } from "@workglow/ai";
+import type { IExecuteContext } from "@workglow/task-graph";
+import { Task, TaskConfigurationError } from "@workglow/task-graph";
+import type { ICredentialStore, ServiceRegistry } from "@workglow/util";
+import {
+  Container,
+  getGlobalCredentialStore,
+  InMemoryCredentialStore,
+  registerCredentialDefaults,
+  ServiceRegistry as ServiceRegistryClass,
+  setGlobalCredentialStore,
+} from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { beforeEach, describe, expect, test } from "vitest";
+
+/**
+ * `TaskRunner.resolveSchemas` writes a resolved value back onto the very port it
+ * read the reference id from, and `run()` MERGES overrides into `runInputData`
+ * rather than resetting it (`Task.setInput` skips `undefined` and leaves absent
+ * keys untouched; neither `run()` nor `runPreview()` calls `resetInputData()`).
+ * A second standalone run of one instance therefore re-resolves whatever the
+ * first run left on the port.
+ *
+ * For `format: "model"` that is harmless — the resolver ignores a non-string, so
+ * pass 2 is a no-op. `format: "credential"` is the lossy exception: it resolves
+ * string → string, and on a store MISS it deliberately returns `undefined`
+ * rather than echoing the id (echoing would send a credential's name as its
+ * value). So run 2 looks the SECRET up as if it were a key, misses, and blanks
+ * the port while leaving it an own property.
+ *
+ * Graph runs escape this entirely — `TaskGraphRunner.run` → `resetGraph` →
+ * `EdgeMaterializer.resetTask` → `resetInputData()` puts the raw id back before
+ * every run — and so do keys supplied as `run()` overrides, since `setInput`
+ * rewrites those ports each time. What is left broken, and what these tests
+ * pin, is the instance whose key lives in `defaults` and which is run twice
+ * directly.
+ */
+describe("TaskRunner re-run input resolution", () => {
+  const SECRET = "https://hooks.example.com/T000/B000/XXXXXXXX";
+  const CREDENTIAL_KEY = "webhook-url";
+
+  /**
+   * A registry scoped to its own container so the credential store never leaks
+   * into the global registry shared by the other suites in this section.
+   */
+  const createCredentialRegistry = async (
+    entries: Readonly<Record<string, string>> = { [CREDENTIAL_KEY]: SECRET }
+  ): Promise<ServiceRegistry> => {
+    const registry = new ServiceRegistryClass(new Container());
+    registerCredentialDefaults(registry);
+    const store: ICredentialStore = new InMemoryCredentialStore();
+    for (const [key, value] of Object.entries(entries)) {
+      await store.put(key, value);
+    }
+    setGlobalCredentialStore(store, registry);
+    return registry;
+  };
+
+  interface NotifyInput extends Record<string, unknown> {
+    url_credential_key?: string;
+    text?: string;
+  }
+  interface NotifyOutput extends Record<string, unknown> {
+    posted_to: string;
+  }
+
+  /** Every URL a {@link WebhookNotifyTask} instance posted to, in order. */
+  const posted: Array<{ url: string; text: string | undefined }> = [];
+
+  /**
+   * Stands in for a webhook-notify task: its endpoint URL lives in the
+   * credential store, so the port carries a key on the way in and the secret
+   * URL by the time `execute` sees it. Fail-closed — a blank URL is a
+   * configuration error, never a silent no-op.
+   */
+  class WebhookNotifyTask extends Task<NotifyInput, NotifyOutput> {
+    public static override type = "WebhookNotifyTask";
+    public static override readonly title = "Webhook Notify";
+    // Two runs of one instance is exactly the shape a cache hit would hide:
+    // a served run never reaches `execute`, so the assertions would pass
+    // without the second resolution ever happening.
+    public static override cacheable = false;
+
+    public static override inputSchema(): DataPortSchema {
+      return {
+        type: "object",
+        properties: {
+          url_credential_key: { type: "string", format: "credential" },
+          text: { type: "string" },
+        },
+        additionalProperties: false,
+      } as const satisfies DataPortSchema;
+    }
+
+    public static override outputSchema(): DataPortSchema {
+      return {
+        type: "object",
+        properties: { posted_to: { type: "string" } },
+        required: ["posted_to"],
+        additionalProperties: false,
+      } as const satisfies DataPortSchema;
+    }
+
+    override async execute(input: NotifyInput, _context: IExecuteContext): Promise<NotifyOutput> {
+      const url = input.url_credential_key;
+      if (!url) {
+        throw new TaskConfigurationError("WebhookNotifyTask: no webhook URL was resolved.");
+      }
+      posted.push({ url, text: input.text });
+      return { posted_to: url };
+    }
+
+    override async executePreview(input: NotifyInput): Promise<NotifyOutput> {
+      return { posted_to: input.url_credential_key ?? "" };
+    }
+  }
+
+  beforeEach(() => {
+    posted.length = 0;
+  });
+
+  describe("re-run with a credential-backed URL", () => {
+    /**
+     * The regression: before the fix, run 2 resolved the SECRET as if it were a
+     * key, missed, and left the port `undefined` — so a fail-closed task threw
+     * and `FetchUrlTask` silently dropped its `Authorization` header. The
+     * assertion is deliberately on the FIXED behaviour (two posts to the same
+     * URL) rather than on either pre-fix error shape.
+     */
+    test("a defaults-configured credential key survives a second run", async () => {
+      const registry = await createCredentialRegistry();
+      const task = new WebhookNotifyTask({
+        defaults: { url_credential_key: CREDENTIAL_KEY },
+      });
+
+      await task.run({ text: "one" }, { registry });
+      await task.run({ text: "two" }, { registry });
+
+      expect(posted).toEqual([
+        { url: SECRET, text: "one" },
+        { url: SECRET, text: "two" },
+      ]);
+    });
+
+    /**
+     * `runPreview()` shares `resolveSchemas` with `run()`, so a preview alone is
+     * enough to burn the port for the real run that follows. Two different entry
+     * points, one memo — the revert has to live on the runner, not inside `run`.
+     *
+     * `runPreview` takes no run config, so it resolves against the runner's own
+     * registry (the global one); the key is put on the global store and removed
+     * again rather than scoped to a private container like the other tests.
+     */
+    test("a preview followed by a run resolves the key both times", async () => {
+      const key = "webhook-url-preview";
+      const store = getGlobalCredentialStore();
+      await store.put(key, SECRET);
+      try {
+        const task = new WebhookNotifyTask({ defaults: { url_credential_key: key } });
+
+        const preview = await task.runPreview({ text: "preview" });
+        expect(preview.posted_to).toBe(SECRET);
+
+        const result = await task.run({ text: "real" });
+        expect(result.posted_to).toBe(SECRET);
+        expect(posted).toEqual([{ url: SECRET, text: "real" }]);
+      } finally {
+        await store.delete(key);
+      }
+    });
+
+    /**
+     * Fail-closed regression guard. The memo records a miss as
+     * `{ resolved: undefined, original: "<key>" }`, so the second run reverts
+     * the port to the key and asks the store again — it must NOT invent a value
+     * or leave the key standing in for its own secret. An absent key is a
+     * configuration error on BOTH runs, exactly as it is on the first.
+     */
+    test("an absent key still fails closed on both runs", async () => {
+      const registry = await createCredentialRegistry({});
+      const task = new WebhookNotifyTask({
+        defaults: { url_credential_key: "no-such-key" },
+      });
+
+      await expect(task.run({ text: "one" }, { registry })).rejects.toThrow(TaskConfigurationError);
+      await expect(task.run({ text: "two" }, { registry })).rejects.toThrow(TaskConfigurationError);
+      expect(posted).toEqual([]);
+    });
+
+    /**
+     * A store that was locked (or simply not yet populated) during run 1 and
+     * available before run 2 now succeeds. Without the memo the port would hold
+     * `undefined` forever after the first miss, so the instance could never
+     * recover — the key it was configured with is gone.
+     */
+    test("a key that appears between runs resolves on the second run", async () => {
+      const registry = await createCredentialRegistry({});
+      const task = new WebhookNotifyTask({
+        defaults: { url_credential_key: CREDENTIAL_KEY },
+      });
+
+      await expect(task.run({ text: "one" }, { registry })).rejects.toThrow(TaskConfigurationError);
+
+      const store = new InMemoryCredentialStore();
+      await store.put(CREDENTIAL_KEY, SECRET);
+      setGlobalCredentialStore(store, registry);
+
+      await task.run({ text: "two" }, { registry });
+      expect(posted).toEqual([{ url: SECRET, text: "two" }]);
+    });
+  });
+
+  describe("idempotent formats are unaffected", () => {
+    const MODEL_ID = "rerun-resolution-test-model";
+
+    interface ModelInput extends Record<string, unknown> {
+      model?: string | ModelConfig;
+    }
+    interface ModelOutput extends Record<string, unknown> {
+      provider: string;
+      model_id: string;
+    }
+
+    /** Reads the resolved {@link ModelConfig} off a `format: "model"` port. */
+    class ModelConsumerTask extends Task<ModelInput, ModelOutput> {
+      public static override type = "RerunModelConsumerTask";
+      public static override readonly title = "Rerun Model Consumer";
+      // Both runs carry identical input, so a cache hit would serve run 2
+      // without resolving anything and the test would pin nothing.
+      public static override cacheable = false;
+
+      public static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { model: ModelConfigSchema },
+          required: ["model"],
+          additionalProperties: false,
+        } as DataPortSchema;
+      }
+
+      public static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            provider: { type: "string" },
+            model_id: { type: "string" },
+          },
+          required: ["provider", "model_id"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      override async execute(input: ModelInput, _context: IExecuteContext): Promise<ModelOutput> {
+        const model = input.model;
+        if (typeof model !== "object" || model === null) {
+          throw new TaskConfigurationError(
+            `RerunModelConsumerTask: model port was not resolved (got ${JSON.stringify(model)}).`
+          );
+        }
+        return { provider: model.provider, model_id: String(model.model_id) };
+      }
+    }
+
+    /**
+     * The memo reverts a rewritten port to the id it came from, so an
+     * idempotent format now RE-resolves on run 2 where it used to pass the
+     * already-resolved object straight through. That must land on an equivalent
+     * model — this is the guard that the revert did not break the formats it was
+     * never aimed at (`model` / `mcp-server` / storage all resolve string →
+     * object and ignore a non-string on the next pass).
+     */
+    test("a defaults-configured model id resolves on both runs", async () => {
+      const repo = getGlobalModelRepository();
+      const existing = await repo.findByName(MODEL_ID).catch(() => undefined);
+      if (!existing) {
+        await repo.addModel({
+          model_id: MODEL_ID,
+          capabilities: ["text.generation"],
+          title: "Re-run resolution test model",
+          description: "Stub model used by the TaskRunner re-run resolution tests",
+          provider: "rerun-test-provider",
+          provider_config: {},
+          metadata: {},
+        } as ModelRecord);
+      }
+
+      const task = new ModelConsumerTask({ defaults: { model: MODEL_ID } });
+
+      const first = await task.run({});
+      const second = await task.run({});
+
+      expect(first).toEqual({ provider: "rerun-test-provider", model_id: MODEL_ID });
+      expect(second).toEqual(first);
+    });
+  });
+});

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -1186,6 +1186,40 @@ describe("FetchUrlTask", () => {
       expect(headers.Authorization).toBe(`Bearer ${SECRET}`);
       expect(headers["X-Trace"]).toBe("keep-me");
     });
+
+    /**
+     * The silent half of the re-run credential bug, and the reason it is fixed
+     * in `TaskRunner` rather than in any one task.
+     *
+     * Input resolution writes the resolved secret back onto `credential_key`
+     * itself, and `run()` merges overrides into `runInputData` rather than
+     * resetting it — so a second standalone run of the same instance used to
+     * look the SECRET up as if it were a key, miss, and leave the port
+     * `undefined`. `applyCredentialToHeaders` returns the headers unchanged for
+     * a falsy credential, so run 2 went out over the wire with NO
+     * `Authorization` header and no error anywhere: an authenticated request
+     * silently downgraded to an anonymous one.
+     *
+     * The key lives in `defaults` here, which is the broken shape. Supplying it
+     * as a `run()` override was always safe (`setInput` rewrites that port every
+     * run), as was any graph run (`resetGraph` restores the raw id first).
+     */
+    test("a defaults-configured credential key still authenticates on a re-run", async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(createMockResponse({ ok: true })));
+
+      const registry = await createCredentialRegistry();
+      const task = new FetchUrlTask({
+        defaults: { url: "https://api.example.com/data", credential_key: CREDENTIAL_KEY },
+      });
+
+      await task.run({}, { registry });
+      expect(lastRequestHeaders().Authorization).toBe(`Bearer ${SECRET}`);
+
+      await task.run({}, { registry });
+      expect(lastRequestHeaders().Authorization).toBe(`Bearer ${SECRET}`);
+
+      expect(mockFetch.mock.calls.length).toBe(2);
+    });
   });
 
   describe("applyCredentialToHeaders", () => {


### PR DESCRIPTION
## The bug

`TaskRunner.resolveSchemas()` resolves format-annotated input ports **in place** — the resolved value replaces the reference id on the very port it was read from — and `run()` *merges* overrides into `runInputData` rather than resetting it (`Task.setInput` skips `undefined` and leaves absent keys untouched; nothing in `run()`/`runPreview()` calls `resetInputData()`). So a second standalone run of one instance re-resolves whatever the first run left behind.

`format: "credential"` is the **only lossy, non-idempotent resolver**. `model` / `mcp-server` / storage resolve string → object and ignore a non-string on pass 2, so re-resolving them is a no-op. Credentials resolve string → **string**, and `CredentialStoreRegistry`'s resolver deliberately returns `undefined` on a miss rather than echoing the id (echoing would thread a credential's *name* through as its *value*, straight into an `Authorization` header). So run 2 looks the **secret** up as if it were a key, misses, and blanks the port while leaving it an own property.

### Exact scope

**Broken:** the key lives in `defaults` and the same instance is run twice standalone — or `runPreview()` then `run()` on one instance (both share `resolveSchemas`).

**Not affected:**

- **Graph runs.** `TaskGraphRunner.run` → `resetGraph` → `EdgeMaterializer.resetTask` → `resetInputData()` puts the raw id back before every run; graph preview likewise.
- **Keys supplied as `run()` overrides.** `setInput` rewrites that port every run.
- **Every other format.** Idempotent, as above.
- **First runs of anything.**

### Why the fix belongs in `TaskRunner`

`FetchUrlTask` has the same bug and **fails silently**. Its `execute()` passes `input.credential_key` to `applyCredentialToHeaders`, which returns the headers unchanged when the credential is falsy — so run 2 sends the request with **no `Authorization` header at all**. No error, no log: an authenticated request silently downgrades to an anonymous one. That is a stronger argument for fixing this centrally than any fail-closed task's error message.

A local fix in a consuming task does not work either: by the time `execute()` runs, the port no longer holds the resolved value — the second resolution has already replaced it with `undefined`. The resolved value is only visible *before* `resolveSchemas`, which `execute()` never sees.

**Confirmed pre-fix failure shape:** the present-but-`undefined` port does **not** trip `validateInput`. Reverting only the `TaskRunner` change and re-running the new tests produces the task's own `TaskConfigurationError` thrown from `execute()`, not a `TaskInvalidInputError`. The `FetchUrlTask` case makes both fetch calls; the second arrives with `Authorization: undefined`.

## The fix — a per-runner revert memo

One private field on `TaskRunner`:

```ts
private readonly resolvedInputOrigins = new Map<string, { resolved: unknown; original: unknown }>();
```

`resolveSchemas()` copies `runInputData`, reverts each memoized port **only when it still holds exactly the value this runner put there** (`Object.is`), resolves the copy, then re-memoizes every port the resolution changed.

The identity guard is what keeps this narrow. `resetInputData` (graph runs), a `run()` override, and a caller's own `task.runInputData = {...}` assignment all leave a value that fails `Object.is` against the memo, so nothing is reverted. The config path already gets the same guarantee from its frozen `originalConfig` snapshot; inputs have no frozen original, so each port carries its own.

A store **miss** is memoized too (`{ resolved: undefined, original: "key" }`), so a store that was locked during run 1 and unlocked before run 2 now works instead of failing identically forever.

## Blast radius

One file, one method, one private field. Nothing in `Task`, `TaskGraphRunner`, `EdgeMaterializer` or any task changes.

Behaviour differs from today **only** when this runner previously rewrote a port **and** that port still holds exactly the rewritten value at the next run. First runs are unaffected (empty map); graph runs are unaffected (`resetInputData` already put the raw id back, so `Object.is` fails); override-supplied ports are unaffected.

For idempotent formats the observable change is that a re-run **re-resolves the original id** instead of passing the resolved object through — which is exactly what `resolveSchemas`' own doc comment already promises for config.

## Rejected alternative

Restoring a whole pre-resolution snapshot of `runInputData` before `setInput`. It would clobber direct `task.runInputData = {...}` assignment (used widely in tests and by `copyInputFromEdgesToNode`) with stale data, and would need a `resetInputData` hook on `Task` to stay safe in graphs — strictly wider for no extra coverage.

## Documented residual

- An instance whose port is set to `undefined` by **direct `runInputData` mutation** after a resolved run would have the old id resurrected on the next run.
- The map holds a reference to the resolved value for the runner's lifetime — a value `runInputData` was already holding anyway.

## Tests

- `packages/test/src/test/task-graph/TaskRunnerRerunResolution.test.ts` (section `graph`) — a `defaults`-configured credential key survives a second run; `runPreview()` then `run()`; an absent key still fails closed on **both** runs (the memo must not invent a value); a key that appears between runs resolves on run 2; and a `format: "model"` port run twice standalone still resolves to an equivalent model (the idempotent-format guard). Each asserts the **fixed** behaviour rather than a pre-fix error shape.
- `packages/test/src/test/task/FetchTask.test.ts` — a `defaults: { credential_key }` instance run twice sends `Authorization` **both** times. The silent-failure sibling.

Verified: `bun scripts/test.ts task graph task-graph vitest` → 218 files / 2420 passed, 24 skipped, exit 0. ESLint clean on `packages/task-graph` and `packages/test` (`--max-warnings 0`); Prettier clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UW1Qr5mxetAQr61YKEY9nz)_