### PR TITLE
docs(util,ai): correct TurboQuant's accuracy claims against an honest int8 baseline

### DIFF
--- a/packages/ai/src/task/VectorQuantizeTask.ts
+++ b/packages/ai/src/task/VectorQuantizeTask.ts
@@ -8,9 +8,10 @@ import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, TypedArray } from "@workglow/util/schema";
 import {
-  nextPowerOf2,
+  DEFAULT_SEED,
   normalizeNumberArray,
   TensorType,
+  turboPaddedLength,
   turboQuantizeToTypedArray,
   TypedArraySchema,
 } from "@workglow/util/schema";
@@ -62,7 +63,7 @@ const inputSchema = {
       enum: Object.values(QuantizationMethod),
       title: "Method",
       description:
-        "Quantization method: 'linear' for simple min-max scaling, 'turbo' for TurboQuant (randomized Hadamard rotation + uniform scalar quantization at the MSE-optimal Gaussian clipping range). Turbo requires a signed integer targetType (int8 or int16). It rotates in nextPowerOf2(d) dimensions, so a non-power-of-2 input needs turboPadToPowerOf2: true, which widens the output to nextPowerOf2(d); without it such an input is rejected rather than silently degraded. Padded turbo is substantially MORE accurate than linear at the common embedding sizes — measured int8 cosine RMSE over 40 seeded pairs, padded turbo vs linear: 0.00034 vs 0.00269 at d=768, 0.00024 vs 0.00331 at d=1536, 0.00021 vs 0.00263 at d=3072. Choose linear when the output must keep its input length.",
+        "Quantization method: 'linear' for simple min-max scaling, 'turbo' for TurboQuant (randomized Hadamard rotation + uniform scalar quantization at the MSE-optimal Gaussian clipping range). Turbo requires a signed integer targetType (int8 or int16). It rotates in turboPaddedLength(d) dimensions, so a non-power-of-2 input needs turboPadToPowerOf2: true, which widens the output to turboPaddedLength(d); without it such an input is rejected rather than silently degraded. Accuracy, as measured int8 cosine RMSE over 40 seeded pairs at d=768: padded turbo 0.00034, a max-abs int8 quantizer 0.00024, this task's own linear path 0.00269. That last figure reflects that path's scaling rather than turbo's advantage — it divides by the L2 norm first, so at d=768 it emits no code larger than 8 of 127 and discards three of its eight bits before any comparison. Turbo's real property is distribution-independence: with 2 dimensions at 20x (the outlier dimensions real embedding models exhibit) turbo measures 0.00039 against max-abs's 0.00174, while on well-conditioned inputs max-abs is the slightly more accurate of the two. Choose linear when the output must keep its input length.",
       default: QuantizationMethod.LINEAR,
     },
     turboSeed: {
@@ -70,13 +71,13 @@ const inputSchema = {
       title: "TurboQuant Seed",
       description:
         "Seed for the random rotation in TurboQuant. All vectors in the same collection must use the same seed for similarity search to work.",
-      default: 42,
+      default: DEFAULT_SEED,
     },
     turboPadToPowerOf2: {
       type: "boolean",
       title: "TurboQuant Pad To Power Of 2",
       description:
-        "Allow method 'turbo' on a non-power-of-2 dimensionality by widening the output to nextPowerOf2(d). Defaults to false because enabling it lengthens the output vector: a storage column sized to d will reject the result, so it has to be an explicit choice rather than a silent one. Ignored unless method is 'turbo'.",
+        "Allow method 'turbo' on a non-power-of-2 dimensionality by widening the output to turboPaddedLength(d). Defaults to false because enabling it lengthens the output vector: a storage column sized to d will reject the result, so it has to be an explicit choice rather than a silent one. Ignored unless method is 'turbo'.",
       default: false,
     },
   },
@@ -129,8 +130,14 @@ const outputSchema = {
       description:
         "Seed of the random rotation applied when method is 'turbo' (absent otherwise). Vectors quantized with different seeds, or mixed with vectors quantized using method 'linear', are NOT comparable: cosine similarity between them is meaningless and no error is raised.",
     },
+    originalDimensions: {
+      type: "integer",
+      title: "Original Dimensions",
+      description:
+        "The input dimensionality before quantization. Differs from the output vector's length only when turboPadToPowerOf2 widened it, and is recorded so a consumer can tell a widened vector from a model that genuinely emits that many dimensions — the two are indistinguishable from the output alone.",
+    },
   },
-  required: ["vector", "originalType", "targetType", "method"],
+  required: ["vector", "originalType", "targetType", "method", "originalDimensions"],
   additionalProperties: false,
 } as const satisfies DataPortSchema;
 
@@ -141,7 +148,7 @@ export type VectorQuantizeTaskInput = {
   readonly method?: QuantizationMethod | undefined;
   readonly turboSeed?: number | undefined;
   /**
-   * Opt into a `nextPowerOf2(d)`-length output for `method: "turbo"` at a non-power-of-2
+   * Opt into a `turboPaddedLength(d)`-length output for `method: "turbo"` at a non-power-of-2
    * dimensionality. Defaults to false: it lengthens the output vector.
    */
   readonly turboPadToPowerOf2?: boolean | undefined;
@@ -154,6 +161,13 @@ export type VectorQuantizeTaskOutput = {
   readonly method: QuantizationMethod;
   /** Rotation seed, present only for `method: "turbo"`. Different seeds are not comparable. */
   readonly turboSeed: number | undefined;
+  /**
+   * Input dimensionality before quantization. Differs from `vector`'s length only when
+   * `turboPadToPowerOf2` widened it; recorded so a consumer can tell a widened vector from
+   * a model that genuinely emits that many dimensions. For the array form this reports the
+   * FIRST vector's length.
+   */
+  readonly originalDimensions: number;
 };
 export type VectorQuantizeTaskConfig = TaskConfig<VectorQuantizeTaskInput>;
 
@@ -193,7 +207,7 @@ export class VectorQuantizeTask extends Task<
       targetType,
       normalize = true,
       method = QuantizationMethod.LINEAR,
-      turboSeed = 42,
+      turboSeed = DEFAULT_SEED,
       turboPadToPowerOf2 = false,
     } = input;
     const isArray = Array.isArray(vector);
@@ -213,21 +227,26 @@ export class VectorQuantizeTask extends Task<
       }
       // Checked here rather than left to turboQuantizeToTypedArray so the message names
       // the task's own input rather than the util's option object. Turbo rotates in
-      // nextPowerOf2(d) dimensions, so at a non-power-of-2 d it either widens the output
+      // turboPaddedLength(d) dimensions, so at a non-power-of-2 d it either widens the output
       // or discards coordinates; only the first is offered.
       const unpadded = turboPadToPowerOf2
         ? undefined
-        : vectors.find((v) => v.length !== nextPowerOf2(v.length));
+        : vectors.find((v) => v.length !== turboPaddedLength(v.length));
       if (unpadded !== undefined) {
-        const padded = nextPowerOf2(unpadded.length);
+        const padded = turboPaddedLength(unpadded.length);
         throw new Error(
           `VectorQuantizeTask: method "turbo" needs turboPadToPowerOf2: true at a non-power-of-2 ` +
             `vector dimensionality, got ${unpadded.length}. Setting it widens the output from ` +
-            `${unpadded.length} to ${padded} values, so size any fixed-width storage column to ` +
-            `${padded}. Padded turbo is the more accurate option at this size — measured int8 ` +
-            `cosine RMSE over 40 seeded pairs, padded turbo vs this task's linear path: 0.00034 ` +
-            `vs 0.00269 at d=768, 0.00024 vs 0.00331 at d=1536, 0.00021 vs 0.00263 at d=3072. ` +
-            `Use method: "linear" instead if the output must keep its ${unpadded.length} length.`
+            `${unpadded.length} to ${padded} values — the output is LONGER than the input, so ` +
+            `size any fixed-width storage column to ${padded}, not ${unpadded.length}. Turbo is ` +
+            `not automatically the more accurate option: against a max-abs int8 quantizer ` +
+            `(divide by max|v|, then scale to +/-127) padded turbo is slightly WORSE on ` +
+            `well-conditioned inputs (int8 cosine RMSE at d=768: 0.00034 vs 0.00024) and several ` +
+            `times BETTER when the input carries outlier dimensions (0.00039 vs 0.00174), which ` +
+            `is the trade padding actually buys. This task's own method: "linear" measures 0.00269 ` +
+            `at d=768, but that reflects its L2-then-x127 scaling (which emits no code larger ` +
+            `than 8 of 127 there) rather than any property of turbo. Use method: "linear" if the ` +
+            `output must keep its ${unpadded.length} length.`
         );
       }
       quantized = vectors.map((v) =>
@@ -246,6 +265,7 @@ export class VectorQuantizeTask extends Task<
       targetType,
       method,
       turboSeed: method === QuantizationMethod.TURBO ? turboSeed : undefined,
+      originalDimensions: vectors[0].length,
     };
   }
 

--- a/packages/test/src/test/rag/VectorQuantizeTask.test.ts
+++ b/packages/test/src/test/rag/VectorQuantizeTask.test.ts
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { report, snap } from "../../binding/testTiming";
 
 /**
- * Deterministic PRNG (mulberry32). The accuracy comparison below asserts a ratio between
+ * Deterministic PRNG (mulberry32). The accuracy comparisons below assert a ratio between
  * two quantizers, so a `Math.random()` draw would make a real regression and an unlucky
  * sample indistinguishable.
  */
@@ -25,6 +25,50 @@ function makeRandom(seed: number): () => number {
     t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
   };
+}
+
+/** Exact cosine, used both for the ground truth and for scoring each quantizer's output. */
+function cosine(a: ArrayLike<number>, b: ArrayLike<number>): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  return dot / Math.sqrt(na * nb);
+}
+
+/**
+ * The int8 baseline the accuracy tests below score against: divide by the LARGEST
+ * ABSOLUTE COORDINATE, then scale to the full [-127, 127] range.
+ *
+ * Deliberately written here rather than obtained by calling the task's `method: "linear"`
+ * path. That path divides by the L2 norm instead and so emits a maximum code of 8 at
+ * d=768 — a baseline that has already thrown away three of its eight bits, which is a
+ * defect to be repaired separately, not a yardstick. Owning the reference in this file
+ * means repairing it cannot move the bounds asserted here.
+ */
+function maxAbsInt8(v: ArrayLike<number>): Int8Array {
+  let largest = 0;
+  for (let i = 0; i < v.length; i++) largest = Math.max(largest, Math.abs(v[i]));
+  const divisor = largest || 1;
+  const out = new Int8Array(v.length);
+  for (let i = 0; i < v.length; i++) out[i] = Math.round((v[i] / divisor) * 127);
+  return out;
+}
+
+/** Padded turbo int8 through the task, at the fixed seed both accuracy tests use. */
+async function turboOf(v: Float32Array): Promise<Int8Array> {
+  const result = await vectorQuantize({
+    vector: v,
+    targetType: TensorType.INT8,
+    method: "turbo",
+    turboSeed: 42,
+    turboPadToPowerOf2: true,
+  });
+  return result.vector as Int8Array;
 }
 
 let _snap = snap();
@@ -359,6 +403,15 @@ describe("VectorQuantizeTask", () => {
       // comparison that does not describe either option now on offer.
       expect(message).not.toContain("0.0164");
 
+      // The message must name the honest baseline, not just this task's own linear path.
+      // Comparing only against `method: "linear"` reads as an 8x win for turbo, but that
+      // path emits a maximum code of 8 of 127 at d=768 — so the gap measures its scaling
+      // defect, not the rotation. A reader deciding between the two needs the max-abs
+      // comparison, where turbo is the slightly WORSE option on well-conditioned input.
+      expect(message).toMatch(/max\|v\||max-abs/);
+      expect(message).toMatch(/WORSE/);
+      expect(message).toMatch(/outlier/);
+
       // The same vector is fine under linear quantization.
       const linear = await vectorQuantize({ vector, targetType: TensorType.INT8 });
       expect((linear.vector as Int8Array).length).toBe(768);
@@ -385,29 +438,33 @@ describe("VectorQuantizeTask", () => {
       expect(result.turboSeed).toBe(42);
     });
 
-    test("should beat the linear path on similarity error at d=768 when padded", async () => {
-      // The measurement behind the rejection message, asserted rather than quoted. The
-      // message previously cited cropped-turbo RMSE (0.0164 at d=768) and told users
-      // linear was more accurate; padded turbo is roughly 8x MORE accurate here, so the
-      // guidance was backwards for the option the task now offers.
+    test("should match a max-abs int8 baseline on similarity error at d=768 when padded", async () => {
+      // The measurement behind the rejection message and the schema description, asserted
+      // rather than quoted.
+      //
+      // The reference is a max-abs int8 quantizer written HERE, deliberately, and it is
+      // not `linearRmse / 4` and not this task's own linear path at any ratio. That path
+      // divides by the vector's L2 norm before scaling by 127, which on a well-spread
+      // d=768 vector leaves every coordinate near 1/sqrt(768) — so the largest code it
+      // ever emits is 8 of a possible 127, and three of its eight bits are gone before
+      // any comparison happens. Beating it by 8x measured that defect, not the rotation.
+      // Worse, it was a test pinned to the wrong thing: repairing `quantizeToInt8` to
+      // divide by max|v| would have turned this assertion red for exactly the right
+      // reason. Computing the reference in this file means the bound cannot move when
+      // that repair lands.
+      //
+      // On this generator turbo is legitimately the WORSE of the two, and the assertion
+      // says so. I.i.d. uniform coordinates are the best possible case for max-abs: no
+      // coordinate is an outlier, so the divisor is representative and the full code
+      // range is used. Measured 0.00034 (turbo) vs 0.00024 (max-abs) — a 1.4x deficit.
+      // The bound admits that and pins the magnitude, so a real regression in either
+      // direction still fails. The case where turbo wins is the next test.
       const d = 768;
       const pairs = 40;
       const rnd = makeRandom(d);
 
-      const cosine = (a: ArrayLike<number>, b: ArrayLike<number>): number => {
-        let dot = 0;
-        let na = 0;
-        let nb = 0;
-        for (let i = 0; i < a.length; i++) {
-          dot += a[i] * b[i];
-          na += a[i] * a[i];
-          nb += b[i] * b[i];
-        }
-        return dot / Math.sqrt(na * nb);
-      };
-
       let turboSquaredError = 0;
-      let linearSquaredError = 0;
+      let maxAbsSquaredError = 0;
       for (let p = 0; p < pairs; p++) {
         const a = new Float32Array(d);
         const b = new Float32Array(d);
@@ -417,33 +474,123 @@ describe("VectorQuantizeTask", () => {
         }
         const exact = cosine(a, b);
 
-        const turboOf = async (v: Float32Array): Promise<Int8Array> =>
-          (
-            await vectorQuantize({
-              vector: v,
-              targetType: TensorType.INT8,
-              method: "turbo",
-              turboSeed: 42,
-              turboPadToPowerOf2: true,
-            })
-          ).vector as Int8Array;
-        const linearOf = async (v: Float32Array): Promise<Int8Array> =>
-          (await vectorQuantize({ vector: v, targetType: TensorType.INT8 })).vector as Int8Array;
-
         const turboError = cosine(await turboOf(a), await turboOf(b)) - exact;
         turboSquaredError += turboError * turboError;
-        const linearError = cosine(await linearOf(a), await linearOf(b)) - exact;
-        linearSquaredError += linearError * linearError;
+        const maxAbsError = cosine(maxAbsInt8(a), maxAbsInt8(b)) - exact;
+        maxAbsSquaredError += maxAbsError * maxAbsError;
       }
 
       const turboRmse = Math.sqrt(turboSquaredError / pairs);
-      const linearRmse = Math.sqrt(linearSquaredError / pairs);
+      const maxAbsRmse = Math.sqrt(maxAbsSquaredError / pairs);
 
-      // Measured: padded turbo 0.00034, linear 0.00269 — a 7.8x gap. The assertion
-      // demands only 4x so an unrelated tweak does not fail it, but the direction is
-      // exactly what the old message got wrong and must not silently reverse.
-      expect(turboRmse).toBeLessThan(linearRmse / 4);
+      // Turbo stays in its distribution-invariant band whatever the input is.
       expect(turboRmse).toBeLessThan(0.001);
+      // ...and is within 2x of the baseline even where the baseline is at its strongest.
+      // Measured ratio is 1.4x; 2x leaves headroom for an unrelated tweak without
+      // admitting a real collapse.
+      expect(turboRmse).toBeLessThan(maxAbsRmse * 2);
+    });
+
+    test("should beat a max-abs int8 baseline when the input carries outlier dimensions", async () => {
+      // This is the claim the rejection message and the schema description now make, and
+      // the reason padded turbo is worth offering at all: its error is roughly invariant
+      // to the input distribution, because the rotation gives every coordinate the same
+      // marginal before the grid is applied.
+      //
+      // Max-abs has no such property. Its divisor is a single order statistic, so one
+      // outlier dimension sets it for the whole vector and crushes every ordinary
+      // coordinate toward zero — real embedding models exhibit exactly this ("massive
+      // activations"), which is why the benign case above is not the case that decides
+      // the recommendation. Gaussian coordinates with 2 dimensions at 20x: measured
+      // turbo 0.00039 vs max-abs 0.00174, a 4.5x advantage the other way.
+      //
+      // Together with the previous test this pins BOTH halves of the wording, so the
+      // corrected claims cannot silently rot: one test fails if turbo is ever presented
+      // as dramatically better in the benign case, the other if it stops being better in
+      // the heavy-tailed one.
+      const d = 768;
+      const pairs = 40;
+      const rnd = makeRandom(d);
+      // Box-Muller off the same seeded PRNG: heavy-tailed inputs must be as reproducible
+      // as the uniform ones, or an unlucky draw is indistinguishable from a regression.
+      const gaussian = (): number =>
+        Math.sqrt(-2 * Math.log(Math.max(rnd(), 1e-12))) * Math.cos(2 * Math.PI * rnd());
+
+      let turboSquaredError = 0;
+      let maxAbsSquaredError = 0;
+      for (let p = 0; p < pairs; p++) {
+        const a = new Float32Array(d);
+        const b = new Float32Array(d);
+        for (let i = 0; i < d; i++) {
+          a[i] = gaussian();
+          b[i] = gaussian();
+        }
+        // Two "massive activation" dimensions, the shape that defeats a max-abs divisor.
+        a[0] *= 20;
+        a[1] *= 20;
+        b[0] *= 20;
+        b[1] *= 20;
+        const exact = cosine(a, b);
+
+        const turboError = cosine(await turboOf(a), await turboOf(b)) - exact;
+        turboSquaredError += turboError * turboError;
+        const maxAbsError = cosine(maxAbsInt8(a), maxAbsInt8(b)) - exact;
+        maxAbsSquaredError += maxAbsError * maxAbsError;
+      }
+
+      const turboRmse = Math.sqrt(turboSquaredError / pairs);
+      const maxAbsRmse = Math.sqrt(maxAbsSquaredError / pairs);
+
+      // Measured 4.5x; asserting 3x leaves headroom without admitting a reversal.
+      expect(turboRmse).toBeLessThan(maxAbsRmse / 3);
+    });
+
+    test("records the shipped linear int8 path's largest emitted code at d=768", async () => {
+      // RECORDED DEFECT, NOT A DESIRED PROPERTY.
+      //
+      // `VectorQuantizeTask.quantizeToInt8` divides by the vector's L2 norm and then
+      // scales by 127. On a well-spread d=768 vector every coordinate is near 1/sqrt(768),
+      // so the largest code the path can emit is 8 — it uses 4 of the 255 available
+      // codes and discards three of its eight bits. That is a pre-existing defect
+      // unrelated to TurboQuant, and it is deliberately NOT fixed here: the divisor
+      // change rescales every stored coordinate ~16x at this width, which cosine survives
+      // (a positive scalar multiple) but `l2` and `ip` do not, and nothing marks a stored
+      // int8 vector with the scaling that produced it.
+      //
+      // This assertion exists so that repair is a deliberate, reviewed change rather than
+      // a surprise. When `quantizeToInt8` is repaired to divide by max|v|, this
+      // expectation changes to 127 and this comment goes away.
+      const d = 768;
+      const rnd = makeRandom(d);
+      const v = new Float32Array(d);
+      for (let i = 0; i < d; i++) v[i] = rnd() - 0.5;
+
+      const linear = (await vectorQuantize({ vector: v, targetType: TensorType.INT8 }))
+        .vector as Int8Array;
+
+      let largest = 0;
+      for (const code of linear) largest = Math.max(largest, Math.abs(code));
+      expect(largest).toBe(8);
+    });
+
+    test("should report originalDimensions alongside a widened turbo vector", async () => {
+      // The output length alone cannot distinguish a 768-dim model widened to 1024 from a
+      // model that genuinely emits 1024 dimensions; `originalDimensions` is what does.
+      const vector = new Float32Array(768);
+      for (let i = 0; i < 768; i++) vector[i] = Math.sin(i * 0.1);
+
+      const padded = await vectorQuantize({
+        vector,
+        targetType: TensorType.INT8,
+        method: "turbo",
+        turboPadToPowerOf2: true,
+      });
+      expect((padded.vector as Int8Array).length).toBe(1024);
+      expect(padded.originalDimensions).toBe(768);
+
+      // Unwidened paths report the input length, which equals the output length.
+      const linear = await vectorQuantize({ vector, targetType: TensorType.INT8 });
+      expect(linear.originalDimensions).toBe(768);
     });
 
     test("should report method and turboSeed on the output", async () => {

--- a/packages/test/src/test/util/TurboQuantize.test.ts
+++ b/packages/test/src/test/util/TurboQuantize.test.ts
@@ -108,13 +108,16 @@ describe("TurboQuantize", () => {
         turboQuantize(new Float32Array([1, 2, -Infinity, 4, 5, 6, 7, 8]), { bits: 4, seed: 42 })
       ).toThrow("NaN or Infinity");
       expect(() =>
-        turboQuantizeToTypedArray(new Float32Array([1, 2, NaN, 4, 5, 6, 7, 8]), TensorType.INT8, 42)
+        turboQuantizeToTypedArray(new Float32Array([1, 2, NaN, 4, 5, 6, 7, 8]), TensorType.INT8, {
+          seed: 42,
+          padToPowerOf2: undefined,
+        })
       ).toThrow("NaN or Infinity");
       expect(() =>
         turboQuantizeToTypedArray(
           new Float32Array([1, 2, Infinity, 4, 5, 6, 7, 8]),
           TensorType.INT8,
-          42
+          { seed: 42, padToPowerOf2: undefined }
         )
       ).toThrow("NaN or Infinity");
     });
@@ -215,7 +218,10 @@ describe("TurboQuantize", () => {
       const v64 = new Float32Array(64);
       for (let i = 0; i < 64; i++) v64[i] = Math.sin(i * 0.7) * ((i % 5) + 1);
       const first16 = Array.from(
-        turboQuantizeToTypedArray(v64, TensorType.INT8, 42).slice(0, 16) as Int8Array
+        turboQuantizeToTypedArray(v64, TensorType.INT8, {
+          seed: 42,
+          padToPowerOf2: undefined,
+        }).slice(0, 16) as Int8Array
       );
       expect(first16).toEqual([
         16, -22, -15, -30, -17, -17, 35, 8, -34, -13, -31, -71, 8, 27, -10, -13,
@@ -280,8 +286,15 @@ describe("TurboQuantize", () => {
       expect(() => turboQuantize(vector, { bits: 4, seed: 1.5 })).toThrow(/seed/);
       expect(() => turboQuantize(vector, { bits: 4, seed: 2 ** 32 + 1 })).toThrow(/seed/);
       expect(() => turboQuantize(vector, { bits: 4, seed: NaN })).toThrow(/seed/);
-      expect(() => turboQuantizeToTypedArray(vector, TensorType.INT8, 1.5)).toThrow(/seed/);
-      expect(() => turboQuantizeToTypedArray(vector, TensorType.INT8, 2 ** 32 + 1)).toThrow(/seed/);
+      expect(() =>
+        turboQuantizeToTypedArray(vector, TensorType.INT8, { seed: 1.5, padToPowerOf2: undefined })
+      ).toThrow(/seed/);
+      expect(() =>
+        turboQuantizeToTypedArray(vector, TensorType.INT8, {
+          seed: 2 ** 32 + 1,
+          padToPowerOf2: undefined,
+        })
+      ).toThrow(/seed/);
 
       // The int32 window itself stays usable at both ends.
       expect(() => turboQuantize(vector, { bits: 4, seed: -(2 ** 31) })).not.toThrow();
@@ -369,7 +382,7 @@ describe("TurboQuantize", () => {
       }
     });
 
-    test("should reject a paddedDimensions that is not nextPowerOf2(dimensions)", () => {
+    test("should reject a paddedDimensions that is not turboPaddedLength(dimensions)", () => {
       // TurboQuantizeResult is a plain serializable record, so a persisted or
       // mismatched value can reach the decode path with a bogus padded length.
       // Without the guard the Walsh-Hadamard butterfly reads past the buffer and
@@ -911,24 +924,24 @@ describe("TurboQuantize", () => {
   describe("turboQuantizeToTypedArray", () => {
     test("should produce Int8Array for INT8 target", () => {
       const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
-      const result = turboQuantizeToTypedArray(vector, TensorType.INT8);
+      const result = turboQuantizeToTypedArray(vector, TensorType.INT8, undefined);
       expect(result).toBeInstanceOf(Int8Array);
       expect(result.length).toBe(vector.length);
     });
 
     test("should produce Int16Array for INT16 target", () => {
       const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
-      const result = turboQuantizeToTypedArray(vector, TensorType.INT16);
+      const result = turboQuantizeToTypedArray(vector, TensorType.INT16, undefined);
       expect(result).toBeInstanceOf(Int16Array);
       expect(result.length).toBe(vector.length);
     });
 
     test("should reject float target types", () => {
       const vector = new Float32Array([1, 2, 3, 4]);
-      expect(() => turboQuantizeToTypedArray(vector, TensorType.FLOAT32)).toThrow(
+      expect(() => turboQuantizeToTypedArray(vector, TensorType.FLOAT32, undefined)).toThrow(
         "signed integer targets only"
       );
-      expect(() => turboQuantizeToTypedArray(vector, TensorType.FLOAT64)).toThrow(
+      expect(() => turboQuantizeToTypedArray(vector, TensorType.FLOAT64, undefined)).toThrow(
         "signed integer targets only"
       );
     });
@@ -937,10 +950,10 @@ describe("TurboQuantize", () => {
       // An unsigned target needs an affine map with a DC offset, and cosine
       // similarity is not translation-invariant — see the DC-offset test below.
       const vector = new Float32Array([1, 2, 3, 4]);
-      expect(() => turboQuantizeToTypedArray(vector, TensorType.UINT8)).toThrow(
+      expect(() => turboQuantizeToTypedArray(vector, TensorType.UINT8, undefined)).toThrow(
         "signed integer targets only"
       );
-      expect(() => turboQuantizeToTypedArray(vector, TensorType.UINT16)).toThrow(
+      expect(() => turboQuantizeToTypedArray(vector, TensorType.UINT16, undefined)).toThrow(
         "signed integer targets only"
       );
     });
@@ -950,7 +963,7 @@ describe("TurboQuantize", () => {
       // keys, so a truthy-but-wrong "range" would slip past a `if (!range)` guard.
       const vector = new Float32Array([1, 2, 3, 4]);
       for (const name of ["constructor", "toString", "__proto__", "hasOwnProperty"]) {
-        expect(() => turboQuantizeToTypedArray(vector, name as TensorType)).toThrow(
+        expect(() => turboQuantizeToTypedArray(vector, name as TensorType, undefined)).toThrow(
           "signed integer targets only"
         );
       }
@@ -965,7 +978,10 @@ describe("TurboQuantize", () => {
       const vector = new Float32Array(d);
       for (let i = 0; i < d; i++) vector[i] = rnd() - 0.5;
 
-      const result = turboQuantizeToTypedArray(vector, TensorType.INT8, 42);
+      const result = turboQuantizeToTypedArray(vector, TensorType.INT8, {
+        seed: 42,
+        padToPowerOf2: undefined,
+      });
 
       let sum = 0;
       let negatives = 0;
@@ -999,8 +1015,14 @@ describe("TurboQuantize", () => {
             b[i] = rnd() - 0.5;
           }
           const trueSim = cosineSimilarity(a, b);
-          const qa = turboQuantizeToTypedArray(a, TensorType.INT8, 42);
-          const qb = turboQuantizeToTypedArray(b, TensorType.INT8, 42);
+          const qa = turboQuantizeToTypedArray(a, TensorType.INT8, {
+            seed: 42,
+            padToPowerOf2: undefined,
+          });
+          const qb = turboQuantizeToTypedArray(b, TensorType.INT8, {
+            seed: 42,
+            padToPowerOf2: undefined,
+          });
           const error = Math.abs(cosineSimilarity(qa, qb) - trueSim);
           squaredError += error * error;
           if (error > maxError) maxError = error;
@@ -1011,13 +1033,14 @@ describe("TurboQuantize", () => {
     });
 
     test("should reject a non-power-of-2 dimensionality", () => {
-      // Keeping the first d of nextPowerOf2(d) rotated coordinates is a lossy random
-      // projection that measures WORSE than linear quantization at exactly the sizes
-      // real embedding models use, so it is refused rather than silently degraded.
+      // Keeping the first d of turboPaddedLength(d) rotated coordinates is a lossy random
+      // projection rather than an orthogonal rotation: it measures roughly 50x worse than
+      // padded turbo (0.0162 vs 0.00034 at d=768) and 70x worse than a max-abs int8
+      // quantizer, so it is refused rather than silently degraded.
       for (const d of [768, 1000, 1536, 3072]) {
-        expect(() => turboQuantizeToTypedArray(new Float32Array(d), TensorType.INT8)).toThrow(
-          /power of 2/
-        );
+        expect(() =>
+          turboQuantizeToTypedArray(new Float32Array(d), TensorType.INT8, undefined)
+        ).toThrow(/power of 2/);
       }
     });
 
@@ -1060,20 +1083,34 @@ describe("TurboQuantize", () => {
     });
 
     test("should reject empty vectors", () => {
-      expect(() => turboQuantizeToTypedArray(new Float32Array(0), TensorType.INT8)).toThrow();
+      expect(() =>
+        turboQuantizeToTypedArray(new Float32Array(0), TensorType.INT8, undefined)
+      ).toThrow();
     });
 
     test("should be deterministic with same seed", () => {
       const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
-      const r1 = turboQuantizeToTypedArray(vector, TensorType.INT8, 123);
-      const r2 = turboQuantizeToTypedArray(vector, TensorType.INT8, 123);
+      const r1 = turboQuantizeToTypedArray(vector, TensorType.INT8, {
+        seed: 123,
+        padToPowerOf2: undefined,
+      });
+      const r2 = turboQuantizeToTypedArray(vector, TensorType.INT8, {
+        seed: 123,
+        padToPowerOf2: undefined,
+      });
       expect(r1).toEqual(r2);
     });
 
     test("should produce different results with different seeds", () => {
       const vector = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
-      const r1 = turboQuantizeToTypedArray(vector, TensorType.INT8, 1);
-      const r2 = turboQuantizeToTypedArray(vector, TensorType.INT8, 2);
+      const r1 = turboQuantizeToTypedArray(vector, TensorType.INT8, {
+        seed: 1,
+        padToPowerOf2: undefined,
+      });
+      const r2 = turboQuantizeToTypedArray(vector, TensorType.INT8, {
+        seed: 2,
+        padToPowerOf2: undefined,
+      });
       expect(r1).not.toEqual(r2);
     });
 
@@ -1087,8 +1124,14 @@ describe("TurboQuantize", () => {
       }
 
       const trueSim = cosineSimilarity(a, b);
-      const qa = turboQuantizeToTypedArray(a, TensorType.INT8, 42);
-      const qb = turboQuantizeToTypedArray(b, TensorType.INT8, 42);
+      const qa = turboQuantizeToTypedArray(a, TensorType.INT8, {
+        seed: 42,
+        padToPowerOf2: undefined,
+      });
+      const qb = turboQuantizeToTypedArray(b, TensorType.INT8, {
+        seed: 42,
+        padToPowerOf2: undefined,
+      });
       const quantSim = cosineSimilarity(qa, qb);
 
       // Turbo Int8 should preserve similarity well
@@ -1105,8 +1148,14 @@ describe("TurboQuantize", () => {
       }
 
       const trueSim = cosineSimilarity(a, b);
-      const qa = turboQuantizeToTypedArray(a, TensorType.INT16, 42);
-      const qb = turboQuantizeToTypedArray(b, TensorType.INT16, 42);
+      const qa = turboQuantizeToTypedArray(a, TensorType.INT16, {
+        seed: 42,
+        padToPowerOf2: undefined,
+      });
+      const qb = turboQuantizeToTypedArray(b, TensorType.INT16, {
+        seed: 42,
+        padToPowerOf2: undefined,
+      });
       const quantSim = cosineSimilarity(qa, qb);
 
       // Int16 should be very close
@@ -1118,8 +1167,14 @@ describe("TurboQuantize", () => {
       const v = new Float32Array(d);
       for (let i = 0; i < d; i++) v[i] = Math.sin(i);
 
-      const qa = turboQuantizeToTypedArray(v, TensorType.INT8, 42);
-      const qb = turboQuantizeToTypedArray(v, TensorType.INT8, 42);
+      const qa = turboQuantizeToTypedArray(v, TensorType.INT8, {
+        seed: 42,
+        padToPowerOf2: undefined,
+      });
+      const qb = turboQuantizeToTypedArray(v, TensorType.INT8, {
+        seed: 42,
+        padToPowerOf2: undefined,
+      });
 
       // Identical input + same seed = identical output
       expect(cosineSimilarity(qa, qb)).toBeCloseTo(1, 10);
@@ -1129,14 +1184,14 @@ describe("TurboQuantize", () => {
       const vector = new Float32Array([0, 0, 0, 0]);
 
       for (const targetType of [TensorType.INT8, TensorType.INT16] as const) {
-        const result = turboQuantizeToTypedArray(vector, targetType);
+        const result = turboQuantizeToTypedArray(vector, targetType, undefined);
         expect(result.length).toBe(4);
         for (let i = 0; i < result.length; i++) {
           expect(result[i]).toBe(0);
         }
       }
 
-      expect(() => turboQuantizeToTypedArray(vector, TensorType.UINT8)).toThrow(
+      expect(() => turboQuantizeToTypedArray(vector, TensorType.UINT8, undefined)).toThrow(
         "signed integer targets only"
       );
     });
@@ -1147,7 +1202,7 @@ describe("TurboQuantize", () => {
       const vector = new Float32Array(d);
       for (let i = 0; i < d; i++) vector[i] = rnd() * 10 - 5;
 
-      const result = turboQuantizeToTypedArray(vector, TensorType.INT8);
+      const result = turboQuantizeToTypedArray(vector, TensorType.INT8, undefined);
       for (let i = 0; i < result.length; i++) {
         expect(result[i]).toBeGreaterThanOrEqual(-127);
         expect(result[i]).toBeLessThanOrEqual(127);
@@ -1160,7 +1215,7 @@ describe("TurboQuantize", () => {
       const vector = new Float32Array(d);
       for (let i = 0; i < d; i++) vector[i] = rnd() * 10 - 5;
 
-      const result = turboQuantizeToTypedArray(vector, TensorType.INT16);
+      const result = turboQuantizeToTypedArray(vector, TensorType.INT16, undefined);
       for (let i = 0; i < result.length; i++) {
         expect(result[i]).toBeGreaterThanOrEqual(-32767);
         expect(result[i]).toBeLessThanOrEqual(32767);

--- a/packages/util/src/vector/TurboQuantize.ts
+++ b/packages/util/src/vector/TurboQuantize.ts
@@ -112,7 +112,12 @@ export interface TurboQuantizeResult {
   readonly norm: number;
 }
 
-const DEFAULT_SEED = 42;
+/**
+ * Rotation seed applied when a caller supplies none. Exported so a downstream default
+ * (a task schema's `default`, a destructuring fallback) cites this constant rather than
+ * repeating the literal, which would silently diverge if the default ever changed.
+ */
+export const DEFAULT_SEED = 42;
 
 /**
  * Current {@link TurboQuantizeResult.version}. Bump whenever the mapping between stored
@@ -123,7 +128,7 @@ const TURBO_QUANTIZE_VERSION = 1;
 /**
  * Upper bound on the dimensionality this module will accept.
  *
- * Every entry point pads the input to `nextPowerOf2(dimensions)` and allocates several
+ * Every entry point pads the input to `turboPaddedLength(dimensions)` and allocates several
  * `Float64Array`s of that length as working buffers, so peak cost is a multiple of the
  * padded length rather than the single buffer a naive estimate assumes: measured peak RSS
  * growth is 32 MB at d = 2^20, about 32 bytes per padded coordinate. 2^20 is already ~340x
@@ -321,7 +326,7 @@ function getSignTable(seed: number, paddedLen: number): readonly Uint8Array[] {
 function randomRotate(values: Float64Array, seed: number): Float64Array {
   const d = values.length;
   // Pad to next power of 2 for Hadamard transform
-  const paddedLen = nextPowerOf2(d);
+  const paddedLen = turboPaddedLength(d);
   const result = new Float64Array(paddedLen);
   result.set(values);
 
@@ -416,8 +421,13 @@ function fastWalshHadamard(data: Float64Array): void {
  * reimplementation without that guard accepts a non-integer, a zero, or a length past
  * {@link MAX_TURBO_DIMENSIONS} and hands it on, so the caller's own carefully worded
  * validation is bypassed and the failure surfaces later as a low-level message.
+ *
+ * Named for TurboQuant rather than for the arithmetic because that guard makes it
+ * TurboQuant-specific: it rejects anything above {@link MAX_TURBO_DIMENSIONS} (2^20) with
+ * a message naming this module, so it is not the general-purpose next-power-of-2 helper a
+ * neutral name would advertise.
  */
-export function nextPowerOf2(n: number): number {
+export function turboPaddedLength(n: number): number {
   assertDimensions(n);
   let p = 1;
   while (p < n) p *= 2;
@@ -489,9 +499,19 @@ const loadingFactorCache = new Map<number, number>();
  * Power-of-two level counts up to 256 come from {@link GAUSSIAN_LOADING_FACTORS}. Anything
  * else is solved numerically by minimizing {@link quantizerDistortion} — needed by
  * {@link turboQuantizeToTypedArray}, whose effective level count is `2 * max + 1`
- * (255 for int8, 65535 for int16) and so is never in the table. The numeric solution
- * reproduces the tabulated values to within 0.35% (0.00% at 64 levels), which is what
- * pins the two paths to the same curve.
+ * (255 for int8, 65535 for int16) and so is never in the table.
+ *
+ * The numeric solution converges onto the tabulated curve as the grid gets finer, and is
+ * loosest at the coarse end where the distortion minimum is shallowest:
+ *
+ * | levels | 2    | 4    | 8    | 16   | 32   | 64   | 128  | 256  |
+ * | ------ | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
+ * | dev    | 4.03%| 1.64%| 0.86%| 0.35%| 0.14%| 0.00%| 0.13%| 0.12%|
+ *
+ * The 4% at 2 levels does not matter, because the solver is never consulted there. Its
+ * only callers are the int8 and int16 typed-array paths, at 255 and 65535 levels — past
+ * the fine end of the table, where the two methods have already agreed to ~0.1% for four
+ * consecutive doublings. The tabulated widths (1-8 bits) never reach the solver at all.
  */
 function optimalLoadingFactor(levels: number): number {
   if (!Number.isInteger(levels) || levels < 2) {
@@ -732,7 +752,7 @@ export function turboQuantize(
   const { values, norm } = normalizeToUnit(vector);
 
   // Step 2: Random rotation — returns all paddedLen coordinates
-  const paddedLen = nextPowerOf2(d);
+  const paddedLen = turboPaddedLength(d);
   const rotated = randomRotate(values, seed);
 
   // Step 3: Scalar quantization per coordinate (all paddedLen)
@@ -791,10 +811,10 @@ function assertQuantizeResultShape(quantized: TurboQuantizeResult): void {
   if (!Number.isFinite(norm) || norm < 0) {
     throw new Error(`TurboQuant norm must be a finite, non-negative number, got ${norm}`);
   }
-  const expectedPadded = nextPowerOf2(dimensions);
+  const expectedPadded = turboPaddedLength(dimensions);
   if (paddedDimensions !== expectedPadded) {
     throw new Error(
-      `TurboQuant paddedDimensions must be nextPowerOf2(dimensions) = ${expectedPadded}, got ${paddedDimensions}`
+      `TurboQuant paddedDimensions must be turboPaddedLength(dimensions) = ${expectedPadded}, got ${paddedDimensions}`
     );
   }
 }
@@ -1001,10 +1021,10 @@ const SIGNED_TARGET_RANGES = {
  * Options for {@link turboQuantizeToTypedArray}.
  */
 export interface TurboQuantizeToTypedArrayOptions {
-  /** Seed for the random rotation. Defaults to the module default when undefined. */
+  /** Seed for the random rotation. Defaults to {@link DEFAULT_SEED} when undefined. */
   readonly seed: number | undefined;
   /**
-   * Accept a non-power-of-2 input length by returning `nextPowerOf2(length)` values
+   * Accept a non-power-of-2 input length by returning `turboPaddedLength(length)` values
    * instead of throwing. The result is LONGER than the input; a storage column sized to
    * the input dimensionality will not hold it.
    */
@@ -1041,26 +1061,53 @@ export interface TurboQuantizeToTypedArrayOptions {
  *
  * ## Power-of-2 dimensions required, or opt into padding
  *
- * The rotation operates on `nextPowerOf2(d)` coordinates, so a non-power-of-2 `d` has to
+ * The rotation operates on `turboPaddedLength(d)` coordinates, so a non-power-of-2 `d` has to
  * either widen the output or discard coordinates. This function does the first on request
  * and never the second.
  *
- * Pass `{ padToPowerOf2: true }` to receive a `nextPowerOf2(d)`-length result. Padding
- * keeps the transform orthogonal, and at that width TurboQuant is the more accurate
- * choice by a wide margin — cosine RMSE against the exact similarity (int8, seed 42, 40
- * seeded pairs), padded turbo vs linear quantization: 0.00034 vs 0.00269 at d=768
- * (MiniLM), 0.00024 vs 0.00331 at d=1536, 0.00021 vs 0.00263 at d=3072. The cost is
- * purely the width: the output is LONGER than the input, so a fixed-width storage column
- * must be declared at the padded width.
+ * Pass `{ padToPowerOf2: true }` to receive a `turboPaddedLength(d)`-length result. Padding
+ * keeps the transform orthogonal. The cost is purely the width: the output is LONGER than
+ * the input, so a fixed-width storage column must be declared at the padded width.
+ *
+ * ### What padding actually buys, measured
+ *
+ * Cosine RMSE against the exact similarity (int8, seed 42, 40 seeded pairs of i.i.d.
+ * uniform coordinates), against two different int8 baselines:
+ *
+ * | d    | padded turbo | L2-then-x127 | max-abs |
+ * | ---- | ------------ | ------------ | ------- |
+ * | 768  | 0.00034      | 0.00269      | 0.00024 |
+ * | 1536 | 0.00024      | 0.00331      | 0.00015 |
+ * | 3072 | 0.00021      | 0.00263      | 0.00012 |
+ *
+ * The middle column is NOT turbo's achievement, and must not be quoted as one. That path
+ * divides by the vector's L2 norm, which on a well-spread vector leaves every coordinate
+ * near `1/sqrt(d)`, so scaling by 127 emits no code larger than 8 at d=768, 6 at d=1536
+ * and 4 at d=3072 — it throws away three of its eight bits before any comparison happens.
+ * Beating it measures that defect, not the rotation.
+ *
+ * Against the honest baseline (divide by `max|v|`, which uses the full code range),
+ * padded turbo is 1.4x-1.8x **worse** on these well-conditioned inputs.
+ *
+ * What the rotation buys is INDEPENDENCE FROM THE INPUT DISTRIBUTION, not a lower error
+ * floor. Turbo's error stays in the 0.0001-0.0004 band whatever the input looks like,
+ * because the rotation makes every coordinate's marginal the same. Max-abs swings with
+ * the input's tail: on Gaussian vectors carrying 2 dimensions at 20x (the "massive
+ * activations" real embedding models exhibit), one outlier sets the divisor and crushes
+ * every other coordinate toward zero — turbo 0.00039 vs max-abs 0.00174 at d=768, turbo
+ * 0.00020 vs max-abs 0.00138 at d=3072.
+ *
+ * So: prefer padded turbo when the corpus may contain outlier dimensions, or when the
+ * embeddings are not under your control. Max-abs int8 is simpler, keeps the input length,
+ * and is slightly more accurate when the coordinates are well behaved.
  *
  * Without that option a non-power-of-2 `d` is rejected rather than silently degraded. The
  * rejected alternative is CROPPING — keeping the first `d` of the rotated coordinates —
- * which makes this a lossy random projection rather than an orthogonal rotation and
- * measures worse than plain linear quantization at exactly the sizes real embedding
- * models use: cropped turbo vs linear, 0.0164 vs 0.0027 at d=768, 0.0126 vs 0.0033 at
- * d=1536, 0.0094 vs 0.0026 at d=3072. Those cropped figures are recorded here only to
- * explain why the variant is not offered; this function no longer emits it, so do not
- * quote them as the cost of turbo at these dimensionalities — padding is.
+ * which makes this a lossy random projection rather than an orthogonal rotation: cropped
+ * turbo measures 0.0162 at d=768, roughly 50x padded turbo and 70x a max-abs int8
+ * quantizer, and 0.0126 at d=1536 / 0.0095 at d=3072. Those figures are recorded here
+ * only to explain why the variant is not offered; this function does not emit it, so do
+ * not quote them as the cost of turbo at these dimensionalities — padding is.
  *
  * {@link turboQuantize} is unaffected either way: it keeps all `paddedLen` coordinates
  * and stays fully invertible at any dimensionality.
@@ -1070,15 +1117,16 @@ export interface TurboQuantizeToTypedArrayOptions {
  *
  * @param vector - Input vector (any TypedArray). Must not contain NaN or Infinity.
  * @param targetType - Target signed integer type (INT8 or INT16)
- * @param seedOrOptions - Rotation seed (default: 42), or an options object. All vectors in
- *   the same collection must use the same seed for similarity search to work.
+ * @param options - Rotation seed and padding opt-in; omit for {@link DEFAULT_SEED} and no
+ *   padding. All vectors in the same collection must use the same seed for similarity
+ *   search to work.
  * @returns TypedArray of the target type, with `.length === vector.length` unless
- *   `padToPowerOf2` widened it to `nextPowerOf2(vector.length)`
+ *   `padToPowerOf2` widened it to `turboPaddedLength(vector.length)`
  */
 export function turboQuantizeToTypedArray(
   vector: TypedArray,
   targetType: TensorType,
-  seedOrOptions: number | TurboQuantizeToTypedArrayOptions = DEFAULT_SEED
+  options: TurboQuantizeToTypedArrayOptions | undefined
 ): TypedArray {
   // `Object.hasOwn` before indexing: a plain `[targetType]` lookup would resolve
   // inherited Object.prototype keys, so a name like "constructor" would yield a
@@ -1090,9 +1138,8 @@ export function turboQuantizeToTypedArray(
   }
   const { max } = SIGNED_TARGET_RANGES[targetType as keyof typeof SIGNED_TARGET_RANGES];
 
-  const seed =
-    typeof seedOrOptions === "number" ? seedOrOptions : (seedOrOptions.seed ?? DEFAULT_SEED);
-  const padToPowerOf2 = typeof seedOrOptions === "number" ? false : seedOrOptions.padToPowerOf2;
+  const seed = options?.seed ?? DEFAULT_SEED;
+  const padToPowerOf2 = options?.padToPowerOf2 ?? false;
 
   const d = vector.length;
   if (d === 0) {
@@ -1101,17 +1148,20 @@ export function turboQuantizeToTypedArray(
   assertDimensions(d);
   assertSeed(seed);
 
-  const paddedLen = nextPowerOf2(d);
+  const paddedLen = turboPaddedLength(d);
   if (paddedLen !== d && padToPowerOf2 !== true) {
     throw new Error(
       `turboQuantizeToTypedArray requires a power of 2 dimensionality, got ${d}. ` +
         `Pass { padToPowerOf2: true } to receive ${paddedLen} values instead — padding keeps the ` +
-        `rotation orthogonal and is the most accurate option at this size (int8 cosine RMSE at ` +
-        `d=768: padded turbo 0.00034 vs linear 0.00269), at the cost of an output LONGER than the ` +
-        `input, so size any fixed-width storage column to ${paddedLen}. Quantize linearly instead ` +
-        `if the output must keep its ${d} length. Returning only the first ${d} of ${paddedLen} ` +
-        `rotated coordinates is not offered: cropping is a lossy random projection that measures ` +
-        `worse than linear here (0.0164 vs 0.0027).`
+        `rotation orthogonal. The output is then LONGER than the input, so size any fixed-width ` +
+        `storage column to ${paddedLen}, not ${d}. Turbo is not automatically the more accurate ` +
+        `choice: against a max-abs int8 quantizer (divide by max|v|, then scale to +/-127) padded ` +
+        `turbo is slightly WORSE on well-conditioned inputs (int8 cosine RMSE at d=768: 0.00034 vs ` +
+        `0.00024) and several times BETTER when the input carries outlier dimensions (0.00039 vs ` +
+        `0.00174), which is the trade padding actually buys — distribution-independence, not a ` +
+        `lower error floor. Quantize with max-abs int8 instead if the output must keep its ${d} ` +
+        `length. Returning only the first ${d} of ${paddedLen} rotated coordinates is not offered: ` +
+        `cropping is a lossy random projection and measures 0.0162 here, ~50x padded turbo.`
     );
   }
 
@@ -1145,7 +1195,7 @@ export function turboQuantizeToTypedArray(
  *
  * Because the Walsh-Hadamard transform requires a power-of-2 length, the vector
  * is zero-padded to the next power of 2 before quantization. The codes buffer
- * therefore covers `nextPowerOf2(dimensions)` coordinates, not `dimensions`.
+ * therefore covers `turboPaddedLength(dimensions)` coordinates, not `dimensions`.
  *
  * @param dimensions - Vector dimensionality
  * @param bits - Bits per dimension (integer, 1-8)
@@ -1154,7 +1204,7 @@ export function turboQuantizeToTypedArray(
 export function turboQuantizeStorageBytes(dimensions: number, bits: number): number {
   assertDimensions(dimensions);
   assertBits(bits);
-  return Math.ceil((nextPowerOf2(dimensions) * bits) / 8);
+  return Math.ceil((turboPaddedLength(dimensions) * bits) / 8);
 }
 
 /**


### PR DESCRIPTION
Blocks merge of #354. Docs, one rename, one unshipped signature change, one new output field, and tests — **no numerics changed**. #354's core numerics (Max 1960 loading factors, the clipping integral, the orthonormal self-inverse WHT, inverse rotation composition, the exact 1-bit angle correction, bit packing, edge cases, no caller mutation) were verified correct and are not touched.

## The problem: an 8x win measured against a defective baseline

The branch claimed padded turbo was "substantially MORE accurate than linear", quoting a ~8x gap. Re-measured on the branch module with the test's own generator (`makeRandom(d)`, `a[i] = rnd() - 0.5`, 40 pairs, int8, seed 42) — cosine RMSE against the exact similarity:

| d | padded turbo | linear as shipped (L2 then ×127) | max-abs int8 | max int8 code the shipped linear emits |
|---|---|---|---|---|
| 768 | 0.00034 | 0.00269 | 0.00024 | 8 |
| 1536 | 0.00024 | 0.00331 | 0.00015 | 6 |
| 3072 | 0.00021 | 0.00263 | 0.00012 | 4 |

The middle column is not turbo's achievement. `quantizeToInt8` divides by the vector's **L2 norm** before scaling by 127, so on a well-spread vector every coordinate sits near `1/√d` and the largest code it emits is **8 of 127** at d=768 — three of its eight bits are gone before any comparison happens. Beating it measures that defect, not the rotation.

**Against `max|v|`, padded turbo is 1.4×/1.6×/1.75× _worse_**, not 8× better.

## But "turbo is worse" is not the honest story either

Turbo's error is ~distribution-invariant (0.0001–0.0004 everywhere); max-abs swings ~20× with the input's tail, because its divisor is a single order statistic. On Gaussian vectors with 2 dimensions at 20× — "massive activations", which real embedding models exhibit:

| d | padded turbo | max-abs int8 |
|---|---|---|
| 768 | 0.00039 | 0.00174 |
| 3072 | 0.00020 | 0.00138 |

So the corrected guidance is: **prefer padded turbo when the corpus may contain outlier dimensions or is not under your control; max-abs int8 is simpler, keeps the input length, and is slightly more accurate when it does not.** What the rotation buys is independence from the input distribution, not a lower error floor.

## Scope decision: `quantizeToInt8` is deliberately NOT fixed here

Follow-up filed as **https://github.com/workglow-dev/libs/issues/796**.

`quantizeToInt8` is `private` (`packages/ai/src/task/VectorQuantizeTask.ts:322`, called only from `:286`) — not an exported function. It is a pre-existing defect on `main`, unrelated to TurboQuant. Changing its divisor from `‖v‖₂` to `max|v|` rescales every stored coordinate ~16× at d=768:

- **`cosine` is safe** — a positive scalar multiple per vector, and cosine is scale-invariant.
- **`l2` and `ip` are not.** `VectorDistanceMetric` includes both, distances under them scale with magnitude, and **there is no version marker on a stored int8 vector**. A corpus written partly before and partly after is incoherent under those metrics and undetectable.

It needs a migration note and probably a `linearScale: "l2" | "max-abs"` input rather than a silent flip. Landing that inside an "add TurboQuant" PR buries a migration-relevant change where no reviewer is looking.

**The hard requirement that follows:** the corrected claims and tests are worded and computed so that repairing `quantizeToInt8` later cannot invalidate them. The **max-abs** baseline is the quoted reference, and the tests compute it **inside the test file** rather than calling the task's linear path.

## Changes

**`packages/util/src/vector/TurboQuantize.ts`**
- Padding paragraph replaced with the three-column table, an explanation of why the middle column is not a yardstick, the outlier-dimension figures, and the actual recommendation. Cropping paragraph keeps its figures but is re-anchored: cropped turbo measures 0.0162 at d=768, ~50× padded turbo and ~70× max-abs, recorded only to explain why the variant is not offered.
- Rejection message rewritten: names the padded length, warns the output is LONGER so a fixed-width column must be sized to it, gives both baseline comparisons and calls distribution-independence "the trade padding actually buys".
- `optimalLoadingFactor`'s "within 0.35%" quoted the 16-level figure as if it were the worst. Measured deviation is **4.03% / 1.64% / 0.86% / 0.35% / 0.14% / 0.00% / 0.13% / 0.12%** at 2…256 levels. Replaced with the curve plus why it does not matter — the solver is only ever called at 255 and 65535 levels, past the fine end, and the tabulated widths never reach it.
- `nextPowerOf2` → **`turboPaddedLength`**. The guard is right; the *name* promised a general-purpose helper while the function throws `TurboQuant dimensions must be at most 1048576`. New on this branch (`git grep nextPowerOf2 origin/main` is empty), so renaming is free.
- `DEFAULT_SEED` exported with JSDoc.
- `turboQuantizeToTypedArray`'s third parameter drops its default and its `number | Options` union → `options: TurboQuantizeToTypedArrayOptions | undefined`. **`{ seed: 42 }` alone was a compile error**, since the interface uses `T | undefined` rather than `T?`. Breaking change to a function that has not shipped — free now, expensive later.

**`packages/ai/src/task/VectorQuantizeTask.ts`**
- `method` description and the throw both rewritten with the honest accuracy story.
- `DEFAULT_SEED` imported and used for the schema `default` and the destructuring default (was a hardcoded `42` in both).
- New **required** output `originalDimensions`, from `vectors[0].length` — the output length alone cannot distinguish a 768-dim model widened to 1024 from a model that genuinely emits 1024 dimensions.

**Tests** (`packages/test/src/test/rag/VectorQuantizeTask.test.ts`)
- The accuracy test scores against a **max-abs int8 quantizer written in the test file**, asserting `turboRmse < 0.001` and `turboRmse < maxAbsRmse * 2`. Not `linearRmse / 4`, and not the task's linear path at any ratio: repairing the quantizer would have turned the old assertion red for exactly the right reason, which is the definition of a test pinned to the wrong thing. Turbo is legitimately the worse of the two on this generator (i.i.d. uniform — the best possible case for max-abs); the bound admits that and pins the magnitude.
- A second case asserts `turboRmse < maxAbsRmse / 3` with Gaussian + 2 dims at 20×. **Together these two mean the new wording cannot silently rot** — one pins that turbo is not dramatically better in the benign case, the other that it is better in the heavy-tailed case.
- A **recorded-defect guard** asserts the shipped linear int8 path emits a max absolute code of **8** at d=768, commented as a *recorded defect, not a desired property*: when `quantizeToInt8` is repaired the expectation changes to 127 and the comment goes away. This is what makes the deferred fix safe.

## Verification

All figures in this PR were re-measured independently against the branch module before any edit and matched the review's numbers exactly, including the solver-deviation curve and the cropped-turbo ratios.

- `bunx vitest run --project test packages/test/src/test/rag/VectorQuantizeTask.test.ts` → **24 passed**
- `bunx vitest run --project test packages/test/src/test/util/TurboQuantize.test.ts` → **72 passed**
- `bun scripts/test.ts util rag vitest` → full section run, result in a follow-up comment
- `bunx eslint` over the four changed files → exit 0
- `bunx prettier "packages/{util,ai,test}/src/**/*.{ts,tsx}" --check` → `All matched files use Prettier code style!`

Note: this repo has no `lint` script — the root script is `format` (`eslint --fix && prettier --check --write`), so eslint and prettier were run directly in check mode.