### PR TITLE
fix(util,ai): TurboQuant norm overflow, ranking claim, decode warning, heterogeneous batches

### DIFF
--- a/packages/ai/src/task/VectorQuantizeTask.ts
+++ b/packages/ai/src/task/VectorQuantizeTask.ts
@@ -212,6 +212,9 @@ export class VectorQuantizeTask extends Task<
     } = input;
     const isArray = Array.isArray(vector);
     const vectors = isArray ? vector : [vector];
+    if (method === QuantizationMethod.TURBO) {
+      this.assertHomogeneousTurboBatch(vectors, turboPadToPowerOf2);
+    }
     const originalType = this.getVectorType(vectors[0]);
 
     let quantized: TypedArray[];
@@ -267,6 +270,50 @@ export class VectorQuantizeTask extends Task<
       turboSeed: method === QuantizationMethod.TURBO ? turboSeed : undefined,
       originalDimensions: vectors[0].length,
     };
+  }
+
+  /**
+   * Rejects a batch whose vectors do not all share one dimensionality, under
+   * `method: "turbo"`.
+   *
+   * The existing power-of-2 check asks a PER-VECTOR question about a BATCH-level
+   * invariant, so `[Float32Array(512), Float32Array(1024)]` passes it: both lengths are
+   * powers of two. Each vector is then rotated in its own `turboPaddedLength(d)` under
+   * `getSignTable(seed, paddedLen)` — a different basis per length — so the two outputs
+   * are not comparable at all, while `originalDimensions` reports only `vectors[0]`'s
+   * length. Turning padding on does not help: 700 and 1100 pass the per-vector check and
+   * land in 1024 and 2048.
+   *
+   * Turbo output is comparable only against output with the same seed and, implicitly, the
+   * same padded length.
+   */
+  private assertHomogeneousTurboBatch(vectors: TypedArray[], turboPadToPowerOf2: boolean): void {
+    if (vectors.length === 0) {
+      // Reached `getVectorType(undefined)` before this guard and threw "Unknown vector
+      // type: undefined", which names neither the input nor the shape of the mistake.
+      throw new Error(
+        `VectorQuantizeTask: input "vector" is an empty array — there is nothing to quantize, ` +
+          `and the output's originalType and originalDimensions describe vectors[0], which does ` +
+          `not exist. Pass at least one vector, or skip the call.`
+      );
+    }
+    const expected = vectors[0]!.length;
+    const index = vectors.findIndex((v) => v.length !== expected);
+    if (index === -1) return;
+
+    const found = vectors[index]!.length;
+    const expectedPadded = turboPaddedLength(expected);
+    const foundPadded = turboPaddedLength(found);
+    throw new Error(
+      `VectorQuantizeTask: every vector in a batch must have the same dimensionality, but ` +
+        `vectors[0] has ${expected} and vectors[${index}] has ${found}. Under method "turbo" each ` +
+        `vector is rotated in its own turboPaddedLength(d) — ${expectedPadded} and ${foundPadded} ` +
+        `here — and the rotation basis is keyed by that padded length, so the two outputs live in ` +
+        `DIFFERENT bases and are not comparable even after padding` +
+        (turboPadToPowerOf2 ? "" : " (nor would turboPadToPowerOf2: true make them so)") +
+        `. The output's originalDimensions would also report only vectors[0]'s ${expected}. ` +
+        `Quantize each dimensionality in a separate call.`
+    );
   }
 
   private getVectorType(vector: TypedArray): TensorType {

--- a/packages/ai/src/task/VectorQuantizeTask.ts
+++ b/packages/ai/src/task/VectorQuantizeTask.ts
@@ -212,9 +212,7 @@ export class VectorQuantizeTask extends Task<
     } = input;
     const isArray = Array.isArray(vector);
     const vectors = isArray ? vector : [vector];
-    if (method === QuantizationMethod.TURBO) {
-      this.assertHomogeneousTurboBatch(vectors, turboPadToPowerOf2);
-    }
+    this.assertHomogeneousBatch(vectors, method, turboPadToPowerOf2);
     const originalType = this.getVectorType(vectors[0]);
 
     let quantized: TypedArray[];
@@ -273,21 +271,30 @@ export class VectorQuantizeTask extends Task<
   }
 
   /**
-   * Rejects a batch whose vectors do not all share one dimensionality, under
-   * `method: "turbo"`.
+   * Rejects a batch whose vectors do not all share one dimensionality and one element
+   * type, under every method.
    *
-   * The existing power-of-2 check asks a PER-VECTOR question about a BATCH-level
-   * invariant, so `[Float32Array(512), Float32Array(1024)]` passes it: both lengths are
-   * powers of two. Each vector is then rotated in its own `turboPaddedLength(d)` under
-   * `getSignTable(seed, paddedLen)` — a different basis per length — so the two outputs
-   * are not comparable at all, while `originalDimensions` reports only `vectors[0]`'s
-   * length. Turning padding on does not help: 700 and 1100 pass the per-vector check and
-   * land in 1024 and 2048.
+   * `originalDimensions` and `originalType` describe `vectors[0]` alone, so a mixed batch
+   * returns metadata that is a claim about one vector presented as a claim about all of
+   * them. What follows differs by method, and the message says which:
    *
-   * Turbo output is comparable only against output with the same seed and, implicitly, the
-   * same padded length.
+   * - `turbo`: each vector is rotated in its own `turboPaddedLength(d)` under
+   *   `getSignTable(seed, paddedLen)` — a different basis per length — so the outputs are
+   *   not comparable at all, and padding does not reconcile them (700 and 1100 land in
+   *   1024 and 2048). The per-vector power-of-2 check passes such a batch: it asks a
+   *   per-vector question about a batch-level invariant.
+   * - `linear`: the outputs keep their input lengths, so `cosineSimilarity` throws
+   *   downstream — but `originalDimensions` has already misreported before that, and a
+   *   fixed-width storage column accepts one output and rejects the other.
+   *
+   * The mixed ELEMENT-TYPE case is the same defect on the other metadata field, and is
+   * rejected for the same reason rather than left to misreport `originalType`.
    */
-  private assertHomogeneousTurboBatch(vectors: TypedArray[], turboPadToPowerOf2: boolean): void {
+  private assertHomogeneousBatch(
+    vectors: TypedArray[],
+    method: QuantizationMethod,
+    turboPadToPowerOf2: boolean
+  ): void {
     if (vectors.length === 0) {
       // Reached `getVectorType(undefined)` before this guard and threw "Unknown vector
       // type: undefined", which names neither the input nor the shape of the mistake.
@@ -297,23 +304,41 @@ export class VectorQuantizeTask extends Task<
           `not exist. Pass at least one vector, or skip the call.`
       );
     }
+
     const expected = vectors[0]!.length;
     const index = vectors.findIndex((v) => v.length !== expected);
-    if (index === -1) return;
+    if (index !== -1) {
+      const found = vectors[index]!.length;
+      const consequence =
+        method === QuantizationMethod.TURBO
+          ? `Under method "turbo" each vector is rotated in its own turboPaddedLength(d) — ` +
+            `${turboPaddedLength(expected)} and ${turboPaddedLength(found)} here — and the ` +
+            `rotation basis is keyed by that padded length, so the two outputs live in DIFFERENT ` +
+            `bases and are not comparable even after padding` +
+            (turboPadToPowerOf2 ? "" : " (nor would turboPadToPowerOf2: true make them so)") +
+            `.`
+          : `Under method "${method}" each output keeps its input length, so cosineSimilarity ` +
+            `throws on any pair of them downstream — and a fixed-width storage column accepts ` +
+            `one and rejects the other.`;
+      throw new Error(
+        `VectorQuantizeTask: every vector in a batch must have the same dimensionality, but ` +
+          `vectors[0] has ${expected} and vectors[${index}] has ${found}. ${consequence} The ` +
+          `output's originalDimensions would also report only vectors[0]'s ${expected}. ` +
+          `Quantize each dimensionality in a separate call.`
+      );
+    }
 
-    const found = vectors[index]!.length;
-    const expectedPadded = turboPaddedLength(expected);
-    const foundPadded = turboPaddedLength(found);
-    throw new Error(
-      `VectorQuantizeTask: every vector in a batch must have the same dimensionality, but ` +
-        `vectors[0] has ${expected} and vectors[${index}] has ${found}. Under method "turbo" each ` +
-        `vector is rotated in its own turboPaddedLength(d) — ${expectedPadded} and ${foundPadded} ` +
-        `here — and the rotation basis is keyed by that padded length, so the two outputs live in ` +
-        `DIFFERENT bases and are not comparable even after padding` +
-        (turboPadToPowerOf2 ? "" : " (nor would turboPadToPowerOf2: true make them so)") +
-        `. The output's originalDimensions would also report only vectors[0]'s ${expected}. ` +
-        `Quantize each dimensionality in a separate call.`
-    );
+    const expectedType = this.getVectorType(vectors[0]!);
+    const typeIndex = vectors.findIndex((v) => this.getVectorType(v) !== expectedType);
+    if (typeIndex !== -1) {
+      throw new Error(
+        `VectorQuantizeTask: every vector in a batch must have the same element type, but ` +
+          `vectors[0] is ${expectedType} and vectors[${typeIndex}] is ` +
+          `${this.getVectorType(vectors[typeIndex]!)}. The output's originalType would report ` +
+          `only vectors[0]'s ${expectedType}, which is the one field a consumer has to reverse ` +
+          `the quantization. Quantize each element type in a separate call.`
+      );
+    }
   }
 
   private getVectorType(vector: TypedArray): TensorType {

--- a/packages/test/src/test/rag/VectorQuantizeTask.test.ts
+++ b/packages/test/src/test/rag/VectorQuantizeTask.test.ts
@@ -239,6 +239,44 @@ describe("VectorQuantizeTask", () => {
     });
   });
 
+  /**
+   * The array input predates the turbo work, so this is the one place the branch changes
+   * RELEASED behavior — deliberately, and from "silently wrong" to "loud". Such a caller
+   * already receives a result whose `originalDimensions` and `originalType` describe only
+   * `vectors[0]`, and whose outputs cannot share a storage column, so there is no correct
+   * use of the input shape being rejected.
+   */
+  test("should reject a heterogeneous batch under linear", async () => {
+    const vectors = [new Float32Array([0.5, -0.5, 0.8]), new Float32Array([0.1, 0.2, 0.3, 0.4])];
+
+    const message = await rejectionMessage(() =>
+      vectorQuantize({ vector: vectors, targetType: TensorType.INT8, normalize: false })
+    );
+
+    expect(message).toMatch(/same dimensionality/);
+    expect(message).toMatch(/vectors\[1\]/);
+    // Method-aware consequence: under linear the outputs keep their lengths, so the break
+    // surfaces downstream in cosineSimilarity and in a fixed-width storage column — a
+    // different failure from turbo's incomparable bases, and the message says which.
+    expect(message).toMatch(/cosineSimilarity/);
+    expect(message).toMatch(/storage column/);
+  });
+
+  test("should reject a batch of mixed element types", async () => {
+    // Same defect on the other metadata field: `originalType` would describe vectors[0]
+    // alone, and that is the field a consumer needs to reverse the quantization.
+    const vectors = [new Float32Array([1, 2, 3, 4]), new Int8Array([1, 2, 3, 4])];
+
+    const message = await rejectionMessage(() =>
+      vectorQuantize({ vector: vectors, targetType: TensorType.INT8, normalize: false })
+    );
+
+    expect(message).toMatch(/same element type/);
+    expect(message).toMatch(/originalType/);
+    expect(message).toMatch(/float32/);
+    expect(message).toMatch(/int8/);
+  });
+
   test("should preserve dimensions when quantizing", async () => {
     const largeVector = new Float32Array(384).map(() => Math.random() * 2 - 1);
 

--- a/packages/test/src/test/rag/VectorQuantizeTask.test.ts
+++ b/packages/test/src/test/rag/VectorQuantizeTask.test.ts
@@ -41,6 +41,20 @@ function cosine(a: ArrayLike<number>, b: ArrayLike<number>): number {
 }
 
 /**
+ * Runs a call expected to be rejected and returns its message, failing loudly if it
+ * resolves instead. `rejects.toThrow(/…/)` cannot assert several independent facts about
+ * one message without re-running the call once per fact.
+ */
+async function rejectionMessage(call: () => Promise<unknown>): Promise<string> {
+  try {
+    await call();
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error("expected the call to be rejected, but it resolved");
+}
+
+/**
  * The int8 baseline the accuracy tests below score against: divide by the LARGEST
  * ABSOLUTE COORDINATE, then scale to the full [-127, 127] range.
  *
@@ -608,6 +622,98 @@ describe("VectorQuantizeTask", () => {
       const linear = await vectorQuantize({ vector, targetType: TensorType.INT8 });
       expect(linear.method).toBe("linear");
       expect(linear.turboSeed).toBeUndefined();
+    });
+
+    /**
+     * The power-of-2 check asks a PER-VECTOR question about a BATCH-level invariant, so a
+     * batch of two different power-of-2 lengths passed it and resolved: each vector was
+     * rotated in its own padded length, under `getSignTable(seed, paddedLen)` — a
+     * different basis per length — while `originalDimensions` reported only 512.
+     */
+    test("should reject a heterogeneous batch under turbo", async () => {
+      const vectors = [new Float32Array(512), new Float32Array(1024)];
+      for (let i = 0; i < 512; i++) vectors[0]![i] = Math.sin(i * 0.1);
+      for (let i = 0; i < 1024; i++) vectors[1]![i] = Math.cos(i * 0.1);
+
+      const message = await rejectionMessage(() =>
+        vectorQuantize({
+          vector: vectors,
+          targetType: TensorType.INT8,
+          method: "turbo",
+          turboSeed: 42,
+        })
+      );
+
+      expect(message).toMatch(/512/);
+      expect(message).toMatch(/1024/);
+      // The index is what makes a 500-vector batch actionable.
+      expect(message).toMatch(/vectors\[1\]/);
+      expect(message).toMatch(/separate call/);
+    });
+
+    /**
+     * The leg that proves the guard is not the existing power-of-2 check under another
+     * name: with padding on, 700 and 1100 both pass that check and are simply rotated in
+     * 1024 and 2048. Before this guard the call resolved with `originalDimensions: 700`.
+     */
+    test("should reject a heterogeneous batch under turbo even with padding enabled", async () => {
+      const vectors = [new Float32Array(700), new Float32Array(1100)];
+      for (let i = 0; i < 700; i++) vectors[0]![i] = Math.sin(i * 0.1);
+      for (let i = 0; i < 1100; i++) vectors[1]![i] = Math.cos(i * 0.1);
+
+      const message = await rejectionMessage(() =>
+        vectorQuantize({
+          vector: vectors,
+          targetType: TensorType.INT8,
+          method: "turbo",
+          turboSeed: 42,
+          turboPadToPowerOf2: true,
+        })
+      );
+
+      expect(message).toMatch(/700/);
+      expect(message).toMatch(/1100/);
+      // The padded widths are the point: they are what differ in the basis, and they are
+      // not visible from the input lengths.
+      expect(message).toMatch(/1024/);
+      expect(message).toMatch(/2048/);
+    });
+
+    test("should reject an empty batch by naming the input", async () => {
+      // Previously reached `getVectorType(undefined)` and threw "Unknown vector type:
+      // undefined", which names neither the input nor the shape of the mistake.
+      const message = await rejectionMessage(() =>
+        vectorQuantize({
+          vector: [],
+          targetType: TensorType.INT8,
+          method: "turbo",
+          turboSeed: 42,
+        })
+      );
+
+      expect(message).toMatch(/empty array/);
+      expect(message).not.toMatch(/Unknown vector type/);
+    });
+
+    /**
+     * The regression guard for the two commits above: a HOMOGENEOUS batch is the shape the
+     * guard must leave untouched, so the existing case is re-asserted here explicitly
+     * rather than assumed to still hold.
+     */
+    test("should still accept a homogeneous turbo batch", async () => {
+      const vectors = [new Float32Array([1, 2, 3, 4]), new Float32Array([5, 6, 7, 8])];
+
+      const result = await vectorQuantize({
+        vector: vectors,
+        targetType: TensorType.INT8,
+        method: "turbo",
+        turboSeed: 42,
+      });
+
+      const out = result.vector as Int8Array[];
+      expect(out.length).toBe(2);
+      out.forEach((v) => expect(v.length).toBe(4));
+      expect(result.originalDimensions).toBe(4);
     });
   });
 });

--- a/packages/test/src/test/util/TurboQuantize.test.ts
+++ b/packages/test/src/test/util/TurboQuantize.test.ts
@@ -7,6 +7,7 @@
 import { setLogger } from "@workglow/util";
 import type { TurboQuantizeResult } from "@workglow/util/schema";
 import {
+  TURBO_MAX_CORRECTED_BITS,
   TensorType,
   clearSignTableCache,
   cosineSimilarity,
@@ -910,6 +911,48 @@ describe("TurboQuantize", () => {
             cosineSimilarity(turboDequantize(wa), turboDequantize(wb))
         )
       ).toBeLessThan(0.01);
+    });
+
+    /**
+     * Exporting a constant creates a new way for the docs and the behavior to diverge:
+     * `TURBO_MAX_CORRECTED_BITS` now tells a caller where decode-then-compare stops being
+     * safe, and nothing else forces it to be the width where that is actually true.
+     *
+     * So this sweeps all eight widths and requires the gap to appear at exactly the widths
+     * the constant claims. It fails if the constant is retuned without the correction
+     * being extended, and equally if the correction is extended without the constant
+     * moving.
+     *
+     * The 0.002 threshold is well above float noise between the two routes (measured at
+     * ~1e-7 at the uncorrected widths) and well below the smallest real gap (the 4-bit
+     * one, the shallowest corrected case).
+     */
+    test("TURBO_MAX_CORRECTED_BITS marks exactly the widths where decode-then-compare differs", () => {
+      const d = 1024;
+      const rnd = makeRandom(31337);
+      const a = new Float32Array(d);
+      const noise = new Float32Array(d);
+      for (let i = 0; i < d; i++) {
+        a[i] = rnd() - 0.5;
+        noise[i] = rnd() - 0.5;
+      }
+      const t = 0.8;
+      const k = Math.sqrt(1 - t * t);
+      const b = new Float32Array(d);
+      for (let i = 0; i < d; i++) b[i] = t * a[i]! + k * noise[i]!;
+
+      expect(TURBO_MAX_CORRECTED_BITS).toBe(4);
+
+      for (let bits = 1; bits <= 8; bits++) {
+        const qa = turboQuantize(a, { bits, seed: 42 });
+        const qb = turboQuantize(b, { bits, seed: 42 });
+        const gap =
+          turboQuantizedCosineSimilarity(qa, qb) -
+          cosineSimilarity(turboDequantize(qa), turboDequantize(qb));
+        expect(gap > 0.002, `bits=${bits} gap=${gap.toFixed(5)}`).toBe(
+          bits <= TURBO_MAX_CORRECTED_BITS
+        );
+      }
     });
 
     test("should have a per-bit-width, per-correlation signed bias within measured bands", () => {

--- a/packages/test/src/test/util/TurboQuantize.test.ts
+++ b/packages/test/src/test/util/TurboQuantize.test.ts
@@ -148,6 +148,68 @@ describe("TurboQuantize", () => {
       expect(() => turboDequantize(quantized)).not.toThrow(/NaN or Infinity/);
     });
 
+    /**
+     * The residual of the max-scaling fix above, and the one case it cannot rescue.
+     *
+     * Max-scaling keeps the ACCUMULATOR in range for any finite input, but the norm is
+     * reconstructed as `maxAbs * rootS`, and that product still overflows once the true
+     * L2 norm passes Number.MAX_VALUE. The record that came back carried
+     * `norm: Infinity`, which is not merely odd: every read path — `turboDequantize`,
+     * `turboQuantizedCosineSimilarity`, `turboQuantizedInnerProduct` — validates `norm`
+     * and throws on it. The encoder was therefore returning a record nothing could read,
+     * and reporting it three function calls later as if the READER were malformed.
+     *
+     * So the throw does not remove a working case; it moves an existing one earlier, to
+     * the point where the caller still holds the input and can act on the message.
+     */
+    test("should reject a vector whose L2 norm overflows a double", () => {
+      const overflowing = new Float64Array(4).fill(1e308);
+
+      expect(() => turboQuantize(overflowing, { bits: 8, seed: 42 })).toThrow(
+        /not representable as a double/
+      );
+      // The message is the whole value of failing here rather than on the read path, so
+      // its actionable halves are asserted, not just the throw: the offending magnitude,
+      // and both ways out.
+      const message = (() => {
+        try {
+          turboQuantize(overflowing, { bits: 8, seed: 42 });
+        } catch (error) {
+          return (error as Error).message;
+        }
+        throw new Error("expected a norm-overflowing vector to be rejected");
+      })();
+      expect(message).toMatch(/1e\+308/);
+      expect(message).toMatch(/Prescale/);
+      expect(message).toMatch(/turboQuantizeToTypedArray/);
+
+      // And that second remedy has to actually work, or the message is advice to nowhere.
+      // `turboQuantizeToTypedArray` discards the norm entirely, so the same input encodes
+      // unchanged — which is also why the guard lives in `turboQuantize` and not in the
+      // shared `normalizeToUnit`.
+      const codes = turboQuantizeToTypedArray(overflowing, TensorType.INT8, {
+        seed: 42,
+        padToPowerOf2: undefined,
+      });
+      expect(codes.length).toBe(4);
+      expect(
+        Array.from(codes as Int8Array),
+        "a norm-free encode of a 1e308 vector must match its unit-scaled twin"
+      ).toEqual(
+        Array.from(
+          turboQuantizeToTypedArray(new Float64Array(4).fill(1), TensorType.INT8, {
+            seed: 42,
+            padToPowerOf2: undefined,
+          }) as Int8Array
+        )
+      );
+
+      // 1e200 (the case above) is still fine: this rejects only what a double cannot hold.
+      expect(() =>
+        turboQuantize(new Float64Array([1e200, 2e200, 3e200, 4e200]), { bits: 8, seed: 42 })
+      ).not.toThrow();
+    });
+
     test("should quantize a vector whose squared norm underflows a double", () => {
       // The mirror failure: below ~1e-162 every `v * v` flushed to zero, so `norm` came
       // back 0 — indistinguishable from a genuine zero vector. The record then decoded to

--- a/packages/test/src/test/util/TurboQuantize.test.ts
+++ b/packages/test/src/test/util/TurboQuantize.test.ts
@@ -1084,6 +1084,184 @@ describe("TurboQuantize", () => {
     });
   });
 
+  /**
+   * WHAT THE MODULE DOC IS ALLOWED TO CLAIM ABOUT RANKING.
+   *
+   * The docstring asserted that "RANKING was never affected — ordering a candidate set was
+   * correct before and is correct now". Half of that is a property of the correction and
+   * half of it is a claim about the estimator, and only the first half is true by
+   * construction. These two cases separate them, and the module doc is written FROM the
+   * numbers the second one records — not the other way round.
+   */
+  describe("ranking fidelity", () => {
+    /**
+     * THE HALF THAT IS TRUE BY CONSTRUCTION.
+     *
+     * Switching the shrinkage correction on or off cannot change a ranking, because the
+     * correction is a monotone reparameterization of the score: it moves every score and
+     * moves none past another. That is the ONLY ranking claim this module can make without
+     * measuring anything, so it is worth pinning directly rather than inferring it from
+     * the end-to-end case below.
+     *
+     * This is a PIN, not a red test — it passes today and is expected to keep passing. The
+     * one mechanism by which the corrected wording could rot is a `shrinkageTable` whose
+     * quadrature is coarsened (fewer Simpson nodes, fewer knots) far enough to make the
+     * tabulated `g` non-monotone; the inverse would then fold back on itself and the
+     * doc's "moves none past another" would quietly stop holding.
+     *
+     * 1 bit is not swept here: its map is the closed form `cos(pi*(1 - r)/2)`, monotone by
+     * inspection over [-1, 1], and it is covered end-to-end by the fidelity case below.
+     *
+     * The map SATURATES at the ends — a ratio at or past the tabulated `g(1)` has no
+     * bracket to interpolate inside and returns exactly ±1 (2 bits from |r| >= 0.99,
+     * 3 bits from 0.995, 4 bits not within this grid). That is a documented clamp, and a
+     * flat region ties scores rather than inverting them, which is exactly the distinction
+     * the doc claim rests on. So: never decreasing anywhere, and strictly increasing
+     * wherever the value is not pinned to an endpoint.
+     */
+    test("the shrinkage correction is strictly monotone at every corrected width", () => {
+      const points = 401;
+      for (const bits of [2, 3, 4] as const) {
+        let previous = Number.NEGATIVE_INFINITY;
+        let previousRatio = Number.NaN;
+        for (let i = 0; i < points; i++) {
+          const ratio = -1 + (2 * i) / (points - 1);
+          const value = invertShrinkage(bits, ratio);
+          const label = `bits=${bits} ${previousRatio} -> ${ratio} gave ${previous} -> ${value}`;
+          if (i > 0) {
+            expect(value, label).toBeGreaterThanOrEqual(previous);
+            if (Math.abs(value) !== 1) expect(value, label).toBeGreaterThan(previous);
+          }
+          previous = value;
+          previousRatio = ratio;
+        }
+      }
+    });
+
+    /**
+     * THE HALF THAT HAD TO BE MEASURED.
+     *
+     * Monotonicity says the CORRECTION preserves ordering. It says nothing about whether
+     * the estimator's ordering matches the exact cosine's — that is quantization noise,
+     * and at 1 bit a whole vector is one sign per coordinate. So the doc bullet gets a
+     * recorded number per bit width, and these are those numbers.
+     *
+     * The corpus is built so the two metrics answer different questions and neither sits
+     * on a knife edge:
+     *
+     * - 10 "relevant" documents planted at t = 0.70 .. 0.88 and 10 "near-miss" ones at
+     *   t = 0.30 .. 0.48. The 0.22 gap between the 10th and 11th planted document (the
+     *   realized exact cosines run 0.876 .. 0.692, then 0.483) is far wider than any
+     *   width's error, so recall@10 measures set membership and is insensitive to noise.
+     * - The 0.02 spacing INSIDE the top 10 is comparable to the estimator's own error at
+     *   the low widths, so exact ordering is sensitive there. A single grid cannot make
+     *   both metrics informative; two spacings can.
+     *
+     * d = 1024 is a power of two, so nothing is padded and the case measures the estimator
+     * rather than the padding. The reference ranking is `cosineSimilarity` on the
+     * UNQUANTIZED vectors, never the planted `t` — a finite sample's realized cosine
+     * differs from `t` by ~1/sqrt(d), which is why the top-10 exact scores above are not
+     * the t values they were built from.
+     *
+     * `recall` and `orderIdentical` are pinned TWO-SIDED. A one-sided bound would let the
+     * corrected wording rot in the direction that matters: "1 bit reorders the top 10" is
+     * a claim that must fail if 1 bit ever stops reordering it, not just if it gets worse.
+     * Kendall tau is a floor rather than an equality because it is the one continuous
+     * number here, and floors non-decreasing in bits keep the case from reading as
+     * flaky-shaped if the grid is ever retuned.
+     */
+    test("ranking fidelity against the exact cosine, per bit width", () => {
+      const d = 1024;
+      const rnd = makeRandom(90210);
+
+      const query = new Float32Array(d);
+      for (let i = 0; i < d; i++) query[i] = rnd() - 0.5;
+
+      const docs: Float32Array[] = [];
+      for (let n = 0; n < 480; n++) {
+        const background = new Float32Array(d);
+        for (let i = 0; i < d; i++) background[i] = rnd() - 0.5;
+        docs.push(background);
+      }
+      /** `t * query + sqrt(1 - t^2) * noise`: a document at planted cosine `t`. */
+      const planted = (t: number): Float32Array => {
+        const noise = new Float32Array(d);
+        for (let i = 0; i < d; i++) noise[i] = rnd() - 0.5;
+        const k = Math.sqrt(1 - t * t);
+        const doc = new Float32Array(d);
+        for (let i = 0; i < d; i++) doc[i] = t * query[i]! + k * noise[i]!;
+        return doc;
+      };
+      for (let j = 0; j < 10; j++) docs.push(planted(0.7 + 0.02 * j));
+      for (let j = 0; j < 10; j++) docs.push(planted(0.3 + 0.02 * j));
+
+      const exactScores = docs.map((doc) => cosineSimilarity(query, doc));
+      const rankBy = (scores: readonly number[]): number[] =>
+        scores.map((_, index) => index).sort((a, b) => scores[b]! - scores[a]!);
+      const exactRank = rankBy(exactScores);
+
+      /**
+       * Kendall tau over the exact top 20, counting only pairs the two rankings both
+       * order: concordant minus discordant, over their total.
+       */
+      const kendallTau = (
+        subset: readonly number[],
+        candidate: readonly number[],
+        reference: readonly number[]
+      ): number => {
+        let concordant = 0;
+        let discordant = 0;
+        for (let i = 0; i < subset.length; i++) {
+          for (let j = i + 1; j < subset.length; j++) {
+            const x = subset[i]!;
+            const y = subset[j]!;
+            const agreement =
+              Math.sign(candidate[x]! - candidate[y]!) * Math.sign(reference[x]! - reference[y]!);
+            if (agreement > 0) concordant++;
+            else if (agreement < 0) discordant++;
+          }
+        }
+        const total = concordant + discordant;
+        return total === 0 ? 1 : (concordant - discordant) / total;
+      };
+
+      /** Measured on this corpus. Every planted document is retrieved at every width. */
+      const RECALL: Record<number, number> = { 1: 1, 2: 1, 4: 1, 8: 1 };
+      /**
+       * Measured: only 1 bit reorders the top 10. A one-sign-per-coordinate code cannot
+       * resolve the 0.02 steps between adjacent planted documents.
+       */
+      const ORDER: Record<number, boolean> = { 1: false, 2: true, 4: true, 8: true };
+      /**
+       * Measured tau over the exact top 20: 0.9368 / 0.9789 / 1.0000 / 1.0000. The floors
+       * sit just below each, and are non-decreasing in bits. Note 2 bits: it reproduces
+       * the top 10 exactly and still transposes a pair further down, which is why the two
+       * metrics are both reported rather than collapsed into one.
+       */
+      const TAU_FLOOR: Record<number, number> = { 1: 0.93, 2: 0.97, 4: 1, 8: 1 };
+
+      for (const bits of [1, 2, 4, 8] as const) {
+        const quantizedQuery = turboQuantize(query, { bits, seed: 42 });
+        const estimatedScores = docs.map((doc) =>
+          turboQuantizedCosineSimilarity(quantizedQuery, turboQuantize(doc, { bits, seed: 42 }))
+        );
+        const estimatedRank = rankBy(estimatedScores);
+
+        const exactTop10 = exactRank.slice(0, 10);
+        const estimatedTop10 = estimatedRank.slice(0, 10);
+        const recall = exactTop10.filter((i) => estimatedTop10.includes(i)).length / 10;
+        const orderIdentical = exactTop10.every((doc, i) => doc === estimatedTop10[i]);
+        const tau = kendallTau(exactRank.slice(0, 20), estimatedScores, exactScores);
+
+        expect(recall, `bits=${bits} recall@10`).toBe(RECALL[bits]!);
+        expect(orderIdentical, `bits=${bits} top-10 order identical`).toBe(ORDER[bits]!);
+        expect(tau, `bits=${bits} tau@20 = ${tau.toFixed(4)}`).toBeGreaterThanOrEqual(
+          TAU_FLOOR[bits]!
+        );
+      }
+    });
+  });
+
   describe("turboPrepareQuery / turboPreparedCosineSimilarity", () => {
     /**
      * BIT-FOR-BIT, at every width, is the whole contract.

--- a/packages/util/src/vector/TurboQuantize.ts
+++ b/packages/util/src/vector/TurboQuantize.ts
@@ -100,7 +100,7 @@
  *
  * 5-8 bits are deliberately left uncorrected: the residual bias is already at or below the
  * estimator's own noise there, and the table build cost scales as `levels^2`. See
- * {@link MAX_CORRECTED_BITS}.
+ * {@link TURBO_MAX_CORRECTED_BITS}.
  *
  * THE COST IS VARIANCE NEAR ORTHOGONALITY. Inverting a map whose slope is below 1 amplifies
  * the estimator's noise by `1/g'(0)`, where that slope is shallowest: 1.57x at 1 bit, 1.13x
@@ -657,8 +657,17 @@ function getQuantizationParams(
  * measured cold build is 16/21/22 ms at 2/3/4 bits, 56 ms at 5, 84 ms at 6 and 555 ms at
  * 8. Paying half a second on the first 8-bit comparison to correct a bias of 0.0001 is not
  * a trade worth offering.
+ *
+ * EXPORTED because it is a boundary a caller has to act on, not just read about: at or
+ * below it, {@link turboDequantize} plus a plain `cosineSimilarity` returns the
+ * UNCORRECTED estimator and disagrees with {@link turboQuantizedCosineSimilarity}; above
+ * it the two routes are interchangeable. A caller integrating with a scorer that takes
+ * raw vectors needs to branch on that, and reading a docstring and hoping is not a branch.
  */
-const MAX_CORRECTED_BITS = 4;
+export const TURBO_MAX_CORRECTED_BITS = 4;
+
+/** Internal alias for {@link TURBO_MAX_CORRECTED_BITS}; one literal, two names. */
+const MAX_CORRECTED_BITS = TURBO_MAX_CORRECTED_BITS;
 
 /**
  * Standard normal CDF; the only special function the shrinkage map needs.
@@ -1178,6 +1187,32 @@ function reconstructRotatedCodes(quantized: TurboQuantizeResult): {
  * affected: cosine similarity is scale-free, so such a record stays fully comparable through
  * {@link turboQuantizedCosineSimilarity}.
  *
+ * ## THE OUTPUT IS NOT SHRINKAGE-CORRECTED AT 1-4 BITS
+ *
+ * These are decoded coordinates, and comparing two of them with a plain `cosineSimilarity`
+ * gives the RAW estimator — the one the correction exists to undo. At 1 bit that reads a
+ * true 0.80 as 0.59; at 2-4 bits it is low by less, but low in the same direction and for
+ * the same reason. The corrected number comes from {@link turboQuantizedCosineSimilarity},
+ * or from {@link turboPrepareQuery} + {@link turboPreparedCosineSimilarity} in a search
+ * loop. At 5-8 bits the shrinkage is left uncorrected by design, so there the two routes
+ * ARE interchangeable; that boundary is {@link TURBO_MAX_CORRECTED_BITS}. Pinned by the
+ * test "turboDequantize + plain cosineSimilarity is NOT shrinkage-corrected at 1-4 bits".
+ *
+ * The warning lives here, and not only on {@link turboPrepareQuery}, because this is the
+ * function on the natural integration path: a `Float32Array` is the only output shape an
+ * `IVectorStorage` backend accepts, so a caller wiring turbo into storage reaches this
+ * one — and reaches the prepared-query docs only if they already understood the problem.
+ *
+ * THERE IS DELIBERATELY NO "corrected-compare" HELPER, because it would be a rename. The
+ * correction inverts a map defined on the CODE-DOMAIN ratio `dot / (codeNormA *
+ * codeNormB)`, and this function has already renormalized its output to the recorded
+ * `norm`, destroying that ratio. So any helper taking two {@link TurboQuantizeResult}s and
+ * returning a corrected number IS {@link turboQuantizedCosineSimilarity}. The case that
+ * genuinely needs one — an `IVectorStorage` backend scoring decoded vectors server-side,
+ * with no hook to substitute a scorer — is not fixable in this module at all, and is
+ * tracked in https://github.com/workglow-dev/libs/issues/798 (see the module doc). No
+ * workaround exists for it today.
+ *
  * @param quantized - The TurboQuant quantization result
  * @returns Reconstructed vector as Float32Array
  */
@@ -1314,7 +1349,7 @@ function assertComparablePair(a: TurboQuantizeResult, b: TurboQuantizeResult): v
  * "these are unrelated" either way, and both remove a bias that moved every absolute
  * threshold in one direction.
  *
- * 5-8 bits are left alone; see {@link MAX_CORRECTED_BITS}.
+ * 5-8 bits are left alone; see {@link TURBO_MAX_CORRECTED_BITS}.
  *
  * The correction itself lives in {@link finishCosine}, shared with the prepared-query
  * path — the two entry points must return the same number for the same pair, and the only

--- a/packages/util/src/vector/TurboQuantize.ts
+++ b/packages/util/src/vector/TurboQuantize.ts
@@ -111,15 +111,34 @@
  * answer is "unrelated" either way; the bias moved every absolute threshold in one
  * direction.
  *
- * RANKING was never affected — the shrinkage is monotone in the true cosine, so ordering a
- * candidate set was correct before and is correct now. ABSOLUTE THRESHOLDS AND CALIBRATION
- * were, and are what this fixes: a 2-bit `cos > 0.8` cut (an ordinary RAG threshold) used
- * to drop pairs whose real cosine was 0.87.
+ * RANKING IS UNCHANGED BY THE CORRECTION — the shrinkage is monotone in the true cosine and
+ * so is its inverse, so applying it moves every score and moves none past another; turning
+ * it on or off cannot reorder a candidate set. That is a statement about the CORRECTION,
+ * not about how well the estimator's ordering matches the exact cosine's, which is a
+ * separate, measured question — see the ordering bullet under Properties. ABSOLUTE
+ * THRESHOLDS AND CALIBRATION are what this fixes: a 2-bit `cos > 0.8` cut (an ordinary RAG
+ * threshold) used to drop pairs whose real cosine was 0.87.
  *
  * Properties:
  * - Data-oblivious: no training or codebook construction needed
  * - Per-vector: each vector quantized independently (streaming-friendly)
- * - Preserves the RANKING induced by inner products and cosine similarity
+ * - The shrinkage correction is strictly monotone, so it never reorders a candidate set.
+ *   Ordering fidelity against the EXACT cosine is a property of the quantizer, and is not
+ *   perfect at the low widths. Measured over 500 documents at d=1024 (480 background, 10
+ *   planted at true cosine 0.70-0.88, 10 near-misses at 0.30-0.48), seeded:
+ *
+ *   | bits | recall@10 | top-10 order identical | Kendall tau over the top 20 |
+ *   | ---- | --------- | ---------------------- | --------------------------- |
+ *   | 1    | 1.00      | no                     | 0.9368                      |
+ *   | 2    | 1.00      | yes                    | 0.9789                      |
+ *   | 4    | 1.00      | yes                    | 1.0000                      |
+ *   | 8    | 1.00      | yes                    | 1.0000                      |
+ *
+ *   So retrieval of a shortlist is unaffected at every width — the planted set comes back
+ *   whole even at 1 bit — while the ORDER within it is not: 1 bit transposes documents
+ *   inside the top 10, and 2 bits reproduces the top 10 exactly but still transposes a
+ *   pair further down. Rerank with exact vectors if the presented order matters at 1-2
+ *   bits.
  */
 
 import { TensorType } from "./Tensor";

--- a/packages/util/src/vector/TurboQuantize.ts
+++ b/packages/util/src/vector/TurboQuantize.ts
@@ -850,10 +850,20 @@ export function invertShrinkage(bits: number, estimate: number): number {
  *
  * A zero vector is not an error — it yields an all-zero `values` buffer and a
  * norm of 0.
+ *
+ * `norm` can still be `Infinity` for a FINITE input: max-scaling keeps the accumulator in
+ * range, but the reconstruction `maxAbs * rootS` overflows once the true L2 norm exceeds
+ * `Number.MAX_VALUE`. `values` is exact in that case, so the direction is intact and the
+ * norm-free encoder is unaffected; only a caller that keeps `norm` has a problem, and it
+ * is that caller's entry point ({@link turboQuantize}) that rejects it.
+ *
+ * `maxAbs` is returned so such a caller can report the coordinate magnitude that produced
+ * the overflow rather than only the `Infinity` it became.
  */
 function normalizeToUnit(vector: TypedArray): {
   readonly values: Float64Array;
   readonly norm: number;
+  readonly maxAbs: number;
 } {
   const d = vector.length;
   let maxAbs = 0;
@@ -868,7 +878,7 @@ function normalizeToUnit(vector: TypedArray): {
 
   const values = new Float64Array(d);
   if (maxAbs === 0) {
-    return { values, norm: 0 };
+    return { values, norm: 0, maxAbs };
   }
 
   let sumSquares = 0;
@@ -880,7 +890,7 @@ function normalizeToUnit(vector: TypedArray): {
   for (let i = 0; i < d; i++) {
     values[i] = vector[i] / maxAbs / rootS;
   }
-  return { values, norm: maxAbs * rootS };
+  return { values, norm: maxAbs * rootS, maxAbs };
 }
 
 /**
@@ -1011,7 +1021,22 @@ export function turboQuantize(
   assertDimensions(d);
 
   // Step 1: Compute norm and normalize
-  const { values, norm } = normalizeToUnit(vector);
+  const { values, norm, maxAbs } = normalizeToUnit(vector);
+  // A finite input can still have a norm no double holds: `normalizeToUnit` keeps the
+  // accumulator in range, but the reconstruction `maxAbs * rootS` overflows above
+  // Number.MAX_VALUE. Rejected here rather than returned, because every read path
+  // (`turboDequantize`, both similarity helpers) checks `norm` and throws on the record
+  // this would otherwise produce — a write that can never be read back.
+  if (!Number.isFinite(norm)) {
+    throw new Error(
+      `TurboQuant cannot encode this vector: its true L2 norm is not representable as a double ` +
+        `(largest absolute coordinate ${maxAbs}, norm overflows to ${norm}), and the record's ` +
+        `\`norm\` field is what every read path rescales by. Prescale the input — cosine ` +
+        `similarity is scale-free, so dividing every coordinate by a constant changes no ` +
+        `similarity — or use turboQuantizeToTypedArray, which records no norm and handles this ` +
+        `input unchanged.`
+    );
+  }
 
   // Step 2: Random rotation — returns all paddedLen coordinates
   const paddedLen = turboPaddedLength(d);
@@ -1027,7 +1052,7 @@ export function turboQuantize(
   // Step 4: Pack into compact representation
   const packed = packCodes(codes, bits);
 
-  return {
+  const result: TurboQuantizeResult = {
     version: TURBO_QUANTIZE_VERSION,
     codes: packed,
     bits,
@@ -1036,6 +1061,12 @@ export function turboQuantize(
     seed,
     norm,
   };
+  // The structural half of the same guarantee: every record this module hands out passes
+  // the check every reader applies. Today that holds only by coincidence — the encoder and
+  // `assertQuantizeResultShape` are two independent statements of the same invariant — and
+  // the check is O(1) on already-computed scalars, so asserting it costs nothing.
+  assertQuantizeResultShape(result);
+  return result;
 }
 
 /**


### PR DESCRIPTION
Stacked onto **#354** (`claude/integrate-arxiv-paper-VF55c`), which is the base of this PR — not `main`. Six commits, deliberately not squashed, so review and revert are granular where the risk is.

## Commits

**1. `fix(util): reject a TurboQuant record whose norm overflows a double`**

`normalizeToUnit` fixed the sumSquares accumulator overflow, but the norm is reconstructed as `maxAbs * rootS` and that product still overflows to Infinity for a large-magnitude *finite* input. `turboQuantize` returned it unvalidated, because `assertQuantizeResultShape` runs only on read paths:

```js
turboQuantize(new Float64Array(4).fill(1e308), { bits: 8, seed: 42 })
// -> { norm: Infinity, ... }
```

`turboDequantize`, `turboQuantizedCosineSimilarity` and `turboQuantizedInnerProduct` all then threw on it — the encoder was writing a record nothing could read, and reporting it three calls later phrased as if the *reader* were malformed. It now throws at encode time, with a message that names `maxAbs`, states that the true L2 norm is not representable as a double, and gives the two ways out: prescale the input (cosine is scale-free, so prescaling changes no similarity), or use `turboQuantizeToTypedArray`, which discards the norm entirely and handles this input unchanged.

The check is deliberately **not** in `normalizeToUnit`: `turboQuantizeToTypedArray` calls it and destructures `values` only, so a 1e308 input is fine on that path today and stays fine. Also asserts `assertQuantizeResultShape` on the constructed record — the structural half, that every record this module hands out passes the check every reader applies, which today holds only by coincidence. O(1).

*Rejected alternative: rescaling.* There is nothing to rescale **to** — the overflow means the true L2 norm exceeds `Number.MAX_VALUE` and no double holds it. Representing it would need a log-norm or `(mantissa, exponent)` field plus a `TURBO_QUANTIZE_VERSION` bump, to serve inputs whose coordinates sit near 1e308.

**2. `test(util): measure TurboQuant's ranking fidelity per bit width`** — lands before the doc commit so the recorded numbers are measured rather than asserted. See the table below.

**3. `docs(util): correct TurboQuant's ranking claim to what the measurement shows`**

The module doc said ranking "was correct before and is correct now" and listed "Preserves the RANKING induced by inner products and cosine similarity" as a property. Those are two claims and only the first is true by construction. The true half is kept and sharpened — the correction is strictly monotone, so it moves every score and moves none past another, and switching it on or off cannot change a ranking — and now says explicitly that this is a statement about the *correction*. The Properties bullet carries the measured per-width ordering fidelity instead of the false blanket claim.

**4. `docs(util): warn that turboDequantize's output is not shrinkage-corrected`**

`turboDequantize`'s docstring never said its output carries the **uncorrected** estimator at 1-4 bits. That warning lived only on `turboPrepareQuery`, which a caller reaches only if they already understood the problem — while `turboDequantize` is the function on the natural integration path, since a `Float32Array` is the only output shape an `IVectorStorage` backend accepts. Adds a section: decode-then-compare with plain `cosineSimilarity` reads a true 0.80 as 0.59 at 1 bit and low-but-less-so at 2-4; the corrected number comes from `turboQuantizedCosineSimilarity` or `turboPrepareQuery` + `turboPreparedCosineSimilarity`; at 5-8 bits the two routes are interchangeable, and that boundary is `MAX_CORRECTED_BITS`.

Promotes the private `MAX_CORRECTED_BITS` to an exported **`TURBO_MAX_CORRECTED_BITS = 4`** so a caller can branch on that boundary programmatically instead of reading a docstring and hoping. The internal name stays as an alias — one literal.

No "corrected-compare" helper, and the docstring says why: the correction inverts a map defined on the **code-domain** ratio `dot / (codeNormA * codeNormB)`, and a decoded `Float32Array` has already been renormalized to the recorded `norm`, destroying that ratio — so any helper taking two `TurboQuantizeResult`s and returning a corrected number *is* `turboQuantizedCosineSimilarity`. The real trap (an `IVectorStorage` backend scoring decoded vectors server-side with no hook) is not fixable in this module and is already tracked as #798, which the module doc cites. The docstring says that rather than implying a workaround exists.

New test: sweeps bits 1-8 on one correlated pair and requires the corrected-vs-decoded gap to exceed 0.002 **iff** `bits <= TURBO_MAX_CORRECTED_BITS` — exporting a constant creates a new way for docs and behavior to diverge, and this fails in both directions.

**5. `fix(ai): reject a heterogeneous vector batch under method "turbo"`**

`VectorQuantizeTask`'s dimensionality guard asks a **per-vector** question (is this length a power of two?) about a **batch-level** invariant, so `[Float32Array(512), Float32Array(1024)]` passed it unchanged: each vector was rotated in its own `paddedLen` under its own sign table (`getSignTable(seed, paddedLen)` is a different basis per length), while `originalDimensions` reported only `vectors[0].length`. Same with `turboPadToPowerOf2: true` and lengths 700/1100 (→ 1024/2048). Turbo output is comparable only against output with the same seed and, implicitly, the same padded length.

Turbo-only in this commit. An empty array now throws naming the input (it previously reached `getVectorType(undefined)` and threw "Unknown vector type: undefined"). Otherwise the first differing vector is reported with its index, both lengths, both padded lengths, the fact that the two live in different bases and are not comparable even after padding, and the remedy: quantize each dimensionality in a separate call.

**6. `fix(ai): reject a heterogeneous vector batch under every method`**

Moves the guard before the `method` branch with a method-aware consequence clause (for linear: the outputs keep their input lengths, so `cosineSimilarity` throws downstream — but `originalDimensions` misreports before that, and a fixed-width storage column accepts one and rejects the other), and folds in the mixed **element-type** case, which misreports `originalType`.

> **This is the only commit touching released behavior.** `VectorQuantizeTask`'s array input predates #354, unlike the codec and the turbo branch, so it is isolated so a reviewer who objects drops exactly this commit and the branch stays coherent. The justification: such a caller already receives a result whose `originalDimensions`/`originalType` describe only `vectors[0]` and whose outputs cannot share a storage column, so there is no correct use of that input shape — the break is from "silently wrong" to "loud". The input schema is `additionalProperties: false` with no opt-out, so there is no gradual path anyway.

## Measured ranking fidelity (commit 2, quoted by commit 3)

Deterministic corpus, `d = 1024` (a power of two, so nothing is padded and the case measures the estimator rather than the padding): 480 background documents, 10 planted at true cosine 0.70-0.88 (0.02 apart) and 10 near-misses at 0.30-0.48. The reference ranking is `cosineSimilarity` on the **unquantized** vectors, never the planted `t` — a finite sample's realized cosine differs from `t` by ~1/√d.

| bits | recall@10 | top-10 order identical | Kendall tau over the top 20 |
| ---- | --------- | ---------------------- | --------------------------- |
| 1    | 1.00      | no                     | 0.9368                      |
| 2    | 1.00      | yes                    | 0.9789                      |
| 4    | 1.00      | yes                    | 1.0000                      |
| 8    | 1.00      | yes                    | 1.0000                      |

Retrieval of a shortlist is unaffected at every width — the planted set comes back whole even at 1 bit — while the **order** within it is not: 1 bit transposes documents inside the top 10, and 2 bits reproduces the top 10 exactly and still transposes a pair further down. The 0.22 gap between the 10th and 11th planted document makes recall@10 insensitive to noise at every width, while the 0.02 spacing inside the top 10 makes ordering sensitive — the two metrics are decoupled so neither sits on a knife edge. `recall` and `orderIdentical` are pinned two-sided, which is what pins the corrected wording in both directions; tau is a floor, non-decreasing in bits.

## Compatibility

`packages/util/src/vector/TurboQuantize.ts` is **added** by #354, so every codec-level export is unreleased and commits 1-4 carry no compat risk — the behavior commit 1 replaces is "returns a record all three read paths throw on", so the throw merely moves earlier. Commit 6 is the only released-behavior change; see its note above.

## Verification

- `bun scripts/test.ts util vitest` — **54 files, 836 passed, 10 skipped** (baseline before any edit, and again after).
- `bun scripts/test.ts util rag vitest` — **77 of 78 files passed, 1081 tests passed, 10 skipped, 1 failed**. The one failure is `src/test/rag/EndToEnd.integration.test.ts` timing out at 160s: an ONNX-download RAG pipeline test (3.6 GB RSS, `onnx:Qwen3-Embedding-0.6B`) that references nothing this branch touches. Run on its own it passes on **both** sides — 8/8 in 73s on this branch, 8/8 in 77s on the base commit — so it is a resource/timeout flake under the sweep's 40-worker parallel load, not a regression.
- `bun scripts/test.ts rag unit vitest` — 21 files, 225 passed.
- `bun run build:types` — 41/41 workspaces, and `TURBO_MAX_CORRECTED_BITS` confirmed to reach `@workglow/util/schema` (declaration emitted, and importing it through the package subpath resolves to `4`).
- `bun run format` — no changes to any file this branch touches (`prettier --check` clean on all four). Prettier did rewrite 12 unrelated files carrying pre-existing drift on the base branch; those were reverted rather than folded in.
- The three commit-5 rejection cases were confirmed **red** against the pre-fix task before the fix landed, and the pre-existing homogeneous cases `should handle array of vectors` and `should handle array of vectors with turbo method` were verified green by name after commit 6.

Run with Node v22.22.2 (the container has no Node 24 available); everything went through `bun` / `bunx vitest` as the repo scripts do.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgxtp7mQECdh7F2UT9CVwN)_