### PR TITLE
fix(tasks): stop replaying method and body across SafeFetch redirects, and stop leaking undici Agents on denial paths

### DIFF
--- a/packages/tasks/src/task/FetchUrlJobError.ts
+++ b/packages/tasks/src/task/FetchUrlJobError.ts
@@ -41,6 +41,15 @@ export const FetchUrlErrorCode = {
    * before the first byte reached anyone and stays retryable.
    */
   BODY_TRUNCATED: "FETCH_BODY_TRUNCATED",
+  /**
+   * A 307/308 redirect crossed to a different origin while the request carried
+   * a body. 307/308 preserve method and body by definition, so there is no
+   * downgrade that both withholds the body and still performs the write the
+   * caller asked for. Deliberately absent from
+   * {@link FETCH_URL_RETRYABLE_ERROR_CODES}: a retry re-issues the same hop and
+   * meets the same refusal.
+   */
+  REDIRECT_BODY_NOT_REPLAYED: "FETCH_REDIRECT_BODY_NOT_REPLAYED",
 } as const;
 
 export type FetchUrlErrorCodeValue = (typeof FetchUrlErrorCode)[keyof typeof FetchUrlErrorCode];

--- a/packages/tasks/src/util/SafeFetch.server.ts
+++ b/packages/tasks/src/util/SafeFetch.server.ts
@@ -28,6 +28,7 @@ import {
 } from "../task/FetchUrlJobError";
 import {
   applyCrossOriginHeaderStrip,
+  applyRedirectMethodAndBody,
   registerSafeFetch,
   type SafeFetchFn,
   type SafeFetchOptions,
@@ -48,6 +49,21 @@ function closeAgent(dispatcher: Agent): void {
 
 async function closeAgentAsync(dispatcher: Agent): Promise<void> {
   await dispatcher.close?.().catch(() => {});
+}
+
+/**
+ * Cancel a response body nobody is going to read.
+ *
+ * Not merely tidy: `Agent.close()` waits for pending requests to complete, and
+ * an un-cancelled redirect body IS one — so cancelling first is what lets the
+ * close actually finish instead of hanging with the socket held open.
+ *
+ * Fire-and-forget with a swallowed rejection: cancelling an already-errored
+ * source rejects, and an unhandled rejection exits the process under Node's
+ * default `--unhandled-rejections=throw`.
+ */
+function discardResponseBody(response: Response): void {
+  void response.body?.cancel().catch(() => {});
 }
 
 interface ResolvedAddress {
@@ -208,78 +224,101 @@ export const serverSafeFetch: SafeFetchFn = async (url, options) => {
   let fetchInit: HopInit = initialFetchInit;
   let prevDispatcher: Agent | undefined;
 
-  for (let hops = 0; hops <= MAX_REDIRECT_HOPS; hops += 1) {
-    const { response, dispatcher } = await fetchOneHop(currentUrl, opts, fetchInit);
+  // Every exit from the loop — a hop that throws (scope/private deny, DNS
+  // failure, socket error), a refused redirect, and the terminal
+  // TOO_MANY_REDIRECTS below — must still close the dispatcher of the hop that
+  // got us here. Those are exactly the redirect-denial paths this file exists
+  // to exercise, so leaking an Agent on them leaks on every denial.
+  try {
+    for (let hops = 0; hops <= MAX_REDIRECT_HOPS; hops += 1) {
+      const { response, dispatcher } = await fetchOneHop(currentUrl, opts, fetchInit);
 
-    // Close the previous hop's dispatcher now that we have the next response.
+      // Close the previous hop's dispatcher now that we have the next response,
+      // and forget it so the `finally` cannot close it a second time.
+      if (prevDispatcher !== undefined) {
+        closeAgent(prevDispatcher);
+        prevDispatcher = undefined;
+      }
+
+      if (!isRedirectStatus(response.status)) {
+        // Pipe through a passthrough TransformStream so the dispatcher is
+        // closed once the body is fully consumed or cancelled. The body belongs
+        // to the caller from here on, so nothing may cancel it on their behalf.
+        const body = response.body;
+        if (body !== null) {
+          const { readable, writable } = new TransformStream();
+          // `.catch` after `.finally` so the dispatcher closes on both paths.
+          // Cancelling the returned readable errors the writable, so `pipeTo`
+          // rejects with the cancel reason — `undefined` for a bare `cancel()` —
+          // and an unhandled rejection exits the process under Node's default
+          // `--unhandled-rejections=throw`. Nothing is lost by swallowing it:
+          // the consumer observes any real pipe error through the readable it
+          // holds.
+          void body
+            .pipeTo(writable)
+            .finally(() => {
+              closeAgent(dispatcher);
+            })
+            .catch(() => {});
+          return new Response(readable, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+          });
+        }
+        closeAgent(dispatcher);
+        return response;
+      }
+
+      if (requestedRedirectMode === "manual") {
+        // The caller receives this response and owns its body; leave it intact.
+        closeAgent(dispatcher);
+        return response;
+      }
+
+      if (requestedRedirectMode === "error") {
+        discardResponseBody(response);
+        closeAgent(dispatcher);
+        throw new TypeError(
+          `Fetch for ${currentUrl} failed because redirect mode was set to 'error'.`
+        );
+      }
+
+      const location = response.headers.get("location");
+      if (!location) {
+        discardResponseBody(response);
+        closeAgent(dispatcher);
+        throw createFetchUrlJobError(
+          FetchUrlErrorCode.REDIRECT_MISSING_LOCATION,
+          `Refusing to follow redirect from ${currentUrl}: missing Location header.`,
+          { url: currentUrl }
+        );
+      }
+
+      // Nobody reads a redirect's body; leaving it pending would block this
+      // dispatcher's close.
+      discardResponseBody(response);
+      prevDispatcher = dispatcher;
+      const nextUrl = new URL(location, currentUrl).toString();
+      // Keep these two adjacent: a credential can ride on a header or in the
+      // body, and the pair is what covers both.
+      fetchInit = applyRedirectMethodAndBody(fetchInit, response.status, currentUrl, nextUrl);
+      // Credential-bearing headers never survive an origin change; the strip is
+      // carried forward, so it is never undone by a later same-origin hop.
+      fetchInit = applyCrossOriginHeaderStrip(fetchInit, currentUrl, nextUrl, sensitiveHeaders);
+      currentUrl = nextUrl;
+    }
+
+    throw createFetchUrlJobError(
+      FetchUrlErrorCode.TOO_MANY_REDIRECTS,
+      `Refusing to fetch ${url}: too many redirects.`,
+      { url }
+    );
+  } finally {
     if (prevDispatcher !== undefined) {
       closeAgent(prevDispatcher);
     }
-
-    if (!isRedirectStatus(response.status)) {
-      // Pipe through a passthrough TransformStream so the dispatcher is
-      // closed once the body is fully consumed or cancelled.
-      const body = response.body;
-      if (body !== null) {
-        const { readable, writable } = new TransformStream();
-        // `.catch` after `.finally` so the dispatcher closes on both paths.
-        // Cancelling the returned readable errors the writable, so `pipeTo`
-        // rejects with the cancel reason — `undefined` for a bare `cancel()` —
-        // and an unhandled rejection exits the process under Node's default
-        // `--unhandled-rejections=throw`. Nothing is lost by swallowing it:
-        // the consumer observes any real pipe error through the readable it
-        // holds.
-        void body
-          .pipeTo(writable)
-          .finally(() => {
-            closeAgent(dispatcher);
-          })
-          .catch(() => {});
-        return new Response(readable, {
-          status: response.status,
-          statusText: response.statusText,
-          headers: response.headers,
-        });
-      }
-      closeAgent(dispatcher);
-      return response;
-    }
-
-    if (requestedRedirectMode === "manual") {
-      closeAgent(dispatcher);
-      return response;
-    }
-
-    if (requestedRedirectMode === "error") {
-      closeAgent(dispatcher);
-      throw new TypeError(
-        `Fetch for ${currentUrl} failed because redirect mode was set to 'error'.`
-      );
-    }
-
-    const location = response.headers.get("location");
-    if (!location) {
-      closeAgent(dispatcher);
-      throw createFetchUrlJobError(
-        FetchUrlErrorCode.REDIRECT_MISSING_LOCATION,
-        `Refusing to follow redirect from ${currentUrl}: missing Location header.`,
-        { url: currentUrl }
-      );
-    }
-
-    prevDispatcher = dispatcher;
-    const nextUrl = new URL(location, currentUrl).toString();
-    // Credential-bearing headers never survive an origin change; the strip is
-    // carried forward, so it is never undone by a later same-origin hop.
-    fetchInit = applyCrossOriginHeaderStrip(fetchInit, currentUrl, nextUrl, sensitiveHeaders);
-    currentUrl = nextUrl;
   }
-
-  throw createFetchUrlJobError(
-    FetchUrlErrorCode.TOO_MANY_REDIRECTS,
-    `Refusing to fetch ${url}: too many redirects.`,
-    { url }
-  );
 };
 
 registerSafeFetch(serverSafeFetch);

--- a/packages/tasks/src/util/SafeFetch.ts
+++ b/packages/tasks/src/util/SafeFetch.ts
@@ -77,20 +77,15 @@ function isCrossOrigin(fromUrl: string, toUrl: string): boolean {
 }
 
 /**
- * Returns a copy of `headers` with the credential-bearing entries removed,
- * preserving the caller's `HeadersInit` shape (`Headers`, entry pairs, or a
- * plain record). Never mutates its argument.
+ * Returns a copy of `headers` without the entries `drop` selects (by header
+ * name), preserving the caller's `HeadersInit` shape (`Headers`, entry pairs, or
+ * a plain record). Never mutates its argument.
  */
-export function stripSensitiveHeaders(
+function removeHeaders(
   headers: HeadersInit | undefined,
-  sensitiveHeaders: readonly string[] | undefined
+  drop: (name: string) => boolean
 ): HeadersInit | undefined {
   if (headers === undefined) return undefined;
-  const extra = new Set((sensitiveHeaders ?? []).map((name) => name.toLowerCase()));
-  const drop = (name: string): boolean => {
-    const lower = name.toLowerCase();
-    return CROSS_ORIGIN_STRIPPED_HEADERS.includes(lower) || extra.has(lower);
-  };
 
   if (typeof Headers !== "undefined" && headers instanceof Headers) {
     const next = new Headers();
@@ -107,6 +102,22 @@ export function stripSensitiveHeaders(
     if (!drop(key)) next[key] = value;
   }
   return next;
+}
+
+/**
+ * Returns a copy of `headers` with the credential-bearing entries removed,
+ * preserving the caller's `HeadersInit` shape (`Headers`, entry pairs, or a
+ * plain record). Never mutates its argument.
+ */
+export function stripSensitiveHeaders(
+  headers: HeadersInit | undefined,
+  sensitiveHeaders: readonly string[] | undefined
+): HeadersInit | undefined {
+  const extra = new Set((sensitiveHeaders ?? []).map((name) => name.toLowerCase()));
+  return removeHeaders(headers, (name) => {
+    const lower = name.toLowerCase();
+    return CROSS_ORIGIN_STRIPPED_HEADERS.includes(lower) || extra.has(lower);
+  });
 }
 
 /**
@@ -127,6 +138,75 @@ export function applyCrossOriginHeaderStrip<T extends { headers?: HeadersInit | 
 ): T {
   if (!isCrossOrigin(fromUrl, toUrl)) return init;
   return { ...init, headers: stripSensitiveHeaders(init.headers, sensitiveHeaders) };
+}
+
+/**
+ * Entity headers that describe a request body. Dropped alongside the body when
+ * a redirect downgrades a request to a bodiless GET.
+ *
+ * This is load-bearing rather than cosmetic: leaving `Content-Length: 47` on a
+ * request that now carries no body makes undici state a length no body
+ * satisfies.
+ */
+export const REDIRECT_BODY_HEADERS: readonly string[] = [
+  "content-encoding",
+  "content-language",
+  "content-length",
+  "content-location",
+  "content-type",
+];
+
+/**
+ * Applies the redirect's method/body rules to a request init, returning the init
+ * for the next hop.
+ *
+ * Without this, every hop replayed the original method and body verbatim, so a
+ * POST whose body carries a `client_secret` was re-POSTed to whatever origin the
+ * previous server's Location header named — the header strip protects headers
+ * only, and a body is not a header.
+ *
+ * - **303 (any method but HEAD), and 301/302 on POST** downgrade to a bodiless
+ *   `GET`. That is what the Fetch spec, browsers, `curl -L` and undici's own
+ *   follow mode all do, so matching it is compatibility rather than a policy of
+ *   ours.
+ * - **307/308 (and 301/302 on a non-POST)** preserve method and body by
+ *   definition. Crossing origins with a body then THROWS
+ *   {@link FetchUrlErrorCode.REDIRECT_BODY_NOT_REPLAYED} rather than silently
+ *   downgrading: a downgrade would suppress the leak but also silently not
+ *   perform the write the caller asked for, and then report success.
+ *
+ * Otherwise `init` is returned unchanged (identity), so a same-origin 307 keeps
+ * its method, body and `Content-Type`.
+ */
+export function applyRedirectMethodAndBody<T extends RequestInit>(
+  init: T,
+  status: number,
+  fromUrl: string,
+  toUrl: string
+): T {
+  const method = (init.method ?? "GET").toUpperCase();
+  const toBodilessGet = (): T => ({
+    ...init,
+    method: "GET",
+    body: undefined,
+    headers: removeHeaders(init.headers, (name) =>
+      REDIRECT_BODY_HEADERS.includes(name.toLowerCase())
+    ),
+  });
+
+  if (status === 303 && method !== "HEAD") return toBodilessGet();
+  if ((status === 301 || status === 302) && method === "POST") return toBodilessGet();
+
+  if (init.body !== undefined && init.body !== null && isCrossOrigin(fromUrl, toUrl)) {
+    throw createFetchUrlJobError(
+      FetchUrlErrorCode.REDIRECT_BODY_NOT_REPLAYED,
+      `Refusing to follow the ${status} redirect from ${fromUrl} to ${toUrl}: a ${status} ` +
+        `preserves the request method and body, and replaying the body cross-origin would ` +
+        `disclose it to an origin the caller did not choose.`,
+      { url: toUrl }
+    );
+  }
+  return init;
 }
 
 export type SafeFetchFn = (url: string, options: SafeFetchOptions) => Promise<Response>;
@@ -226,6 +306,9 @@ async function defaultSafeFetch(url: string, options: SafeFetchOptions): Promise
     }
 
     const nextUrl = new URL(location, currentUrl).toString();
+    // Keep these two adjacent: a credential can ride on a header or in the
+    // body, and the pair is what covers both.
+    fetchOptions = applyRedirectMethodAndBody(fetchOptions, response.status, currentUrl, nextUrl);
     // Credential-bearing headers never survive an origin change; the strip is
     // carried forward, so it is never undone by a later same-origin hop.
     fetchOptions = applyCrossOriginHeaderStrip(fetchOptions, currentUrl, nextUrl, sensitiveHeaders);

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -1172,6 +1172,10 @@ describe("FetchUrlTask", () => {
       { label: "DNS_FAILED", code: FetchUrlErrorCode.DNS_FAILED },
       { label: "REDIRECT_MISSING_LOCATION", code: FetchUrlErrorCode.REDIRECT_MISSING_LOCATION },
       { label: "TOO_MANY_REDIRECTS", code: FetchUrlErrorCode.TOO_MANY_REDIRECTS },
+      {
+        label: "REDIRECT_BODY_NOT_REPLAYED",
+        code: FetchUrlErrorCode.REDIRECT_BODY_NOT_REPLAYED,
+      },
       { label: "NO_RESPONSE_BODY", code: FetchUrlErrorCode.NO_RESPONSE_BODY },
       { label: "CONFIGURATION", code: FetchUrlErrorCode.CONFIGURATION },
     ];

--- a/packages/test/src/test/task/FetchUrlSsrf.test.ts
+++ b/packages/test/src/test/task/FetchUrlSsrf.test.ts
@@ -22,6 +22,7 @@ import {
 } from "@workglow/task-graph";
 import {
   classifyUrl,
+  FetchUrlErrorCode,
   FetchUrlTask,
   getSafeFetchImpl,
   registerSafeFetch,
@@ -484,6 +485,17 @@ describe("defaultSafeFetch cross-origin redirect header strip", () => {
     return out;
   };
 
+  /** The body the mock received on call `index` (0-based). */
+  const bodyOnCall = (index: number): unknown =>
+    (fetchMock.mock.calls[index]?.[1] as { body?: unknown } | undefined)?.body;
+
+  /** The method the mock received on call `index` (0-based). */
+  const methodOnCall = (index: number): string | undefined =>
+    (fetchMock.mock.calls[index]?.[1] as { method?: string } | undefined)?.method;
+
+  /** A body carrying a secret that must never reach a redirect target. */
+  const SECRET_BODY = JSON.stringify({ client_secret: "sk-body-secret-1234567890" });
+
   beforeEach(() => {
     prevSafeFetch = getSafeFetchImpl();
     resetSafeFetch();
@@ -615,6 +627,136 @@ describe("defaultSafeFetch cross-origin redirect header strip", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(fetchMock.mock.calls[2]?.[0]).toBe("https://api.vendor.example/final");
     expect(headersOnCall(2).authorization).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Method / body handling across a redirect. Stripping the credential HEADER
+  // does nothing for a credential in the request BODY: a POST carrying
+  // `client_secret` was re-POSTed verbatim to whatever origin the Location
+  // named.
+  // -------------------------------------------------------------------------
+
+  test("a 303 downgrades a POST to a bodiless GET and drops the body headers", async () => {
+    // RFC 9110: 303 means "fetch the result with GET". Leaving Content-Length
+    // on a request that now has no body makes the transport state a length no
+    // body satisfies.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://attacker.example/", 303))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      method: "POST",
+      body: SECRET_BODY,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(SECRET_BODY.length),
+        "X-Trace-Id": "trace-1",
+      },
+    });
+
+    expect(methodOnCall(1)).toBe("GET");
+    expect(bodyOnCall(1)).toBeUndefined();
+    expect(headersOnCall(1)["content-type"]).toBeUndefined();
+    expect(headersOnCall(1)["content-length"]).toBeUndefined();
+    // Targeted, not a blanket wipe.
+    expect(headersOnCall(1)["x-trace-id"]).toBe("trace-1");
+  });
+
+  test("a cross-origin 302 on a POST downgrades to a bodiless GET", async () => {
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://attacker.example/", 302))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      method: "POST",
+      body: SECRET_BODY,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(methodOnCall(1)).toBe("GET");
+    expect(bodyOnCall(1)).toBeUndefined();
+    expect(headersOnCall(1)["content-type"]).toBeUndefined();
+  });
+
+  test("a same-origin 302 on a POST downgrades to a bodiless GET too", async () => {
+    // The POST -> GET rewrite is not a cross-origin defense, it is what the
+    // Fetch spec, browsers, curl -L and undici's own follow mode all do.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://api.vendor.example/x/v2", 302))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      method: "POST",
+      body: SECRET_BODY,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(methodOnCall(1)).toBe("GET");
+    expect(bodyOnCall(1)).toBeUndefined();
+  });
+
+  test("a cross-origin 307 carrying a body is refused rather than replayed", async () => {
+    // 307/308 preserve method and body by definition, so there is no downgrade
+    // that still performs the caller's write. Refusing is the only answer that
+    // neither leaks the body nor reports a write that never happened.
+    fetchMock.mockResolvedValueOnce(redirect("https://attacker.example/", 307));
+
+    const error = await safeFetch("https://api.vendor.example/x", {
+      method: "POST",
+      body: SECRET_BODY,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(PermanentJobError);
+    expect((error as { code?: string }).code).toBe(FetchUrlErrorCode.REDIRECT_BODY_NOT_REPLAYED);
+    // The refusal happens before the second hop is issued at all.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a same-origin 307 still replays method and body", async () => {
+    // Anti-regression: refusing every 307 would break same-origin APIs that
+    // redirect a write within their own origin.
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://api.vendor.example/x/v2", 307))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x", {
+      method: "POST",
+      body: SECRET_BODY,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(methodOnCall(1)).toBe("POST");
+    expect(bodyOnCall(1)).toBe(SECRET_BODY);
+    expect(headersOnCall(1)["content-type"]).toBe("application/json");
+  });
+
+  for (const status of [301, 302, 303] as const) {
+    test(`a ${status} never replays the request body to the redirect target`, async () => {
+      fetchMock
+        .mockResolvedValueOnce(redirect("https://attacker.example/", status))
+        .mockResolvedValueOnce(ok());
+
+      await safeFetch("https://api.vendor.example/x", {
+        method: "POST",
+        body: SECRET_BODY,
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(String(bodyOnCall(1) ?? "")).not.toContain("client_secret");
+      expect(JSON.stringify(fetchMock.mock.calls[1])).not.toContain("client_secret");
+    });
+  }
+
+  test("a 303 on a GET stays a bodiless GET", async () => {
+    fetchMock
+      .mockResolvedValueOnce(redirect("https://api.vendor.example/x/v2", 303))
+      .mockResolvedValueOnce(ok());
+
+    await safeFetch("https://api.vendor.example/x");
+
+    expect(methodOnCall(1)).toBe("GET");
+    expect(bodyOnCall(1)).toBeUndefined();
   });
 });
 

--- a/packages/test/src/test/task/SafeFetchServerTransport.test.ts
+++ b/packages/test/src/test/task/SafeFetchServerTransport.test.ts
@@ -14,7 +14,8 @@
  * `--unhandled-rejections=throw` terminates the process.
  */
 
-import { FetchUrlTask, getSafeFetchImpl, safeFetch } from "@workglow/tasks";
+import { PermanentJobError } from "@workglow/job-queue";
+import { FetchUrlErrorCode, FetchUrlTask, getSafeFetchImpl, safeFetch } from "@workglow/tasks";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { gzipSync } from "node:zlib";
@@ -63,6 +64,75 @@ function trackedTimeout(fn: () => void, ms: number): void {
 async function drainRejections(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setImmediate(resolve));
+}
+
+/** Method and collected body of every request a test server received. */
+interface RecordedCall {
+  readonly method: string;
+  readonly body: string;
+}
+
+/**
+ * Records every inbound request and answers 200 with "landed". `seen` carries
+ * the headers; `calls` carries the method and the collected body, which is what
+ * a redirect must never replay to a target the caller did not choose.
+ */
+async function recordingServer(): Promise<{
+  target: TestServer;
+  seen: RequestLog;
+  calls: RecordedCall[];
+}> {
+  const seen: RequestLog = [];
+  const calls: RecordedCall[] = [];
+  const target = await withServer((req, res) => {
+    seen.push({ ...req.headers });
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      calls.push({ method: req.method ?? "", body: Buffer.concat(chunks).toString("utf8") });
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("landed");
+    });
+  });
+  return { target, seen, calls };
+}
+
+/** Answers every request with a redirect to `location`. */
+async function redirectingServer(location: string, status = 302): Promise<TestServer> {
+  return withServer((req, res) => {
+    // Drain the request body before answering, so node does not destroy the
+    // socket on an unconsumed POST and turn a redirect test into a reset.
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(status, { location });
+      res.end();
+    });
+  });
+}
+
+/**
+ * A redirect whose body can never complete: it states a Content-Length far
+ * larger than the bytes it sends and never ends. That makes the leak assertions
+ * deterministic — a merely large body is sometimes swallowed whole by socket
+ * buffers, which frees the connection for reasons that have nothing to do with
+ * dispatcher lifetime. Here only cancelling the body can free it.
+ *
+ * `location` may be omitted to produce a 302 with no Location header.
+ */
+async function stallingRedirectServer(location: string | undefined): Promise<TestServer> {
+  return withServer((req, res) => {
+    req.resume();
+    // The client destroys the socket when it cancels; the write that loses is
+    // not a test failure.
+    res.on("error", () => {});
+    const headers: Record<string, string> = {
+      "content-type": "text/plain",
+      "content-length": "50000000",
+    };
+    if (location !== undefined) headers.location = location;
+    res.writeHead(302, headers);
+    res.write("x".repeat(65_536));
+  });
 }
 
 async function waitForNoConnections(server: http.Server, timeoutMs: number): Promise<number> {
@@ -282,25 +352,6 @@ describe("SafeFetch server transport (real node:http, no mocks)", () => {
   // guard.
   // ---------------------------------------------------------------------------
   describe("cross-origin redirect header strip", () => {
-    /** Records every inbound request's headers and answers 200 with "landed". */
-    async function recordingServer(): Promise<{ target: TestServer; seen: RequestLog }> {
-      const seen: RequestLog = [];
-      const target = await withServer((req, res) => {
-        seen.push({ ...req.headers });
-        res.writeHead(200, { "content-type": "text/plain" });
-        res.end("landed");
-      });
-      return { target, seen };
-    }
-
-    /** Answers every request with a 302 to `location`. */
-    async function redirectingServer(location: string): Promise<TestServer> {
-      return withServer((_req, res) => {
-        res.writeHead(302, { location });
-        res.end();
-      });
-    }
-
     test("a cross-origin 302 drops Authorization before the second hop", async () => {
       // The finding itself: a vendor that answers 302 to an attacker origin
       // would otherwise receive the bearer token verbatim.
@@ -445,6 +496,171 @@ describe("SafeFetch server transport (real node:http, no mocks)", () => {
       const finalHop = seen.find((headers) => headers["x-path"] === "/final");
       expect(finalHop).toBeDefined();
       expect(finalHop!.authorization).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Redirect method / body handling, over the real transport.
+  //
+  // The server loop is an independent implementation of the browser one, so the
+  // decisive cases are mirrored here: only a real server can report the method
+  // and the bytes that actually arrived, and only a real transport shows whether
+  // a stated Content-Length still matches the request it rode in on.
+  // ---------------------------------------------------------------------------
+  describe("cross-origin redirect method and body", () => {
+    const SECRET_BODY = JSON.stringify({ client_secret: "sk-body-secret-1234567890" });
+
+    test("a cross-origin 303 arrives as a bodiless GET with no Content-Length", async () => {
+      const { target, seen, calls } = await recordingServer();
+      const hop = await redirectingServer(`${target.origin}/landed`, 303);
+
+      const response = await safeFetch(`${hop.origin}/start`, {
+        allowPrivate: true,
+        method: "POST",
+        body: SECRET_BODY,
+        headers: { "content-type": "application/json" },
+      });
+
+      expect(await response.text()).toBe("landed");
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.method).toBe("GET");
+      expect(calls[0]!.body).toBe("");
+      expect(seen[0]!["content-length"]).toBeUndefined();
+      expect(seen[0]!["content-type"]).toBeUndefined();
+    });
+
+    test("a cross-origin 302 on a POST arrives as a bodiless GET", async () => {
+      const { target, seen, calls } = await recordingServer();
+      const hop = await redirectingServer(`${target.origin}/landed`, 302);
+
+      const response = await safeFetch(`${hop.origin}/start`, {
+        allowPrivate: true,
+        method: "POST",
+        body: SECRET_BODY,
+        headers: { "content-type": "application/json" },
+      });
+
+      expect(await response.text()).toBe("landed");
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.method).toBe("GET");
+      expect(calls[0]!.body).toBe("");
+      expect(seen[0]!["content-length"]).toBeUndefined();
+    });
+
+    test("a cross-origin 307 carrying a body is refused and never reaches the target", async () => {
+      const { target, calls } = await recordingServer();
+      const hop = await redirectingServer(`${target.origin}/landed`, 307);
+
+      const error = await safeFetch(`${hop.origin}/start`, {
+        allowPrivate: true,
+        method: "POST",
+        body: SECRET_BODY,
+        headers: { "content-type": "application/json" },
+      }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(PermanentJobError);
+      expect((error as { code?: string }).code).toBe(FetchUrlErrorCode.REDIRECT_BODY_NOT_REPLAYED);
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dispatcher lifetime on the redirect paths.
+  //
+  // Each hop gets its own undici Agent, and an Agent that is never closed keeps
+  // its keep-alive socket open — so the server's own connection count is a real,
+  // unmocked assertion about dispatcher lifetime. The waits are generous on
+  // purpose: a fix that merely DELAYS the close must still fail.
+  // ---------------------------------------------------------------------------
+  describe("dispatcher lifetime across redirects", () => {
+    const CONNECTION_WAIT_MS = 2000;
+
+    test("a redirect to a denied target frees the previous hop's connection", async () => {
+      // The leak is on exactly the denial path the SSRF work exists to
+      // exercise: hop 2 throws before anything closes hop 1's Agent.
+      const denied = await withServer((_req, res) => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("should-never-be-reached");
+      });
+      const hop = await redirectingServer(`${denied.origin}/admin`);
+
+      const error = await safeFetch(`${hop.origin}/start`, {
+        allowPrivate: true,
+        privateResourceScopes: [`${hop.origin}/*`],
+      }).catch((e: unknown) => e);
+
+      expect((error as { code?: string }).code).toBe(FetchUrlErrorCode.SCOPE_DENIED);
+      expect(await waitForNoConnections(hop.server, CONNECTION_WAIT_MS)).toBe(0);
+
+      await drainRejections();
+      expect(unhandled).toEqual([]);
+    });
+
+    test("exhausting the redirect budget frees every connection", async () => {
+      // The terminal throw sits outside the loop, so the final hop's Agent was
+      // never closed at all.
+      const loop = await withServer((_req, res) => {
+        res.writeHead(302, { location: "/again" });
+        res.end();
+      });
+
+      const error = await safeFetch(`${loop.origin}/start`, { allowPrivate: true }).catch(
+        (e: unknown) => e
+      );
+
+      expect((error as { code?: string }).code).toBe(FetchUrlErrorCode.TOO_MANY_REDIRECTS);
+      expect(await waitForNoConnections(loop.server, CONNECTION_WAIT_MS)).toBe(0);
+
+      await drainRejections();
+      expect(unhandled).toEqual([]);
+    });
+
+    test("a followed redirect with a non-empty body drains it and frees the connection", async () => {
+      // Agent.close() waits for pending requests, and an un-cancelled redirect
+      // body IS one — so without the drain the close never completes.
+      const { target } = await recordingServer();
+      const hop = await stallingRedirectServer(`${target.origin}/landed`);
+
+      const response = await safeFetch(`${hop.origin}/start`, { allowPrivate: true });
+      expect(await response.text()).toBe("landed");
+
+      expect(await waitForNoConnections(hop.server, CONNECTION_WAIT_MS)).toBe(0);
+
+      await drainRejections();
+      expect(unhandled).toEqual([]);
+    });
+
+    test("a 302 with no Location frees the connection", async () => {
+      const hop = await stallingRedirectServer(undefined);
+
+      const error = await safeFetch(`${hop.origin}/start`, { allowPrivate: true }).catch(
+        (e: unknown) => e
+      );
+
+      expect((error as { code?: string }).code).toBe(FetchUrlErrorCode.REDIRECT_MISSING_LOCATION);
+      expect(await waitForNoConnections(hop.server, CONNECTION_WAIT_MS)).toBe(0);
+
+      await drainRejections();
+      expect(unhandled).toEqual([]);
+    });
+
+    test("redirect:'manual' still hands the caller a readable body", async () => {
+      // The caller owns that body, so nothing may cancel it on their behalf.
+      const hop = await withServer((_req, res) => {
+        res.writeHead(302, { location: "/elsewhere", "content-type": "text/plain" });
+        res.end("manual-body");
+      });
+
+      const response = await safeFetch(`${hop.origin}/start`, {
+        allowPrivate: true,
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(302);
+      expect(await response.text()).toBe("manual-body");
+
+      await drainRejections();
+      expect(unhandled).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## What was broken

**[HIGH] Cross-origin redirects replayed the request method and body.** Both redirect loops — `SafeFetch.server.ts` and the browser `SafeFetch.ts` — carried `method` and `body` forward on every hop. `applyCrossOriginHeaderStrip` rewrites *headers* only, so a POST whose body carries a `client_secret` was re-POSTed verbatim to whatever origin the previous server's `Location` header named: `Authorization` stripped, the body secret not. A compromised or attacker-influenced upstream chooses that target.

RFC 9110 additionally requires a 303 to become a bodiless GET, so a non-idempotent write was being submitted twice.

**[MEDIUM] `serverSafeFetch` leaked undici Agents and never drained redirect bodies.** `prevDispatcher` was closed only after the *next* hop returned. A hop that throws (`SCOPE_DENIED` / `PRIVATE_DENIED` / `DNS_FAILED` / socket error) and the terminal `TOO_MANY_REDIRECTS` therefore left it open — i.e. it leaked on exactly the redirect-denial paths the SSRF work exists to exercise. No redirect body was ever cancelled on any branch.

## Why it matters

A leaked Agent keeps its keep-alive socket open for the life of the process, on a path a hostile upstream can trigger at will. And the two defects compound: `Agent.close()` waits for pending requests, and an un-cancelled redirect body **is** one — so today's `closeAgent(prevDispatcher)` can itself hang. Cancelling the body first is what makes the close actually complete.

## What changed

`applyRedirectMethodAndBody(init, status, fromUrl, toUrl)` is exported from `SafeFetch.ts` beside `applyCrossOriginHeaderStrip`, and both loops call it immediately before the header strip — the two are kept adjacent so a future edit cannot separate them:

- **303 (any method but HEAD), and 301/302 on POST** → bodiless `GET`, dropping `REDIRECT_BODY_HEADERS` (`content-encoding`, `content-language`, `content-length`, `content-location`, `content-type`) with it. Dropping those is load-bearing, not cosmetic: leaving `Content-Length: 47` on a bodiless request makes undici state a length no body satisfies. The POST → GET rewrite matches the Fetch spec, browsers, `curl -L` and undici's own follow mode.
- **307/308 cross-origin with a body** → throws the new permanent `FETCH_REDIRECT_BODY_NOT_REPLAYED`, rather than silently downgrading. A downgrade would suppress the leak but also silently not perform the write the caller asked for, and then report success. The code is deliberately **absent** from `FETCH_URL_RETRYABLE_ERROR_CODES` — a retry re-issues the same hop and meets the same refusal.
- Everything else (307/308 same-origin, 301/302 on a non-POST) is returned unchanged by identity, so a same-origin 307 keeps its method, body and `Content-Type`.

Dispatcher / body lifecycle in `serverSafeFetch`:

- The whole loop **including** the terminal `TOO_MANY_REDIRECTS` throw is wrapped in `try { … } finally { if (prevDispatcher !== undefined) closeAgent(prevDispatcher); }`.
- `prevDispatcher` is set back to `undefined` when closed inside the loop, so the `finally` cannot double-close and the success return (which hands the dispatcher's lifetime to the passthrough pipe) leaves nothing to touch.
- New `discardResponseBody()` cancels the body on the `redirect:"error"` throw, the missing-`Location` throw, and the follow branch. **Not** on the `manual` branch (the caller owns that body) and **not** on the terminal non-redirect return (the passthrough owns it).

## How it was verified

Tests were written first and each confirmed failing for the stated reason before any implementation landed.

- `FetchUrlSsrf.test.ts` — 9 new cases over the real `defaultSafeFetch` loop with `globalThis.fetch` mocked: 303 downgrade with the body headers dropped, 302-on-POST cross- and same-origin, 307 cross-origin refused (`PermanentJobError`, correct code, `fetchMock` called exactly **once**), 307 same-origin still replaying method and body, `client_secret` never present in call 1 for each of 301/302/303, and 303-on-GET. 8 failed before the fix; the 307 same-origin case is an anti-regression guard that passes on both sides.
- `SafeFetchServerTransport.test.ts` — the server loop is an independent implementation, so the decisive cases are mirrored over real `node:http`: cross-origin 303 and 302-on-POST arriving as bodiless GETs with no `Content-Length`, and cross-origin 307 rejecting with the recording server seeing **zero** requests. Plus four Agent-lifetime cases asserting on the server's own connection count (a genuinely unmocked signal) with a generous 2000 ms wait, so a fix that merely *delays* the close still fails: a redirect to a denied target, an exhausted redirect budget, a followed redirect with a non-empty body, and a 302 with no `Location`. A fifth proves `redirect:"manual"` still hands the caller a readable body.
  - The two body-drain cases initially passed vacuously with a 2 MB body — socket buffers sometimes swallow it whole, freeing the connection for reasons unrelated to dispatcher lifetime. They now use a body that can never complete (stated `Content-Length` far larger than the bytes sent), which failed deterministically across 3 consecutive pre-fix runs.
- `FetchTask.test.ts` — `REDIRECT_BODY_NOT_REPLAYED` added to the `permanentCases` table, proving it passes through the task layer as permanent rather than being rewrapped as a retryable `NETWORK_ERROR`.

Actual output:

```
$ bun scripts/test.ts task vitest
Running all tests in sections [task] — 66 file(s)
 Test Files  66 passed (66)
      Tests  1047 passed | 24 skipped (1071)

$ bun run format
Checking formatting...
All matched files use Prettier code style!

$ npx tsc -p tsconfig.typecheck.json --noEmit
(no output)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgxtp7mQECdh7F2UT9CVwN)_