### PR TITLE
Treat a listening session's state as one unit across shutdown

### DIFF
--- a/packages/test/src/test/trigger/IntervalTrigger.test.ts
+++ b/packages/test/src/test/trigger/IntervalTrigger.test.ts
@@ -1108,13 +1108,20 @@ describe("IntervalTrigger", () => {
       expect(vi.getTimerCount()).toBe(0);
     });
 
-    test("rejects a non-positive stop deadline", () => {
+    test("rejects a non-positive stop deadline", async () => {
+      // The constructor throws synchronously — there is no promise to carry the
+      // failure. `stop()` REJECTS instead, so a caller stopping a set of
+      // triggers is not taken down before its siblings are even asked.
       expect(() => new IntervalTrigger({ intervalMs: PERIOD, stopTimeoutMs: 0 })).toThrow(
         TriggerConfigurationError
       );
       const trigger = new IntervalTrigger({ intervalMs: PERIOD });
-      expect(() => trigger.stop({ timeoutMs: -1 })).toThrow(TriggerConfigurationError);
-      expect(() => trigger.stop({ timeoutMs: 1.5 })).toThrow(TriggerConfigurationError);
+      await expect(trigger.stop({ timeoutMs: -1 })).rejects.toBeInstanceOf(
+        TriggerConfigurationError
+      );
+      await expect(trigger.stop({ timeoutMs: 1.5 })).rejects.toBeInstanceOf(
+        TriggerConfigurationError
+      );
     });
   });
 });

--- a/packages/test/src/test/trigger/WorkflowTriggers.test.ts
+++ b/packages/test/src/test/trigger/WorkflowTriggers.test.ts
@@ -12,6 +12,7 @@ import type {
   TriggerEventListener,
   TriggerEventListeners,
   TriggerEvents,
+  TriggerHandler,
 } from "@workglow/triggers";
 import {
   CronTrigger,
@@ -135,14 +136,46 @@ class WedgedTrigger implements ITrigger {
   public readonly kind = "wedged";
   public readonly events = new EventEmitter<TriggerEventListeners>();
   public running = false;
+  /**
+   * Handed to every fire and NEVER aborted: a wedged stop abandons its
+   * handlers, it does not cancel them. That is what makes a run started by this
+   * trigger outlive the session that scheduled it.
+   */
+  private readonly controller = new AbortController();
+  private handler: TriggerHandler | undefined;
 
   constructor(public readonly id: string) {}
 
-  public start(): void {
+  public start(handler: TriggerHandler): void {
+    this.handler = handler;
     this.running = true;
   }
 
+  /**
+   * Delivers one fire on demand, so a test can wedge a workflow RUN rather than
+   * only a `stop()`. Rejections are reported on `error` exactly as a real
+   * trigger's loop reports them.
+   */
+  public fire(scheduledAt: number): void {
+    const handler = this.handler;
+    if (!handler) return;
+    void Promise.resolve(
+      handler({
+        triggerId: this.id,
+        scheduledAt,
+        signal: this.controller.signal,
+        payload: undefined,
+      })
+    ).catch((error: unknown) => {
+      this.events.emit("error", error instanceof Error ? error : new Error(String(error)));
+    });
+  }
+
   public stop(): Promise<void> {
+    // The schedule really is cancelled — it is the DRAIN that never completes.
+    // Reporting `running` forever instead would make every later listen() fail
+    // the already-running check and hide what these tests are about.
+    this.running = false;
     return new Promise<void>(() => {});
   }
 
@@ -199,12 +232,13 @@ interface WarnRecord {
 }
 
 /**
- * Installs a logger that records `warn` calls; returns the sink and a restore fn.
- * Built from scratch rather than spread from the installed logger, whose methods
- * live on a class prototype and would be lost.
+ * Installs a logger that records `warn` and `error` calls; returns both sinks
+ * and a restore fn. Built from scratch rather than spread from the installed
+ * logger, whose methods live on a class prototype and would be lost.
  */
-function captureWarnings(): { warnings: WarnRecord[]; restore: () => void } {
+function captureLogs(): { warnings: WarnRecord[]; errors: WarnRecord[]; restore: () => void } {
   const warnings: WarnRecord[] = [];
+  const errors: WarnRecord[] = [];
   const previous = getLogger();
   const noop = (): void => {};
   const logger: ILogger = {
@@ -213,7 +247,9 @@ function captureWarnings(): { warnings: WarnRecord[]; restore: () => void } {
     warn: (message: string, meta?: Record<string, unknown>) => {
       warnings.push({ message, meta });
     },
-    error: noop,
+    error: (message: string, meta?: Record<string, unknown>) => {
+      errors.push({ message, meta });
+    },
     fatal: noop,
     child: () => logger,
     time: noop,
@@ -222,7 +258,7 @@ function captureWarnings(): { warnings: WarnRecord[]; restore: () => void } {
     groupEnd: noop,
   };
   setLogger(logger);
-  return { warnings, restore: () => setLogger(previous) };
+  return { warnings, errors, restore: () => setLogger(previous) };
 }
 
 /**
@@ -730,10 +766,49 @@ describe("Workflow trigger bindings", () => {
     const second: ITriggerListenerHandle = await workflow.listen();
     expect(second).toBe(first);
 
+    // But a repeat call CARRYING CONFIGURATION throws: the handle is shared, so
+    // there is nowhere for a second configuration to go. Merging would let this
+    // caller's signal tear down the first caller's schedule, leak an abort
+    // listener per call, and leave no answer to whose stopTimeoutMs wins.
+    await expect(workflow.listen({ stopTimeoutMs: PERIOD })).rejects.toBeInstanceOf(
+      WorkflowTriggerError
+    );
+    await expect(workflow.listen({ stopTimeoutMs: PERIOD })).rejects.toThrow(/configured once/);
+    await expect(workflow.listen({ signal: new AbortController().signal })).rejects.toBeInstanceOf(
+      WorkflowTriggerError
+    );
+
+    // The rejected calls changed nothing: the original session is still the one
+    // running, and still the one the handle stops.
     await advanceFakeTimers(PERIOD * 2);
     expect(executions).toHaveLength(2);
 
     await first.stop();
+  });
+
+  test("a second listen()'s signal is rejected rather than silently ignored", async () => {
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    workflow.trigger(trigger, { input: () => ({ label: "tick" }) });
+
+    const handle = await workflow.listen();
+    const controller = new AbortController();
+
+    await expect(workflow.listen({ signal: controller.signal })).rejects.toBeInstanceOf(
+      WorkflowTriggerError
+    );
+
+    // Aborting does nothing BECAUSE THE CALL THREW — the caller was told its
+    // cancellation was never wired, rather than handed a handle that quietly
+    // ignores it.
+    controller.abort();
+    await flushAsyncWork();
+
+    expect(trigger.running).toBe(true);
+    await advanceFakeTimers(PERIOD * 2);
+    expect(executions).toHaveLength(2);
+
+    await handle.stop();
   });
 
   test("listen() with no bound trigger throws a typed error", async () => {
@@ -987,7 +1062,7 @@ describe("Workflow trigger bindings", () => {
 
   describe("stop deadline", () => {
     test("listen({ stopTimeoutMs }) bounds stop() even when a trigger ignores the option", async () => {
-      const { warnings, restore } = captureWarnings();
+      const { warnings, restore } = captureLogs();
       try {
         const workflow = createWorkflow();
         const wedged = new WedgedTrigger("wedged-1");
@@ -1020,7 +1095,7 @@ describe("Workflow trigger bindings", () => {
     });
 
     test("stop({ timeoutMs }) overrides the listen() default", async () => {
-      const { warnings, restore } = captureWarnings();
+      const { warnings, restore } = captureLogs();
       try {
         const workflow = createWorkflow();
         workflow.trigger(new WedgedTrigger("wedged-2"));
@@ -1039,7 +1114,7 @@ describe("Workflow trigger bindings", () => {
     });
 
     test("a set of triggers that all stop cleanly reports nothing", async () => {
-      const { warnings, restore } = captureWarnings();
+      const { warnings, restore } = captureLogs();
       try {
         const workflow = createWorkflow();
         workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "a" }), {
@@ -1059,6 +1134,270 @@ describe("Workflow trigger bindings", () => {
         // The deadline timer is cleared once the drain wins the race.
         expect(vi.getTimerCount()).toBe(0);
       } finally {
+        restore();
+      }
+    });
+  });
+
+  describe("one listening session's state", () => {
+    // The handle, the run chain and the pending counters belong to ONE session:
+    // created by exactly one listen(), destroyed by exactly one release. These
+    // tests pin the two ends of that — a stop() that cannot complete leaves the
+    // session either fully intact or fully released, never half.
+
+    test("listen({ stopTimeoutMs }) rejects a malformed deadline and starts nothing", async () => {
+      // Validated at listen() rather than at stop(): unvalidated, the ONLY
+      // symptom is a shutdown that cannot complete — the one moment the
+      // schedule most needs to be stoppable.
+      for (const value of [0, -1, 1.5, Number.NaN]) {
+        const workflow = createWorkflow();
+        const trigger = new IntervalTrigger({ intervalMs: PERIOD, id: `bad-${String(value)}` });
+        workflow.trigger(trigger, { input: () => ({ label: "listened" }) });
+
+        await expect(workflow.listen({ stopTimeoutMs: value })).rejects.toBeInstanceOf(
+          TriggerConfigurationError
+        );
+        await expect(workflow.listen({ stopTimeoutMs: value })).rejects.toThrow(/stopTimeoutMs/);
+
+        // Checked before any state is touched, so nothing was scheduled.
+        expect(trigger.running).toBe(false);
+        await advanceFakeTimers(PERIOD * 3);
+        expect(executions).toEqual([]);
+
+        // ... and the workflow is still free to listen properly.
+        const handle = await workflow.listen({ stopTimeoutMs: PERIOD });
+        await advanceFakeTimers(PERIOD);
+        expect(executions).toEqual(["listened"]);
+        await handle.stop();
+        executions.length = 0;
+      }
+    });
+
+    test("a malformed listen() deadline is rejected before an already-aborted signal", async () => {
+      // Both arguments are wrong. The configuration error is the one to report:
+      // a malformed number is wrong whatever the signal is doing, and whether
+      // or not the workflow is already listening.
+      const workflow = createWorkflow();
+      workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }));
+
+      await expect(
+        workflow.listen({ signal: AbortSignal.abort(), stopTimeoutMs: 0 })
+      ).rejects.toBeInstanceOf(TriggerConfigurationError);
+    });
+
+    test("stop({ timeoutMs }) rejects a malformed deadline and leaves the handle usable", async () => {
+      const workflow = createWorkflow();
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD, id: "still-listening" });
+      workflow.trigger(trigger, { input: () => ({ label: "tick" }) });
+
+      const handle = await workflow.listen();
+      await advanceFakeTimers(PERIOD);
+      expect(executions).toHaveLength(1);
+
+      // Nothing was attempted, so nothing was released.
+      await expect(handle.stop({ timeoutMs: 0 })).rejects.toBeInstanceOf(TriggerConfigurationError);
+
+      // The session is fully intact: still running, still firing, still owned by
+      // this handle — so a corrected call actually stops it.
+      expect(trigger.running).toBe(true);
+      await advanceFakeTimers(PERIOD * 2);
+      expect(executions).toHaveLength(3);
+
+      await handle.stop();
+      expect(trigger.running).toBe(false);
+      await advanceFakeTimers(PERIOD * 3);
+      expect(executions).toHaveLength(3);
+      // And THAT release really happened, rather than the schedule merely
+      // going quiet with the binding lock still held.
+      expect(() =>
+        workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "after" }))
+      ).not.toThrow();
+    });
+
+    test("a trigger whose stop() rejects is reported and leaves the workflow re-listenable", async () => {
+      const { errors, restore } = captureLogs();
+      try {
+        const workflow = createWorkflow();
+        const rejecting = new RejectingStopTrigger("rejects-on-stop");
+        const healthy = new IntervalTrigger({ intervalMs: PERIOD, id: "healthy" });
+        workflow.trigger(rejecting);
+        workflow.trigger(healthy, { input: () => ({ label: "healthy" }) });
+
+        const handle = await workflow.listen();
+        await advanceFakeTimers(PERIOD);
+        expect(executions).toEqual(["healthy"]);
+
+        // Every trigger was asked to stop and the failure is then propagated:
+        // `stop()` resolving has to mean everything stopped.
+        const failure = await handle.stop().then(
+          () => undefined,
+          (error: unknown) => error
+        );
+        expect(failure).toBeInstanceOf(WorkflowTriggerError);
+        expect(String(failure)).toContain("rejects-on-stop");
+        expect((failure as Error).cause).toBeInstanceOf(Error);
+        expect(errors.some((entry) => entry.message === "Trigger failed to stop")).toBe(true);
+
+        // The sibling was not held hostage by the failure.
+        expect(healthy.running).toBe(false);
+
+        // The handle was released anyway: a rejected stop() is not evidence the
+        // trigger is still scheduling, and holding the handle would lock
+        // trigger() out forever and keep handing back dead triggers.
+        expect(() =>
+          workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "after" }), {
+            input: () => ({ label: "after" }),
+          })
+        ).not.toThrow();
+
+        const next = await workflow.listen();
+        await advanceFakeTimers(PERIOD);
+        expect(executions).toContain("after");
+        await next.stop().catch(() => {});
+      } finally {
+        restore();
+      }
+    });
+
+    test("a run abandoned by a timed-out stop does not poison the next session", async () => {
+      const { restore } = captureLogs();
+      const gate = createGate();
+      try {
+        const workflow = createWorkflow();
+        const wedged = new WedgedTrigger("wedged-run");
+        workflow.trigger(wedged, {
+          input: (context) => ({ label: `fire@${context.scheduledAt - START}` }),
+        });
+
+        const errors: Error[] = [];
+        wedged.on("error", (error) => errors.push(error));
+
+        const handle = await workflow.listen();
+        holdGate = gate;
+        wedged.fire(START + PERIOD);
+        await drainUntil(() => executions.length === 1);
+        expect(executions).toEqual(["fire@100"]);
+
+        // The deadline expires with that run still parked. Its signal is never
+        // aborted, so the run is ABANDONED rather than cancelled — it is still
+        // the recorded tail of the workflow's run chain.
+        const stopping = handle.stop({ timeoutMs: PERIOD });
+        await advanceFakeTimers(PERIOD);
+        await stopping;
+
+        // From here on nothing parks; only the abandoned run is still held.
+        holdGate = undefined;
+
+        const next = await workflow.listen();
+        wedged.fire(START + PERIOD * 2);
+        await flushAsyncWork();
+
+        // The new session's fire reaches the workflow and COLLIDES with the
+        // abandoned run — the documented trade. Today it instead waits on a
+        // promise nothing can settle: no error, no execution, a schedule that
+        // is running and permanently silent.
+        expect(completed).toEqual([]);
+        expect(errors).toHaveLength(1);
+        expect(String(errors[0])).toMatch(/already running/i);
+
+        // And the collision really is per-fire and self-clearing: once the
+        // abandoned run finishes, the session is healthy with no residue.
+        gate.open();
+        await drainUntil(() => completed.length >= 1);
+        wedged.fire(START + PERIOD * 3);
+        await drainUntil(() => completed.length >= 2);
+        expect(completed).toEqual(["fire@100", "fire@300"]);
+        expect(errors).toHaveLength(1);
+
+        const stoppingNext = next.stop({ timeoutMs: PERIOD });
+        await advanceFakeTimers(PERIOD);
+        await stoppingNext;
+      } finally {
+        // Let the abandoned run finish rather than outlive the test.
+        holdGate = undefined;
+        gate.open();
+        await flushAsyncWork();
+        restore();
+      }
+    });
+
+    test("a run abandoned by a timed-out stop does not exhaust the next session's backlog", async () => {
+      const { restore } = captureLogs();
+      const gate = createGate();
+      const laterGate = createGate();
+      try {
+        const workflow = createWorkflow();
+        const wedged = new WedgedTrigger("wedged-backlog");
+        const errors: Error[] = [];
+        wedged.on("error", (error) => errors.push(error));
+        workflow.trigger(wedged, {
+          input: (context) => ({ label: `fire@${context.scheduledAt - START}` }),
+          maxPendingFires: 1,
+        });
+
+        const handle = await workflow.listen();
+        holdGate = gate;
+        wedged.fire(START + PERIOD);
+        await drainUntil(() => executions.length === 1);
+        // Queues behind the parked run: this binding's pending count is now 1.
+        wedged.fire(START + PERIOD * 2);
+        await flushAsyncWork();
+        expect(errors).toEqual([]);
+
+        const stopping = handle.stop({ timeoutMs: PERIOD });
+        await advanceFakeTimers(PERIOD);
+        await stopping;
+
+        // The abandoned pair is still parked, so the count they were charged
+        // against is exactly the residue the next session must not inherit.
+        holdGate = undefined;
+        const next = await workflow.listen();
+        wedged.fire(START + PERIOD * 3);
+        await flushAsyncWork();
+
+        // This fire reaches the workflow — where it collides with the abandoned
+        // run, which is the documented trade. What it must NOT be is dropped
+        // against a backlog the previous session abandoned, which is what
+        // happens today: the count is still 1, so the fire never gets that far.
+        expect(errors).toHaveLength(1);
+        expect(errors[0]?.message).not.toContain("maxPendingFires");
+        expect(String(errors[0])).toMatch(/already running/i);
+
+        // Now let the abandoned pair settle. The queued one decrements a
+        // counter the release already reset, which is what the clamp is for:
+        // unclamped it goes NEGATIVE, and a negative count makes the
+        // `waiting >= limit` drop test unreachable — the unbounded backlog
+        // `maxPendingFires` exists to prevent.
+        gate.open();
+        await drainUntil(() => completed.length >= 2);
+        expect(completed).toEqual(["fire@100", "fire@200"]);
+
+        // So the fresh session's backlog must still bound at 1: one fire runs,
+        // one queues under the limit, and the third is dropped. That third drop
+        // is reachable only if the counter really is 0 rather than negative.
+        holdGate = laterGate;
+        wedged.fire(START + PERIOD * 4);
+        await drainUntil(() => executions.length === 3);
+        wedged.fire(START + PERIOD * 5);
+        await flushAsyncWork();
+        expect(errors).toHaveLength(1);
+        wedged.fire(START + PERIOD * 6);
+        await flushAsyncWork();
+        expect(errors).toHaveLength(2);
+        expect(errors[1]?.message).toContain("maxPendingFires: 1");
+
+        holdGate = undefined;
+        laterGate.open();
+        await drainUntil(() => completed.length >= 4);
+
+        const stoppingNext = next.stop({ timeoutMs: PERIOD });
+        await advanceFakeTimers(PERIOD);
+        await stoppingNext;
+      } finally {
+        holdGate = undefined;
+        gate.open();
+        laterGate.open();
+        await flushAsyncWork();
         restore();
       }
     });

--- a/packages/triggers/README.md
+++ b/packages/triggers/README.md
@@ -103,9 +103,33 @@ scope exit.
   `stopTimeoutMs` on the trigger, `timeoutMs` on the `stop()` call, or
   `stopTimeoutMs` on `listen()` (which forwards to each trigger AND bounds the
   set, so a third-party `ITrigger` that ignores the option cannot wedge its
-  siblings). Past the deadline the still-pending handlers are **abandoned — they
-  keep running** — a `TriggerStopTimeoutError` carrying the count is emitted on
-  `error`, and the trigger is released so it can be started again.
+  siblings). Every deadline is a positive integer, and each is validated where
+  it is supplied — `listen({ stopTimeoutMs })` at listen time, the `timeoutMs`
+  on a `stop()` call as its first act — so a malformed one is never discovered
+  during the shutdown it was meant to bound. A `stop()` rejected for a malformed
+  deadline has attempted nothing: the session is untouched, and a corrected call
+  still stops it. Past the
+  deadline the still-pending handlers are **abandoned — they keep running** — a
+  `TriggerStopTimeoutError` carrying the count is emitted on `error`, and the
+  trigger is released so it can be started again. Under the workflow bindings
+  the abandoned run is released along with the rest of the session's state, so
+  the next `listen()` starts clean rather than queueing its first fire behind a
+  promise nothing can settle; if that run is still going, the collision surfaces
+  as a per-fire "already running" error on the trigger's `error` event.
+- **A stop that resolves means everything stopped** — `handle.stop()` and
+  `workflow.stopListening()` ask every trigger, report each failure through the
+  logger, release the handle, and then **reject** with a `WorkflowTriggerError`
+  naming the triggers whose own `stop()` rejected (`cause` carries the first
+  reason). The handle is released either way: a rejected `stop()` is not
+  evidence that a trigger is still scheduling, and holding the handle would lock
+  `workflow.trigger(...)` out and keep handing back dead triggers. An expired
+  deadline is the exception and still resolves — it is opt-in, and its
+  documented outcome is a warning plus handlers that keep running.
+- **A listening session is configured once** — `listen()` called again while
+  already listening returns the same handle, but only when it carries no
+  options. A repeat call passing `signal` or `stopTimeoutMs` throws: the handle
+  is shared, so the second caller's abort would tear down the first caller's
+  schedule. To change the configuration, `stopListening()` and listen again.
 - **Overlap** — `overlap: "skip" | "queue" | "concurrent"`, default `"skip"`. A
   tick arriving while the previous handler runs is dropped (and emits `skip`); a
   trigger is a clock, not a work queue, so a slow handler cannot grow a backlog.

--- a/packages/triggers/src/trigger/BaseTrigger.ts
+++ b/packages/triggers/src/trigger/BaseTrigger.ts
@@ -291,10 +291,22 @@ export abstract class BaseTrigger implements ITrigger {
    * abandoned — they keep running — and the expiry is reported on `error`.
    */
   public stop(options: TriggerStopOptions = {}): Promise<void> {
-    const timeoutMs =
-      options.timeoutMs === undefined
-        ? this.stopTimeoutMs
-        : assertPositiveInteger(options.timeoutMs, "timeoutMs");
+    let timeoutMs: number | undefined;
+    try {
+      timeoutMs =
+        options.timeoutMs === undefined
+          ? this.stopTimeoutMs
+          : assertPositiveInteger(options.timeoutMs, "timeoutMs");
+    } catch (error) {
+      // Returned as a REJECTION rather than thrown synchronously: a caller
+      // stopping a set of triggers must not be taken down before its siblings
+      // are even asked. Only the computation is wrapped — the method stays
+      // non-`async` deliberately, because the body publishes `run.stopping` and
+      // returns that exact promise, which is what makes concurrent `stop()`
+      // calls join one drain. An `async` wrapper would hand each caller a fresh
+      // promise and break that identity.
+      return Promise.reject(error);
+    }
     const run = this._run;
     if (!run) return Promise.resolve();
     if (run.stopping) return run.stopping;

--- a/packages/triggers/src/workflow/WorkflowTriggers.ts
+++ b/packages/triggers/src/workflow/WorkflowTriggers.ts
@@ -71,7 +71,10 @@ export interface WorkflowListenOptions {
   readonly signal?: AbortSignal | undefined;
   /**
    * Default deadline for {@link ITriggerListenerHandle.stop}, in milliseconds.
-   * Unbounded by default; see {@link TriggerStopOptions.timeoutMs}.
+   * A positive integer, VALIDATED BY `listen()` — a malformed one would
+   * otherwise surface only at `stop()`, where the thing that fails is the
+   * shutdown itself. Unbounded by default; see
+   * {@link TriggerStopOptions.timeoutMs}.
    *
    * Forwarded to each trigger's own `stop()` AND applied again around the whole
    * set, because a trigger is an interface: a third-party `ITrigger` that
@@ -97,6 +100,20 @@ export interface ITriggerListenerHandle extends AsyncDisposable {
    * Pass {@link TriggerStopOptions.timeoutMs} (or `stopTimeoutMs` on
    * {@link Workflow.listen}) to bound that wait; unbounded by default, so a
    * handler that never settles never lets this resolve.
+   *
+   * Resolving means EVERY trigger stopped. Two ways it rejects instead, and the
+   * two leave the session in deliberately opposite states:
+   *
+   * - a malformed `timeoutMs` rejects before anything is attempted, leaving the
+   *   session fully intact and this handle still usable; while
+   * - a trigger whose own `stop()` rejected is reported and then re-thrown as a
+   *   {@link WorkflowTriggerError} naming it, with `cause` set to the first
+   *   reason — after every trigger was asked to stop and the handle released,
+   *   so the workflow can listen again.
+   *
+   * An expired `timeoutMs` is NOT a rejection: the deadline is opt-in and its
+   * documented outcome is that the abandoned handlers keep running, reported by
+   * a warning.
    */
   stop(options?: TriggerStopOptions): Promise<void>;
 }
@@ -189,11 +206,23 @@ declare module "@workglow/task-graph" {
      * runner); this method only owns the schedule.
      *
      * Calling it again while already listening returns the same handle rather
-     * than starting a second set of timers.
+     * than starting a second set of timers — but only for a call carrying NO
+     * configuration. A listening session is configured once: to change its
+     * configuration, `stopListening()` and listen again.
      *
+     * @throws {@link TriggerConfigurationError} when `options.stopTimeoutMs` is
+     *   not a positive integer — checked first, because a malformed number is
+     *   wrong whatever the signal's state and whether or not this workflow is
+     *   already listening.
      * @throws the signal's abort reason when `options.signal` is already
      *   aborted — checked before any state is touched, so the workflow is left
      *   exactly as it was and stays free to bind and listen later.
+     * @throws {@link WorkflowTriggerError} when this workflow is already
+     *   listening AND the call carries a `signal` or a `stopTimeoutMs`. The
+     *   handle is shared, so there is nowhere for a second configuration to go:
+     *   merging would let this caller's abort tear down the first caller's
+     *   schedule, leak an abort listener per call, and leave no answer to whose
+     *   `stopTimeoutMs` wins.
      * @throws {@link WorkflowTriggerError} when a bound trigger is already
      *   running (it is driving another workflow, and a trigger holds one
      *   handler). Checked before any state is touched too, so a rejected
@@ -204,6 +233,11 @@ declare module "@workglow/task-graph" {
     /**
      * Stops every trigger started by {@link Workflow.listen}. A no-op when not
      * listening. Bounded only if `listen()` was given a `stopTimeoutMs`.
+     *
+     * REJECTS when a trigger's own `stop()` rejected — see
+     * {@link ITriggerListenerHandle.stop}, whose contract this shares: the
+     * triggers were all asked and the handle released, but resolving has to
+     * mean everything stopped. An expired deadline still resolves.
      */
     stopListening(): Promise<void>;
   }
@@ -273,7 +307,16 @@ export async function listenWorkflow(
   workflow: Workflow,
   options: WorkflowListenOptions = {}
 ): Promise<ITriggerListenerHandle> {
-  // FIRST, before the handle lookup and before any state is touched. An
+  // Validated FIRST — ahead of the signal and ahead of the handle lookup —
+  // because a malformed deadline is wrong regardless of what the signal is
+  // doing and regardless of whether this workflow is already listening. Left
+  // unvalidated, its only symptom was a `stop()` that could not complete: the
+  // one moment the schedule most needs to be stoppable.
+  if (options.stopTimeoutMs !== undefined) {
+    assertPositiveInteger(options.stopTimeoutMs, "stopTimeoutMs");
+  }
+
+  // Before the handle lookup and before any state is touched. An
   // already-aborted signal starts nothing (`BaseTrigger.start` bails on one),
   // so the old path returned a handle that had already been removed from
   // `workflowHandles` and whose triggers were never scheduled: a listen() that
@@ -281,7 +324,21 @@ export async function listenWorkflow(
   options.signal?.throwIfAborted();
 
   const existing = workflowHandles.get(workflow);
-  if (existing) return existing;
+  if (existing) {
+    // A bare repeat call is a documented no-op: it hands back the running
+    // session. A repeat call carrying CONFIGURATION is not, because there is
+    // nowhere for that configuration to go — the handle is shared. Wiring the
+    // second caller's `signal` would let consumer B's abort tear down consumer
+    // A's schedule and leak an abort listener per call, and there is no
+    // defensible answer to whose `stopTimeoutMs` wins.
+    if (options.signal !== undefined || options.stopTimeoutMs !== undefined) {
+      throw new WorkflowTriggerError(
+        "This workflow is already listening and a listening session is configured once: to " +
+          "change its configuration, call stopListening() and listen again."
+      );
+    }
+    return existing;
+  }
 
   const bindings = workflowBindings.get(workflow) ?? [];
   if (bindings.length === 0) {
@@ -314,13 +371,42 @@ export async function listenWorkflow(
   const triggers = bindings.map((binding) => binding.trigger);
   let detachAbort: (() => void) | undefined;
 
+  /**
+   * Destroys this listening session. The handle, the run chain and the pending
+   * counters are ONE session's state — created by exactly one `listen()` and
+   * destroyed by exactly one call to this — so all three go together, behind
+   * the SAME identity check: a stale release (a timed-out `stop()` finishing
+   * after a fresh `listen()`) must not wipe a newer session's state.
+   *
+   * Clearing the chain is what stops a run abandoned by a timed-out `stop()`
+   * from being awaited by the next session's first fire, which would otherwise
+   * queue behind a promise nothing can settle — a schedule that is running and
+   * permanently silent. The residual trade is a possible collision: if the
+   * abandoned run is still going, that first fire can hit `Workflow`'s
+   * "already running" error on the trigger's `error` event. That is the
+   * intended exchange — a loud, per-fire, self-clearing error instead of silent
+   * permanent death. The abandoned chain cannot take the new tail down with it:
+   * its own `finally` deletes the entry only while it is still the recorded
+   * tail (see {@link runWorkflowForFire}).
+   */
   const releaseHandle = (): void => {
     detachAbort?.();
     detachAbort = undefined;
-    if (workflowHandles.get(workflow) === handle) workflowHandles.delete(workflow);
+    if (workflowHandles.get(workflow) !== handle) return;
+    workflowHandles.delete(workflow);
+    workflowRunChains.delete(workflow);
+    for (const binding of bindings) binding.pending = 0;
   };
 
   const stop = async (stopOptions: TriggerStopOptions = {}): Promise<void> => {
+    // The FIRST statement, so a malformed deadline rejects before any trigger
+    // is asked to stop and before the handle is released: nothing was
+    // attempted, so the session is left fully intact — still installed, still
+    // stoppable through a corrected `handle.stop()`. `options.stopTimeoutMs`
+    // needs no re-check; `listen()` validated it.
+    if (stopOptions.timeoutMs !== undefined) {
+      assertPositiveInteger(stopOptions.timeoutMs, "timeoutMs");
+    }
     const timeoutMs = stopOptions.timeoutMs ?? options.stopTimeoutMs;
     const triggerStopOptions: TriggerStopOptions = timeoutMs === undefined ? {} : { timeoutMs };
 
@@ -343,22 +429,44 @@ export async function listenWorkflow(
     const results =
       timeoutMs === undefined ? await settling : await settleWithin(settling, timeoutMs);
 
-    // Released either way: leaving the handle installed after a timed-out stop
-    // locks `workflow.trigger(...)` forever and makes `listen()` keep handing
-    // back triggers that are on their way out.
+    // Released whatever happened — a timed-out drain and a rejected
+    // `trigger.stop()` alike. Neither is evidence that a trigger is still
+    // scheduling, and leaving the handle installed locks
+    // `workflow.trigger(...)` forever while making `listen()` keep handing back
+    // triggers that are on their way out. The failure is propagated below
+    // instead, which reports it without holding the workflow hostage.
     releaseHandle();
 
     if (results === undefined) {
+      // The deadline is opt-in and its documented outcome is that the abandoned
+      // handlers keep running, so it warns rather than rejecting: the caller
+      // asked to get on with shutting down.
       getLogger().warn("Timed out stopping workflow triggers", {
         timeoutMs,
         triggerIds: [...outstanding].map((trigger) => trigger.id),
       });
       return;
     }
-    for (const result of results) {
-      if (result.status === "rejected") {
-        getLogger().error("Trigger failed to stop", { error: String(result.reason) });
-      }
+
+    // `allSettled` preserves order, so a result's index names its trigger.
+    const failures: { readonly id: string; readonly reason: unknown }[] = [];
+    results.forEach((result, index) => {
+      if (result.status !== "rejected") return;
+      const id = triggers[index]?.id ?? "unknown";
+      failures.push({ id, reason: result.reason });
+      getLogger().error("Trigger failed to stop", { triggerId: id, error: String(result.reason) });
+    });
+    if (failures.length > 0) {
+      // Reported AND propagated: every trigger was asked and the handle is
+      // already released, but a `stop()` that resolves has to mean everything
+      // stopped — reporting through the logger alone left a caller told its
+      // shutdown succeeded while a trigger it named was never stopped.
+      throw new WorkflowTriggerError(
+        `Trigger(s) ${failures.map((failure) => `"${failure.id}"`).join(", ")} failed to stop. ` +
+          `Every trigger was asked and the handle was released, so this workflow can listen ` +
+          `again — but stop() resolving means every trigger stopped.`,
+        { cause: failures[0]!.reason }
+      );
     }
   };
   const handle: ITriggerListenerHandle = {
@@ -414,6 +522,9 @@ export async function listenWorkflow(
  * Stops every trigger {@link listenWorkflow} started for `workflow`. The
  * free-function form of {@link Workflow.stopListening}; a no-op when the
  * workflow is not listening.
+ *
+ * Rejects when a trigger's own `stop()` rejected — see
+ * {@link ITriggerListenerHandle.stop} for the full contract.
  */
 export async function stopWorkflowListening(workflow: Workflow): Promise<void> {
   await workflowHandles.get(workflow)?.stop();
@@ -511,7 +622,14 @@ async function runWorkflowForFire(
       // `catch`, not a bare await: a fire whose run rejected must not take the
       // fires queued behind it down with it.
       await predecessor.catch(() => {});
-      binding.pending -= 1;
+      // Clamped, because this decrement can outlive the session that counted
+      // it: a chain abandoned by a timed-out `stop()` still decrements when its
+      // predecessor eventually settles, and by then `releaseHandle` has reset
+      // the counter to 0. Unclamped that drives it NEGATIVE, which makes the
+      // `waiting >= limit` drop test unreachable — reintroducing, in the
+      // backlog counter itself, the unbounded growth `maxPendingFires` exists
+      // to prevent.
+      binding.pending = Math.max(0, binding.pending - 1);
       // The wait can outlast the trigger. A fire that queued behind a slow run
       // must not start a new one after `stop()`.
       if (context.signal.aborted) return;
@@ -534,7 +652,10 @@ async function runWorkflowForFire(
     if (context.signal.aborted) return;
     throw error;
   } finally {
-    // Identity check: a later fire may already have claimed the tail.
+    // Identity check: a later fire may already have claimed the tail — and so
+    // may a later listening SESSION, since `releaseHandle` clears the tail with
+    // the rest of the session's state. A chain abandoned by a timed-out
+    // `stop()` therefore settles without deleting the new session's tail.
     if (workflowRunChains.get(workflow) === chain) workflowRunChains.delete(workflow);
   }
 }


### PR DESCRIPTION
Retargeted to `main`. The triggers package landed in #820 (which superseded #679), so this no longer stacks on anything — the diff is 1 commit, 5 files, +537/−34, and it is all follow-up fixes to the code #820 introduced.

Three MEDIUM findings compose into one outcome: **a misconfigured or wedged shutdown leaves an unstoppable schedule.** They are fixed as one change around one invariant, now stated in the code:

> The handle, the run chain and the pending counters are one listening session's state — created by exactly one `listen()`, destroyed by exactly one `releaseHandle()`, and a `stop()` that cannot complete must fail loudly with that state either fully intact or fully released, never half.

## What changed

All in `packages/triggers/src/workflow/WorkflowTriggers.ts` unless noted.

- **`listen()` validates `stopTimeoutMs` first**, ahead of the signal check and the handle lookup: a malformed number is wrong whatever the signal is doing and whether or not the workflow is already listening. Unvalidated, its only symptom was a `stop()` that could not complete — the one moment the schedule most needs to be stoppable.
- **`stop()` validates its own `timeoutMs` as its first statement**, so a bad value rejects *before* any `trigger.stop()` and *before* `releaseHandle()`. Nothing was attempted, so the session is left fully intact and a corrected `handle.stop()` still works.
- **`releaseHandle()` clears the run chain and zeroes every binding's `pending`**, behind the same identity check that already guarded the handle delete (so a stale release cannot wipe a newer session). Otherwise a run abandoned by a timed-out stop stays the recorded tail and the next session's first fire queues behind a promise nothing can settle — a schedule that is running and permanently silent.
- **The pending decrement is clamped at `Math.max(0, …)`.** This is what makes the reset above safe: an abandoned chain still decrements when its predecessor eventually settles, and unclamped that drives the counter negative — which makes the `waiting >= limit` drop test unreachable, reintroducing in the backlog counter the unbounded growth `maxPendingFires` exists to prevent.
- **A trigger whose `stop()` rejects is reported as before and then propagated** as a `WorkflowTriggerError` naming the failing trigger ids, `cause` set to the first reason. The handle is still released — a rejected `trigger.stop()` is not evidence the trigger is still scheduling (the suite's own `RejectingStopTrigger` sets `running = false` and *then* rejects), and keeping it would lock `workflow.trigger(...)` out and hand back dead triggers forever.
- **`BaseTrigger.stop()`** (`packages/triggers/src/trigger/BaseTrigger.ts`) returns a *rejected promise* for a malformed `timeoutMs` instead of throwing synchronously, so a caller stopping a set is not taken down before its siblings are asked. Only the `timeoutMs` computation is wrapped — the method stays non-`async` deliberately, because the body publishes `run.stopping` and returns that exact promise, which is what makes concurrent `stop()` calls join one drain.

### Residual, documented in the code

Clearing the chain means a fresh `listen()`'s first fire can collide with the abandoned run and get `Workflow`'s "already running" error on the trigger's `error` event. That is the intended trade — a loud, per-fire, self-clearing error instead of silent permanent death — and it is noted where the delete lives. The abandoned chain's own `finally` identity check already prevents it from deleting the new session's tail.

### Repeat `listen()` semantics

A repeat `listen()` **throws** `WorkflowTriggerError` if it carries any configuration (`signal` or `stopTimeoutMs` defined); a configuration-free repeat still returns the installed handle, as documented. Merging is wrong — the handle is shared, so wiring the second caller's signal lets consumer B's abort tear down consumer A's schedule, it leaks an abort listener per call, and there is no defensible answer to whose `stopTimeoutMs` wins. Throwing unconditionally would break a documented contract and a passing test for a genuinely harmless no-arg call. The rule is in the error message: *a listening session is configured once; to change its configuration, `stopListening()` and listen again.*

## Droppable independently

The `stop()` **propagation** change is the one that alters an existing success contract — `handle.stop()` / `workflow.stopListening()` can now reject where they previously resolved after logging. It is separable from the rest and can be dropped if a reviewer objects; the other fixes stand without it. Two paths were checked for it: the caller-abort listener already does `stop().catch(() => {})`, and `[Symbol.asyncDispose]` legitimately surfaces the error at scope exit. The timeout path deliberately keeps resolving-with-warn — the deadline is opt-in and documented as "the abandoned handlers keep running".

Now that `packages/triggers` has landed via #820, the blast radius is checkable rather than hypothetical: it is a brand-new package with no consumers outside itself, so the only two call sites in the repo are the two named above.

## Tests

Written first and confirmed failing against the unmodified source, each for its stated reason:

| test | failed today because |
| --- | --- |
| `listen({ stopTimeoutMs })` rejects `0/-1/1.5/NaN` and starts nothing | listen resolved and scheduled; breakage only appeared at stop time |
| `stop({ timeoutMs: 0 })` rejects and leaves the handle usable | resolved, `releaseHandle` had already run, trigger fired forever |
| a wedged run does not poison a later `listen()` | the new fire awaited the abandoned chain forever — no error, no execution |
| a wedged run does not exhaust `maxPendingFires` next session | `Dropped a fire … maxPendingFires` — pending was still 1 from the abandoned session |
| a rejecting `stop()` leaves the workflow re-listenable | `stop()` resolved, so the failure was invisible to the caller |
| a repeat `listen()` carrying options throws (both variants) | all three resolved to the same handle |
| a second `listen()`'s signal is not silently ignored | the call resolved, wiring nothing |
| validation order: config before abort | threw the abort reason, not the configuration error |

The wedged-run cases needed `WedgedTrigger` to deliver a fire (it now captures its handler and exposes `fire()`, with a signal it never aborts — a wedged stop abandons handlers rather than cancelling them) and to report `running = false` from its never-settling `stop()`, so a later `listen()` is reachable. `captureWarnings` became `captureLogs` and also records `error`.

One test edit outside the new set: `packages/test/src/test/trigger/IntervalTrigger.test.ts` — "rejects a non-positive stop deadline" now awaits `rejects.toBeInstanceOf(TriggerConfigurationError)` for the two `stop()` assertions. The constructor assertion stays synchronous.

## Verified

- `bun scripts/test.ts trigger vitest` — **187 passed, 6 files**
- `bun run format` — clean
- `bun run build:types` — 42/42 successful

Docs updated: `WorkflowListenOptions.stopTimeoutMs`, `ITriggerListenerHandle.stop`, the `Workflow.listen` / `Workflow.stopListening` declarations, and the README's stop/deadline bullet (plus two new bullets for the resolve contract and the configured-once rule).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgxtp7mQECdh7F2UT9CVwN)_