### PR TITLE
Always return a Promise from getOutputStreamByRef

### DIFF
--- a/packages/task-graph/CHANGELOG.md
+++ b/packages/task-graph/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @workglow/task-graph
 
+## Unreleased
+
+### Breaking Changes
+
+- **refactor(task-graph)**: `TaskOutputRepository.getOutputStreamByRef` (and
+  `getOutputStreamByRefForRun`) always return a Promise
+
+  Both were declared as a tri-state union —
+  `AsyncIterable<Uint8Array> | undefined | Promise<AsyncIterable<Uint8Array> | undefined>` —
+  which does not compose with `StreamPortCodec.materialize`, whose parameter is the
+  iterable alone. Every consumer had to decide for itself whether a given backing needed
+  awaiting, and the tree had grown two narrowings of the one interface in opposite
+  directions: the concrete repositories overrode it with the synchronous half, while the
+  streaming contract helper declared its own Promise-only version.
+
+  The union also made the await in `streamRefViaBacking` load-bearing by convention
+  rather than by type. That await is what turns an asynchronous backing's dangling ref
+  into `undefined` — a cache miss — instead of a truthy Promise a caller reads as a live
+  stream, and nothing in the signature required it.
+
+  Migration for an implementor: mark the method `async`. A backing that can answer
+  synchronously still does; the cost is one microtask per ref, not per chunk. Callers
+  that were relying on the synchronous return must `await` it — including in assertions,
+  where `expect(repo.getOutputStreamByRef(ref)).toBeDefined()` previously passed for a
+  dangling ref, because a Promise is always defined.
+
 ## 0.3.44
 
 ### Bug Fixes

--- a/packages/task-graph/src/cache/__tests__/FsFolderStreamPort.test.ts
+++ b/packages/task-graph/src/cache/__tests__/FsFolderStreamPort.test.ts
@@ -54,7 +54,7 @@ describe("FsFolderTaskOutputRepository.saveOutputStreamPort", () => {
     expect(ref.mode).toBe("append");
     expect(ref.size).toBeGreaterThan(0);
 
-    const back = repo.getOutputStreamByRef(ref);
+    const back = await repo.getOutputStreamByRef(ref);
     expect(back).toBeDefined();
     expect(await codec.materialize(back!, "text")).toBe("Bonjour monde");
   });
@@ -75,7 +75,7 @@ describe("FsFolderTaskOutputRepository.saveOutputStreamPort", () => {
       {}
     );
     expect(ref.mode).toBe("object");
-    const back = repo.getOutputStreamByRef(ref);
+    const back = await repo.getOutputStreamByRef(ref);
     expect(await codec.materialize(back!, "items")).toEqual([
       { id: 1, v: "b" },
       { id: 2, v: "c" },
@@ -124,7 +124,7 @@ describe("FsFolderTaskOutputRepository.saveOutputStreamPort", () => {
       {}
     );
     expect(a.$ref).not.toBe(b.$ref);
-    expect(await text.materialize(repo.getOutputStreamByRef(a)!, "text")).toBe("x");
+    expect(await text.materialize((await repo.getOutputStreamByRef(a))!, "text")).toBe("x");
     const blob = await repo.getOutputByRef(b);
     expect(Array.from(new Uint8Array(await blob!.arrayBuffer()))).toEqual([1]);
   });

--- a/packages/task-graph/src/cache/resolveRef.ts
+++ b/packages/task-graph/src/cache/resolveRef.ts
@@ -23,7 +23,7 @@ export type CacheRefResolver = (ref: CacheRef) => Promise<Blob | undefined>;
  */
 export type CacheRefStreamResolver = (
   ref: CacheRef
-) => AsyncIterable<Uint8Array> | undefined | Promise<AsyncIterable<Uint8Array> | undefined>;
+) => Promise<AsyncIterable<Uint8Array> | undefined>;
 
 /**
  * Object shape carrying the optional by-ref readers a cache backing exposes
@@ -33,9 +33,7 @@ export type CacheRefStreamResolver = (
  */
 export interface RefStreamBacking {
   readonly getOutputByRef?: (ref: CacheRef) => Promise<Blob | undefined>;
-  readonly getOutputStreamByRef?: (
-    ref: CacheRef
-  ) => AsyncIterable<Uint8Array> | undefined | Promise<AsyncIterable<Uint8Array> | undefined>;
+  readonly getOutputStreamByRef?: (ref: CacheRef) => Promise<AsyncIterable<Uint8Array> | undefined>;
 }
 
 /** Adapt a `Blob` to the `AsyncIterable<Uint8Array>` chunk shape. */
@@ -63,10 +61,6 @@ export async function streamRefViaBacking(
   backing: RefStreamBacking
 ): Promise<AsyncIterable<Uint8Array> | undefined> {
   if (typeof backing.getOutputStreamByRef === "function") {
-    // Await so an asynchronous backing (a DB store that cannot probe existence
-    // synchronously) resolves a dangling ref to `undefined` — a cache miss —
-    // rather than a truthy Promise the caller would mistake for a live stream.
-    // Synchronous backings return the iterable directly; awaiting it is a no-op.
     const stream = await backing.getOutputStreamByRef(ref);
     if (stream !== undefined) return stream;
   }

--- a/packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts
@@ -391,15 +391,17 @@ export class FsFolderTaskOutputRepository extends TaskOutputTabularRepository {
     return path === undefined ? undefined : this.readBlobAt(path);
   }
 
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const path = this.blobPath(ref);
     return path === undefined ? undefined : this.openBlobStreamAt(path);
   }
 
-  override getOutputStreamByRefForRun(
+  override async getOutputStreamByRefForRun(
     ref: CacheRef,
     runId: string
-  ): AsyncIterable<Uint8Array> | undefined {
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const path = this.blobPathInRunScope(ref, runId);
     return path === undefined ? undefined : this.openBlobStreamAt(path);
   }

--- a/packages/task-graph/src/storage/TaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/TaskOutputRepository.ts
@@ -146,20 +146,23 @@ export abstract class TaskOutputRepository {
    * an async iterable of bytes for the referenced entry, or `undefined` when
    * the entry is absent or this backing does not support streaming retrieval.
    *
-   * Synchronous backings (filesystem `openSync`, in-memory) return the iterable
-   * directly. Asynchronous backings (IndexedDB, SQL) that cannot probe
-   * existence synchronously MAY return a Promise; the runtime's read helper
-   * ({@link streamRefViaBacking}) awaits it, so a dangling ref still resolves to
-   * `undefined` (a cache miss) rather than a silently empty stream.
+   * Always a Promise, even for a backing that can answer synchronously
+   * (filesystem `openSync`, in-memory). Resolving the ref is one await per ref,
+   * not per chunk, so the cost is nil — and the uniform shape is what lets a
+   * caller hand the result straight to a consumer that takes an iterable
+   * (`StreamPortCodec.materialize`), rather than every call site deciding for
+   * itself whether this particular backing needs awaiting. It also keeps the
+   * absent-entry answer honest for asynchronous backings (IndexedDB, SQL) that
+   * cannot probe existence synchronously: a dangling ref resolves to
+   * `undefined` — a cache miss — where an un-awaited Promise would read as a
+   * live stream.
    *
    * Implementations MUST yield bounded-size chunks (e.g. filesystem read
    * chunks): cache-hit replay paces consumers per chunk, so yielding the
    * whole payload as one chunk defeats the memory bound this reader exists
    * to provide.
    */
-  getOutputStreamByRef?(
-    ref: CacheRef
-  ): AsyncIterable<Uint8Array> | undefined | Promise<AsyncIterable<Uint8Array> | undefined>;
+  getOutputStreamByRef?(ref: CacheRef): Promise<AsyncIterable<Uint8Array> | undefined>;
 
   /**
    * OPTIONAL cleanup hook for orphan blobs. Called by the runner when a
@@ -324,13 +327,12 @@ export abstract class TaskOutputRepository {
    * OPTIONAL run-scoped streaming reader counterpart of
    * {@link getOutputStreamByRef}. A `ref` that was NOT produced by a `*ForRun`
    * writer for the given `runId` MUST resolve to `undefined`; foreign refs
-   * never throw. Same synchronous / Promise-returning shape as the unscoped
-   * variant so async backings can probe existence before returning an iterable.
+   * never throw. Same Promise-returning shape as the unscoped variant.
    */
   getOutputStreamByRefForRun?(
     ref: CacheRef,
     runId: string
-  ): AsyncIterable<Uint8Array> | undefined | Promise<AsyncIterable<Uint8Array> | undefined>;
+  ): Promise<AsyncIterable<Uint8Array> | undefined>;
 
   /**
    * OPTIONAL run-scoped counterpart of {@link deleteOutputByRef}. A `ref` that

--- a/packages/task-graph/src/task-graph/__tests__/AsyncStreamReader.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/AsyncStreamReader.test.ts
@@ -5,10 +5,15 @@
  */
 
 /**
- * The streaming read helper `streamRefViaBacking` must support backings whose
- * `getOutputStreamByRef` is asynchronous (DB stores that cannot probe existence
- * synchronously), while leaving the synchronous FsFolder/in-memory path
- * byte-identical.
+ * The streaming read helper `streamRefViaBacking` reads through a backing's
+ * `getOutputStreamByRef`, which the interface declares as Promise-returning so
+ * a DB store that cannot probe existence synchronously resolves a dangling ref
+ * to `undefined` rather than to a truthy Promise.
+ *
+ * The type says Promise; the runtime must not depend on it. A JavaScript
+ * implementation — or one compiled before the signature collapsed — can still
+ * hand back a bare iterable, and the helper's `await` is a no-op on a
+ * non-thenable, so those backings keep working. The last case pins that.
  */
 
 import type { CacheRef } from "@workglow/task-graph";
@@ -57,15 +62,24 @@ describe("streamRefViaBacking with async getOutputStreamByRef", () => {
     expect(await streamRefViaBacking(makeCacheRef({ $ref: "x://c" }), backing)).toBeUndefined();
   });
 
-  it("leaves the synchronous reader path byte-identical (no Promise leak)", async () => {
-    // A sync backing returns a live AsyncIterable directly, never a Promise.
-    const backing = {
-      getOutputStreamByRef: (_ref: CacheRef): AsyncIterable<Uint8Array> | undefined =>
-        gen(new Uint8Array([7])),
-    };
-    const raw = backing.getOutputStreamByRef(makeCacheRef({ $ref: "x://d" }));
-    expect(typeof (raw as unknown as Promise<unknown>)?.then).not.toBe("function");
-    const stream = await streamRefViaBacking(makeCacheRef({ $ref: "x://d" }), backing);
+  it("still reads a backing that returns a bare iterable instead of a Promise", async () => {
+    // The interface requires a Promise, so this shape is only reachable from
+    // JavaScript or from an implementation compiled against the older
+    // signature — hence the cast, which is the point of the test rather than a
+    // convenience. `await` on a non-thenable is a no-op, so such a backing must
+    // keep working; the cast is what lets the test prove it.
+    const syncBacking = {
+      getOutputStreamByRef: (_ref: CacheRef): AsyncIterable<Uint8Array> => gen(new Uint8Array([7])),
+    } as unknown as Parameters<typeof streamRefViaBacking>[1];
+
+    const raw = (
+      syncBacking as unknown as { getOutputStreamByRef: (r: CacheRef) => unknown }
+    ).getOutputStreamByRef(makeCacheRef({ $ref: "x://d" }));
+    // The premise: this backing really is synchronous, so the assertion below
+    // is measuring the no-op await rather than an ordinary Promise round-trip.
+    expect(typeof (raw as { then?: unknown })?.then).not.toBe("function");
+
+    const stream = await streamRefViaBacking(makeCacheRef({ $ref: "x://d" }), syncBacking);
     expect(await collect(stream!)).toEqual([7]);
   });
 });

--- a/packages/task-graph/src/task-graph/__tests__/CacheHitPartialRefMiss.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/CacheHitPartialRefMiss.test.ts
@@ -83,7 +83,9 @@ class PerPortMemoryRepo extends TaskOutputRepository {
     const bytes = this.blobs.get(ref.$ref);
     return bytes === undefined ? undefined : new Blob([bytes as unknown as BlobPart]);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const bytes = this.blobs.get(ref.$ref);
     if (bytes === undefined) return undefined;
     return (async function* () {

--- a/packages/task-graph/src/task-graph/__tests__/CacheHitReplayParity.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/CacheHitReplayParity.test.ts
@@ -80,7 +80,9 @@ class StreamPortMemoryRepo extends TaskOutputRepository {
     const bytes = this.blobs.get(ref.$ref);
     return bytes === undefined ? undefined : new Blob([bytes as unknown as BlobPart]);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const bytes = this.blobs.get(ref.$ref);
     if (bytes === undefined) return undefined;
     // Yield in two slices to exercise multi-chunk decode on replay.

--- a/packages/task-graph/src/task-graph/__tests__/CacheStreamReplayFailure.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/CacheStreamReplayFailure.test.ts
@@ -57,7 +57,9 @@ class RiggedReplayRepo extends TaskOutputRepository {
   corruptRows(row: TaskOutput): void {
     for (const key of this.rows.keys()) this.rows.set(key, row);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const factory = this.refStreams.get(ref.$ref);
     if (!factory) return undefined;
     return factory();

--- a/packages/task-graph/src/task-graph/__tests__/NoAccumulationCacheableConsumer.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/NoAccumulationCacheableConsumer.test.ts
@@ -89,7 +89,9 @@ class StreamPortMemoryRepo extends TaskOutputRepository {
     const bytes = this.blobs.get(ref.$ref);
     return bytes === undefined ? undefined : new Blob([bytes as unknown as BlobPart]);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const bytes = this.blobs.get(ref.$ref);
     if (bytes === undefined) return undefined;
     return (async function* () {

--- a/packages/task-graph/src/task-graph/__tests__/NoAccumulationPassthrough.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/NoAccumulationPassthrough.test.ts
@@ -91,7 +91,9 @@ class StreamPortMemoryRepo extends TaskOutputRepository {
     const bytes = this.blobs.get(ref.$ref);
     return bytes === undefined ? undefined : new Blob([bytes as unknown as BlobPart]);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const bytes = this.blobs.get(ref.$ref);
     if (bytes === undefined) return undefined;
     return (async function* () {

--- a/packages/task-graph/src/task-graph/__tests__/PassthroughWatchdogIdle.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/PassthroughWatchdogIdle.test.ts
@@ -83,7 +83,9 @@ class StreamPortMemoryRepo extends TaskOutputRepository {
     const bytes = this.blobs.get(ref.$ref);
     return bytes === undefined ? undefined : new Blob([bytes as unknown as BlobPart]);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const bytes = this.blobs.get(ref.$ref);
     if (bytes === undefined) return undefined;
     return (async function* () {

--- a/packages/task-graph/src/task-graph/__tests__/StreamBackpressureEngaged.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/StreamBackpressureEngaged.test.ts
@@ -96,7 +96,9 @@ class StreamPortMemoryRepo extends TaskOutputRepository {
     const bytes = this.blobs.get(ref.$ref);
     return bytes === undefined ? undefined : new Blob([bytes as Uint8Array<ArrayBuffer>]);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const bytes = this.blobs.get(ref.$ref);
     if (bytes === undefined) return undefined;
     return (async function* () {

--- a/packages/task-graph/src/task-graph/__tests__/StreamMixedModeFanout.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/StreamMixedModeFanout.test.ts
@@ -98,7 +98,9 @@ class StreamPortMemoryRepo extends TaskOutputRepository {
     const bytes = this.blobs.get(ref.$ref);
     return bytes === undefined ? undefined : new Blob([bytes as Uint8Array<ArrayBuffer>]);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const bytes = this.blobs.get(ref.$ref);
     if (bytes === undefined) return undefined;
     return (async function* () {

--- a/packages/task-graph/src/task-graph/__tests__/StreamPumpPassthroughLiveness.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/StreamPumpPassthroughLiveness.test.ts
@@ -85,7 +85,9 @@ class StreamPortMemoryRepo extends TaskOutputRepository {
     const bytes = this.blobs.get(ref.$ref);
     return bytes === undefined ? undefined : new Blob([bytes as unknown as BlobPart]);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const bytes = this.blobs.get(ref.$ref);
     if (bytes === undefined) return undefined;
     return (async function* () {

--- a/packages/task-graph/src/task/ConditionalTask.ts
+++ b/packages/task-graph/src/task/ConditionalTask.ts
@@ -113,7 +113,12 @@ export class ConditionalTask<
     return false;
   }
 
-  public override getCachePolicy(): CachePolicy {
+  // Keeps the base signature's parameter even though the answer ignores it: an
+  // override declaring zero parameters still satisfies `ITask` structurally,
+  // but it narrows the arity seen through the CONCRETE type, so a caller
+  // holding a `ConditionalTask` (rather than an `ITask`) could no longer pass
+  // the inputs `TaskRunner` passes through the interface.
+  public override getCachePolicy(_inputs: Input): CachePolicy {
     return { kind: "none" };
   }
 

--- a/packages/task-graph/src/testing/StreamingMemoryRepo.ts
+++ b/packages/task-graph/src/testing/StreamingMemoryRepo.ts
@@ -64,7 +64,9 @@ export class StreamingMemoryRepo extends TaskOutputRepository {
     const bytes = this.streamed.get(key);
     return bytes === undefined ? undefined : new Blob([bytes as unknown as BlobPart]);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     const key = ref.$ref.replace(/^inmem:\/\//, "");
     const bytes = this.streamed.get(key);
     if (bytes === undefined) return undefined;

--- a/packages/test/src/test/task-graph-cache/RunPrivateClearRunCost.test.ts
+++ b/packages/test/src/test/task-graph-cache/RunPrivateClearRunCost.test.ts
@@ -286,21 +286,21 @@ describe("run-private clearRun cost over an FsFolder backing", () => {
 
     // (c) This process's own pair is gone — row and blob both.
     expect(await resumed.getOutput("T", { p: "after" })).toBeUndefined();
-    expect(resumed.getOutputStreamByRef!(ownRef)).toBeUndefined();
+    expect(await resumed.getOutputStreamByRef!(ownRef)).toBeUndefined();
 
     // (b) NO DANGLING BLOB. The pre-crash ROW survives (it was never named),
     // so its blob must survive with it. A prefix sweep of the run's blobs
     // deletes the blob while leaving the row readable, and the reference only
     // fails much later — when a consumer's `hydrateInputRefs` throws.
     expect(await resumed.getOutput("T", { p: "before" })).toBeDefined();
-    expect(resumed.getOutputStreamByRef!(preCrashRef)).toBeDefined();
+    expect(await resumed.getOutputStreamByRef!(preCrashRef)).toBeDefined();
 
     // (d) The leftover pair is reclaimed together by the age sweep, which is
     // the reclaim story the surviving ROW already relied on.
     await new Promise((resolve) => setTimeout(resolve, 5));
     await resumed.clearOlderThan(0);
     expect(await resumed.getOutput("T", { p: "before" })).toBeUndefined();
-    expect(resumed.getOutputStreamByRef!(preCrashRef)).toBeUndefined();
+    expect(await resumed.getOutputStreamByRef!(preCrashRef)).toBeUndefined();
   });
 
   it("a run that wrote nothing announces no prune", async () => {

--- a/packages/test/src/test/task-graph-cache/RunPrivateFsFolderStream.test.ts
+++ b/packages/test/src/test/task-graph-cache/RunPrivateFsFolderStream.test.ts
@@ -130,7 +130,7 @@ describe("run-private streaming over an FsFolder backing", () => {
     // Run A's row and blob are gone; the ref no longer resolves.
     expect(await repoA.getOutput("T", { p: 1 })).toBeUndefined();
     expect(await repoA.size()).toBe(0);
-    expect(repoA.getOutputStreamByRef!(refA)).toBeUndefined();
+    expect(await repoA.getOutputStreamByRef!(refA)).toBeUndefined();
 
     // Run B is untouched: its row still reads and its blob survives.
     expect(await repoB.getOutput("T", { p: 1 })).toEqual({ ok: "B" });
@@ -169,8 +169,8 @@ describe("run-private streaming over an FsFolder backing", () => {
     await repoA.clearRun();
 
     // Only the blob this wrapper minted is gone.
-    expect(repoA.getOutputStreamByRef!(ownRef)).toBeUndefined();
-    const survived = repoA.getOutputStreamByRef!(foreignRef);
+    expect(await repoA.getOutputStreamByRef!(ownRef)).toBeUndefined();
+    const survived = await repoA.getOutputStreamByRef!(foreignRef);
     expect(survived).toBeDefined();
     expect(await codec.materialize(survived!, "text")).toBe("pre-crash");
     expect(blobNames(folder)).toHaveLength(1);
@@ -178,7 +178,7 @@ describe("run-private streaming over an FsFolder backing", () => {
     // The age sweep is what reclaims it — same story as the surviving rows.
     await new Promise((resolve) => setTimeout(resolve, 5));
     await backing.deleteRunOlderThan("run-A", 0);
-    expect(repoA.getOutputStreamByRef!(foreignRef)).toBeUndefined();
+    expect(await repoA.getOutputStreamByRef!(foreignRef)).toBeUndefined();
     expect(blobNames(folder)).toHaveLength(0);
   });
 

--- a/packages/test/src/test/task-graph/CacheStreamOut.test.ts
+++ b/packages/test/src/test/task-graph/CacheStreamOut.test.ts
@@ -182,7 +182,7 @@ function runCacheStreamOutContractTests(name: string, setup: () => Promise<Contr
       const { repo } = await setup();
       const ref = makeCacheRef({ $ref: "fsfolder://blobs/never-written.bin" });
       expect(await repo.getOutputByRef!(ref)).toBeUndefined();
-      expect(repo.getOutputStreamByRef!(ref)).toBeUndefined();
+      expect(await repo.getOutputStreamByRef!(ref)).toBeUndefined();
     });
 
     it("clear() makes previously written refs dangle", async () => {
@@ -197,7 +197,7 @@ function runCacheStreamOutContractTests(name: string, setup: () => Promise<Contr
       );
       await repo.clear();
       expect(await repo.getOutputByRef!(ref)).toBeUndefined();
-      expect(repo.getOutputStreamByRef!(ref)).toBeUndefined();
+      expect(await repo.getOutputStreamByRef!(ref)).toBeUndefined();
     });
 
     it("a sibling instance over the same backing resolves the ref (cross-process)", async () => {
@@ -258,7 +258,7 @@ describe("FsFolderTaskOutputRepository specifics", () => {
     const repo = new FsFolderTaskOutputRepository(folder);
     const evil = makeCacheRef({ $ref: "fsfolder://blobs/../../etc/passwd.bin" });
     expect(await repo.getOutputByRef!(evil)).toBeUndefined();
-    expect(repo.getOutputStreamByRef!(evil)).toBeUndefined();
+    expect(await repo.getOutputStreamByRef!(evil)).toBeUndefined();
   });
 
   it("clearOlderThan prunes blob files alongside rows", async () => {
@@ -274,7 +274,7 @@ describe("FsFolderTaskOutputRepository specifics", () => {
     );
     // Negative age puts the cutoff in the future: everything is "older".
     await repo.clearOlderThan(-60_000);
-    expect(repo.getOutputStreamByRef!(ref)).toBeUndefined();
+    expect(await repo.getOutputStreamByRef!(ref)).toBeUndefined();
   });
 
   it("task types with colliding sanitized names get distinct blobs", async () => {

--- a/packages/test/src/test/task-graph/InputRefPortGating.test.ts
+++ b/packages/test/src/test/task-graph/InputRefPortGating.test.ts
@@ -27,7 +27,9 @@ class CountingRepo extends StreamingMemoryRepo {
     this.byRefReads++;
     return super.getOutputByRef(ref);
   }
-  override getOutputStreamByRef(ref: CacheRef): AsyncIterable<Uint8Array> | undefined {
+  override async getOutputStreamByRef(
+    ref: CacheRef
+  ): Promise<AsyncIterable<Uint8Array> | undefined> {
     this.byRefReads++;
     return super.getOutputStreamByRef(ref);
   }

--- a/packages/test/src/test/task-graph/TaskOutputRepositoryStream.test.ts
+++ b/packages/test/src/test/task-graph/TaskOutputRepositoryStream.test.ts
@@ -92,7 +92,7 @@ describe("TaskOutputRepository.saveOutputStreamPort", () => {
       gen(new Uint8Array([4, 5])),
       {}
     );
-    const stream = repo.getOutputStreamByRef(ref);
+    const stream = await repo.getOutputStreamByRef(ref);
     expect(stream).toBeDefined();
     const collected: number[] = [];
     for await (const chunk of stream!) {


### PR DESCRIPTION
## Summary

`TaskOutputRepository.getOutputStreamByRef` (and `getOutputStreamByRefForRun`) were declared as a tri-state union:

```ts
AsyncIterable<Uint8Array> | undefined | Promise<AsyncIterable<Uint8Array> | undefined>
```

`StreamPortCodec.materialize` takes `AsyncIterable<Uint8Array>`. The two do not compose, so every consumer had to decide for itself whether a given backing needed awaiting — and the tree had grown **two narrowings of the one interface, in opposite directions**: the concrete repositories (`FsFolderTaskOutputRepository`, `StreamingMemoryRepo`) overrode it with the synchronous half, while `streamingTaskOutputRepositoryContract.ts` declared its own Promise-only version.

Both are now `Promise<AsyncIterable<Uint8Array> | undefined>`.

## Why it mattered even though nothing was broken

Both production `materialize` call sites — `CacheCoordinator.ts` and `TaskRunner.ts` — funnel through `streamRefViaBacking()`, which awaits internally. That await was doing double duty: collapsing the union **and** turning an asynchronous backing's dangling ref into `undefined` (a cache miss) rather than a truthy Promise a caller reads as a live stream. Nothing in the signature required it. Now the type does.

A backing that can answer synchronously still does; the cost is one microtask **per ref**, not per chunk.

## The test churn is the interface's own evidence

Un-awaited call sites failed loudly once the union collapsed — `TypeError: bytes is not async iterable` from `streamCodec`, and `expected Promise{…} to be undefined` from nine assertions.

One did not fail, and is the point of the change:

```ts
expect(resumed.getOutputStreamByRef!(preCrashRef)).toBeDefined();
```

A Promise is always defined, so that assertion passed **vacuously** — it would have held for a dangling ref. It now awaits and tests what it claims to.

## Changes

- `TaskOutputRepository`: both declarations collapsed to Promise; JSDoc rewritten (the "synchronous backings return the iterable directly" paragraph is gone).
- `resolveRef.ts`: `CacheRefStreamResolver` and `RefStreamBacking.getOutputStreamByRef` follow; `streamRefViaBacking`'s explanatory comment about awaiting a maybe-sync value is no longer needed.
- `FsFolderTaskOutputRepository` and `StreamingMemoryRepo` overrides marked `async`. `TabularStreamingTaskOutputRepository` already was.
- Call sites awaited across `CacheStreamOut`, `InputRefPortGating`, `TaskOutputRepositoryStream`, `RunPrivateClearRunCost`, `RunPrivateFsFolderStream`, `FsFolderStreamPort`.

## Breaking change

An external implementor must mark the method `async`; a caller relying on the synchronous return must `await`. Changelog entry added under `## Unreleased` in `@workglow/task-graph` with the migration note.

## Verification

```
turbo run build-types                      → 41 successful, 41 total
bun scripts/test.ts graph task task-graph vitest
                                           → 223 files passed, 2515 passed | 24 skipped
eslint + prettier --check on changed files → clean
```

https://claude.ai/code/session_01RFf49R1YHc5s8JAAEhRHyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFf49R1YHc5s8JAAEhRHyj)_