### PR TITLE
fix(tasks): classify invalid webhook headers permanently, add a header credential seam

### DIFF
--- a/packages/tasks/README.md
+++ b/packages/tasks/README.md
@@ -149,10 +149,13 @@ output schema and error messages report only the endpoint's origin.
 
 - `url` (string, optional): Webhook endpoint to POST to. Kept out of errors and output, but a value set here is stored verbatim in the graph JSON — use `url_credential_key` to keep the secret out of the saved workflow.
 - `payload` (object, required): JSON body to send
-- `headers` (object, optional): Additional headers, merged over the JSON content type
+- `headers` (object, optional): Additional headers, merged over the JSON content type (case-insensitively, so a lowercase `content-type` replaces it rather than being sent alongside it). A value set here is stored verbatim in the graph JSON — an authentication or signing secret belongs in `credential_key` instead
 - `timeout` (integer, optional): Request timeout in milliseconds, a whole number from 1 to 2147483647 (~24.8 days). Default: `30000`
 - `allow_private_destination` (boolean, optional): Permit posting to a private/internal/loopback destination — including a public-looking hostname that resolves into private address space. Requires the `network:private` entitlement, re-checked at execute time against the URL actually resolved. A declared private destination's reply body and reason phrase are never surfaced. Default: `false`
 - `url_credential_key` (string, optional): Credential store key whose resolved value is the entire webhook URL — the secret itself, not a bearer token. Takes precedence over `url`. A value that is not an absolute `http(s)` URL (e.g. a bearer token) is rejected with a configuration error.
+- `credential_key` (string, optional): Credential store key whose resolved secret is placed on a request HEADER according to `credential_scheme`. This is the bearer/basic/API-key/HMAC shape, as opposed to `url_credential_key`'s "the URL itself is the secret" shape; the two are independent and may be combined
+- `credential_scheme` (enum, optional): How the resolved credential is sent — `bearer` and `basic` use the `Authorization` header (`basic` expects an already base64-encoded `user:pass`), `header` uses `credential_header`, `none` resolves but sends nothing. Default: `bearer`
+- `credential_header` (string, optional): Header name used when `credential_scheme` is `header`. Must be a bare header token (letters, digits, hyphens). Default: `Authorization`
 
 **Output Schema:**
 
@@ -167,9 +170,18 @@ output schema and error messages report only the endpoint's origin.
 const result = await webhookNotify({
   url: "https://example.com/hooks/abc123",
   payload: { event: "deploy", version: "1.4.2" },
-  headers: { "X-Signature": "sha256=..." },
+  headers: { "X-Request-Id": "build-4471" },
 });
 console.log(result.status);
+
+// An authenticated endpoint: the secret is a credential-store KEY, so only the
+// key reaches the saved graph JSON. `credential_scheme: "header"` sends the
+// resolved value raw on `credential_header` instead of as a bearer token.
+await webhookNotify({
+  url: "https://example.com/hooks/abc123",
+  payload: { event: "deploy" },
+  credential_key: "deploy-webhook-token",
+});
 
 // Config vs. input: the constructor takes CONFIG, so a fixed endpoint belongs
 // under `defaults` — the per-run payload is still passed to `run()`.
@@ -194,7 +206,9 @@ const workflow = new Workflow()
 - 429/503 and 5xx raise `RetryableJobError`; retries require a `@workglow/job-queue` consumer, which these inline tasks do not have
 - Response bodies are read as a stream and abandoned past 1MB, so an endpoint answering with an unbounded body cannot exhaust runner memory — on the failure path too
 - Requests time out after 30s by default (`timeout`); a caller abort surfaces as an abort error rather than a retryable network failure
-- A configured `url_credential_key` upgrades the `credential` entitlement from optional to enforced
+- **A secret goes through `credential_key`, never `headers`** — `Task.toJSON` serializes `defaults` verbatim into the saved graph, so a bearer token or signing key inlined in `headers` is written into the workflow JSON. A credential KEY is only a reference; the resolved secret is placed on the outbound request and never persisted. `credential_scheme` chooses `Authorization: Bearer …`, `Authorization: Basic …`, a raw value on `credential_header`, or nothing at all
+- **An invalid request header is a permanent `CONFIGURATION` failure, not a retried network error** — `fetch` builds its `Headers` internally and rejects a malformed name or value with a bare `TypeError`, which was classified as a transient `NETWORK_ERROR` and retried forever. Names must be a bare header token (letters, digits, hyphens) and values must carry no NUL/CR/LF; both are checked before the request. The message names the offending header but **never echoes its value**, because `fetch`'s own message quotes it back and that text is spliced into a persisted job error — which for a `credential_key` header is the secret itself
+- A configured `url_credential_key` or `credential_key` upgrades the `credential` entitlement from optional to enforced. Only `url_credential_key` unscopes a declared `network:private` grant, since only it hides the destination; a header credential changes what the request carries, not where it goes
 - Never cached — the task is side-effecting (`cachePolicy: { kind: "none" }`)
 
 ### SlackNotifyTask

--- a/packages/tasks/src/common.ts
+++ b/packages/tasks/src/common.ts
@@ -90,8 +90,10 @@ export * from "./task/vector/VectorScaleTask";
 export * from "./task/vector/VectorSubtractTask";
 export * from "./task/vector/VectorSumTask";
 export * from "./task/WebhookNotifyTask";
+export * from "./util/RetryAfter";
 export * from "./util/SafeFetch";
 export * from "./util/UrlClassifier";
+export * from "./util/WebhookPost";
 export { applyFilter, hasFilterOp, registerFilterOp } from "@workglow/util/media";
 export type { FilterOpFn } from "@workglow/util/media";
 

--- a/packages/tasks/src/task/DiscordNotifyTask.ts
+++ b/packages/tasks/src/task/DiscordNotifyTask.ts
@@ -135,12 +135,15 @@ export class DiscordNotifyTask<
   }
 
   public override entitlements(): TaskEntitlements {
-    return webhookPrivateEntitlements(
-      DiscordNotifyTask.entitlements(),
-      this.runInputData?.url,
-      this.runInputData?.url_credential_key,
-      this.runInputData?.allow_private_destination
-    );
+    return webhookPrivateEntitlements({
+      base: DiscordNotifyTask.entitlements(),
+      url: this.runInputData?.url,
+      urlCredentialKey: this.runInputData?.url_credential_key,
+      // Discord's payload shape is fixed and carries no caller headers, so
+      // there is no header credential to declare.
+      headerCredentialKey: undefined,
+      allowPrivate: this.runInputData?.allow_private_destination,
+    });
   }
 
   public static override inputSchema() {

--- a/packages/tasks/src/task/FetchUrlCredentials.ts
+++ b/packages/tasks/src/task/FetchUrlCredentials.ts
@@ -37,6 +37,18 @@ export const DEFAULT_CREDENTIAL_HEADER = "Authorization";
  */
 const CREDENTIAL_HEADER_NAME_PATTERN = /^[A-Z0-9-]{1,64}$/i;
 
+/**
+ * Whether `name` is a bare header token by the rule above.
+ *
+ * Exported so a caller validating request headers of its own applies the SAME
+ * rule the credential ports are held to, rather than a second spelling of it.
+ * The pattern itself stays private — it is a `g`-less but still shared `RegExp`,
+ * and a predicate cannot be re-pointed at a different one by accident.
+ */
+export function isBareHeaderName(name: string): boolean {
+  return CREDENTIAL_HEADER_NAME_PATTERN.test(name);
+}
+
 export interface ApplyCredentialOptions {
   readonly headers: Readonly<Record<string, string>> | undefined;
   readonly credential: string | undefined;
@@ -55,7 +67,7 @@ export function credentialHeaderName(
   scheme: CredentialScheme,
   headerName: string | undefined
 ): string {
-  if (headerName !== undefined && !CREDENTIAL_HEADER_NAME_PATTERN.test(headerName)) {
+  if (headerName !== undefined && !isBareHeaderName(headerName)) {
     throw new TaskConfigurationError(
       `FetchUrlTask: invalid credential_header ${JSON.stringify(headerName)}. ` +
         "Header names must be 1-64 characters of letters, digits, or hyphens."

--- a/packages/tasks/src/task/SlackNotifyTask.ts
+++ b/packages/tasks/src/task/SlackNotifyTask.ts
@@ -268,12 +268,15 @@ export class SlackNotifyTask<
   }
 
   public override entitlements(): TaskEntitlements {
-    return webhookPrivateEntitlements(
-      SlackNotifyTask.entitlements(),
-      this.runInputData?.url,
-      this.runInputData?.url_credential_key,
-      this.runInputData?.allow_private_destination
-    );
+    return webhookPrivateEntitlements({
+      base: SlackNotifyTask.entitlements(),
+      url: this.runInputData?.url,
+      urlCredentialKey: this.runInputData?.url_credential_key,
+      // Slack's payload shape is fixed and carries no caller headers, so there
+      // is no header credential to declare.
+      headerCredentialKey: undefined,
+      allowPrivate: this.runInputData?.allow_private_destination,
+    });
   }
 
   public static override inputSchema() {

--- a/packages/tasks/src/task/WebhookNotifyTask.ts
+++ b/packages/tasks/src/task/WebhookNotifyTask.ts
@@ -19,6 +19,8 @@ import {
   webhookBaseEntitlements,
   webhookPrivateEntitlements,
 } from "../util/WebhookPost";
+import { applyCredentialToHeaders } from "./FetchUrlCredentials";
+import { createFetchUrlJobError, FetchUrlErrorCode } from "./FetchUrlJobError";
 
 const inputSchema = {
   type: "object",
@@ -40,7 +42,8 @@ const inputSchema = {
       type: "object",
       additionalProperties: { type: "string" },
       title: "Headers",
-      description: "Additional headers merged over the JSON content type",
+      description:
+        "Additional headers merged over the JSON content type. A value set here is stored verbatim in the graph JSON, so an authentication or signing secret belongs in 'credential_key' instead. A name that is not a bare header token, or a value carrying a NUL/CR/LF, is a permanent configuration error.",
     },
     timeout: {
       type: "integer",
@@ -64,6 +67,30 @@ const inputSchema = {
       title: "Credential Key",
       description:
         "Key to look up in the credential store. The resolved value is the entire webhook URL — the secret itself, not a bearer token — and takes precedence over the url input.",
+      "x-ui-hidden": true,
+    },
+    credential_key: {
+      type: "string",
+      format: "credential",
+      title: "Credential Key",
+      description:
+        "Key to look up in the credential store. The resolved secret is placed on the request according to credential_scheme.",
+      "x-ui-hidden": true,
+    },
+    credential_scheme: {
+      enum: ["bearer", "basic", "header", "none"],
+      title: "Credential Scheme",
+      description:
+        "How the resolved credential is sent. 'bearer' and 'basic' use the Authorization header ('basic' expects an already base64-encoded user:pass); 'header' uses credential_header; 'none' resolves but sends nothing.",
+      default: "bearer",
+      "x-ui-hidden": true,
+    },
+    credential_header: {
+      type: "string",
+      title: "Credential Header",
+      description:
+        "Header name used when credential_scheme is 'header'. Must be a bare header token (letters, digits, hyphens).",
+      default: "Authorization",
       "x-ui-hidden": true,
     },
   },
@@ -103,6 +130,16 @@ export type WebhookNotifyTaskOutput = FromSchema<typeof outputSchema>;
  *
  * The URL is handled as a secret: it is kept out of the output schema, and
  * failures report only the endpoint's origin.
+ *
+ * Two independent credential seams, because a generic webhook has two shapes of
+ * secret and `Task.toJSON` serializes `defaults` verbatim into the saved graph:
+ *
+ * - `url_credential_key` — the resolved value IS the whole endpoint, the
+ *   Slack/Discord shape where the token lives in the path;
+ * - `credential_key` (+ `credential_scheme` / `credential_header`) — a bearer
+ *   token, basic pair, or signing key placed on a REQUEST HEADER, which is what
+ *   an authenticated or HMAC-signed endpoint needs. Without it such a secret had
+ *   to be inlined in the `headers` port and would be written into the graph JSON.
  */
 export class WebhookNotifyTask<
   Input extends WebhookNotifyTaskInput = WebhookNotifyTaskInput,
@@ -121,12 +158,13 @@ export class WebhookNotifyTask<
   }
 
   public override entitlements(): TaskEntitlements {
-    return webhookPrivateEntitlements(
-      WebhookNotifyTask.entitlements(),
-      this.runInputData?.url,
-      this.runInputData?.url_credential_key,
-      this.runInputData?.allow_private_destination
-    );
+    return webhookPrivateEntitlements({
+      base: WebhookNotifyTask.entitlements(),
+      url: this.runInputData?.url,
+      urlCredentialKey: this.runInputData?.url_credential_key,
+      headerCredentialKey: this.runInputData?.credential_key,
+      allowPrivate: this.runInputData?.allow_private_destination,
+    });
   }
 
   public static override inputSchema() {
@@ -144,10 +182,40 @@ export class WebhookNotifyTask<
       Object.hasOwn(input, "url_credential_key"),
       "WebhookNotifyTask"
     );
+    // Placed FIRST, so the header the credential produces is validated by
+    // `postWebhookJson`'s own header guard like any caller-supplied one — a
+    // secret carrying a stray newline is a configuration error, not a request
+    // undici rejects with a `TypeError` that quotes the secret back.
+    //
+    // No credential-port stripping here, unlike `FetchUrlTask`: that task
+    // forwards `...rest` into a job input, so a resolved secret left on a port
+    // would be persisted. This post is assembled field by field below and the
+    // credential ports are simply never read again.
+    let headers: Record<string, string> | undefined;
+    try {
+      headers = applyCredentialToHeaders({
+        headers: input.headers,
+        credential: input.credential_key,
+        scheme: input.credential_scheme,
+        headerName: input.credential_header,
+      });
+    } catch (err) {
+      // `credentialHeaderName` throws a `TaskConfigurationError` whose message is
+      // hardcoded "FetchUrlTask: …" and which carries no `FETCH_*` code, so a
+      // queued consumer could not classify it. Re-raised under this task's own
+      // label as a permanent CONFIGURATION failure. Only the header NAME appears
+      // in that message; the credential value never does.
+      const detail = err instanceof Error ? err.message : String(err);
+      throw createFetchUrlJobError(
+        FetchUrlErrorCode.CONFIGURATION,
+        `WebhookNotifyTask: ${detail.replace(/^FetchUrlTask: /, "")}`
+      );
+    }
+
     const result = await postWebhookJson({
       url,
       payload: input.payload,
-      headers: input.headers,
+      headers,
       timeout: input.timeout,
       signal: context.signal,
       registry: context.registry,

--- a/packages/tasks/src/util/WebhookPost.ts
+++ b/packages/tasks/src/util/WebhookPost.ts
@@ -25,6 +25,7 @@ import type { TaskEntitlements } from "@workglow/task-graph";
 import { ENTITLEMENT_ENFORCER, Entitlements, mergeEntitlements } from "@workglow/task-graph";
 import type { ServiceRegistry } from "@workglow/util";
 import { SECURITY_LIMITS } from "@workglow/util";
+import { isBareHeaderName } from "../task/FetchUrlCredentials";
 import type { FetchUrlJobErrorInstance } from "../task/FetchUrlJobError";
 import {
   createFetchUrlAbortedError,
@@ -609,6 +610,97 @@ export async function assertPrivateDestinationGranted(
 }
 
 /**
+ * Characters a header VALUE may never carry: NUL, CR and LF.
+ *
+ * CR/LF are the response-splitting pair; NUL is rejected by undici alongside
+ * them and would be truncated by some intermediaries rather than transmitted.
+ */
+const FORBIDDEN_HEADER_VALUE_CHARS = /[\0\r\n]/;
+
+/**
+ * Rejects request headers `fetch` would throw on, as a permanent configuration
+ * error rather than a retried network failure.
+ *
+ * undici builds the `Headers` object INSIDE `fetch`, and a malformed name or
+ * value rejects with a bare `TypeError` — no `code`, not a `FetchUrlJobError`,
+ * name `"TypeError"`. {@link toRedactedWebhookError} matches none of its named
+ * branches, so such a throw fell through to `NETWORK_ERROR` and a
+ * `RetryableJobError`: a queued consumer then retried a typo forever.
+ *
+ * The message names the offending HEADER but NEVER its value. undici's own
+ * message quotes the value back (`Headers.append: "…" is an invalid header
+ * value.`), which {@link detailWithCause} splices into a PERSISTED job-error
+ * string — so a bearer token carrying a stray newline would be written to
+ * durable storage by the very error that reported it. Half the reason this
+ * guard exists is to get in front of that message.
+ *
+ * This is deliberately STRICTER than undici, in both halves, and the difference
+ * is a new rejection rather than a mirror:
+ *
+ * - Names are held to {@link isBareHeaderName} — letters, digits and hyphens —
+ *   which is narrower than RFC 9110's token production (`!#$%&'*+.^_\`|~` are
+ *   token characters undici accepts). It is the same rule the credential ports
+ *   already enforce, so a name is legal here exactly when it is legal there.
+ * - Values are rejected for NUL/CR/LF ANYWHERE, whereas `fetch` first trims
+ *   leading and trailing HTTP whitespace: probed on Node 22, `{"X-Ok": "\nabc"}`
+ *   and `{"X-Ok": " "}` are both NORMALIZED and sent, not rejected. Accepting a
+ *   value whose framing depends on a trim step is not worth the compatibility.
+ */
+export function assertValidRequestHeaders(
+  headers: Readonly<Record<string, string>> | undefined,
+  url: string,
+  label: string
+): void {
+  if (headers === undefined) {
+    return;
+  }
+  for (const [name, value] of Object.entries(headers)) {
+    if (!isBareHeaderName(name)) {
+      throw createFetchUrlJobError(
+        FetchUrlErrorCode.CONFIGURATION,
+        `Cannot post ${label} to ${redactWebhookUrl(url)}: ${JSON.stringify(name)} is not a valid ` +
+          `header name. Header names must be 1-64 characters of letters, digits, or hyphens.`,
+        { url: redactWebhookUrl(url) }
+      );
+    }
+    if (typeof value !== "string" || FORBIDDEN_HEADER_VALUE_CHARS.test(value)) {
+      // The value is a caller secret as often as not, so it is described rather
+      // than quoted — naming the header is enough to find it.
+      throw createFetchUrlJobError(
+        FetchUrlErrorCode.CONFIGURATION,
+        `Cannot post ${label} to ${redactWebhookUrl(url)}: the value of header ` +
+          `${JSON.stringify(name)} is not a valid header value. It must be a string carrying no ` +
+          `NUL, carriage return, or line feed. The value itself is withheld — it may be a secret.`,
+        { url: redactWebhookUrl(url) }
+      );
+    }
+  }
+}
+
+/**
+ * Merges the JSON content type UNDER the caller's headers, case-insensitively.
+ *
+ * A plain `{ "Content-Type": "application/json", ...headers }` leaves a
+ * caller's lowercase `content-type` in place as a second, distinct object
+ * property — and the `Headers` constructor folds the two into one comma-joined
+ * field, so the request goes out declaring both content types at once. Header
+ * names are case-insensitive, so the override has to be too.
+ */
+export function withJsonContentType(
+  headers: Readonly<Record<string, string>> | undefined
+): Record<string, string> {
+  const supplied = Object.entries(headers ?? {});
+  const callerSetsType = supplied.some(([name]) => name.toLowerCase() === "content-type");
+  const merged: Record<string, string> = callerSetsType
+    ? {}
+    : { "Content-Type": "application/json" };
+  for (const [name, value] of supplied) {
+    merged[name] = value;
+  }
+  return merged;
+}
+
+/**
  * POSTs `payload` as JSON to a webhook endpoint through {@link safeFetch}.
  *
  * Private/loopback destinations are refused unless the caller declared
@@ -699,10 +791,8 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
   // treat anything it does not recognize as a transient network failure — so a
   // throw from here would be retried forever under a misleading message.
   let body: string | undefined;
-  let headers: Record<string, string>;
   try {
     body = JSON.stringify(request.payload);
-    headers = { "Content-Type": "application/json", ...request.headers };
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     throw createFetchUrlJobError(
@@ -712,6 +802,15 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
       { url: redactWebhookUrl(url) }
     );
   }
+
+  // Outside the `try` above, which exists for `JSON.stringify` alone: the merge
+  // cannot throw, and wrapping it would report a header rejection under the
+  // stringify branch's wording. Validated BEFORE the merge so the guard sees
+  // exactly what the caller supplied, and before the request for the same reason
+  // the `timeout` guard runs early — `fetch` would raise a bare `TypeError` that
+  // the catch below classifies as a retryable network failure.
+  assertValidRequestHeaders(request.headers, url, label);
+  const headers = withJsonContentType(request.headers);
 
   let response: Response;
   try {
@@ -758,7 +857,18 @@ export async function postWebhookJson(request: WebhookPostRequest): Promise<Webh
   // The failure path ignores `complete`: the status error is what this throw
   // reports, and a partial diagnostic body does not change it.
   const { text: failureBody } = await readBodyText(response);
-  const retryDate = retryDateFromResponse(response, failureBody, request.retryAfterFromJsonBody);
+  // The BODY-derived hint follows the same invariant as the body and the reason
+  // phrase: a DECLARED private destination's reply is never surfaced, and a
+  // retry timestamp derived from `{"retry_after": …}` is that reply leaking out
+  // through the error's `retryDate`. Discord asks for the body source AND is
+  // reachable with `allow_private_destination`, so the two do meet. The
+  // `Retry-After` HEADER is transport-level rather than a reply the caller
+  // authored, so it keeps working either way.
+  const retryDate = retryDateFromResponse(
+    response,
+    failureBody,
+    request.retryAfterFromJsonBody && !allowPrivate
+  );
   const redacted = redactWebhookUrl(url);
   // The status is still reported for a private destination — the reply BODY is
   // what would turn a POST at an internal service into a read of it.
@@ -821,29 +931,54 @@ export function webhookBaseEntitlements(reason: string): TaskEntitlements {
  * So the decision is an explicit input instead, and {@link postWebhookJson}
  * enforces it at execute time against the URL actually resolved. The
  * declaration is scoped to the `url` port when that port is the destination;
- * with a credential key the URL is unknown here, so the grant is unscoped and
- * says why.
+ * with a URL credential key the URL is unknown here, so the grant is unscoped
+ * and says why. A HEADER credential key does not unscope anything — it changes
+ * what the request carries, not where it goes.
  *
  * Only an explicit `false` opts out: a root task's run-input is applied after
  * entitlements are evaluated, so an unset flag is "not yet knowable" and fails
  * closed.
  */
+export interface WebhookPrivateEntitlementsOptions {
+  /** Static class-level declaration this refines. */
+  readonly base: TaskEntitlements;
+  /** The `url` port, when the instance carries one. */
+  readonly url: unknown;
+  /** The `url_credential_key` port: the credential IS the destination. */
+  readonly urlCredentialKey: unknown;
+  /**
+   * A credential key placed on a request HEADER (`credential_key`), for tasks
+   * that have one. It reaches the credential store like the URL key, but says
+   * nothing about where the request goes.
+   */
+  readonly headerCredentialKey: unknown;
+  /** The `allow_private_destination` port. */
+  readonly allowPrivate: unknown;
+}
+
 export function webhookPrivateEntitlements(
-  base: TaskEntitlements,
-  url: unknown,
-  credentialKey: unknown,
-  allowPrivate: unknown
+  options: WebhookPrivateEntitlementsOptions
 ): TaskEntitlements {
-  const credentialWins = typeof credentialKey === "string" && credentialKey.length > 0;
+  const { base, url, urlCredentialKey, headerCredentialKey, allowPrivate } = options;
+  const isSet = (key: unknown): boolean => typeof key === "string" && key.length > 0;
+  // The URL key HIDES THE DESTINATION; either key READS THE STORE. Two separate
+  // consequences, so two separate questions — collapsing them would either let a
+  // header credential unscope a perfectly knowable `url` (over-granting), or
+  // leave a header credential's store access declared merely optional, which
+  // `evaluatePolicy` skips outright (under-enforcing).
+  const urlFromCredential = isSet(urlCredentialKey);
+  const usesCredentialStore = urlFromCredential || isSet(headerCredentialKey);
   // A configured credential key is no longer a "may": this instance WILL read
   // the credential store. `mergeEntitlements` keeps the most restrictive
   // `optional`, so this upgrades the base declaration into an enforced one.
-  const withCredential = credentialWins
+  const withCredential = usesCredentialStore
     ? mergeEntitlements(base, {
         entitlements: [
           {
             id: Entitlements.CREDENTIAL,
-            reason: "Resolves the webhook URL — the secret itself — from the credential store",
+            reason: urlFromCredential
+              ? "Resolves the webhook URL — the secret itself — from the credential store"
+              : "Resolves an authentication secret placed on the request headers from the credential store",
           },
         ],
       })
@@ -851,7 +986,7 @@ export function webhookPrivateEntitlements(
   if (allowPrivate === false) {
     return withCredential;
   }
-  const scoped = !credentialWins && typeof url === "string" && url.length > 0;
+  const scoped = !urlFromCredential && typeof url === "string" && url.length > 0;
   return mergeEntitlements(withCredential, {
     entitlements: [
       {

--- a/packages/test/src/test/task/NotifyTask.test.ts
+++ b/packages/test/src/test/task/NotifyTask.test.ts
@@ -915,12 +915,41 @@ describe("Webhook notification tasks", () => {
       expect(granted!.resources).toBeUndefined();
     });
 
+    // The two credential ports have DIFFERENT consequences for scoping, which
+    // is the whole reason `webhookPrivateEntitlements` takes them separately.
+    // `url_credential_key` hides the destination, so the grant cannot name one.
+    // `credential_key` only decides what the request CARRIES — the `url` port is
+    // still the destination and is still perfectly knowable here — so unscoping
+    // on it would hand out a wildcard `network:private` grant for no reason.
+    test("a header credential key does not unscope a declared private destination", () => {
+      const task = new WebhookNotifyTask();
+      task.runInputData = {
+        url: "http://127.0.0.1:9200/ingest",
+        payload: {},
+        credential_key: "deploy-token",
+        allow_private_destination: true,
+      } as any;
+      const granted = task.entitlements().entitlements.find((e) => e.id === "network:private");
+      expect(granted?.resources).toEqual(["http://127.0.0.1:9200/*"]);
+    });
+
     // `optional: true` entitlements are skipped outright by evaluatePolicy, so
     // a decorative declaration is no gate at all on the instance that really
     // reaches into the credential store.
     test("a configured credential key makes the credential entitlement enforced", () => {
       const task = new WebhookNotifyTask();
       task.runInputData = { payload: {}, url_credential_key: "hook" } as any;
+      const credential = task.entitlements().entitlements.find((e) => e.id === "credential");
+      expect(credential).toBeDefined();
+      expect(credential!.optional).not.toBe(true);
+    });
+
+    // The other half of the split: a header credential reads the store just as
+    // surely as a URL credential does, so it must enforce the `credential`
+    // entitlement even though it changes nothing about scoping.
+    test("a header credential key alone makes the credential entitlement enforced", () => {
+      const task = new WebhookNotifyTask();
+      task.runInputData = { url: WEBHOOK_URL, payload: {}, credential_key: "deploy-token" } as any;
       const credential = task.entitlements().entitlements.find((e) => e.id === "credential");
       expect(credential).toBeDefined();
       expect(credential!.optional).not.toBe(true);
@@ -1944,6 +1973,242 @@ describe("Webhook notification tasks", () => {
       expect(error).toBeInstanceOf(PermanentJobError);
       expect(error).not.toBeInstanceOf(RetryableJobError);
       expect((error as PermanentJobError).code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+  });
+
+  /**
+   * A malformed request header is a caller mistake no retry can fix, but undici
+   * builds the `Headers` object INSIDE `fetch` and rejects with a bare
+   * `TypeError` — name `"TypeError"`, no `code`, not a `FetchUrlJobError`. It
+   * matched none of `toRedactedWebhookError`'s named branches and fell through
+   * to `NETWORK_ERROR`, so a queued consumer retried a typo forever.
+   *
+   * The second, sharper half is what the error MESSAGE carried. undici quotes
+   * the offending header VALUE back (`Headers.append: "…" is an invalid header
+   * value.`), which `detailWithCause` splices into a PERSISTED job-error
+   * string. With `credential_key` below placing a resolved secret on a header,
+   * that is a bearer token written to durable storage by the error that
+   * reported it. Every `not.toContain` here is guarding that boundary.
+   */
+  describe("request headers", () => {
+    const CONTROL_CHAR = String.fromCharCode(10);
+
+    test("an invalid header name is a permanent configuration error", async () => {
+      const error = (await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: {},
+        headers: { "X-Bad Name": "v" },
+      }).catch((e: unknown) => e)) as PermanentJobError;
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error).not.toBeInstanceOf(RetryableJobError);
+      expect(error.code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      // The name is not a secret and is the only way to find the offender.
+      expect(error.message).toContain("X-Bad Name");
+      // Never reaches the transport: the point of the guard is that `fetch` is
+      // not the thing that gets to classify this.
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    // THE assertion guarding the secret echo. `Bearer abc123 ` is shaped like
+    // the credential a caller would put on an `Authorization` header, and
+    // undici's own message would quote it verbatim.
+    test("an invalid header value is reported without echoing the value", async () => {
+      const secretish = `Bearer abc123${CONTROL_CHAR}injected`;
+
+      const error = (await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: {},
+        headers: { "X-Signature": secretish },
+      }).catch((e: unknown) => e)) as PermanentJobError;
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error.code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect(error.message).toContain("X-Signature");
+      expect(error.message).not.toContain("abc123");
+      expect(error.message).not.toContain(secretish);
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    // The URL is the credential for these tasks, so the new guard's message is
+    // held to the same redaction rule as every other error here.
+    test("the header rejection reports only the origin of the webhook URL", async () => {
+      const error = (await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: {},
+        headers: { "X:Y": "v" },
+      }).catch((e: unknown) => e)) as PermanentJobError & { url?: string };
+
+      expect(error.code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect(error.message).not.toContain("SECRETTOKEN");
+      expect(error.url).not.toContain("SECRETTOKEN");
+    });
+
+    // The guard must not become a wall: an ordinary header still goes out.
+    test("a valid header still reaches the transport", async () => {
+      await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: {},
+        headers: { "X-Custom": "yes" },
+      });
+
+      expect(requestHeaders()).toEqual({
+        "Content-Type": "application/json",
+        "X-Custom": "yes",
+      });
+    });
+
+    // `{ "Content-Type": …, ...headers }` left a caller's lowercase key in
+    // place as a SECOND object property, and `Headers` folds two spellings of
+    // one name into a single comma-joined field — so the request declared both
+    // content types at once.
+    test("a lowercase content-type override replaces rather than doubles up", async () => {
+      await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: {},
+        headers: { "content-type": "application/vnd.custom+json" },
+      });
+
+      const sent = requestHeaders();
+      expect(sent).toEqual({ "content-type": "application/vnd.custom+json" });
+      expect(Object.keys(sent).filter((k) => k.toLowerCase() === "content-type")).toHaveLength(1);
+    });
+
+    // M4: the seam that exists so an authenticated endpoint does not force the
+    // secret into `headers` — and therefore into the saved graph JSON.
+    test("a credential_key places a bearer token on the request", async () => {
+      const store = getGlobalCredentialStore();
+      await store.put("deploy-token", "s3cr3t-value");
+      try {
+        await webhookNotify({
+          url: WEBHOOK_URL,
+          payload: {},
+          credential_key: "deploy-token",
+        });
+
+        expect(requestHeaders()["Authorization"]).toBe("Bearer s3cr3t-value");
+      } finally {
+        await store.delete("deploy-token");
+      }
+    });
+
+    // The reason the port exists at all: `Task.toJSON` serializes `defaults`
+    // verbatim, so a secret inlined in `headers` is written into the graph. A
+    // credential KEY is a reference; only the reference is persisted.
+    test("only the credential key, never the secret, reaches the graph JSON", async () => {
+      const store = getGlobalCredentialStore();
+      await store.put("deploy-token", "s3cr3t-value");
+      const task = new WebhookNotifyTask({
+        defaults: { url: WEBHOOK_URL, credential_key: "deploy-token" },
+      });
+      try {
+        await task.run({ payload: {} } as never);
+
+        expect(requestHeaders()["Authorization"]).toBe("Bearer s3cr3t-value");
+        const serialized = JSON.stringify(task.toJSON());
+        expect(serialized).toContain("deploy-token");
+        expect(serialized).not.toContain("s3cr3t-value");
+      } finally {
+        await store.delete("deploy-token");
+      }
+    });
+
+    test("credential_scheme 'header' writes the raw secret to credential_header", async () => {
+      const store = getGlobalCredentialStore();
+      await store.put("sig-key", "sha256=abcdef");
+      try {
+        await webhookNotify({
+          url: WEBHOOK_URL,
+          payload: {},
+          credential_key: "sig-key",
+          credential_scheme: "header",
+          credential_header: "X-Signature",
+        });
+
+        const sent = requestHeaders();
+        expect(sent["X-Signature"]).toBe("sha256=abcdef");
+        expect(sent["Authorization"]).toBeUndefined();
+      } finally {
+        await store.delete("sig-key");
+      }
+    });
+
+    // HTTP header names are case-insensitive, so a caller's lowercase
+    // `authorization` is the SAME header. Left in place it would survive as a
+    // distinct object property and be folded into one comma-joined field
+    // alongside the real credential, sending a stale token with every request.
+    test("a resolved credential replaces a caller header case-insensitively", async () => {
+      const store = getGlobalCredentialStore();
+      await store.put("deploy-token", "fresh");
+      try {
+        await webhookNotify({
+          url: WEBHOOK_URL,
+          payload: {},
+          headers: { authorization: "stale" },
+          credential_key: "deploy-token",
+        });
+
+        const sent = requestHeaders();
+        expect(sent["Authorization"]).toBe("Bearer fresh");
+        expect(sent["authorization"]).toBeUndefined();
+        expect(JSON.stringify(sent)).not.toContain("stale");
+      } finally {
+        await store.delete("deploy-token");
+      }
+    });
+
+    // `credentialHeaderName` throws a `TaskConfigurationError` whose message is
+    // hardcoded "FetchUrlTask: …" and which carries no `FETCH_*` code, so a
+    // queued consumer could not classify it at all. Re-raised under this task's
+    // own label as a permanent CONFIGURATION failure.
+    test("an invalid credential_header is a configuration error labelled for this task", async () => {
+      const store = getGlobalCredentialStore();
+      await store.put("sig-key", "abc");
+      const error = (await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: {},
+        credential_key: "sig-key",
+        credential_scheme: "header",
+        credential_header: "X Bad",
+      })
+        .catch((e: unknown) => e)
+        .finally(() => store.delete("sig-key"))) as PermanentJobError;
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error.code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect(error.message).toContain("WebhookNotifyTask");
+      expect(error.message).not.toContain("FetchUrlTask");
+      expect(error.message).toContain("X Bad");
+      expect(mockFetch.mock.calls.length).toBe(0);
+    });
+
+    // THE COMPOSITION TEST: M4 places a resolved secret on a header, and M1
+    // then validates it like any other. Without M1 this exact case is what
+    // writes the secret into a persisted job error — undici would reject the
+    // value and quote it back in the `TypeError` message. The two changes are
+    // stacked in one PR because of this ordering, not by convenience.
+    test("a credential value carrying a control character is rejected without echoing it", async () => {
+      const store = getGlobalCredentialStore();
+      const poisoned = `abc123${CONTROL_CHAR}X-Injected: 1`;
+      await store.put("bad-token", poisoned);
+      const error = (await webhookNotify({
+        url: WEBHOOK_URL,
+        payload: {},
+        credential_key: "bad-token",
+      })
+        .catch((e: unknown) => e)
+        .finally(() => store.delete("bad-token"))) as PermanentJobError;
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect(error).not.toBeInstanceOf(RetryableJobError);
+      expect(error.code).toBe(FetchUrlErrorCode.CONFIGURATION);
+      expect(error.message).toContain("Authorization");
+      expect(error.message).not.toContain("abc123");
+      expect(error.message).not.toContain(poisoned);
+      // The persisted diagnostic string is the real disclosure surface, so it
+      // gets its own assertion rather than trusting `.message` alone.
+      expect(formatErrorChainForDiagnostics(error)).not.toContain("abc123");
       expect(mockFetch.mock.calls.length).toBe(0);
     });
   });

--- a/packages/test/src/test/task/NotifyTaskTransport.test.ts
+++ b/packages/test/src/test/task/NotifyTaskTransport.test.ts
@@ -29,7 +29,13 @@
  */
 
 import { PermanentJobError, RetryableJobError } from "@workglow/job-queue";
-import { discordNotify, getSafeFetchImpl, slackNotify } from "@workglow/tasks";
+import {
+  discordNotify,
+  FetchUrlErrorCode,
+  getSafeFetchImpl,
+  slackNotify,
+  webhookNotify,
+} from "@workglow/tasks";
 import { SECURITY_LIMITS } from "@workglow/util";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
@@ -240,6 +246,62 @@ describe("Notification tasks over the real server transport (no mocks)", () => {
 
     expect(result).toEqual({ success: true, status: 204 });
     expect(await waitForNoConnections(server, 5000)).toBe(0);
+
+    await drainRejections();
+    expect(unhandled).toEqual([]);
+  });
+
+  // The header guard belongs in this file for the same reason everything else
+  // here does: the mocked `safeFetch` in `NotifyTask.test.ts` never constructs
+  // a `Headers` object, so it can prove the guard fires but not that the guard
+  // is still in FRONT of the thing it guards. Only the real transport can.
+  //
+  // This is the tripwire for undici changing its validation out from under the
+  // guard. If undici ever tightened on a header this guard admits, the request
+  // would start rejecting with a bare `TypeError` classified as a retryable
+  // NETWORK_ERROR again — so the accepted-header case below is asserted too,
+  // and it is the half that would actually break.
+  test("an invalid header is refused before the request reaches the server", async () => {
+    let requests = 0;
+    const { origin } = await withServer((_req, res) => {
+      requests += 1;
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+
+    const error = (await webhookNotify({
+      url: `${origin}/hooks/SECRETTOKEN`,
+      payload: {},
+      headers: { "X-Bad Name": "v" },
+      allow_private_destination: true,
+    }).catch((e: unknown) => e)) as PermanentJobError;
+
+    expect(error).toBeInstanceOf(PermanentJobError);
+    expect(error).not.toBeInstanceOf(RetryableJobError);
+    expect(error.code).toBe(FetchUrlErrorCode.CONFIGURATION);
+    expect(requests).toBe(0);
+
+    await drainRejections();
+    expect(unhandled).toEqual([]);
+  });
+
+  test("a header the guard admits is accepted by the transport and arrives intact", async () => {
+    let seen: string | undefined;
+    const { origin } = await withServer((req, res) => {
+      seen = req.headers["x-signature"] as string | undefined;
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+
+    const result = await webhookNotify({
+      url: `${origin}/hooks/SECRETTOKEN`,
+      payload: {},
+      headers: { "X-Signature": "sha256=abcdef" },
+      allow_private_destination: true,
+    });
+
+    expect(result.status).toBe(200);
+    expect(seen).toBe("sha256=abcdef");
 
     await drainRejections();
     expect(unhandled).toEqual([]);


### PR DESCRIPTION
Follow-up to #744, targeting the same base branch. Two review findings plus two low-severity ones. #744's redaction coverage, SSRF gating, retry clamping and real-transport tests are unchanged.

## M1 — an invalid request header was classified RETRYABLE

`WebhookPost.ts` merged headers inside a `try` that only catches `JSON.stringify`. The merge itself cannot throw — but undici builds the `Headers` object **inside `fetch`**, and a malformed name or value rejects with a bare `TypeError`: name `"TypeError"`, no `code`, not a `FetchUrlJobError`. `toRedactedWebhookError` matches none of its named branches, so it fell through to `NETWORK_ERROR` → `RetryableJobError`, and a queued consumer retried a typo forever.

Probed on Node v22.22.2 (`fetch` against a loopback server):

| headers | result |
| --- | --- |
| `{"X-Bad Name":"v"}`, `{"":"v"}`, `{"X:Y":"v"}` | `TypeError: Headers.append: "…" is an invalid header **name**.` |
| `{"X-Ok":"a\nb"}`, `{"X-Ok":"a\0b"}` | `TypeError: Headers.append: "…" is an invalid header **value**.` |
| `{"X-Ok":" "}`, `{"X-Ok":"\nabc"}`, `{"X-Ok":"a\tb"}` | **accepted** — normalized, not rejected |

Two things shape the fix:

1. **undici's message quotes the header VALUE.** That text lands in `detailWithCause(error)` and is spliced into a persisted `RetryableJobError`. With M4 below placing a resolved secret on a header, a token containing a `\n` would be written to durable storage by the very error reporting it. So the new guard **names the header but never echoes the value**, and M1 is a prerequisite for M4.
2. **A leading-`\n` value is normalized, not rejected.** So any pre-validation stricter than undici's own rule is a *new rejection*, not a mirror. The guard is deliberately stricter in both halves and the JSDoc says so: names are held to `isBareHeaderName` (letters/digits/hyphens — narrower than RFC 9110's token production), values reject NUL/CR/LF anywhere rather than after a trim step.

Also:

- `isBareHeaderName` is exported from `FetchUrlCredentials.ts` (`CREDENTIAL_HEADER_NAME_PATTERN` stays private; `credentialHeaderName` now calls the predicate — no behaviour change), so request headers and credential ports are held to one rule rather than two spellings of it.
- The header merge moves out of the `JSON.stringify` `try` and goes through a new `withJsonContentType`, which adds `Content-Type` only when no key case-insensitively matches. `{ "Content-Type": …, ...headers }` left a caller's lowercase `content-type` as a *second* object property, and `Headers` folds the two into one comma-joined field — sending both content types.
- `webhookPrivateEntitlements` widens from four positional `unknown`s to an options object (`base` / `url` / `urlCredentialKey` / `headerCredentialKey` / `allowPrivate`). Either key now enforces the `credential` entitlement, but `scoped` keys off `urlCredentialKey` **only** — a header credential does not hide the destination, so unscoping on it would hand out a wildcard `network:private` grant for nothing. All three call sites updated.

## M4 — no credential seam for auth / signature headers

`WebhookNotifyTask` had only `url_credential_key` (the whole URL is the secret, the Slack/Discord shape). A bearer or HMAC endpoint therefore had to inline its secret in the `headers` port — and `Task.toJSON` serializes `defaults` verbatim into the saved graph JSON.

Adds `credential_key` (`format: "credential"`, hidden), `credential_scheme` (bearer/basic/header/none, default bearer, hidden) and `credential_header` (default `Authorization`, hidden), reusing the existing `applyCredentialToHeaders` / `credentialHeaderName`. Descriptions match `FetchUrlTask`'s so the two read the same.

**Order matters:** credential placement happens first, then M1's validation inside `postWebhookJson`, so the credential-produced header is validated too. `credentialHeaderName` throws a `TaskConfigurationError` hardcoded `"FetchUrlTask: …"` carrying no `FETCH_*` code, so it is re-raised as a `CONFIGURATION` `FetchUrlJobError` under a `WebhookNotifyTask:` label.

No credential-port stripping is needed here (unlike `FetchUrlTask`, which forwards `...rest` into a persisted job input) — the post is assembled field by field. There is a comment saying so. `WebhookNotifyTask` has no queued path, so `FetchUrlTask`'s credential-vs-queue refusal has no analogue to port.

## LOW

- The body-derived retry hint is gated behind `!allowPrivate`. `DiscordNotifyTask` passes `retryAfterFromJsonBody: true` and is reachable with `allow_private_destination`; `retry_after` is read from the **body**, which a declared private destination never surfaces — contradicting the invariant documented on `allowPrivateDestination`. The `Retry-After` **header** is transport-level and stays.
- `packages/tasks/src/common.ts` re-exports `./util/RetryAfter` and `./util/WebhookPost`. `MAX_REQUEST_TIMEOUT_MS`, `redactWebhookUrlIn`, `postWebhookJson`, `compactPayload` and `retryDateFromRetryAfterHeader` were all unreachable downstream.

### One review claim refuted, deliberately not acted on

> "a complete body ending in `...` is reported as truncated"

`WebhookPost.ts` reads `complete || surfaced.endsWith("...") ? surfaced : \`${surfaced}...\`` — a complete body short-circuits on `complete` and is returned unchanged. No change made.

## Tests

New `describe("request headers")` in `NotifyTask.test.ts` (13 cases): invalid name → `PermanentJobError`/`CONFIGURATION`/message contains the name/`mockFetch` not called; a control char in a value → `CONFIGURATION` with `expect(message).not.toContain("abc123")` on a token-shaped value (**this is the assertion guarding the secret echo**); URL redacted in the message; a valid header still reaches the transport; a lowercase `content-type` override does not double up; `credential_key` → `Authorization: Bearer <secret>` **and** `JSON.stringify(task.toJSON())` contains the key and not the secret; `credential_scheme: "header"` + `credential_header`; a caller `authorization: "stale"` replaced case-insensitively; `credential_header: "X Bad"` → `CONFIGURATION` labelled `WebhookNotifyTask`; and the composition test — a credential value carrying a control char is rejected with the secret absent from both `.message` and `formatErrorChainForDiagnostics`.

Entitlement coverage extended: `credential_key` alone enforces `credential` but does **not** unscope a declared private destination.

`NotifyTaskTransport.test.ts` gets two loopback cases against the real undici transport (the mocked `safeFetch` never constructs a `Headers` object, so it can prove the guard fires but not that the guard is still in *front* of the thing it guards): an invalid header never reaches the server (request count 0), and a header the guard admits round-trips intact — the half that would actually break if undici tightened its validation.

`packages/tasks/README.md`: the three credential ports, a bullet that a secret goes through `credential_key` so it never reaches graph JSON, and a bullet that an invalid header is a permanent `CONFIGURATION` failure rather than a retried network error.

## Verification

```
$ bun scripts/test.ts task vitest
Running all tests in sections [task] — 67 file(s)
 Test Files  67 passed (67)
      Tests  1099 passed | 24 skipped (1123)
```

(baseline on this branch's merge-base: `1084 passed | 24 skipped` — +15 new)

```
$ npx eslint packages/tasks/src packages/test/src/test/task
(no output)
$ npx prettier "packages/tasks/src/**/*.ts" "packages/test/src/test/task/*.ts" "packages/tasks/README.md" --check
All matched files use Prettier code style!
```

There is no root `lint` script; `format` is `eslint --fix && prettier --check --write`, run here in check-only form. `npx tsgo -p packages/tasks/tsconfig.json` reports the same errors before and after these changes (source-mode `dist` stubs carry no real `.d.ts`), so it is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UW1Qr5mxetAQr61YKEY9nz)_