### PR TITLE
fix(tasks): fail a queued "stream" fetch whose deltas never arrived

### DIFF
--- a/packages/job-queue/src/job/JobQueueClient.ts
+++ b/packages/job-queue/src/job/JobQueueClient.ts
@@ -901,6 +901,13 @@ export class JobQueueClient<Input, Output> {
     // not knowable at send time, so the alternative — withholding `onStream`
     // from every durable-storage queue — would refuse streaming for the
     // ordinary single-process deployment that works today.
+    //
+    // That gap is closed at drain time instead, where the answer is observable:
+    // a locally-claimed job always publishes a terminal `finish` marker, so a
+    // consumer whose delivery is mandatory (`FetchUrlTask`'s
+    // `consumeJobStream`, under `requireStreamDelivery`) fails a stream that
+    // settled successfully without ever producing one, rather than reporting an
+    // empty body as a successful read.
     if (this.server || this.hasStreamChannel()) {
       handle.onStream = (callback: JobStreamListener) => this.onJobStream(id, callback);
     }

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -1174,7 +1174,7 @@ export class FetchUrlTask<
         return;
       }
 
-      yield* this.consumeJobStream(handle);
+      yield* this.consumeJobStream(handle, input.response_type === "stream");
     } catch (err: any) {
       throw new JobTaskFailedError(err);
     } finally {
@@ -1230,8 +1230,26 @@ export class FetchUrlTask<
    * An `error` event is not decoration on any of this: it is the only in-band
    * report of a failure the completion signal may not carry, so it is queued
    * in order and raised as a throw when the consumer reaches it.
+   *
+   * **`requireStreamDelivery` closes the gap a handle's own capability cannot.**
+   * `onStream` is advertised whenever the client has an attached server, which
+   * on a durable queue is the *possibility* of delivery rather than a
+   * guarantee: the job may be claimed by a worker in another process, whose
+   * events never reach here. Which process claims a job is not knowable at
+   * `send` time, so the only honest advertise-time answer would be to withhold
+   * `onStream` from every durable queue — refusing streaming for the ordinary
+   * single-process deployment that works today. The discriminator is available
+   * here instead, and it is the terminal marker rather than a delta count: a
+   * locally-claimed job always emits it (`FetchUrlJob.executeStream` calls
+   * `emitStreamEnd` whenever the context carries `emitStreamEvent`, which
+   * `JobQueueWorker.executeJob` supplies unconditionally), even for a 304 or a
+   * zero-length body, while a remotely-claimed one produces nothing and this
+   * loop exits through its settlement fallback with `streamEnded` false.
    */
-  private async *consumeJobStream(handle: JobHandle<Output>): AsyncIterable<StreamEvent<Output>> {
+  private async *consumeJobStream(
+    handle: JobHandle<Output>,
+    requireStreamDelivery: boolean
+  ): AsyncIterable<StreamEvent<Output>> {
     const pending: Array<{ readonly event: StreamEventLike; readonly release: () => void }> = [];
     let wake: (() => void) | undefined;
     let closed = false;
@@ -1316,6 +1334,18 @@ export class FetchUrlTask<
       }
       await settlement;
       if (failed) throw toJobFailure(failure);
+      // Ordered after the failure check on purpose: a job that genuinely failed
+      // should report its own cause, which is the better diagnosis. This
+      // complaint is only for a job that SUCCEEDED while delivering nothing.
+      if (requireStreamDelivery && !streamEnded) {
+        throw new TaskFailedError(
+          `FetchUrlTask: the queue's stream events never reached this process — the job was ` +
+            `likely claimed by a worker in another process — so response_type "stream" would ` +
+            `report a successful fetch with an empty body. Use a materializing response_type ` +
+            `(text/json/blob/arraybuffer), which travels in the job's settled output, a carrier ` +
+            `implementing the stream channel, or run the worker in-process.`
+        );
+      }
       yield { type: "finish", data: output } as StreamEvent<Output>;
     } finally {
       closed = true;

--- a/packages/test/src/test/task/FetchTaskQueuedStream.test.ts
+++ b/packages/test/src/test/task/FetchTaskQueuedStream.test.ts
@@ -334,6 +334,41 @@ describe("queued fetch streams over the job channel", () => {
         await storage.deleteAll();
       }
     });
+
+    // A body of no bytes produces no delta and is still a complete delivery —
+    // the job emits its terminal marker either way. So the undelivered-stream
+    // check below must key on that marker and not on a delta count, which
+    // would condemn this run as having received nothing.
+    test(`does not mistake a zero-length body for an undelivered stream (${backend.name})`, async () => {
+      const queueName = `queued-stream-empty-body-${backend.name}`;
+      const { storage, server } = await registerQueue(queueName, backend.make(queueName));
+      responder = () =>
+        Promise.resolve(
+          new Response(new Uint8Array(0), {
+            status: 200,
+            headers: { "content-type": "application/octet-stream", "content-length": "0" },
+          })
+        );
+
+      try {
+        await server.start();
+        const task = new FetchUrlTask({ queue: queueName });
+        const seen: StreamEvent[] = [];
+        task.on("stream_chunk", (e: StreamEvent) => seen.push(e));
+
+        const out = (await task.run({
+          url: "https://example.com/empty.bin",
+          response_type: "stream",
+        })) as FetchUrlTaskOutput;
+
+        expect(out.metadata?.status).toBe(200);
+        expect(totalDeltaBytes(seen)).toBe(0);
+        expect(seen.at(-1)?.type).toBe("finish");
+      } finally {
+        await server.stop();
+        await storage.deleteAll();
+      }
+    });
   }
 
   // A cross-process carrier hands back a handle with no `onStream` at all — no
@@ -398,6 +433,63 @@ describe("queued fetch streams over the job channel", () => {
     // the empty-bodied finish this exists to prevent.
     expect(waitFor).not.toHaveBeenCalled();
     expect(seen.some((e) => e.type === "finish")).toBe(false);
+  });
+
+  // A handle that DOES advertise `onStream` is only the possibility of
+  // delivery. A durable queue's job may be claimed by a worker in another
+  // process, which publishes its deltas nowhere this client can see — and no
+  // advertise-time check can know that, because which process claims a job is
+  // not decided until long after `send`. So the drain has to catch it: a
+  // locally-claimed job always produces the terminal marker, so a stream that
+  // settles successfully without one delivered nothing.
+  test("fails loudly when a handle advertising onStream delivers nothing", async () => {
+    const queueName = "queued-stream-undelivered";
+    const stub = makeStubHandle();
+    registerStubQueue(queueName, stub.handle);
+
+    const task = new FetchUrlTask({ queue: queueName });
+    const seen: StreamEvent[] = [];
+    task.on("stream_chunk", (e: StreamEvent) => seen.push(e));
+
+    const failure = task
+      .run({ url: "https://example.com/f.bin", response_type: "stream" })
+      .catch((e: unknown) => e);
+
+    await stub.listening;
+    // Settles SUCCESSFULLY, carrying the metadata-only payload a "stream" job
+    // returns — and never invokes the listener. That is precisely the shape a
+    // remotely-claimed job has here.
+    stub.settle({ metadata: { status: 200 } } as FetchUrlTaskOutput);
+
+    const error = await failure;
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toMatch(/stream/i);
+    expect(String(error)).toMatch(/empty body/i);
+    expect(String(error)).toMatch(/never reached/i);
+    expect(seen.some((e) => e.type === "finish")).toBe(false);
+  });
+
+  // ...and the same undelivering handle is perfectly fine for a materializing
+  // response_type, whose bytes travel in the settled output rather than as
+  // deltas. The check must be inert there, or it would break the channel-less
+  // path that already works.
+  test("a materializing response_type still passes the settled output through", async () => {
+    const queueName = "queued-stream-undelivered-text";
+    const stub = makeStubHandle();
+    registerStubQueue(queueName, stub.handle);
+
+    const task = new FetchUrlTask({ queue: queueName });
+    const running = task
+      .run({ url: "https://example.com/f.txt", response_type: "text" })
+      .catch((e: unknown) => e);
+
+    await stub.listening;
+    stub.settle({ text: "hello", metadata: { status: 200 } } as FetchUrlTaskOutput);
+
+    const out = await running;
+    expect(out).not.toBeInstanceOf(Error);
+    expect((out as FetchUrlTaskOutput).text).toBe("hello");
+    expect((out as FetchUrlTaskOutput).metadata?.status).toBe(200);
   });
 
   // ---------------------------------------------------------------------------
@@ -762,7 +854,12 @@ describe("FetchUrlTask subclass dispatch", () => {
       .execute({ url: "https://example.com/keys/abc", response_type: "stream" }, executeContext())
       .catch((e: unknown) => e);
 
-    await stub.listening;
+    const listener = await stub.listening;
+    // The stream itself completed — the marker is what says so — and the job
+    // then settled carrying nothing. Without the marker the run fails as an
+    // undelivered stream instead, which is a different (and correct) complaint
+    // that has no resolved request to name.
+    void listener({ type: "finish", data: { metadata: { status: 200 } } });
     stub.settle(undefined as unknown as FetchUrlTaskOutput);
 
     const error = await failure;
@@ -995,6 +1092,10 @@ describe("queued fetch stream adapter", () => {
               port: "body",
               binaryDelta: new Uint8Array([9, 9]),
             });
+            // Behind it, so the loop still has to notice the late delta on its
+            // own: a marker delivered here can only END the loop, never
+            // resurrect an event the loop already walked past.
+            void listener?.({ type: "finish", data: { metadata: { status: 200 } } });
           }, 0);
         }
       }
@@ -1031,7 +1132,15 @@ describe("queued fetch stream adapter", () => {
         seen.push(event as StreamEvent);
         if (event.type !== "binary-delta") continue;
         const next = trailing.shift();
-        if (next === undefined) continue;
+        if (next === undefined) {
+          // The chain is spent, so close it the way a carrier does. Registered
+          // on a timer like every link before it, hence still strictly after
+          // the loop's termination check for the delta just yielded.
+          setTimeout(() => {
+            void listener?.({ type: "finish", data: { metadata: { status: 200 } } });
+          }, 0);
+          continue;
+        }
         setTimeout(() => {
           void listener?.({
             type: "binary-delta",
@@ -1142,7 +1251,10 @@ describe("queued fetch stream adapter", () => {
       .execute({ url: "https://example.com/a.bin", response_type: "stream" }, executeContext())
       .catch((e: unknown) => e);
 
-    await stub.listening;
+    const listener = await stub.listening;
+    // A complete delivery — marker and all — whose job then settled on
+    // nothing. The output is what is missing here, not the stream.
+    void listener({ type: "finish", data: { metadata: { status: 200 } } });
     stub.settle(undefined as unknown as FetchUrlTaskOutput);
 
     const error = await failure;
@@ -1201,6 +1313,9 @@ describe("queued fetch stream adapter", () => {
     for (const chunk of flood) {
       void listener({ type: "binary-delta", port: "body", binaryDelta: chunk });
     }
+    // Delivered while the whole flood is still queued, so it also pins that the
+    // marker ends the loop only after everything ahead of it has been drained.
+    void listener({ type: "finish", data: { metadata: { status: 200 } } });
     stub.settle({ metadata: { status: 200 } } as FetchUrlTaskOutput);
 
     await run;


### PR DESCRIPTION
## The bug

`JobQueueClient.createJobHandle` sets `onStream` whenever the client has an attached server — and `resolveOrCreateQueue` always starts one, so **every** queue advertises the capability, including a SQLite/Postgres queue whose job may be claimed by a worker in **another process**.

`FetchUrlTask` refused `response_type: "stream"` only when `typeof handle.onStream !== "function"`. So for a remotely-claimed job the guard passed, `consumeJobStream` drained zero deltas, and it yielded `{ type: "finish", data: output }` where `output` is `{ metadata }` alone — the run reported **SUCCESS with no `body`**. That is the exact outcome the existing refusal's own comment calls "the one failure this path must not produce", and no status code or length check exposes it.

## Why the fix is at drain time, not advertise time

Which process claims a job is not knowable at `send()` time. Making the capability honest could only mean withholding `onStream` from *every* durable queue — which would refuse streaming for the ordinary single-process SQLite deployment that works today and is covered per-backend by `FetchTaskQueuedStream.test.ts`.

## The discriminator is `streamEnded`, not a delta count

`FetchUrlJob.executeStream` always calls `emitStreamEnd` when the context carries `emitStreamEvent`, and `JobQueueWorker.executeJob` supplies it unconditionally. So a locally-claimed job **always** produces the terminal marker — even for a 304 or a zero-length body — while a remotely-claimed one produces nothing and `consumeJobStream` exits via its settlement fallback with `streamEnded === false`.

Keying on the marker is therefore precise and free of the zero-byte/304 false positives a delta count would have. That is not a hypothetical: implementing the naive delta-count version locally fails the new zero-length-body test on **both** queue backends.

## Changes

- `consumeJobStream` gains `requireStreamDelivery: boolean`. Inside the `try`, after `await settlement` and after the `if (failed) throw toJobFailure(failure)` check, but before the `finish` yield, a successful run that never saw the marker throws `TaskFailedError`. Ordering after the failure check is deliberate — a job that genuinely failed should report its own cause, which is the better diagnosis; the delivery complaint is only for a job that **succeeded** while delivering nothing.
- The message names the cause and the fix, mirroring the existing channel-less refusal a few lines above.
- Call site passes `input.response_type === "stream"`.
- `createJobHandle`'s doc comment in `JobQueueClient.ts` now points at this drain-time check as the thing that closes the gap the paragraph previously only documented. **No code change in job-queue.**

## Caveat

The failure is **post-hoc** — the job has already run, so a non-idempotent fetch has already happened. That is strictly better than the current outcome (success reported over an empty body). The check is inert for every other `response_type` and for any run whose stream did arrive.

## Tests

New, in `packages/test/src/test/task/FetchTaskQueuedStream.test.ts`:

- **`fails loudly when a handle advertising onStream delivers nothing`** — a stub handle that exposes `onStream`, settles `{ metadata: { status: 200 } }`, and never invokes the listener. Confirmed failing before the fix, resolving with `{ metadata: { status: 200 } }` and no body.
- **`a materializing response_type still passes the settled output through`** — the same undelivering handle with `response_type: "text"` resolves with the text intact, guarding against the check firing on the legitimate channel-less path.
- **`does not mistake a zero-length body for an undelivered stream`** — a real queue, 200 with a zero-byte body and `content-length: 0`, run for **both** backends in the existing table. This is the false positive a delta-count implementation produces, and it was verified to be a real guard by temporarily implementing that version.

Five existing stub-carrier tests were adapted rather than weakened. They modelled carriers that deliver deltas but never a terminal marker — a shape the real `FetchUrlJob` never produces — and each now delivers the marker in a position that preserves exactly what it pins (the late-event window, the post-settlement drain chain, the flood ordering, the `finish payload` diagnosis). The settlement fallback itself is still exercised by the falsy-rejection and channel-less-text tests. The existing delivered-stream tests are untouched and passing.

## Verification

- `bun scripts/test.ts task vitest` — **66 files, 1033 passed | 24 skipped**.
- `bunx turbo run build-types` — 41/41 packages, clean (a real typecheck of both changed sources and the test file).
- `bun run format` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgxtp7mQECdh7F2UT9CVwN)_