### PR TITLE
feat(triggers): add the triggers package with cron, interval, and polling triggers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -359,6 +359,7 @@
         "@workglow/task-graph": "workspace:*",
         "@workglow/tasks": "workspace:*",
         "@workglow/tf-mediapipe": "workspace:*",
+        "@workglow/triggers": "workspace:*",
         "@workglow/util": "workspace:*",
         "@workglow/xai": "workspace:*",
         "aws-sdk-client-mock": "catalog:",
@@ -368,6 +369,18 @@
         "pg": "catalog:",
         "playwright": "catalog:",
         "vitest": "catalog:",
+      },
+    },
+    "packages/triggers": {
+      "name": "@workglow/triggers",
+      "version": "0.3.45",
+      "devDependencies": {
+        "@workglow/task-graph": "workspace:*",
+        "@workglow/util": "workspace:*",
+      },
+      "peerDependencies": {
+        "@workglow/task-graph": "workspace:*",
+        "@workglow/util": "workspace:*",
       },
     },
     "packages/util": {
@@ -408,6 +421,7 @@
         "@workglow/task-graph": "workspace:*",
         "@workglow/tasks": "workspace:*",
         "@workglow/tf-mediapipe": "workspace:*",
+        "@workglow/triggers": "workspace:*",
         "@workglow/util": "workspace:*",
         "@workglow/xai": "workspace:*",
         "tslog": "^5.1.0",
@@ -1659,6 +1673,8 @@
     "@workglow/test": ["@workglow/test@workspace:packages/test"],
 
     "@workglow/tf-mediapipe": ["@workglow/tf-mediapipe@workspace:providers/tf-mediapipe"],
+
+    "@workglow/triggers": ["@workglow/triggers@workspace:packages/triggers"],
 
     "@workglow/util": ["@workglow/util@workspace:packages/util"],
 

--- a/packages/task-graph/src/task-graph/IWorkflow.ts
+++ b/packages/task-graph/src/task-graph/IWorkflow.ts
@@ -24,6 +24,17 @@ export interface WorkflowRunConfig {
    * multiple runs, then dispose at app shutdown.
    */
   readonly resourceScope?: ResourceScope;
+  /**
+   * Caller-owned cancellation for THIS run only.
+   *
+   * It is bridged onto the run's own controller, so aborting it cancels this
+   * run and nothing else — the listener is removed when the run ends, so a
+   * long-lived signal driving many runs accumulates nothing. That is the
+   * difference from `Workflow.abort()`, which trips the single current-run
+   * controller and therefore cancels whichever run started last — the wrong
+   * granularity when several callers (e.g. two triggers) drive one workflow.
+   */
+  readonly signal?: AbortSignal | undefined;
 }
 
 export interface IWorkflow<

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -235,6 +235,9 @@ export class Workflow<
     this.events.emit("start");
     const ctx = new WorkflowRunContext();
     this._currentRun = ctx;
+    // A caller-supplied signal cancels only THIS run; `abort()` keeps working
+    // through the run's own controller, which both sources feed.
+    if (config?.signal) ctx.linkSignal(config.signal);
     // Streaming unsub lives on the context (not the bridge) so concurrent
     // run() calls don't clobber each other's subscriptions.
     ctx.unsubStreaming = this._bridge?.beginRun();

--- a/packages/task-graph/src/task-graph/WorkflowRunContext.ts
+++ b/packages/task-graph/src/task-graph/WorkflowRunContext.ts
@@ -21,14 +21,38 @@
 export class WorkflowRunContext {
   readonly abortController: AbortController;
   unsubStreaming?: () => void;
+  private detachSignal?: () => void;
 
   constructor() {
     this.abortController = new AbortController();
   }
 
-  /** Releases the streaming subscription if one is held. Idempotent. */
+  /**
+   * Bridges a caller-supplied per-run signal onto this run's controller, so the
+   * run is cancelled by either source and the graph still sees ONE signal.
+   *
+   * A removable listener rather than `AbortSignal.any([own, caller])`: the
+   * composite that `any` mints is retained by its sources until it is collected
+   * (measurably ~1.7 KB per composite on Node 22 even after a forced GC), and a
+   * long-lived caller signal — a trigger's, say — would collect one per fire.
+   * The listener installed here is detached by {@link dispose} at run end, so
+   * nothing accumulates however many runs a driver starts.
+   */
+  linkSignal(signal: AbortSignal): void {
+    if (signal.aborted) {
+      this.abortController.abort(signal.reason);
+      return;
+    }
+    const onAbort = (): void => this.abortController.abort(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    this.detachSignal = () => signal.removeEventListener("abort", onAbort);
+  }
+
+  /** Releases the streaming subscription and the caller-signal bridge. Idempotent. */
   dispose(): void {
     this.unsubStreaming?.();
     this.unsubStreaming = undefined;
+    this.detachSignal?.();
+    this.detachSignal = undefined;
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -68,6 +68,7 @@
     "@workglow/storage": "workspace:*",
     "@workglow/supabase": "workspace:*",
     "@workglow/task-graph": "workspace:*",
+    "@workglow/triggers": "workspace:*",
     "@workglow/tasks": "workspace:*",
     "@workglow/tf-mediapipe": "workspace:*",
     "@workglow/util": "workspace:*",

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -172,6 +172,33 @@ describe("Workflow", () => {
 
       await expect(runPromise).rejects.toThrow();
     });
+
+    it("should abort a run through a caller-supplied runConfig.signal", async () => {
+      // Per-run cancellation: the caller aborts THIS run without touching the
+      // workflow's own current-run controller, which is what several
+      // independent drivers (e.g. triggers) on one workflow need.
+      workflow = workflow.longRunning();
+      const controller = new AbortController();
+
+      const runPromise = workflow.run({}, { registry, signal: controller.signal });
+      await sleep(1);
+      controller.abort();
+
+      await expect(runPromise).rejects.toThrow();
+    });
+
+    it("should still honour abort() when a runConfig.signal is supplied", async () => {
+      // Both sources stay live: combining them must not shadow `abort()`.
+      workflow = workflow.longRunning();
+      const controller = new AbortController();
+
+      const runPromise = workflow.run({}, { registry, signal: controller.signal });
+      await sleep(1);
+      workflow.abort();
+
+      await expect(runPromise).rejects.toThrow();
+      expect(controller.signal.aborted).toBe(false);
+    });
   });
 
   describe("pop", () => {

--- a/packages/test/src/test/trigger/CronSchedule.test.ts
+++ b/packages/test/src/test/trigger/CronSchedule.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CronExpressionError,
+  CronUnsatisfiableError,
+  nextCronFireTime,
+  parseCronExpression,
+  TriggerError,
+} from "@workglow/triggers";
+import { describe, expect, test } from "vitest";
+
+const iso = (ms: number): string => new Date(ms).toISOString();
+const at = (text: string): number => Date.parse(text);
+
+describe("parseCronExpression", () => {
+  test("expands every supported field form", () => {
+    const schedule = parseCronExpression("15,45 0-6/2 1,15 */3 1-5");
+    expect([...schedule.minutes]).toEqual([15, 45]);
+    expect([...schedule.hours]).toEqual([0, 2, 4, 6]);
+    expect([...schedule.daysOfMonth]).toEqual([1, 15]);
+    expect([...schedule.months]).toEqual([1, 4, 7, 10]);
+    expect([...schedule.daysOfWeek]).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test("normalizes whitespace and reports the normalized expression", () => {
+    expect(parseCronExpression("  0   9 * *  1  ").expression).toBe("0 9 * * 1");
+  });
+
+  test("treats day-of-week 7 as Sunday", () => {
+    expect([...parseCronExpression("0 0 * * 7").daysOfWeek]).toEqual([0]);
+    expect([...parseCronExpression("0 0 * * 0,7").daysOfWeek]).toEqual([0]);
+  });
+
+  test("tracks which day fields are restricted", () => {
+    const unrestricted = parseCronExpression("0 0 * * *");
+    expect(unrestricted.dayOfMonthRestricted).toBe(false);
+    expect(unrestricted.dayOfWeekRestricted).toBe(false);
+
+    const both = parseCronExpression("0 0 1 * 1");
+    expect(both.dayOfMonthRestricted).toBe(true);
+    expect(both.dayOfWeekRestricted).toBe(true);
+  });
+
+  describe.each([
+    ["empty", "   "],
+    ["four fields", "0 9 * *"],
+    ["six fields (seconds)", "0 0 9 * * *"],
+    ["macro", "@daily"],
+    ["month name", "0 0 1 JAN *"],
+    ["day name", "0 0 * * MON"],
+    ["minute out of range", "60 * * * *"],
+    ["hour out of range", "0 24 * * *"],
+    ["day-of-month out of range", "0 0 32 * *"],
+    ["month out of range", "0 0 1 13 *"],
+    ["day-of-week out of range", "0 0 * * 8"],
+    ["inverted range", "0 10-5 * * *"],
+    ["zero step", "*/0 * * * *"],
+    ["negative step", "*/-1 * * * *"],
+    ["double step", "*/2/2 * * * *"],
+    ["open-ended step", "5/10 * * * *"],
+    ["empty list entry", "0,,5 * * * *"],
+    ["Quartz L", "0 0 L * *"],
+    ["Quartz W", "0 0 15W * *"],
+    ["Quartz #", "0 0 * * 5#3"],
+    ["Quartz ?", "0 0 ? * *"],
+  ])("rejects %s", (_label, expression) => {
+    test(`"${expression}" throws a typed error`, () => {
+      expect(() => parseCronExpression(expression)).toThrow(CronExpressionError);
+      // Every package error is a TriggerError, and every TriggerError is an Error.
+      expect(() => parseCronExpression(expression)).toThrow(TriggerError);
+      expect(() => parseCronExpression(expression)).toThrow(Error);
+    });
+  });
+});
+
+describe("nextCronFireTime", () => {
+  // 2026-03-10T12:34:56Z is a Tuesday.
+  const anchor = at("2026-03-10T12:34:56.000Z");
+
+  test.each([
+    ["* * * * *", anchor, "2026-03-10T12:35:00.000Z"],
+    ["*/5 * * * *", anchor, "2026-03-10T12:35:00.000Z"],
+    ["*/5 * * * *", at("2026-03-10T12:35:00.000Z"), "2026-03-10T12:40:00.000Z"],
+    ["0 9 * * 1-5", anchor, "2026-03-11T09:00:00.000Z"],
+    ["0 9 * * 1-5", at("2026-03-13T10:00:00.000Z"), "2026-03-16T09:00:00.000Z"],
+    ["0 0 1 * *", anchor, "2026-04-01T00:00:00.000Z"],
+    ["15,45 * * * *", anchor, "2026-03-10T12:45:00.000Z"],
+    ["15,45 * * * *", at("2026-03-10T12:45:00.000Z"), "2026-03-10T13:15:00.000Z"],
+    ["0-30/10 * * * *", anchor, "2026-03-10T13:00:00.000Z"],
+    ["0-30/10 * * * *", at("2026-03-10T13:00:00.000Z"), "2026-03-10T13:10:00.000Z"],
+    ["0-30/10 * * * *", at("2026-03-10T13:30:00.000Z"), "2026-03-10T14:00:00.000Z"],
+  ])("%s after %s -> %s", (expression, from, expected) => {
+    expect(iso(nextCronFireTime(parseCronExpression(expression), from))).toBe(expected);
+  });
+
+  test("a time exactly on a boundary returns the NEXT match, not the same one", () => {
+    const schedule = parseCronExpression("0 0 * * *");
+    const midnight = at("2026-03-10T00:00:00.000Z");
+    expect(iso(nextCronFireTime(schedule, midnight))).toBe("2026-03-11T00:00:00.000Z");
+  });
+
+  test("sub-minute remainders do not skip the upcoming minute", () => {
+    const schedule = parseCronExpression("* * * * *");
+    expect(iso(nextCronFireTime(schedule, at("2026-03-10T00:00:00.001Z")))).toBe(
+      "2026-03-10T00:01:00.000Z"
+    );
+  });
+
+  test("rolls over month and year boundaries", () => {
+    const schedule = parseCronExpression("0 0 1 * *");
+    expect(iso(nextCronFireTime(schedule, at("2026-12-15T00:00:00.000Z")))).toBe(
+      "2027-01-01T00:00:00.000Z"
+    );
+    expect(
+      iso(nextCronFireTime(parseCronExpression("30 23 31 12 *"), at("2026-01-01T00:00:00.000Z")))
+    ).toBe("2026-12-31T23:30:00.000Z");
+  });
+
+  test("finds the next leap day", () => {
+    const schedule = parseCronExpression("0 0 29 2 *");
+    expect(iso(nextCronFireTime(schedule, at("2026-03-01T00:00:00.000Z")))).toBe(
+      "2028-02-29T00:00:00.000Z"
+    );
+    expect(iso(nextCronFireTime(schedule, at("2028-02-29T00:00:00.000Z")))).toBe(
+      "2032-02-29T00:00:00.000Z"
+    );
+  });
+
+  test("skips the 31st in months that do not have one", () => {
+    const schedule = parseCronExpression("0 0 31 * *");
+    expect(iso(nextCronFireTime(schedule, at("2026-01-31T00:00:00.000Z")))).toBe(
+      "2026-03-31T00:00:00.000Z"
+    );
+  });
+
+  test("finds a leap day across a century non-leap year", () => {
+    // 2100 is divisible by 100 but not 400, so it is NOT a leap year: the gap
+    // from 2096-02-29 to 2104-02-29 is just under eight years, longer than a
+    // five-year search horizon would reach.
+    const schedule = parseCronExpression("0 0 29 2 *");
+    expect(iso(nextCronFireTime(schedule, at("2097-03-01T00:00:00.000Z")))).toBe(
+      "2104-02-29T00:00:00.000Z"
+    );
+  });
+
+  test("day-of-month and day-of-week use OR semantics when both are restricted", () => {
+    // The 1st of the month, OR any Monday.
+    const schedule = parseCronExpression("0 0 1 * 1");
+    // 2026-03-10 is a Tuesday; the next Monday is the 16th.
+    expect(iso(nextCronFireTime(schedule, anchor))).toBe("2026-03-16T00:00:00.000Z");
+    // ...and the 1st of April fires even though it is a Wednesday.
+    expect(iso(nextCronFireTime(schedule, at("2026-03-30T12:00:00.000Z")))).toBe(
+      "2026-04-01T00:00:00.000Z"
+    );
+  });
+
+  test("a day list plus a weekday still ORs", () => {
+    const schedule = parseCronExpression("0 0 1,15 * 1");
+    // 2026-03-10 is a Tuesday: the 15th (a Sunday) arrives before the 16th.
+    expect(iso(nextCronFireTime(schedule, anchor))).toBe("2026-03-15T00:00:00.000Z");
+  });
+
+  test("a day field beginning with * keeps AND semantics (Vixie parity)", () => {
+    // Vixie tests the LEADING character, so `*/2` is a "star" field: the
+    // expression means "an odd day of the month AND a Monday", not "or".
+    const schedule = parseCronExpression("0 0 */2 * 1");
+    expect(schedule.dayOfMonthRestricted).toBe(false);
+    expect(schedule.dayOfWeekRestricted).toBe(true);
+    // Mondays after the Tuesday anchor are the 16th (even, no match) and the
+    // 23rd (odd, match). Under OR semantics this would answer the 11th.
+    expect(iso(nextCronFireTime(schedule, anchor))).toBe("2026-03-23T00:00:00.000Z");
+  });
+
+  test("a restricted day-of-month alone must match (no OR fallback)", () => {
+    const schedule = parseCronExpression("0 0 1 * *");
+    expect(iso(nextCronFireTime(schedule, at("2026-03-16T00:00:00.000Z")))).toBe(
+      "2026-04-01T00:00:00.000Z"
+    );
+  });
+
+  test("a restricted day-of-week alone must match (no OR fallback)", () => {
+    const schedule = parseCronExpression("0 0 * * 1");
+    expect(iso(nextCronFireTime(schedule, at("2026-03-10T00:00:00.000Z")))).toBe(
+      "2026-03-16T00:00:00.000Z"
+    );
+  });
+
+  test("throws a typed error for a satisfiable-looking but impossible expression", () => {
+    const schedule = parseCronExpression("0 0 30 2 *");
+    expect(() => nextCronFireTime(schedule, anchor)).toThrow(CronUnsatisfiableError);
+    expect(() => nextCronFireTime(schedule, anchor)).toThrow(TriggerError);
+  });
+});

--- a/packages/test/src/test/trigger/CronTrigger.test.ts
+++ b/packages/test/src/test/trigger/CronTrigger.test.ts
@@ -1,0 +1,267 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CronExpressionError, CronTrigger, CronUnsatisfiableError } from "@workglow/triggers";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { advanceFakeTimers, flushAsyncWork } from "../helpers/advanceFakeTimers";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * `CronTrigger` reads the wall clock to compute its next fire, so the system
+ * time and the timer queue must be faked together — advancing timers alone
+ * would leave `Date.now()` behind and every computed delay would be wrong.
+ */
+function useFakeClock(at: number): void {
+  vi.useFakeTimers();
+  vi.setSystemTime(at);
+}
+
+const isoFires = (fires: number[]): string[] => fires.map((ms) => new Date(ms).toISOString());
+
+describe("CronTrigger", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("rejects an invalid expression at construction, not at the first tick", () => {
+    expect(() => new CronTrigger({ expression: "not a cron" })).toThrow(CronExpressionError);
+    expect(() => new CronTrigger({ expression: "@hourly" })).toThrow(CronExpressionError);
+  });
+
+  test("exposes the normalized expression and the cron kind", () => {
+    const trigger = new CronTrigger({ expression: "  */5   * * * *  " });
+    expect(trigger.expression).toBe("*/5 * * * *");
+    expect(trigger.kind).toBe("cron");
+  });
+
+  test("fires on every matching minute boundary", async () => {
+    useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
+    const trigger = new CronTrigger({ expression: "*/5 * * * *" });
+    const fires: number[] = [];
+    trigger.start((context) => {
+      fires.push(context.scheduledAt);
+      expect(Date.now()).toBe(context.scheduledAt);
+    });
+
+    await advanceFakeTimers(15 * MINUTE);
+
+    expect(isoFires(fires)).toEqual([
+      "2026-03-10T12:05:00.000Z",
+      "2026-03-10T12:10:00.000Z",
+      "2026-03-10T12:15:00.000Z",
+    ]);
+
+    await trigger.stop();
+  });
+
+  test("does not fire before the first matching instant", async () => {
+    useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
+    const trigger = new CronTrigger({ expression: "*/5 * * * *" });
+    const fires: number[] = [];
+    trigger.start((context) => {
+      fires.push(context.scheduledAt);
+    });
+
+    await advanceFakeTimers(5 * MINUTE - 1);
+    expect(fires).toEqual([]);
+
+    await advanceFakeTimers(1);
+    expect(fires).toHaveLength(1);
+
+    await trigger.stop();
+  });
+
+  test("starting exactly on a boundary waits for the NEXT one", async () => {
+    useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
+    const trigger = new CronTrigger({ expression: "0 * * * *" });
+    const fires: number[] = [];
+    trigger.start((context) => {
+      fires.push(context.scheduledAt);
+    });
+
+    await advanceFakeTimers(HOUR - 1);
+    expect(fires).toEqual([]);
+
+    await advanceFakeTimers(1);
+    expect(isoFires(fires)).toEqual(["2026-03-10T13:00:00.000Z"]);
+
+    await trigger.stop();
+  });
+
+  test("does not drift over 100 minute boundaries", async () => {
+    const start = Date.UTC(2026, 2, 10, 12, 0, 0);
+    useFakeClock(start);
+    const trigger = new CronTrigger({ expression: "* * * * *" });
+    const fires: number[] = [];
+    trigger.start((context) => {
+      fires.push(context.scheduledAt);
+    });
+
+    await advanceFakeTimers(100 * MINUTE);
+
+    expect(fires).toHaveLength(100);
+    expect(fires).toEqual(Array.from({ length: 100 }, (_, i) => start + (i + 1) * MINUTE));
+
+    await trigger.stop();
+  });
+
+  test("skips weekends for a weekday schedule", async () => {
+    // Friday 2026-03-13, one hour before the 09:00 UTC fire.
+    useFakeClock(Date.UTC(2026, 2, 13, 8, 0, 0));
+    const trigger = new CronTrigger({ expression: "0 9 * * 1-5" });
+    const fires: number[] = [];
+    trigger.start((context) => {
+      fires.push(context.scheduledAt);
+    });
+
+    // Through Tuesday morning: Friday fires, Saturday and Sunday are skipped
+    // entirely, then Monday and Tuesday fire.
+    await advanceFakeTimers(4 * DAY + 2 * HOUR);
+
+    expect(isoFires(fires)).toEqual([
+      "2026-03-13T09:00:00.000Z",
+      "2026-03-16T09:00:00.000Z",
+      "2026-03-17T09:00:00.000Z",
+    ]);
+
+    await trigger.stop();
+  });
+
+  test("a wait longer than the host timer ceiling still fires once, at the right time", async () => {
+    // A monthly schedule is ~31 days out — past the ~24.8-day setTimeout limit,
+    // where an unchunked delay would overflow and fire immediately.
+    useFakeClock(Date.UTC(2026, 0, 1, 0, 0, 1));
+    const trigger = new CronTrigger({ expression: "0 0 1 * *" });
+    const fires: number[] = [];
+    trigger.start((context) => {
+      fires.push(context.scheduledAt);
+    });
+
+    await advanceFakeTimers(25 * DAY);
+    expect(fires).toEqual([]);
+
+    await advanceFakeTimers(7 * DAY);
+    expect(isoFires(fires)).toEqual(["2026-02-01T00:00:00.000Z"]);
+
+    await trigger.stop();
+  });
+
+  test("a backward clock step delays a cron fire rather than misfiring it", async () => {
+    // A cron expression names a calendar instant, so a clock corrected backwards
+    // means the appointment has NOT arrived yet and the trigger must wait the
+    // correction out. This is the guard that the interval triggers' "an expiry
+    // is a fire whatever the clock reads" rule is never applied here too.
+    useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
+    const trigger = new CronTrigger({ expression: "*/5 * * * *" });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(2 * MINUTE);
+    // Clock steps back 10 minutes; 3 minutes of monotonic delay remain.
+    vi.setSystemTime(Date.now() - 10 * MINUTE);
+    await advanceFakeTimers(3 * MINUTE);
+    await advanceFakeTimers(0);
+    expect(fires).toBe(0);
+
+    // The clock reaches 12:05 for real.
+    await advanceFakeTimers(10 * MINUTE);
+    expect(fires).toBe(1);
+
+    await trigger.stop();
+  });
+
+  test("stop() halts further fires", async () => {
+    useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
+    const trigger = new CronTrigger({ expression: "* * * * *" });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(2 * MINUTE);
+    expect(fires).toBe(2);
+
+    await trigger.stop();
+    await advanceFakeTimers(10 * MINUTE);
+    expect(fires).toBe(2);
+  });
+
+  test("a second start() is a no-op", async () => {
+    useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
+    const trigger = new CronTrigger({ expression: "* * * * *" });
+    let fires = 0;
+    const handler = (): void => {
+      fires += 1;
+    };
+    trigger.start(handler);
+    trigger.start(handler);
+
+    await advanceFakeTimers(3 * MINUTE);
+    expect(fires).toBe(3);
+
+    await trigger.stop();
+  });
+
+  test("a start() that cannot compute a first fire leaves the trigger stopped", async () => {
+    // `0 0 30 2 *` parses fine — February simply never has a 30th — so the
+    // failure surfaces on the FIRST schedule, which is where `start()` must
+    // leave the trigger untouched rather than half-live.
+    useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
+    const trigger = new CronTrigger({ expression: "0 0 30 2 *" });
+    let fires = 0;
+    const handler = (): void => {
+      fires += 1;
+    };
+
+    expect(() => trigger.start(handler)).toThrow(CronUnsatisfiableError);
+    expect(trigger.running).toBe(false);
+    // A trigger left reporting `running` would swallow every later start() as a
+    // no-op; this one must still report the real failure.
+    expect(() => trigger.start(handler)).toThrow(CronUnsatisfiableError);
+
+    await advanceFakeTimers(DAY);
+    expect(fires).toBe(0);
+
+    // A valid trigger started afterwards schedules normally.
+    const healthy = new CronTrigger({ expression: "* * * * *" });
+    let healthyFires = 0;
+    healthy.start(() => {
+      healthyFires += 1;
+    });
+    await advanceFakeTimers(2 * MINUTE);
+    expect(healthyFires).toBe(2);
+
+    await healthy.stop();
+    await trigger.stop();
+  });
+
+  test("a handler rejection does not stop the schedule", async () => {
+    useFakeClock(Date.UTC(2026, 2, 10, 12, 0, 0));
+    const trigger = new CronTrigger({ expression: "* * * * *" });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+    let fires = 0;
+    trigger.start(async () => {
+      fires += 1;
+      throw new Error("handler failed");
+    });
+
+    await advanceFakeTimers(3 * MINUTE);
+    await flushAsyncWork();
+
+    expect(fires).toBe(3);
+    expect(errors).toHaveLength(3);
+    expect(trigger.running).toBe(true);
+
+    await trigger.stop();
+  });
+});

--- a/packages/test/src/test/trigger/IntervalTrigger.test.ts
+++ b/packages/test/src/test/trigger/IntervalTrigger.test.ts
@@ -1,0 +1,1120 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ITriggerFireContext } from "@workglow/triggers";
+import {
+  IntervalTrigger,
+  TriggerConfigurationError,
+  TriggerStopTimeoutError,
+} from "@workglow/triggers";
+import type { ILogger } from "@workglow/util";
+import { getLogger, setLogger } from "@workglow/util";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { advanceFakeTimers, flushAsyncWork } from "../helpers/advanceFakeTimers";
+
+const START = Date.UTC(2026, 0, 1, 0, 0, 0);
+const PERIOD = 100;
+
+interface Gate {
+  readonly promise: Promise<void>;
+  readonly open: () => void;
+}
+
+function createGate(): Gate {
+  let open: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { promise, open };
+}
+
+interface WarnRecord {
+  readonly message: string;
+  readonly meta: Record<string, unknown> | undefined;
+}
+
+/**
+ * Installs a logger that records `warn` calls; returns the sink and a restore fn.
+ * Built from scratch rather than spread from the installed logger, whose methods
+ * live on a class prototype and would be lost.
+ */
+function captureWarnings(): { warnings: WarnRecord[]; restore: () => void } {
+  const warnings: WarnRecord[] = [];
+  const previous = getLogger();
+  const noop = (): void => {};
+  const logger: ILogger = {
+    debug: noop,
+    info: noop,
+    warn: (message: string, meta?: Record<string, unknown>) => {
+      warnings.push({ message, meta });
+    },
+    error: noop,
+    fatal: noop,
+    child: () => logger,
+    time: noop,
+    timeEnd: noop,
+    group: noop,
+    groupEnd: noop,
+  };
+  setLogger(logger);
+  return { warnings, restore: () => setLogger(previous) };
+}
+
+describe("IntervalTrigger", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("rejects a non-positive or non-integer period", () => {
+    expect(() => new IntervalTrigger({ intervalMs: 0 })).toThrow(TriggerConfigurationError);
+    expect(() => new IntervalTrigger({ intervalMs: -5 })).toThrow(TriggerConfigurationError);
+    expect(() => new IntervalTrigger({ intervalMs: 1.5 })).toThrow(TriggerConfigurationError);
+    expect(() => new IntervalTrigger({ intervalMs: Number.NaN })).toThrow(
+      TriggerConfigurationError
+    );
+  });
+
+  test("rejects a handler that is not a function", () => {
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    expect(() => trigger.start(undefined as never)).toThrow(TriggerConfigurationError);
+    // Nothing was touched: no timer, and the trigger is still startable.
+    expect(trigger.running).toBe(false);
+  });
+
+  test("rejects an unknown overlap policy", () => {
+    expect(() => new IntervalTrigger({ intervalMs: PERIOD, overlap: "whenever" as never })).toThrow(
+      TriggerConfigurationError
+    );
+  });
+
+  test("does not fire before a full period has elapsed", async () => {
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    const fires: number[] = [];
+    trigger.start((context) => {
+      fires.push(context.scheduledAt);
+    });
+
+    await advanceFakeTimers(PERIOD - 1);
+    expect(fires).toEqual([]);
+
+    await advanceFakeTimers(1);
+    expect(fires).toEqual([START + PERIOD]);
+
+    await trigger.stop();
+  });
+
+  test("fires exactly N times over N periods", async () => {
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(PERIOD * 7);
+    expect(fires).toBe(7);
+
+    await trigger.stop();
+  });
+
+  test("does not drift over 100 periods", async () => {
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    const scheduled: number[] = [];
+    trigger.start((context) => {
+      scheduled.push(context.scheduledAt);
+      expect(Date.now()).toBe(context.scheduledAt);
+    });
+
+    await advanceFakeTimers(PERIOD * 100);
+
+    expect(scheduled).toHaveLength(100);
+    const expected = Array.from({ length: 100 }, (_, i) => START + (i + 1) * PERIOD);
+    expect(scheduled).toEqual(expected);
+    // The 100th fire lands on the exact multiple — no accumulated slippage.
+    expect(scheduled[99]).toBe(START + 100 * PERIOD);
+
+    await trigger.stop();
+  });
+
+  test("stop() halts further fires", async () => {
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(PERIOD * 2);
+    expect(fires).toBe(2);
+    expect(trigger.running).toBe(true);
+
+    await trigger.stop();
+    expect(trigger.running).toBe(false);
+
+    await advanceFakeTimers(PERIOD * 5);
+    expect(fires).toBe(2);
+  });
+
+  test("stop() is idempotent and emits stop once", async () => {
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    let stops = 0;
+    trigger.on("stop", () => {
+      stops += 1;
+    });
+    trigger.start(() => {});
+
+    await trigger.stop();
+    await trigger.stop();
+    expect(stops).toBe(1);
+  });
+
+  test("a second start() is a no-op and leaves no extra timer", async () => {
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    let starts = 0;
+    trigger.on("start", () => {
+      starts += 1;
+    });
+    let fires = 0;
+    const handler = (): void => {
+      fires += 1;
+    };
+
+    trigger.start(handler);
+    trigger.start(handler);
+    expect(starts).toBe(1);
+
+    await advanceFakeTimers(PERIOD * 3);
+    expect(fires).toBe(3);
+
+    await trigger.stop();
+    await advanceFakeTimers(PERIOD * 3);
+    expect(fires).toBe(3);
+  });
+
+  test("a handler rejection does not stop the loop and emits the real Error", async () => {
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => {
+      errors.push(error);
+    });
+
+    let fires = 0;
+    trigger.start(async () => {
+      fires += 1;
+      throw new TypeError(`boom ${fires}`);
+    });
+
+    await advanceFakeTimers(PERIOD * 3);
+
+    expect(fires).toBe(3);
+    expect(errors).toHaveLength(3);
+    expect(errors[0]).toBeInstanceOf(TypeError);
+    expect(errors[0]?.message).toBe("boom 1");
+
+    await trigger.stop();
+  });
+
+  test("a thrown non-Error is wrapped rather than dropped", async () => {
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+    trigger.start(() => {
+      throw "plain string";
+    });
+
+    await advanceFakeTimers(PERIOD);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+    expect(errors[0]?.message).toBe("plain string");
+
+    await trigger.stop();
+  });
+
+  describe("overlap policies", () => {
+    test("skip (default) drops ticks while a handler is in flight", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const fired: number[] = [];
+      const skipped: number[] = [];
+      trigger.on("skip", (scheduledAt) => skipped.push(scheduledAt));
+
+      trigger.start(async (context) => {
+        fired.push(context.scheduledAt);
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(fired).toEqual([START + PERIOD]);
+
+      await advanceFakeTimers(PERIOD * 2);
+      expect(fired).toEqual([START + PERIOD]);
+      expect(skipped).toEqual([START + PERIOD * 2, START + PERIOD * 3]);
+
+      gate.open();
+      await flushAsyncWork();
+
+      await advanceFakeTimers(PERIOD);
+      expect(fired).toEqual([START + PERIOD, START + PERIOD * 4]);
+
+      await trigger.stop();
+    });
+
+    test("queue holds one missed tick and runs it after the handler settles", async () => {
+      const trigger = new IntervalTrigger({
+        intervalMs: PERIOD,
+        overlap: "queue",
+        maxQueuedFires: 1,
+      });
+      const gate = createGate();
+      const fired: number[] = [];
+      const skipped: number[] = [];
+      trigger.on("skip", (scheduledAt) => skipped.push(scheduledAt));
+
+      trigger.start(async (context) => {
+        fired.push(context.scheduledAt);
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD * 3);
+      // Tick 1 ran; tick 2 was queued; tick 3 exceeded the bound and was skipped.
+      expect(fired).toEqual([START + PERIOD]);
+      expect(skipped).toEqual([START + PERIOD * 3]);
+
+      gate.open();
+      await flushAsyncWork();
+      // The queued tick keeps its own scheduled instant.
+      expect(fired).toEqual([START + PERIOD, START + PERIOD * 2]);
+
+      await trigger.stop();
+    });
+
+    test("concurrent invokes the handler regardless of what is in flight", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD, overlap: "concurrent" });
+      const gate = createGate();
+      const fired: number[] = [];
+      const skipped: number[] = [];
+      trigger.on("skip", (scheduledAt) => skipped.push(scheduledAt));
+
+      trigger.start(async (context) => {
+        fired.push(context.scheduledAt);
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD * 3);
+      expect(fired).toEqual([START + PERIOD, START + PERIOD * 2, START + PERIOD * 3]);
+      expect(skipped).toEqual([]);
+
+      gate.open();
+      await flushAsyncWork();
+      await trigger.stop();
+    });
+
+    test("rejects a non-positive queue bound", () => {
+      expect(
+        () => new IntervalTrigger({ intervalMs: PERIOD, overlap: "queue", maxQueuedFires: 0 })
+      ).toThrow(TriggerConfigurationError);
+    });
+
+    test("maxConcurrentFires caps concurrent fan-out, degrading the excess to skips", async () => {
+      // Without a cap, a handler slower than the period gains one more
+      // invocation every tick, indefinitely — the fan-out is bounded only by
+      // whatever the handler itself runs out of first.
+      const trigger = new IntervalTrigger({
+        intervalMs: PERIOD,
+        overlap: "concurrent",
+        maxConcurrentFires: 2,
+      });
+      const gate = createGate();
+      const fired: number[] = [];
+      const skipped: number[] = [];
+      trigger.on("skip", (scheduledAt) => skipped.push(scheduledAt));
+
+      trigger.start(async (context) => {
+        fired.push(context.scheduledAt);
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD * 4);
+      expect(fired).toEqual([START + PERIOD, START + PERIOD * 2]);
+      expect(skipped).toEqual([START + PERIOD * 3, START + PERIOD * 4]);
+
+      // Once the in-flight invocations settle, the cap stops applying.
+      gate.open();
+      await flushAsyncWork();
+      await advanceFakeTimers(PERIOD);
+      expect(fired).toEqual([START + PERIOD, START + PERIOD * 2, START + PERIOD * 5]);
+
+      await trigger.stop();
+    });
+
+    test("concurrent stays unbounded when no cap is given", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD, overlap: "concurrent" });
+      const gate = createGate();
+      let fires = 0;
+      const skipped: number[] = [];
+      trigger.on("skip", (scheduledAt) => skipped.push(scheduledAt));
+
+      trigger.start(async () => {
+        fires += 1;
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD * 6);
+      expect(fires).toBe(6);
+      expect(skipped).toEqual([]);
+
+      gate.open();
+      await flushAsyncWork();
+      await trigger.stop();
+    });
+
+    test("rejects a non-positive concurrency bound", () => {
+      expect(
+        () =>
+          new IntervalTrigger({ intervalMs: PERIOD, overlap: "concurrent", maxConcurrentFires: 0 })
+      ).toThrow(TriggerConfigurationError);
+      expect(
+        () =>
+          new IntervalTrigger({
+            intervalMs: PERIOD,
+            overlap: "concurrent",
+            maxConcurrentFires: 1.5,
+          })
+      ).toThrow(TriggerConfigurationError);
+    });
+  });
+
+  describe("skip logging", () => {
+    test("a contiguous run of skips logs once, then a count when it ends", async () => {
+      // A wedged handler at a 1s period would otherwise write 3,600 identical
+      // warnings an hour, forever.
+      const { warnings, restore } = captureWarnings();
+      try {
+        const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+        const gate = createGate();
+        const skips: number[] = [];
+        trigger.on("skip", (scheduledAt) => skips.push(scheduledAt));
+        trigger.start(async () => {
+          await gate.promise;
+        });
+
+        await advanceFakeTimers(PERIOD);
+        await advanceFakeTimers(PERIOD * 4);
+
+        // The EVENT still fires per dropped tick; only the log is collapsed.
+        expect(skips).toHaveLength(4);
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]?.message).toContain("skipped");
+
+        gate.open();
+        await flushAsyncWork();
+        await advanceFakeTimers(PERIOD);
+
+        expect(warnings).toHaveLength(2);
+        expect(warnings[1]?.meta?.skipped).toBe(4);
+
+        await trigger.stop();
+      } finally {
+        restore();
+      }
+    });
+
+    test("an isolated skip logs once and adds no summary", async () => {
+      // The ordinary intermittent case must not have its log volume doubled.
+      const { warnings, restore } = captureWarnings();
+      try {
+        const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+        const gate = createGate();
+        const skips: number[] = [];
+        trigger.on("skip", (scheduledAt) => skips.push(scheduledAt));
+        trigger.start(async () => {
+          await gate.promise;
+        });
+
+        await advanceFakeTimers(PERIOD * 2);
+        expect(skips).toHaveLength(1);
+
+        gate.open();
+        await flushAsyncWork();
+        await advanceFakeTimers(PERIOD);
+
+        expect(warnings).toHaveLength(1);
+
+        await trigger.stop();
+      } finally {
+        restore();
+      }
+    });
+
+    test("stopping mid-skip still reports the skip count", async () => {
+      const { warnings, restore } = captureWarnings();
+      try {
+        const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+        const gate = createGate();
+        const skips: number[] = [];
+        trigger.on("skip", (scheduledAt) => skips.push(scheduledAt));
+        trigger.start(async () => {
+          await gate.promise;
+        });
+
+        await advanceFakeTimers(PERIOD * 4);
+        expect(skips).toHaveLength(3);
+
+        const stopping = trigger.stop();
+        expect(warnings.map((warning) => warning.meta?.skipped)).toContain(3);
+
+        gate.open();
+        await stopping;
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  test("a period past the host timer ceiling is served in chunks", async () => {
+    // A delay over 2^31-1 ms overflows a host timer and fires IMMEDIATELY, so
+    // an unchunked wait would turn a very long period into a hot loop.
+    const maxTimerDelay = 2_147_483_647;
+    const intervalMs = 2 ** 31 + PERIOD;
+    const trigger = new IntervalTrigger({ intervalMs });
+    const fires: number[] = [];
+    trigger.start((context) => {
+      fires.push(context.scheduledAt);
+    });
+
+    await advanceFakeTimers(maxTimerDelay);
+    expect(fires).toEqual([]);
+
+    await advanceFakeTimers(intervalMs - maxTimerDelay);
+    expect(fires).toEqual([START + intervalMs]);
+
+    await trigger.stop();
+  });
+
+  test("a backward clock step does not stall the loop", async () => {
+    // A fixed-interval period is measured by the host timer, not by the wall
+    // clock, so an NTP correction backwards must not turn one 60s period into a
+    // 31-minute silence. Both assertions are load-bearing: re-arming the pending
+    // tick alone would fire once and then go quiet for the size of the step,
+    // because the next target is still computed off the pre-step anchor.
+    const trigger = new IntervalTrigger({ intervalMs: 60_000 });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(30_000);
+    // Sinon shifts every pending callAt by the same delta, so 30s of monotonic
+    // delay remains on a timer whose target is now 30 minutes in the future.
+    vi.setSystemTime(Date.now() - 1_800_000);
+    await advanceFakeTimers(30_000);
+    await advanceFakeTimers(0);
+    expect(fires).toBe(1);
+
+    await advanceFakeTimers(60_000);
+    expect(fires).toBe(2);
+
+    await trigger.stop();
+  });
+
+  test("a host timer that fires a hair early still waits for its instant", async () => {
+    // Hosts do fire a timer a millisecond early. That shortfall is jitter, not a
+    // clock step, so the tick is re-armed for the remainder rather than fired.
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(PERIOD - 1);
+    vi.setSystemTime(Date.now() - 1);
+    await advanceFakeTimers(1);
+    expect(fires).toBe(0);
+
+    await advanceFakeTimers(1);
+    expect(fires).toBe(1);
+
+    await trigger.stop();
+  });
+
+  test("unrefTimer unrefs the scheduled timer without changing the schedule", async () => {
+    // A running trigger otherwise keeps a Node process alive; the opt-out must
+    // not change when it fires.
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD, unrefTimer: true });
+    let fires = 0;
+    trigger.start(() => {
+      fires += 1;
+    });
+
+    await advanceFakeTimers(PERIOD * 3);
+    expect(fires).toBe(3);
+
+    await trigger.stop();
+  });
+
+  describe("listener errors", () => {
+    test("a throwing skip listener does not escape the timer callback", async () => {
+      // `skip` is emitted from inside a setTimeout callback, where a throw is an
+      // uncaughtException — a `metrics.inc(...)` on a torn-down client would
+      // take the whole process down.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      trigger.on("skip", () => {
+        throw new Error("skip listener boom");
+      });
+
+      let fires = 0;
+      trigger.start(async () => {
+        fires += 1;
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(fires).toBe(1);
+
+      await advanceFakeTimers(PERIOD);
+      expect(errors.map((error) => error.message)).toContain("skip listener boom");
+
+      // ...and the trigger is still a clock afterwards.
+      gate.open();
+      await flushAsyncWork();
+      await advanceFakeTimers(PERIOD);
+      expect(fires).toBe(2);
+      expect(trigger.running).toBe(true);
+
+      await trigger.stop();
+    });
+
+    test("a throwing stop listener does not produce an unhandled rejection", async () => {
+      const rejections: unknown[] = [];
+      const onRejection = (reason: unknown): void => {
+        rejections.push(reason);
+      };
+      process.on("unhandledRejection", onRejection);
+      try {
+        const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+        const errors: Error[] = [];
+        trigger.on("error", (error) => errors.push(error));
+        trigger.on("stop", () => {
+          throw new Error("stop listener boom");
+        });
+
+        const controller = new AbortController();
+        trigger.start(() => {}, { signal: controller.signal });
+        await advanceFakeTimers(PERIOD);
+
+        // The caller-signal path stops the trigger from an event listener,
+        // where there is no caller left to observe a rejected promise.
+        controller.abort();
+        await flushAsyncWork();
+
+        expect(trigger.running).toBe(false);
+        expect(errors.map((error) => error.message)).toContain("stop listener boom");
+        expect(rejections).toEqual([]);
+      } finally {
+        process.off("unhandledRejection", onRejection);
+      }
+    });
+  });
+
+  describe("abort", () => {
+    test("a tick queued before stop() neither fires nor invokes the handler", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const fires: number[] = [];
+      const calls: number[] = [];
+      trigger.on("fire", (context) => fires.push(context.scheduledAt));
+
+      trigger.start((context) => {
+        calls.push(context.scheduledAt);
+      });
+
+      // SYNCHRONOUS advance, deliberately: `dispatch` defers the tick chain by
+      // one microtask (so it is registered in `run.pending` before it runs),
+      // and `advanceFakeTimers` flushes microtasks — which would close the very
+      // window under test. This leaves the chain queued but not yet started.
+      vi.advanceTimersByTime(PERIOD);
+      expect(fires).toEqual([]);
+      expect(calls).toEqual([]);
+
+      // `stop()` clears `run.active`, but the drain AWAITS that queued chain,
+      // so it still gets to run. Without the guard at the top of the chain, its
+      // first tick fired — emitting `fire` and invoking the handler with an
+      // already-aborted signal, after the trigger reported itself stopped.
+      await trigger.stop();
+      await flushAsyncWork();
+
+      expect(fires).toEqual([]);
+      expect(calls).toEqual([]);
+      expect(trigger.running).toBe(false);
+    });
+
+    test("stop() aborts the signal handed to the handler and waits for it to settle", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      let context: ITriggerFireContext | undefined;
+      let settled = false;
+
+      trigger.start(async (fireContext) => {
+        context = fireContext;
+        await gate.promise;
+        settled = true;
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(context?.signal.aborted).toBe(false);
+
+      const stopping = trigger.stop();
+      expect(context?.signal.aborted).toBe(true);
+      expect(settled).toBe(false);
+
+      gate.open();
+      await stopping;
+      expect(settled).toBe(true);
+      expect(trigger.running).toBe(false);
+    });
+
+    test("a handler that rejects because stop() aborted it is not reported as an error", async () => {
+      // The ordinary shape of a cooperative handler: forward the signal, reject
+      // when it aborts. Reporting that on `error` makes every graceful shutdown
+      // look like a failure and pushes callers into installing absorbing
+      // `error` listeners, which then swallow the failures that do matter.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+
+      trigger.start(
+        (context) =>
+          new Promise<void>((_resolve, reject) => {
+            context.signal.addEventListener(
+              "abort",
+              () => reject(new DOMException("Aborted", "AbortError")),
+              { once: true }
+            );
+          })
+      );
+
+      await advanceFakeTimers(PERIOD);
+      await trigger.stop();
+
+      expect(errors).toEqual([]);
+      expect(trigger.running).toBe(false);
+    });
+
+    test("a handler that fails for its own reasons DURING stop is still reported", async () => {
+      // The gap the run-state check alone leaves open, and the reason the guard
+      // tests the error's shape as well: shutdown is exactly when a handler
+      // flushes buffers, closes connections and commits — the work most likely
+      // to fail for real. Keying only on `run.signal.aborted` files every one of
+      // those at `debug`, so the trigger reports a clean stop while the flush
+      // that lost data goes unmentioned. The test below covers a failure with no
+      // stop in flight; this one covers a failure racing it.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+
+      const gate = createGate();
+      trigger.start(async () => {
+        await gate.promise;
+        throw new Error("flush failed");
+      });
+
+      await advanceFakeTimers(PERIOD);
+      const stopping = trigger.stop();
+      // The handler is in flight and the signal is now aborted, so the failure
+      // below lands in precisely the window the guard has to tell apart.
+      gate.open();
+      await stopping;
+
+      expect(errors.map((error) => error.message)).toEqual(["flush failed"]);
+      expect(trigger.running).toBe(false);
+    });
+
+    test("a handler that throws for its own reasons is still reported", async () => {
+      // The guard above keys on the run's signal, so it must not blanket
+      // everything: a real failure before any stop() is still a failure.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+
+      trigger.start(() => {
+        throw new Error("sink down");
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(errors.map((error) => error.message)).toEqual(["sink down"]);
+
+      await trigger.stop();
+    });
+
+    test("a caller signal stops the trigger when it aborts", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const controller = new AbortController();
+      let fires = 0;
+      trigger.start(
+        () => {
+          fires += 1;
+        },
+        { signal: controller.signal }
+      );
+
+      await advanceFakeTimers(PERIOD * 2);
+      expect(fires).toBe(2);
+
+      controller.abort();
+      await flushAsyncWork();
+      expect(trigger.running).toBe(false);
+
+      await advanceFakeTimers(PERIOD * 3);
+      expect(fires).toBe(2);
+    });
+
+    test("a restart while stop() is draining is not clobbered by that stop()", async () => {
+      // `stop()` releases the handler/signal only AFTER awaiting the in-flight
+      // handler. A `start()` inside that window belongs to a new generation —
+      // the old stop must not null out its state, or the trigger would report
+      // `running` while never firing again.
+      const gate = createGate();
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+
+      let firstFires = 0;
+      trigger.start(async () => {
+        firstFires += 1;
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(firstFires).toBe(1);
+
+      // stop() blocks on the gated handler; restart before it settles.
+      const stopping = trigger.stop();
+      let secondFires = 0;
+      trigger.start(() => {
+        secondFires += 1;
+      });
+      gate.open();
+      await stopping;
+
+      expect(trigger.running).toBe(true);
+      await advanceFakeTimers(PERIOD * 2);
+      expect(secondFires).toBe(2);
+
+      await trigger.stop();
+    });
+
+    test("a restart during stop() does not emit stop while the trigger is running", async () => {
+      // An observer that sees `stop` while `running` is true concludes the
+      // trigger is dead and stops watching it — while it is actively firing.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const runningAtStop: boolean[] = [];
+      trigger.on("stop", () => runningAtStop.push(trigger.running));
+
+      trigger.start(async () => {
+        await gate.promise;
+      });
+      await advanceFakeTimers(PERIOD);
+
+      // NOT awaited: the gated gen-1 handler keeps the old run draining.
+      const stopping = trigger.stop();
+      trigger.start(() => {});
+
+      gate.open();
+      await stopping;
+
+      // Gen 1 drained, but gen 2 owns the trigger.
+      expect(runningAtStop).toEqual([]);
+      expect(trigger.running).toBe(true);
+
+      // ...and the real stop still reports itself.
+      await trigger.stop();
+      expect(runningAtStop).toEqual([false]);
+    });
+
+    test("a restart during stop() does not emit spurious skips (skip policy)", async () => {
+      // The first generation's handler is still gated when the second starts.
+      // Overlap state belongs to a RUN, not to the trigger: if the new
+      // generation's ticks could see the old handler's in-flight count, every
+      // one of them would be dropped as an overlap until the stale handler
+      // happened to settle.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const skips: number[] = [];
+      trigger.on("skip", (scheduledAt) => skips.push(scheduledAt));
+
+      let gen1Fires = 0;
+      trigger.start(async () => {
+        gen1Fires += 1;
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(gen1Fires).toBe(1);
+
+      const stopping = trigger.stop();
+      let gen2Fires = 0;
+      trigger.start(() => {
+        gen2Fires += 1;
+      });
+
+      // Advance BEFORE releasing the old handler: this is the window where the
+      // stale run is still counted as in flight.
+      await advanceFakeTimers(PERIOD * 2);
+      expect(skips).toEqual([]);
+      expect(gen2Fires).toBe(2);
+      expect(gen1Fires).toBe(1);
+
+      gate.open();
+      await stopping;
+      await trigger.stop();
+    });
+
+    test("a queued tick from the old generation is not delivered to the new handler", async () => {
+      // Under a shared queue the OLD chain drains a tick the NEW generation
+      // queued — invoking the new handler with the old, already-aborted signal.
+      const trigger = new IntervalTrigger({
+        intervalMs: PERIOD,
+        overlap: "queue",
+        maxQueuedFires: 1,
+      });
+      const gate = createGate();
+      trigger.start(async () => {
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      const stopping = trigger.stop();
+      const abortedOnArrival: boolean[] = [];
+      trigger.start((context) => {
+        abortedOnArrival.push(context.signal.aborted);
+      });
+
+      await advanceFakeTimers(PERIOD * 2);
+      gate.open();
+      await stopping;
+      await flushAsyncWork();
+
+      expect(abortedOnArrival.length).toBeGreaterThan(0);
+      expect(abortedOnArrival).not.toContain(true);
+
+      await trigger.stop();
+    });
+
+    test("stop() called twice concurrently resolves only after the handler settles", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      let settled = false;
+      trigger.start(async () => {
+        await gate.promise;
+        settled = true;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      const resolved: string[] = [];
+      const first = trigger.stop().then(() => {
+        resolved.push("first");
+      });
+      const second = trigger.stop().then(() => {
+        resolved.push("second");
+      });
+
+      await flushAsyncWork();
+      // Neither call may resolve while the handler is still running: `stop()`
+      // means "no handler of this run is still in flight".
+      expect(resolved).toEqual([]);
+      expect(settled).toBe(false);
+
+      gate.open();
+      await Promise.all([first, second]);
+
+      expect(settled).toBe(true);
+      expect(resolved).toHaveLength(2);
+    });
+
+    test("stop() called from a fire listener still waits for the handler", async () => {
+      // `trigger.once("fire", () => trigger.stop())` is the ordinary idiom for
+      // "run once". The fire emit and the handler's synchronous head run inside
+      // the tick chain, so a stop() begun there must still see that chain as
+      // pending — otherwise it drains an empty set and resolves while the
+      // handler is running, which is the opposite of what stop() promises.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const order: string[] = [];
+      trigger.on("stop", () => order.push("stop-event"));
+
+      let stopping: Promise<void> | undefined;
+      trigger.once("fire", () => {
+        stopping = trigger.stop();
+      });
+      trigger.start(async () => {
+        order.push("handler-start");
+        await new Promise<void>((resolve) => setTimeout(resolve, PERIOD / 2));
+        order.push("handler-end");
+      });
+
+      await advanceFakeTimers(PERIOD);
+      expect(order).toEqual(["handler-start"]);
+      expect(stopping).toBeDefined();
+
+      let stopResolved = false;
+      void stopping!.then(() => {
+        stopResolved = true;
+      });
+      await flushAsyncWork();
+      expect(stopResolved).toBe(false);
+
+      // Let the handler's own timer run out.
+      await advanceFakeTimers(PERIOD);
+      await stopping;
+
+      expect(order).toEqual(["handler-start", "handler-end", "stop-event"]);
+      expect(trigger.running).toBe(false);
+    });
+
+    test("an already-aborted caller signal schedules nothing", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      let fires = 0;
+      trigger.start(
+        () => {
+          fires += 1;
+        },
+        { signal: AbortSignal.abort() }
+      );
+
+      expect(trigger.running).toBe(false);
+      await advanceFakeTimers(PERIOD * 3);
+      expect(fires).toBe(0);
+    });
+  });
+
+  describe("stop deadline", () => {
+    test("stop() is unbounded by default and waits for a handler that never settles", async () => {
+      // The default MUST stay unbounded: it is what makes "await stop() means no
+      // handler of that run is still running" true. A bounded default would turn
+      // that documented guarantee into a lie for every caller that never asked.
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      trigger.start(async () => {
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      let resolved = false;
+      const stopping = trigger.stop();
+      void stopping.then(() => {
+        resolved = true;
+      });
+
+      await advanceFakeTimers(PERIOD * 50);
+      expect(resolved).toBe(false);
+
+      gate.open();
+      await stopping;
+      expect(resolved).toBe(true);
+    });
+
+    test("stop({ timeoutMs }) abandons what is still in flight and reports the count", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const errors: Error[] = [];
+      const stops: string[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      trigger.on("stop", () => stops.push("stop"));
+      trigger.start(async () => {
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      const stopping = trigger.stop({ timeoutMs: PERIOD * 5 });
+      await advanceFakeTimers(PERIOD * 5);
+      await stopping;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(TriggerStopTimeoutError);
+      expect(errors[0]?.message).toContain("1 handler invocation(s)");
+      // The `stop` event still fires: the run was released, not stranded.
+      expect(stops).toEqual(["stop"]);
+      expect(trigger.running).toBe(false);
+      // The deadline timer was cleared rather than left to fire on a dead run.
+      expect(vi.getTimerCount()).toBe(0);
+
+      // A restart works, which is the point of running the release tail on the
+      // timeout path: otherwise `_run` stays set and every start() is a no-op.
+      let fires = 0;
+      trigger.start(() => {
+        fires += 1;
+      });
+      await advanceFakeTimers(PERIOD);
+      expect(fires).toBe(1);
+
+      gate.open();
+      await trigger.stop();
+    });
+
+    test("stopTimeoutMs supplies the default deadline for a bare stop()", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD, stopTimeoutMs: PERIOD * 3 });
+      const gate = createGate();
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      trigger.start(async () => {
+        await gate.promise;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      const stopping = trigger.stop();
+      await advanceFakeTimers(PERIOD * 3);
+      await stopping;
+
+      expect(errors[0]).toBeInstanceOf(TriggerStopTimeoutError);
+      expect(trigger.running).toBe(false);
+
+      gate.open();
+      await flushAsyncWork();
+    });
+
+    test("a handler that settles inside the deadline reports nothing", async () => {
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      const gate = createGate();
+      const errors: Error[] = [];
+      let settled = false;
+      trigger.on("error", (error) => errors.push(error));
+      trigger.start(async () => {
+        await gate.promise;
+        settled = true;
+      });
+
+      await advanceFakeTimers(PERIOD);
+
+      const stopping = trigger.stop({ timeoutMs: PERIOD * 5 });
+      gate.open();
+      await stopping;
+
+      expect(settled).toBe(true);
+      expect(errors).toEqual([]);
+      // The deadline timer is cancelled once the drain wins the race.
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    test("rejects a non-positive stop deadline", () => {
+      expect(() => new IntervalTrigger({ intervalMs: PERIOD, stopTimeoutMs: 0 })).toThrow(
+        TriggerConfigurationError
+      );
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      expect(() => trigger.stop({ timeoutMs: -1 })).toThrow(TriggerConfigurationError);
+      expect(() => trigger.stop({ timeoutMs: 1.5 })).toThrow(TriggerConfigurationError);
+    });
+  });
+});

--- a/packages/test/src/test/trigger/PollingTrigger.test.ts
+++ b/packages/test/src/test/trigger/PollingTrigger.test.ts
@@ -1,0 +1,689 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  firesOnChange,
+  isNonEmptyPollResult,
+  PollingTrigger,
+  TriggerConfigurationError,
+  TriggerPollTimeoutError,
+} from "@workglow/triggers";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { advanceFakeTimers, flushAsyncWork } from "../helpers/advanceFakeTimers";
+
+const START = Date.UTC(2026, 0, 1, 0, 0, 0);
+const PERIOD = 100;
+
+interface Gate {
+  readonly promise: Promise<void>;
+  readonly open: () => void;
+}
+
+function createGate(): Gate {
+  let open: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { promise, open };
+}
+
+describe("PollingTrigger", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("rejects invalid options", () => {
+    expect(() => new PollingTrigger({ intervalMs: 0, poll: () => 1 })).toThrow(
+      TriggerConfigurationError
+    );
+    expect(() => new PollingTrigger({ intervalMs: PERIOD, poll: undefined as never })).toThrow(
+      TriggerConfigurationError
+    );
+  });
+
+  describe("isNonEmptyPollResult", () => {
+    test.each([
+      [undefined, false],
+      [null, false],
+      [[], false],
+      ["", false],
+      [[1], true],
+      ["x", true],
+      [0, true],
+      [false, true],
+      [{}, true],
+    ])("%o -> %s", (value, expected) => {
+      expect(isNonEmptyPollResult(value)).toBe(expected);
+    });
+  });
+
+  test("fires only on a non-empty result, and never on an empty one", async () => {
+    const results: unknown[] = [[], [], ["a"], [], ["b", "c"]];
+    let polls = 0;
+    const trigger = new PollingTrigger<unknown>({
+      intervalMs: PERIOD,
+      poll: () => results[polls++],
+    });
+
+    const payloads: unknown[] = [];
+    trigger.start((context) => {
+      payloads.push(context.payload);
+    });
+
+    await advanceFakeTimers(PERIOD * 5);
+
+    expect(polls).toBe(5);
+    // Five polls, two interesting results — that conditional fire is the whole
+    // difference from an IntervalTrigger.
+    expect(payloads).toEqual([["a"], ["b", "c"]]);
+
+    await trigger.stop();
+  });
+
+  test("hands the poll result to the handler as the payload", async () => {
+    const trigger = new PollingTrigger({
+      intervalMs: PERIOD,
+      poll: () => ({ id: 7 }),
+    });
+    const payloads: unknown[] = [];
+    trigger.start((context) => {
+      payloads.push(context.payload);
+    });
+
+    await advanceFakeTimers(PERIOD);
+    expect(payloads).toEqual([{ id: 7 }]);
+    expect(trigger.lastResult).toEqual({ id: 7 });
+
+    await trigger.stop();
+  });
+
+  test("firesOnChange only fires when the result differs from the previous one", async () => {
+    const results = ["a", "a", "b", "b", "c"];
+    let polls = 0;
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      poll: () => results[polls++]!,
+      shouldFire: firesOnChange,
+    });
+
+    const payloads: string[] = [];
+    trigger.start((context) => {
+      payloads.push(context.payload as string);
+    });
+
+    await advanceFakeTimers(PERIOD * 5);
+    expect(payloads).toEqual(["a", "b", "c"]);
+
+    await trigger.stop();
+  });
+
+  test("a custom predicate sees both the current and the previous result", async () => {
+    const values = [1, 5, 2, 9];
+    let polls = 0;
+    const seen: Array<[number, number | undefined]> = [];
+    const trigger = new PollingTrigger<number>({
+      intervalMs: PERIOD,
+      poll: () => values[polls++]!,
+      shouldFire: (result, previous) => {
+        seen.push([result, previous]);
+        return previous !== undefined && result > previous;
+      },
+    });
+
+    const payloads: number[] = [];
+    trigger.start((context) => {
+      payloads.push(context.payload as number);
+    });
+
+    await advanceFakeTimers(PERIOD * 4);
+
+    expect(seen).toEqual([
+      [1, undefined],
+      [5, 1],
+      [2, 5],
+      [9, 2],
+    ]);
+    expect(payloads).toEqual([5, 9]);
+
+    await trigger.stop();
+  });
+
+  test("a throwing poll fn does not kill the loop and emits the error", async () => {
+    let polls = 0;
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      poll: () => {
+        polls += 1;
+        if (polls === 2) throw new RangeError("poll exploded");
+        return `value-${polls}`;
+      },
+    });
+
+    const errors: Error[] = [];
+    const payloads: unknown[] = [];
+    trigger.on("error", (error) => errors.push(error));
+    trigger.start((context) => {
+      payloads.push(context.payload);
+    });
+
+    await advanceFakeTimers(PERIOD * 3);
+
+    expect(polls).toBe(3);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(RangeError);
+    expect(errors[0]?.message).toBe("poll exploded");
+    // The loop kept polling after the failure.
+    expect(payloads).toEqual(["value-1", "value-3"]);
+    expect(trigger.running).toBe(true);
+
+    await trigger.stop();
+  });
+
+  test("a failed poll leaves the previous result untouched", async () => {
+    let polls = 0;
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      poll: () => {
+        polls += 1;
+        if (polls === 2) throw new Error("nope");
+        return "steady";
+      },
+      shouldFire: firesOnChange,
+    });
+    trigger.on("error", () => {});
+
+    const payloads: unknown[] = [];
+    trigger.start((context) => {
+      payloads.push(context.payload);
+    });
+
+    await advanceFakeTimers(PERIOD * 3);
+
+    // Poll 3 returns the same value poll 1 did, so change detection stays quiet.
+    expect(payloads).toEqual(["steady"]);
+    expect(trigger.lastResult).toBe("steady");
+
+    await trigger.stop();
+  });
+
+  test("a failed handler does not consume the change", async () => {
+    // At-most-once here is silent data loss: the update the handler failed on is
+    // never offered again, because the baseline already moved past it.
+    const results = ["a", "b", "b", "b"];
+    let polls = 0;
+    let failNext = true;
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      poll: () => results[polls++]!,
+      shouldFire: firesOnChange,
+    });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+
+    const payloads: string[] = [];
+    trigger.start((context) => {
+      payloads.push(context.payload as string);
+      if (context.payload === "b" && failNext) {
+        failNext = false;
+        throw new Error("sink down");
+      }
+    });
+
+    await advanceFakeTimers(PERIOD * 4);
+
+    // "b" is re-delivered on the next poll that still observes it, then settles.
+    expect(payloads).toEqual(["a", "b", "b"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toBe("sink down");
+    expect(trigger.lastResult).toBe("b");
+
+    await trigger.stop();
+  });
+
+  test("a failed handler does not resurrect a value a later tick already delivered", async () => {
+    // Under `concurrent`, a slow failing tick settles AFTER a newer one advanced
+    // the baseline. Restoring unconditionally would re-deliver a value that has
+    // already been handled successfully.
+    const results = ["a", "b", "c", "c"];
+    let polls = 0;
+    const gate = createGate();
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      overlap: "concurrent",
+      poll: () => results[polls++]!,
+      shouldFire: firesOnChange,
+    });
+    trigger.on("error", () => {});
+
+    const payloads: string[] = [];
+    trigger.start(async (context) => {
+      payloads.push(context.payload as string);
+      if (context.payload === "b") {
+        await gate.promise;
+        throw new Error("sink down");
+      }
+    });
+
+    await advanceFakeTimers(PERIOD * 3);
+    expect(payloads).toEqual(["a", "b", "c"]);
+
+    gate.open();
+    await flushAsyncWork();
+    await advanceFakeTimers(PERIOD);
+
+    expect(payloads).toEqual(["a", "b", "c"]);
+    expect(trigger.lastResult).toBe("c");
+
+    await trigger.stop();
+  });
+
+  test("passes the trigger's abort signal to the poll function", async () => {
+    const signals: AbortSignal[] = [];
+    const trigger = new PollingTrigger<number>({
+      intervalMs: PERIOD,
+      poll: (signal) => {
+        signals.push(signal);
+        return 1;
+      },
+    });
+    trigger.start(() => {});
+
+    await advanceFakeTimers(PERIOD);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+
+    await trigger.stop();
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  test("a restart resets the change-detection baseline", async () => {
+    // The baseline belongs to a RUN. Carrying it across a stop/start would make
+    // the first poll of the new run look unchanged and swallow the very value
+    // the restarted trigger was meant to report.
+    let polls = 0;
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      poll: () => {
+        polls += 1;
+        return "steady";
+      },
+      shouldFire: firesOnChange,
+    });
+
+    const payloads: unknown[] = [];
+    const handler = (context: { payload: unknown }): void => {
+      payloads.push(context.payload);
+    };
+
+    trigger.start(handler);
+    await advanceFakeTimers(PERIOD * 2);
+    expect(payloads).toEqual(["steady"]);
+    await trigger.stop();
+
+    trigger.start(handler);
+    await advanceFakeTimers(PERIOD);
+    expect(payloads).toEqual(["steady", "steady"]);
+    expect(polls).toBe(3);
+
+    await trigger.stop();
+  });
+
+  test("a restart while stop() is still draining also resets the baseline", async () => {
+    // The awaited restart above is the easy half. A stop() that is NOT awaited
+    // hands the trigger to the new run while the old one is still draining, and
+    // per-run state that lives on the trigger would carry the old baseline into
+    // it — leaving a firesOnChange poller that never fires again.
+    let polls = 0;
+    const gate = createGate();
+    const trigger = new PollingTrigger<string>({
+      intervalMs: PERIOD,
+      poll: () => {
+        polls += 1;
+        return "steady";
+      },
+      shouldFire: firesOnChange,
+    });
+
+    const firstPayloads: unknown[] = [];
+    trigger.start(async (context) => {
+      firstPayloads.push(context.payload);
+      await gate.promise;
+    });
+
+    await advanceFakeTimers(PERIOD);
+    expect(firstPayloads).toEqual(["steady"]);
+    expect(trigger.lastResult).toBe("steady");
+
+    // NOT awaited: the gated handler keeps the old run draining.
+    const stopping = trigger.stop();
+    const secondPayloads: unknown[] = [];
+    trigger.start((context) => {
+      secondPayloads.push(context.payload);
+    });
+
+    expect(trigger.lastResult).toBeUndefined();
+    expect(trigger.consecutiveFailures).toBe(0);
+
+    await advanceFakeTimers(PERIOD);
+    expect(secondPayloads).toEqual(["steady"]);
+    expect(polls).toBe(2);
+
+    gate.open();
+    await stopping;
+    await trigger.stop();
+  });
+
+  describe("errorBackoff", () => {
+    test("rejects an invalid backoff", () => {
+      expect(
+        () =>
+          new PollingTrigger({
+            intervalMs: PERIOD,
+            poll: () => 1,
+            errorBackoff: { initialMs: 0, maxMs: 100 },
+          })
+      ).toThrow(TriggerConfigurationError);
+      expect(
+        () =>
+          new PollingTrigger({
+            intervalMs: PERIOD,
+            poll: () => 1,
+            errorBackoff: { initialMs: 200, maxMs: 100 },
+          })
+      ).toThrow(TriggerConfigurationError);
+    });
+
+    test("slows the loop down while the poll keeps failing, and recovers", async () => {
+      let polls = 0;
+      let failing = true;
+      const trigger = new PollingTrigger<number>({
+        intervalMs: PERIOD,
+        poll: () => {
+          polls += 1;
+          if (failing) throw new Error("dependency down");
+          return polls;
+        },
+        errorBackoff: { initialMs: PERIOD * 2, maxMs: PERIOD * 8 },
+      });
+      trigger.on("error", () => {});
+      trigger.start(() => {});
+
+      // Full-rate ticks at P and 2P (the tick after a failure is already
+      // scheduled), then backoff: 2P, 4P, 8P, 8P...
+      await advanceFakeTimers(PERIOD * 2);
+      expect(polls).toBe(2);
+      expect(trigger.consecutiveFailures).toBe(2);
+
+      await advanceFakeTimers(PERIOD * 2);
+      expect(polls).toBe(3);
+
+      // Without backoff the same window would have added 10 more polls.
+      await advanceFakeTimers(PERIOD * 10);
+      expect(polls).toBeLessThan(7);
+
+      failing = false;
+      await advanceFakeTimers(PERIOD * 8);
+      expect(trigger.consecutiveFailures).toBe(0);
+
+      // One backed-off gap is still outstanding (the tick after the recovering
+      // poll was scheduled before it succeeded); after that, full rate resumes.
+      const recovered = polls;
+      await advanceFakeTimers(PERIOD * 4);
+      expect(polls).toBeGreaterThanOrEqual(recovered + 3);
+
+      await trigger.stop();
+    });
+
+    test("a host that slept through a backed-off gap does not replay the backlog", async () => {
+      // The backed-off target is measured from the previous tick's instant, so a
+      // host suspended across several gaps leaves it far in the past. Unclamped,
+      // every one of those stale targets is already due and the loop replays the
+      // whole backlog as a burst of setTimeout(0) ticks.
+      let polls = 0;
+      const trigger = new PollingTrigger<number>({
+        intervalMs: PERIOD,
+        poll: () => {
+          polls += 1;
+          throw new Error("dependency down");
+        },
+        errorBackoff: { initialMs: PERIOD * 2, maxMs: PERIOD * 2 },
+      });
+      trigger.on("error", () => {});
+      let skips = 0;
+      trigger.on("skip", () => {
+        skips += 1;
+      });
+      trigger.start(() => {});
+
+      // Ticks at P and 2P; the tick after those is armed for START + 4P.
+      await advanceFakeTimers(PERIOD * 2);
+      expect(polls).toBe(2);
+
+      // The host freezes for 10s. Sinon shifts every pending callAt by the same
+      // delta, so the timer keeps its 200ms of MONOTONIC delay while the wall
+      // clock jumps 10s past the target it was armed for.
+      vi.setSystemTime(START + PERIOD * 2 + 10_000);
+      await advanceFakeTimers(PERIOD * 2);
+      // A replayed backlog arrives as zero-delay ticks, which fake timers space a
+      // millisecond apart, so give it a whole period to show itself. The clamped
+      // loop has nothing due until START + 10_600.
+      await advanceFakeTimers(PERIOD);
+
+      expect(polls).toBe(3);
+      expect(skips).toBe(0);
+
+      await trigger.stop();
+    });
+  });
+
+  describe("pollTimeoutMs", () => {
+    // Deliberately not a multiple of PERIOD, so a deadline lands between ticks
+    // and the assertions do not depend on same-instant timer ordering.
+    const POLL_TIMEOUT = 250;
+
+    test("rejects an invalid pollTimeoutMs", () => {
+      expect(
+        () => new PollingTrigger({ intervalMs: PERIOD, poll: () => 1, pollTimeoutMs: 0 })
+      ).toThrow(TriggerConfigurationError);
+      expect(
+        () => new PollingTrigger({ intervalMs: PERIOD, poll: () => 1, pollTimeoutMs: 1.5 })
+      ).toThrow(TriggerConfigurationError);
+    });
+
+    test("a hung poll wedges the trigger when no timeout is configured", async () => {
+      // The default is unchanged, deliberately: a deadline nobody asked for
+      // would break a legitimately slow poll on upgrade. A hang is not a throw,
+      // so nothing reaches `error` and every later tick is dropped instead.
+      const trigger = new PollingTrigger<string>({
+        intervalMs: PERIOD,
+        poll: () => new Promise<string>(() => {}),
+      });
+      const errors: Error[] = [];
+      const payloads: unknown[] = [];
+      let skips = 0;
+      trigger.on("error", (error) => errors.push(error));
+      trigger.on("skip", () => {
+        skips += 1;
+      });
+      trigger.start((context) => {
+        payloads.push(context.payload);
+      });
+
+      await advanceFakeTimers(PERIOD * 5);
+
+      expect(errors).toEqual([]);
+      expect(skips).toBe(4);
+      expect(payloads).toEqual([]);
+      expect(trigger.running).toBe(true);
+
+      // Not stopped: `stop()` awaits the in-flight tick, and that tick is the
+      // pending poll — the same wedge, seen from the other side.
+    });
+
+    test("pollTimeoutMs fails a hung poll and the loop keeps going", async () => {
+      let polls = 0;
+      const trigger = new PollingTrigger<string>({
+        intervalMs: PERIOD,
+        pollTimeoutMs: POLL_TIMEOUT,
+        poll: () => {
+          polls += 1;
+          if (polls === 1) return new Promise<string>(() => {});
+          return "ok";
+        },
+      });
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      const payloads: unknown[] = [];
+      trigger.start((context) => {
+        payloads.push(context.payload);
+      });
+
+      // Poll 1 starts at START + PERIOD; its deadline is START + 350.
+      await advanceFakeTimers(PERIOD * 3);
+      expect(errors).toEqual([]);
+      expect(payloads).toEqual([]);
+
+      // 350 -> the deadline fires; 400 -> the next tick polls a healthy source.
+      await advanceFakeTimers(PERIOD);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(TriggerPollTimeoutError);
+      expect(payloads).toEqual(["ok"]);
+      expect(trigger.running).toBe(true);
+
+      await trigger.stop();
+    });
+
+    test("the deadline aborts the signal handed to the poll", async () => {
+      let observed: AbortSignal | undefined;
+      const trigger = new PollingTrigger<string>({
+        intervalMs: PERIOD,
+        pollTimeoutMs: POLL_TIMEOUT,
+        poll: (signal) => {
+          observed ??= signal;
+          return new Promise<string>((_resolve, reject) => {
+            signal.addEventListener("abort", () => reject(new Error("poll aborted")), {
+              once: true,
+            });
+          });
+        },
+      });
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      trigger.start(() => {});
+
+      await advanceFakeTimers(PERIOD * 4);
+
+      expect(observed?.aborted).toBe(true);
+      expect(observed?.reason).toBeInstanceOf(TriggerPollTimeoutError);
+      // The tick fails with the TIMEOUT, not with the poll's own abort error:
+      // a cooperative poll rejects synchronously on abort and would otherwise
+      // win the race with its own error, hiding why the tick failed.
+      expect(errors[0]).toBeInstanceOf(TriggerPollTimeoutError);
+
+      await trigger.stop();
+    });
+
+    test("stop() aborts an in-flight poll's signal when a timeout is configured", async () => {
+      let observed: AbortSignal | undefined;
+      const trigger = new PollingTrigger<string>({
+        intervalMs: PERIOD,
+        pollTimeoutMs: PERIOD * 10,
+        poll: (signal) => {
+          observed ??= signal;
+          return new Promise<string>((_resolve, reject) => {
+            // An AbortError, not a plain one: quieting a stopped tick keys on
+            // the error's SHAPE as well as the run's state, so that a genuine
+            // failure during shutdown — a flush or a commit, the work most
+            // likely to fail there — is still reported rather than filed at
+            // debug alongside the cancellations. This is the convention the
+            // rest of the repo already constructs.
+            signal.addEventListener(
+              "abort",
+              () => reject(new DOMException("poll aborted", "AbortError")),
+              { once: true }
+            );
+          });
+        },
+      });
+      // A COLLECTING listener, not an absorbing one. The poll rejects because
+      // stop() aborted it, which is the graceful path — reporting it on `error`
+      // makes every orderly shutdown look like a failure, and the absorbing
+      // listener this test used to need was the evidence.
+      const errors: Error[] = [];
+      trigger.on("error", (error) => errors.push(error));
+      trigger.start(() => {});
+
+      await advanceFakeTimers(PERIOD);
+      expect(observed?.aborted).toBe(false);
+
+      const stopping = trigger.stop();
+      // Synchronous, through the run controller the per-poll controller follows.
+      expect(observed?.aborted).toBe(true);
+
+      await stopping;
+      expect(trigger.running).toBe(false);
+      expect(errors).toEqual([]);
+      // The deadline timer was cleared rather than left to fire on a dead run.
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    test("a timed-out poll drives errorBackoff", async () => {
+      let polls = 0;
+      const trigger = new PollingTrigger<string>({
+        intervalMs: PERIOD,
+        pollTimeoutMs: POLL_TIMEOUT,
+        errorBackoff: { initialMs: PERIOD * 4, maxMs: PERIOD * 4 },
+        poll: () => {
+          polls += 1;
+          return new Promise<string>(() => {});
+        },
+      });
+      trigger.on("error", () => {});
+      trigger.start(() => {});
+
+      // The first deadline fires at START + 350: a timeout is a POLL failure.
+      await advanceFakeTimers(PERIOD * 4);
+      expect(trigger.consecutiveFailures).toBeGreaterThanOrEqual(1);
+
+      const polled = polls;
+      await advanceFakeTimers(PERIOD * 20);
+      // At the full rate that window is 20 polls; backed off it is a handful.
+      expect(polls - polled).toBeLessThan(10);
+
+      // This poll ignores its signal, so its DEADLINE is what releases the
+      // drain — which is also how a timeout bounds `stop()` on a hung poll.
+      const stopping = trigger.stop();
+      await advanceFakeTimers(POLL_TIMEOUT);
+      await stopping;
+      expect(trigger.running).toBe(false);
+    });
+  });
+
+  test("stop() halts polling", async () => {
+    let polls = 0;
+    const trigger = new PollingTrigger<number>({
+      intervalMs: PERIOD,
+      poll: () => {
+        polls += 1;
+        return polls;
+      },
+    });
+    trigger.start(() => {});
+
+    await advanceFakeTimers(PERIOD * 2);
+    expect(polls).toBe(2);
+
+    await trigger.stop();
+    await advanceFakeTimers(PERIOD * 5);
+    expect(polls).toBe(2);
+  });
+});

--- a/packages/test/src/test/trigger/TriggerInstall.test.ts
+++ b/packages/test/src/test/trigger/TriggerInstall.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Workflow } from "@workglow/task-graph";
+import {
+  bindWorkflowTrigger,
+  getWorkflowTriggers,
+  installWorkflowTriggers,
+  IntervalTrigger,
+  listenWorkflow,
+  stopWorkflowListening,
+} from "@workglow/triggers";
+import { describe, expect, test } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+const triggersSource = (relative: string): string =>
+  readFileSync(resolve(repoRoot, "packages/triggers/src", relative), "utf8");
+
+/**
+ * The barrel must stay PURE. `workglow` re-exports it, and `workglow`'s manifest
+ * declares only `./dist/auto-bootstrap.js` side-effectful — an allow-list that
+ * is only honest while importing `@workglow/triggers` installs nothing. If the
+ * import-time `Workflow.prototype` patch ever comes back, a bundler must keep
+ * the whole barrel, and with it `@workglow/duckdb`, `postgres`, `sqlite` and
+ * `mcp`, none of which declare `sideEffects` at all.
+ */
+describe("installWorkflowTriggers", () => {
+  // FIRST, before anything in this file installs: the behavioral guard.
+  test("importing the package leaves Workflow.prototype unpatched", () => {
+    expect(Object.prototype.hasOwnProperty.call(Workflow.prototype, "trigger")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(Workflow.prototype, "listen")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(Workflow.prototype, "stopListening")).toBe(false);
+    expect(new Workflow().trigger).toBeUndefined();
+  });
+
+  /**
+   * The backstop for the case above. That test depends on this file being the
+   * first to touch `Workflow.prototype` in its process — true under vitest's
+   * per-file isolation, but not a property the source itself carries. This one
+   * reads the source and holds no matter what ran first.
+   */
+  test("no module body patches Workflow.prototype outside the installer", () => {
+    const common = triggersSource("common.ts");
+    expect(common).not.toMatch(/^\s*import\s+["']\.\/workflow\/WorkflowTriggers["']/m);
+
+    const module = triggersSource("workflow/WorkflowTriggers.ts");
+    const assignments = module.match(/^Workflow\.prototype\.\w+\s*=/gm) ?? [];
+    // Every assignment is indented, i.e. inside installWorkflowTriggers().
+    expect(assignments).toEqual([]);
+    expect(module).toMatch(/export function installWorkflowTriggers\(\): void \{/);
+  });
+
+  test("the free functions work with no install at all", async () => {
+    const workflow = new Workflow();
+    const trigger = new IntervalTrigger({ intervalMs: 60_000, unrefTimer: true });
+
+    expect(bindWorkflowTrigger(workflow, trigger)).toBe(workflow);
+    expect(getWorkflowTriggers(workflow)).toEqual([trigger]);
+
+    const handle = await listenWorkflow(workflow);
+    expect(handle.triggers).toEqual([trigger]);
+    expect(trigger.running).toBe(true);
+
+    await stopWorkflowListening(workflow);
+    expect(trigger.running).toBe(false);
+  });
+
+  test("installs the fluent methods, and is idempotent", () => {
+    installWorkflowTriggers();
+
+    const installed = Workflow.prototype.trigger;
+    expect(typeof installed).toBe("function");
+    expect(typeof Workflow.prototype.listen).toBe("function");
+    expect(typeof Workflow.prototype.stopListening).toBe("function");
+
+    // A second call must not re-wrap: a consumer calling it defensively at every
+    // entry point would otherwise build a chain of delegating closures.
+    installWorkflowTriggers();
+    expect(Workflow.prototype.trigger).toBe(installed);
+  });
+
+  test("the installed methods delegate to the free functions", async () => {
+    installWorkflowTriggers();
+
+    const workflow = new Workflow();
+    const trigger = new IntervalTrigger({ intervalMs: 60_000, unrefTimer: true });
+
+    expect(workflow.trigger(trigger)).toBe(workflow);
+    expect(getWorkflowTriggers(workflow)).toEqual([trigger]);
+
+    const handle = await workflow.listen();
+    expect(handle.triggers).toEqual([trigger]);
+
+    await workflow.stopListening();
+    expect(trigger.running).toBe(false);
+  });
+});

--- a/packages/test/src/test/trigger/WorkflowTriggers.test.ts
+++ b/packages/test/src/test/trigger/WorkflowTriggers.test.ts
@@ -1,0 +1,1078 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CachePolicy, IExecuteContext, WorkflowRunConfig } from "@workglow/task-graph";
+import { Task, Workflow } from "@workglow/task-graph";
+import type {
+  ITrigger,
+  ITriggerListenerHandle,
+  TriggerEventListener,
+  TriggerEventListeners,
+  TriggerEvents,
+} from "@workglow/triggers";
+import {
+  CronTrigger,
+  CronUnsatisfiableError,
+  getWorkflowTriggers,
+  installWorkflowTriggers,
+  IntervalTrigger,
+  PollingTrigger,
+  TriggerConfigurationError,
+  WorkflowTriggerError,
+} from "@workglow/triggers";
+import type { ILogger } from "@workglow/util";
+import { EventEmitter, getLogger, ResourceScope, setLogger } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { advanceFakeTimers, flushAsyncWork } from "../helpers/advanceFakeTimers";
+
+const START = Date.UTC(2026, 0, 1, 0, 0, 0);
+const PERIOD = 100;
+
+type RecorderInput = { label: string };
+type RecorderOutput = { recorded: string };
+
+interface Gate {
+  readonly promise: Promise<void>;
+  readonly open: () => void;
+}
+
+function createGate(): Gate {
+  let open: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { promise, open };
+}
+
+/** Records every execution so a test can assert what each trigger fire ran with. */
+const executions: string[] = [];
+let failNextRuns = 0;
+/**
+ * When set, every execution parks on this gate until it opens or its run's
+ * signal aborts — which is how a test observes WHICH in-flight run a trigger's
+ * `stop()` cancelled.
+ */
+let holdGate: Gate | undefined;
+const completed: string[] = [];
+const abortedRuns: string[] = [];
+/** Highest number of executions ever in flight at once. */
+let peakConcurrency = 0;
+let inFlight = 0;
+
+class RecorderTask extends Task<RecorderInput, RecorderOutput> {
+  public static override type = "TriggerRecorderTask";
+  public static override category = "Test";
+  public static override title = "Trigger Recorder";
+  public static override description = "Records its input for trigger tests.";
+  // Each fire must actually execute; a cached output would hide repeat runs.
+  public static override cachePolicy: CachePolicy = { kind: "none" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { label: { type: "string", default: "none" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { recorded: { type: "string" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  override async execute(input: RecorderInput, context: IExecuteContext): Promise<RecorderOutput> {
+    executions.push(input.label);
+    inFlight += 1;
+    peakConcurrency = Math.max(peakConcurrency, inFlight);
+    try {
+      if (failNextRuns > 0) {
+        failNextRuns -= 1;
+        throw new Error(`run failed for ${input.label}`);
+      }
+      const gate = holdGate;
+      if (gate) {
+        await new Promise<void>((resolve) => {
+          const done = (): void => {
+            context.signal.removeEventListener("abort", done);
+            resolve();
+          };
+          context.signal.addEventListener("abort", done, { once: true });
+          void gate.promise.then(done);
+        });
+        if (context.signal.aborted) {
+          abortedRuns.push(input.label);
+          throw new Error(`aborted ${input.label}`);
+        }
+      }
+      completed.push(input.label);
+      return { recorded: input.label };
+    } finally {
+      inFlight -= 1;
+    }
+  }
+}
+
+function createWorkflow(): Workflow {
+  return new Workflow().addTask(RecorderTask, { label: "default" });
+}
+
+/**
+ * A third-party `ITrigger` whose `stop()` never settles AND which ignores
+ * `TriggerStopOptions` entirely — the shape of any implementation written
+ * before the option existed. It is why the deadline is applied again around the
+ * whole set: forwarding it to each trigger alone would leave this one wedging
+ * every sibling on the workflow.
+ */
+class WedgedTrigger implements ITrigger {
+  public readonly kind = "wedged";
+  public readonly events = new EventEmitter<TriggerEventListeners>();
+  public running = false;
+
+  constructor(public readonly id: string) {}
+
+  public start(): void {
+    this.running = true;
+  }
+
+  public stop(): Promise<void> {
+    return new Promise<void>(() => {});
+  }
+
+  public on<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.on(name, fn);
+  }
+
+  public off<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.off(name, fn);
+  }
+
+  public once<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.once(name, fn);
+  }
+}
+
+/**
+ * A trigger whose `stop()` REJECTS. `listenWorkflow`'s stop path reports each
+ * rejection through the logger, so this is what puts a logger call on the
+ * caller-abort listener's path — where a throw has no caller left to catch it.
+ */
+class RejectingStopTrigger implements ITrigger {
+  public readonly kind = "rejecting-stop";
+  public readonly events = new EventEmitter<TriggerEventListeners>();
+  public running = false;
+
+  constructor(public readonly id: string) {}
+
+  public start(): void {
+    this.running = true;
+  }
+
+  public stop(): Promise<void> {
+    this.running = false;
+    return Promise.reject(new Error("stop boom"));
+  }
+
+  public on<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.on(name, fn);
+  }
+
+  public off<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.off(name, fn);
+  }
+
+  public once<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.once(name, fn);
+  }
+}
+
+interface WarnRecord {
+  readonly message: string;
+  readonly meta: Record<string, unknown> | undefined;
+}
+
+/**
+ * Installs a logger that records `warn` calls; returns the sink and a restore fn.
+ * Built from scratch rather than spread from the installed logger, whose methods
+ * live on a class prototype and would be lost.
+ */
+function captureWarnings(): { warnings: WarnRecord[]; restore: () => void } {
+  const warnings: WarnRecord[] = [];
+  const previous = getLogger();
+  const noop = (): void => {};
+  const logger: ILogger = {
+    debug: noop,
+    info: noop,
+    warn: (message: string, meta?: Record<string, unknown>) => {
+      warnings.push({ message, meta });
+    },
+    error: noop,
+    fatal: noop,
+    child: () => logger,
+    time: noop,
+    timeEnd: noop,
+    group: noop,
+    groupEnd: noop,
+  };
+  setLogger(logger);
+  return { warnings, restore: () => setLogger(previous) };
+}
+
+/**
+ * Flushes microtasks until `predicate` holds. Serialized runs hand off to each
+ * other over several microtask turns, and advancing the clock instead would
+ * deliver more fires — which is exactly what these tests are counting.
+ */
+async function drainUntil(predicate: () => boolean): Promise<void> {
+  for (let pass = 0; pass < 50 && !predicate(); pass += 1) {
+    await flushAsyncWork();
+  }
+}
+
+// The fluent methods this suite exercises are opt-in: importing the package
+// installs nothing (see TriggerInstall.test.ts). Install once for the file.
+installWorkflowTriggers();
+
+describe("Workflow trigger bindings", () => {
+  beforeEach(() => {
+    executions.length = 0;
+    completed.length = 0;
+    abortedRuns.length = 0;
+    holdGate = undefined;
+    failNextRuns = 0;
+    peakConcurrency = 0;
+    inFlight = 0;
+    vi.useFakeTimers();
+    vi.setSystemTime(START);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("installWorkflowTriggers() adds the lifecycle methods to the prototype", () => {
+    expect(typeof Workflow.prototype.trigger).toBe("function");
+    expect(typeof Workflow.prototype.listen).toBe("function");
+    expect(typeof Workflow.prototype.stopListening).toBe("function");
+  });
+
+  test("trigger() is chainable and records bindings in order", () => {
+    const workflow = createWorkflow();
+    const first = new IntervalTrigger({ intervalMs: PERIOD, id: "first" });
+    const second = new IntervalTrigger({ intervalMs: PERIOD, id: "second" });
+
+    expect(workflow.trigger(first)).toBe(workflow);
+    workflow.trigger(second);
+
+    expect(getWorkflowTriggers(workflow).map((trigger) => trigger.id)).toEqual(["first", "second"]);
+  });
+
+  test("bindings are per-workflow, not global", () => {
+    const a = createWorkflow();
+    const b = createWorkflow();
+    a.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "only-a" }));
+
+    expect(getWorkflowTriggers(a)).toHaveLength(1);
+    expect(getWorkflowTriggers(b)).toHaveLength(0);
+  });
+
+  test("runs the workflow once per fire with the mapped input", async () => {
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    workflow.trigger(trigger, {
+      input: (context) => ({ label: `fire@${context.scheduledAt - START}` }),
+    });
+
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD * 3);
+    expect(executions).toEqual(["fire@100", "fire@200", "fire@300"]);
+
+    await handle.stop();
+  });
+
+  test("listen() resolves immediately rather than blocking until stopped", async () => {
+    const workflow = createWorkflow();
+    workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }));
+
+    let resolved = false;
+    const listening = workflow.listen().then((handle) => {
+      resolved = true;
+      return handle;
+    });
+
+    await flushAsyncWork();
+    expect(resolved).toBe(true);
+
+    await (await listening).stop();
+  });
+
+  test("a polling trigger forwards its payload into the run input", async () => {
+    const workflow = createWorkflow();
+    const batches = [[], ["x", "y"], []] as string[][];
+    let polls = 0;
+    workflow.trigger(
+      new PollingTrigger<string[]>({
+        intervalMs: PERIOD,
+        poll: () => batches[polls++]!,
+      }),
+      { input: (context) => ({ label: (context.payload as string[]).join("+") }) }
+    );
+
+    const handle = await workflow.listen();
+    await advanceFakeTimers(PERIOD * 3);
+
+    // Only the non-empty poll started a run.
+    expect(executions).toEqual(["x+y"]);
+
+    await handle.stop();
+  });
+
+  test("multiple triggers on one workflow all drive runs", async () => {
+    const workflow = createWorkflow();
+    workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }), {
+      input: () => ({ label: "fast" }),
+    });
+    workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD * 2 }), {
+      input: () => ({ label: "slow" }),
+    });
+
+    const handle = await workflow.listen();
+    await advanceFakeTimers(PERIOD * 2);
+
+    expect(executions.filter((label) => label === "fast")).toHaveLength(2);
+    expect(executions.filter((label) => label === "slow")).toHaveLength(1);
+
+    await handle.stop();
+  });
+
+  test("genuinely overlapping fires run one at a time instead of colliding", async () => {
+    // `overlap: "concurrent"` invokes the handler on every tick regardless of
+    // what is in flight, so with a handler slower than the period the fires
+    // really do overlap. One Workflow owns one TaskGraph, which refuses to be
+    // run re-entrantly, so an unserialized second fire is lost to a
+    // "Graph is already running" error on the trigger's `error` event.
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD, overlap: "concurrent" });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+    workflow.trigger(trigger, {
+      input: (context) => ({ label: `fire@${context.scheduledAt - START}` }),
+      maxPendingFires: 5,
+    });
+
+    const gate = createGate();
+    holdGate = gate;
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD * 3);
+    // Three fires dispatched; only the first is executing.
+    expect(executions).toEqual(["fire@100"]);
+    expect(peakConcurrency).toBe(1);
+
+    holdGate = undefined;
+    gate.open();
+    await drainUntil(() => completed.length >= 3);
+
+    expect(executions).toEqual(["fire@100", "fire@200", "fire@300"]);
+    expect(completed).toEqual(["fire@100", "fire@200", "fire@300"]);
+    // Strictly sequential: no run ever started while another was executing.
+    expect(peakConcurrency).toBe(1);
+    expect(errors).toEqual([]);
+
+    await handle.stop();
+  });
+
+  test("a fire past maxPendingFires is dropped and reported on the error event", async () => {
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD, overlap: "concurrent" });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+    workflow.trigger(trigger, {
+      input: (context) => ({ label: `fire@${context.scheduledAt - START}` }),
+      maxPendingFires: 1,
+    });
+
+    const gate = createGate();
+    holdGate = gate;
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD * 3);
+    // fire@100 is running and fire@200 is waiting, so fire@300 exceeds the bound.
+    expect(executions).toEqual(["fire@100"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(WorkflowTriggerError);
+    expect(errors[0]?.message).toContain("maxPendingFires");
+
+    holdGate = undefined;
+    gate.open();
+    await drainUntil(() => completed.length >= 2);
+
+    // The dropped fire never runs; the bounded one still does.
+    expect(executions).toEqual(["fire@100", "fire@200"]);
+    expect(errors).toHaveLength(1);
+
+    await handle.stop();
+  });
+
+  test("maxPendingFires is validated at bind time", () => {
+    // It was the only numeric bound in the package read raw, and it breaks in
+    // BOTH directions:
+    //
+    //   NaN / Infinity — the drop test is `waiting >= limit`, and both
+    //   `NaN >= NaN` and `n >= Infinity` are false, so the drop branch is
+    //   UNREACHABLE. Every overlapping fire queues instead, each retaining a
+    //   chain closure and its captured `input` — the unbounded backlog the
+    //   default of 1 exists to prevent, silently reintroduced by a typo.
+    //
+    //   0 / negative — `0 >= 0` is true, so EVERY overlapping fire is dropped,
+    //   and the error message interpolates the bogus limit back at the caller
+    //   ("maxPendingFires: 0"), reading like a deliberate configuration.
+    //
+    // 1.5 is here because a fractional bound is meaningless for a count and
+    // the other five bounds reject it; `Number.isInteger` covers all five
+    // cases in one test.
+    for (const value of [Number.NaN, Number.POSITIVE_INFINITY, 0, -1, 1.5]) {
+      const workflow = createWorkflow();
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+
+      expect(() => workflow.trigger(trigger, { maxPendingFires: value })).toThrow(
+        TriggerConfigurationError
+      );
+      expect(() => workflow.trigger(trigger, { maxPendingFires: value })).toThrow(
+        /maxPendingFires/
+      );
+      // Rejected BEFORE the binding is recorded, so a failed bind leaves the
+      // workflow exactly as it was and free to bind properly afterwards.
+      expect(getWorkflowTriggers(workflow)).toEqual([]);
+    }
+  });
+
+  test("a valid maxPendingFires still binds, and so does omitting it", () => {
+    // Guards the validation against over-rejecting: the point is to catch the
+    // five shapes above, not to narrow what callers may legitimately pass.
+    const workflow = createWorkflow();
+    const bounded = new IntervalTrigger({ intervalMs: PERIOD, id: "bounded" });
+    const defaulted = new IntervalTrigger({ intervalMs: PERIOD, id: "defaulted" });
+    const explicitlyUndefined = new IntervalTrigger({ intervalMs: PERIOD, id: "undef" });
+
+    workflow.trigger(bounded, { maxPendingFires: 5 });
+    workflow.trigger(defaulted);
+    workflow.trigger(explicitlyUndefined, { maxPendingFires: undefined });
+
+    expect(getWorkflowTriggers(workflow).map((trigger) => trigger.id)).toEqual([
+      "bounded",
+      "defaulted",
+      "undef",
+    ]);
+  });
+
+  test("a runConfig carrying a signal is rejected at bind time", () => {
+    // `runConfig` is captured ONCE and reused for every fire forever, while an
+    // AbortSignal is one-shot: once the caller aborts, every later fire would
+    // start a run that is born cancelled while the schedule kept ticking —
+    // one error event per period, indefinitely. Rejecting is better than
+    // silently dropping it, and better than bridging it per fire (which leaks
+    // one composite signal per fire, retained by the long-lived source).
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    const controller = new AbortController();
+
+    expect(() =>
+      workflow.trigger(trigger, {
+        runConfig: { signal: controller.signal } as WorkflowRunConfig,
+      })
+    ).toThrow(WorkflowTriggerError);
+    // The message must name the SUPPORTED alternative: a caller reaching for
+    // `runConfig.signal` wants to cancel something, and a bare refusal leaves
+    // them without the answer.
+    expect(() =>
+      workflow.trigger(trigger, {
+        runConfig: { signal: controller.signal } as WorkflowRunConfig,
+      })
+    ).toThrow(/listen\(\{ signal \}\)/);
+    expect(getWorkflowTriggers(workflow)).toEqual([]);
+  });
+
+  test("a runConfig without a signal is still forwarded, and the fire's own signal wins", async () => {
+    // The rejection above must not have cost the option its actual job.
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    const resourceScope = new ResourceScope();
+    const runSpy = vi.spyOn(workflow, "run");
+
+    workflow.trigger(trigger, { runConfig: { resourceScope } });
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    const config = runSpy.mock.calls[0]?.[1];
+    expect(config?.resourceScope).toBe(resourceScope);
+    // The trigger supplies the run's cancellation, unconditionally — cheap
+    // defense against a `runConfig` object mutated after binding.
+    const signal = config?.signal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+
+    await handle.stop();
+    expect(signal?.aborted).toBe(true);
+
+    runSpy.mockRestore();
+  });
+
+  test("a rejecting stop() on caller abort produces no unhandled rejection", async () => {
+    // The caller-signal listener stops the triggers from an event handler,
+    // where there is no caller left to observe a rejected promise: `stop()`
+    // reports its own failures through the logger, and a logger that throws
+    // used to turn that into a process-killing unhandledRejection.
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown): void => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", onRejection);
+    const previousLogger = getLogger();
+    try {
+      const workflow = createWorkflow();
+      const trigger = new RejectingStopTrigger("rejects-on-stop");
+      workflow.trigger(trigger);
+
+      const controller = new AbortController();
+      const handle = await workflow.listen({ signal: controller.signal });
+      expect(handle.triggers).toHaveLength(1);
+
+      // `stop()` logs each rejected trigger stop at `error`; this logger turns
+      // that report into a throw, which is what escapes the listener.
+      const noop = (): void => {};
+      const throwingLogger: ILogger = {
+        debug: noop,
+        info: noop,
+        warn: noop,
+        error: () => {
+          throw new Error("logger boom");
+        },
+        fatal: noop,
+        child: () => throwingLogger,
+        time: noop,
+        timeEnd: noop,
+        group: noop,
+        groupEnd: noop,
+      };
+      setLogger(throwingLogger);
+
+      controller.abort();
+      await flushAsyncWork();
+      setLogger(previousLogger);
+
+      expect(rejections).toEqual([]);
+      // And the handle was released, so the workflow is usable again — an
+      // abort must not lock `trigger()` out forever.
+      expect(() =>
+        workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "after-abort" }))
+      ).not.toThrow();
+    } finally {
+      setLogger(previousLogger);
+      process.off("unhandledRejection", onRejection);
+    }
+  });
+
+  test("one binding's backlog is not charged against another binding's limit", async () => {
+    // The counter used to be workflow-global while the limit came from the
+    // arriving fire's binding. The fast trigger filled the shared count to 5,
+    // and the slow trigger's FIRST fire was then dropped with a message reading
+    // "5 fire(s) are already waiting ... (maxPendingFires: 1)" — quoting a
+    // limit belonging to a trigger that had never queued anything.
+    const workflow = createWorkflow();
+    const fast = new IntervalTrigger({ intervalMs: PERIOD, id: "fast", overlap: "concurrent" });
+    // Fires once, well after the fast trigger has filled its own backlog.
+    const slow = new IntervalTrigger({ intervalMs: PERIOD * 4, id: "slow", overlap: "concurrent" });
+
+    const errors: Error[] = [];
+    fast.on("error", (error) => errors.push(error));
+    slow.on("error", (error) => errors.push(error));
+
+    workflow.trigger(fast, {
+      input: (context) => ({ label: `fast@${context.scheduledAt - START}` }),
+      maxPendingFires: 5,
+    });
+    // Default (1): its own first fire queues, and must not see the fast
+    // trigger's backlog at all.
+    workflow.trigger(slow, { input: () => ({ label: "slow" }) });
+
+    const gate = createGate();
+    holdGate = gate;
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD * 4);
+
+    // The fast trigger queued 3 fires behind the running one, under its own
+    // limit of 5, and the slow trigger's single fire queued under its own 1.
+    expect(executions).toEqual(["fast@100"]);
+    expect(
+      errors.map((error) => error.message).filter((message) => message.includes("slow"))
+    ).toEqual([]);
+    expect(errors).toEqual([]);
+
+    holdGate = undefined;
+    gate.open();
+    await drainUntil(() => completed.length >= 5);
+
+    expect(completed).toContain("slow");
+    expect(errors).toEqual([]);
+
+    await handle.stop();
+  });
+
+  test("a dropped fire names the trigger it came from", async () => {
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({
+      intervalMs: PERIOD,
+      id: "chatty",
+      overlap: "concurrent",
+    });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+    workflow.trigger(trigger, {
+      input: (context) => ({ label: `fire@${context.scheduledAt - START}` }),
+      maxPendingFires: 1,
+    });
+
+    const gate = createGate();
+    holdGate = gate;
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD * 3);
+
+    expect(errors).toHaveLength(1);
+    // Trigger and count in one message, so the quoted limit can never belong to
+    // a different trigger than the backlog.
+    expect(errors[0]?.message).toContain('trigger "chatty"');
+    expect(errors[0]?.message).toContain("1 fire(s) from that trigger");
+    expect(errors[0]?.message).toContain("maxPendingFires: 1");
+
+    holdGate = undefined;
+    gate.open();
+    await drainUntil(() => completed.length >= 2);
+    await handle.stop();
+  });
+
+  test("stopListening() halts further runs", async () => {
+    const workflow = createWorkflow();
+    workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }), {
+      input: () => ({ label: "tick" }),
+    });
+
+    await workflow.listen();
+    await advanceFakeTimers(PERIOD * 2);
+    expect(executions).toHaveLength(2);
+
+    await workflow.stopListening();
+    await advanceFakeTimers(PERIOD * 5);
+    expect(executions).toHaveLength(2);
+  });
+
+  test("stopListening() without listening is a no-op", async () => {
+    const workflow = createWorkflow();
+    await expect(workflow.stopListening()).resolves.toBeUndefined();
+  });
+
+  test("a rejecting run does not stop the trigger", async () => {
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    const errors: Error[] = [];
+    trigger.on("error", (error) => errors.push(error));
+    workflow.trigger(trigger, { input: () => ({ label: "risky" }) });
+
+    failNextRuns = 1;
+    const handle = await workflow.listen();
+
+    await advanceFakeTimers(PERIOD * 3);
+
+    expect(executions).toHaveLength(3);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+    expect(trigger.running).toBe(true);
+
+    await handle.stop();
+  });
+
+  test("await using disposes the handle and stops the triggers", async () => {
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    workflow.trigger(trigger, { input: () => ({ label: "scoped" }) });
+
+    {
+      await using handle = await workflow.listen();
+      expect(handle.triggers).toEqual([trigger]);
+      await advanceFakeTimers(PERIOD * 2);
+      expect(executions).toHaveLength(2);
+    }
+
+    expect(trigger.running).toBe(false);
+    await advanceFakeTimers(PERIOD * 3);
+    expect(executions).toHaveLength(2);
+  });
+
+  test("listen() twice returns the same handle instead of double-scheduling", async () => {
+    const workflow = createWorkflow();
+    workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }), {
+      input: () => ({ label: "once" }),
+    });
+
+    const first: ITriggerListenerHandle = await workflow.listen();
+    const second: ITriggerListenerHandle = await workflow.listen();
+    expect(second).toBe(first);
+
+    await advanceFakeTimers(PERIOD * 2);
+    expect(executions).toHaveLength(2);
+
+    await first.stop();
+  });
+
+  test("listen() with no bound trigger throws a typed error", async () => {
+    const workflow = createWorkflow();
+    await expect(workflow.listen()).rejects.toBeInstanceOf(WorkflowTriggerError);
+  });
+
+  test("binding a trigger while listening throws", async () => {
+    const workflow = createWorkflow();
+    workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }));
+    const handle = await workflow.listen();
+
+    expect(() => workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }))).toThrow(
+      WorkflowTriggerError
+    );
+
+    await handle.stop();
+    // Once stopped, binding is allowed again.
+    expect(() => workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }))).not.toThrow();
+  });
+
+  test("binding the same trigger twice to one workflow throws", () => {
+    // Not catchable by a `running` check: neither binding is running yet. One
+    // `ITrigger` holds one handler, so the second `start()` is a no-op and the
+    // second binding's `input` mapper would never run.
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD, id: "shared" });
+    workflow.trigger(trigger);
+
+    expect(() => workflow.trigger(trigger, { input: () => ({ label: "never" }) })).toThrow(
+      WorkflowTriggerError
+    );
+    expect(() => workflow.trigger(trigger)).toThrow(/shared/);
+    // The rejected binding was not recorded.
+    expect(getWorkflowTriggers(workflow)).toEqual([trigger]);
+  });
+
+  test("listen() with a trigger already running for another workflow throws", async () => {
+    const a = createWorkflow();
+    const b = createWorkflow();
+    const shared = new IntervalTrigger({ intervalMs: PERIOD, id: "shared" });
+    a.trigger(shared, { input: () => ({ label: "a" }) });
+    b.trigger(shared, { input: () => ({ label: "b" }) });
+
+    const handleA = await a.listen();
+    await expect(b.listen()).rejects.toBeInstanceOf(WorkflowTriggerError);
+
+    // Rejected BEFORE any state was touched, so b is unchanged and still
+    // bindable — the point of checking ahead of the handle registration.
+    expect(() => b.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "other" }))).not.toThrow();
+
+    await handleA.stop();
+  });
+
+  test("a rejected listen() leaves the other workflow's schedule intact", async () => {
+    // Previously b.listen() resolved with a handle listing the shared trigger
+    // while the handler stayed a's — and `b.stopListening()` then killed a's
+    // schedule, from a workflow that had never run once.
+    const a = createWorkflow();
+    const b = createWorkflow();
+    const shared = new IntervalTrigger({ intervalMs: PERIOD, id: "shared" });
+    a.trigger(shared, { input: () => ({ label: "a" }) });
+    b.trigger(shared, { input: () => ({ label: "b" }) });
+
+    const handleA = await a.listen();
+    await expect(b.listen()).rejects.toBeInstanceOf(WorkflowTriggerError);
+
+    await b.stopListening();
+    expect(shared.running).toBe(true);
+
+    await advanceFakeTimers(PERIOD * 2);
+    expect(executions).toEqual(["a", "a"]);
+
+    await handleA.stop();
+  });
+
+  test("a trigger is bindable again once the workflow using it has stopped", async () => {
+    const a = createWorkflow();
+    const b = createWorkflow();
+    const shared = new IntervalTrigger({ intervalMs: PERIOD, id: "shared" });
+    a.trigger(shared, { input: () => ({ label: "a" }) });
+    b.trigger(shared, { input: () => ({ label: "b" }) });
+
+    await (await a.listen()).stop();
+    const handleB = await b.listen();
+
+    await advanceFakeTimers(PERIOD);
+    expect(executions).toEqual(["b"]);
+
+    await handleB.stop();
+  });
+
+  test("a caller signal passed to listen() stops every trigger", async () => {
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+    workflow.trigger(trigger, { input: () => ({ label: "abortable" }) });
+    const controller = new AbortController();
+
+    await workflow.listen({ signal: controller.signal });
+    await advanceFakeTimers(PERIOD);
+    expect(executions).toHaveLength(1);
+
+    controller.abort();
+    await flushAsyncWork();
+
+    expect(trigger.running).toBe(false);
+    await advanceFakeTimers(PERIOD * 3);
+    expect(executions).toHaveLength(1);
+  });
+
+  test("a trigger whose start() throws leaves no started triggers and no handle", async () => {
+    const workflow = createWorkflow();
+    const healthy = new IntervalTrigger({ intervalMs: PERIOD, id: "healthy" });
+    // Parses fine; February has no 30th, so it fails on the first schedule.
+    const doomed = new CronTrigger({ expression: "0 0 30 2 *", id: "doomed" });
+    workflow.trigger(healthy, { input: () => ({ label: "healthy" }) });
+    workflow.trigger(doomed);
+
+    await expect(workflow.listen()).rejects.toBeInstanceOf(CronUnsatisfiableError);
+
+    expect(healthy.running).toBe(false);
+    await advanceFakeTimers(PERIOD * 3);
+    expect(executions).toEqual([]);
+
+    // No handle was registered, so the workflow is still bindable/listenable.
+    expect(() => workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }))).not.toThrow();
+  });
+
+  test("stopping a trigger cancels the run that trigger started", async () => {
+    // The trigger's signal is forwarded as `runConfig.signal`, so it cancels
+    // exactly the run this fire started — rather than `workflow.abort()`, which
+    // trips the workflow's single current-run controller and would cancel
+    // whichever run happens to be current, no matter who started it.
+    const workflow = createWorkflow();
+    const trigger = new IntervalTrigger({ intervalMs: PERIOD, id: "owner" });
+    workflow.trigger(trigger, { input: () => ({ label: "owned" }) });
+
+    const handle = await workflow.listen();
+    const gate = createGate();
+    holdGate = gate;
+
+    await advanceFakeTimers(PERIOD);
+    expect(executions).toEqual(["owned"]);
+    expect(abortedRuns).toEqual([]);
+
+    const stopping = trigger.stop();
+    await flushAsyncWork();
+    expect(abortedRuns).toEqual(["owned"]);
+    expect(completed).toEqual([]);
+
+    holdGate = undefined;
+    gate.open();
+    await stopping;
+
+    // The cancellation is the expected path, not an error to report.
+    expect(trigger.running).toBe(false);
+    await handle.stop();
+  });
+
+  test("a second trigger keeps running when the first one is stopped", async () => {
+    const workflow = createWorkflow();
+    const first = new IntervalTrigger({ intervalMs: PERIOD * 4, id: "first" });
+    const second = new IntervalTrigger({ intervalMs: PERIOD, id: "second" });
+    workflow.trigger(first, { input: () => ({ label: "first" }) });
+    workflow.trigger(second, { input: () => ({ label: "second" }) });
+
+    const handle = await workflow.listen();
+    await advanceFakeTimers(PERIOD * 4);
+    expect(executions).toContain("first");
+    expect(executions.filter((label) => label === "second")).toHaveLength(4);
+
+    await first.stop();
+    executions.length = 0;
+
+    await advanceFakeTimers(PERIOD * 4);
+    expect(executions).not.toContain("first");
+    expect(executions.filter((label) => label === "second")).toHaveLength(4);
+    expect(second.running).toBe(true);
+
+    await handle.stop();
+  });
+
+  test("a caller signal abort releases the handle so the workflow can listen again", async () => {
+    const workflow = createWorkflow();
+    workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }), {
+      input: () => ({ label: "before" }),
+    });
+    const controller = new AbortController();
+
+    await workflow.listen({ signal: controller.signal });
+    await advanceFakeTimers(PERIOD);
+    expect(executions).toEqual(["before"]);
+
+    controller.abort();
+    await flushAsyncWork();
+
+    // The handle must be gone, or binding stays locked and listen() keeps
+    // handing back a stale handle whose triggers are all dead.
+    expect(() =>
+      workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }), {
+        input: () => ({ label: "after" }),
+      })
+    ).not.toThrow();
+
+    const handle = await workflow.listen();
+    await advanceFakeTimers(PERIOD);
+    expect(executions).toContain("after");
+
+    await handle.stop();
+  });
+
+  describe("an already-aborted listen() signal", () => {
+    test("rejects instead of returning an inert handle", async () => {
+      // The old path returned a handle that had already been removed from the
+      // registry and whose triggers were never scheduled — a listen() that
+      // looked successful and did nothing.
+      const workflow = createWorkflow();
+      const trigger = new IntervalTrigger({ intervalMs: PERIOD });
+      workflow.trigger(trigger, { input: () => ({ label: "never" }) });
+
+      await expect(workflow.listen({ signal: AbortSignal.abort() })).rejects.toBeInstanceOf(Error);
+
+      expect(trigger.running).toBe(false);
+      await advanceFakeTimers(PERIOD * 3);
+      expect(executions).toEqual([]);
+    });
+
+    test("leaves the workflow free to bind and listen again", async () => {
+      // Checked before any state is touched, so the binding lock was never
+      // taken and the handle registry was never written.
+      const workflow = createWorkflow();
+      workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }), {
+        input: () => ({ label: "first" }),
+      });
+
+      await expect(workflow.listen({ signal: AbortSignal.abort() })).rejects.toBeInstanceOf(Error);
+
+      expect(() =>
+        workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "later" }), {
+          input: () => ({ label: "later" }),
+        })
+      ).not.toThrow();
+
+      const handle = await workflow.listen();
+      await advanceFakeTimers(PERIOD);
+      expect(executions).toContain("later");
+
+      await handle.stop();
+    });
+  });
+
+  describe("stop deadline", () => {
+    test("listen({ stopTimeoutMs }) bounds stop() even when a trigger ignores the option", async () => {
+      const { warnings, restore } = captureWarnings();
+      try {
+        const workflow = createWorkflow();
+        const wedged = new WedgedTrigger("wedged-1");
+        const healthy = new IntervalTrigger({ intervalMs: PERIOD, id: "healthy" });
+        workflow.trigger(wedged);
+        workflow.trigger(healthy, { input: () => ({ label: "healthy" }) });
+
+        const handle = await workflow.listen({ stopTimeoutMs: PERIOD * 5 });
+        await advanceFakeTimers(PERIOD);
+        expect(executions).toContain("healthy");
+
+        const stopping = handle.stop();
+        await advanceFakeTimers(PERIOD * 5);
+        await stopping;
+
+        // The sibling actually stopped rather than being held hostage.
+        expect(healthy.running).toBe(false);
+        const timedOut = warnings.find(
+          (warning) => warning.message === "Timed out stopping workflow triggers"
+        );
+        expect(timedOut?.meta?.triggerIds).toEqual(["wedged-1"]);
+
+        // The handle was released, so binding and listening are possible again.
+        expect(() =>
+          workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "after" }))
+        ).not.toThrow();
+      } finally {
+        restore();
+      }
+    });
+
+    test("stop({ timeoutMs }) overrides the listen() default", async () => {
+      const { warnings, restore } = captureWarnings();
+      try {
+        const workflow = createWorkflow();
+        workflow.trigger(new WedgedTrigger("wedged-2"));
+
+        const handle = await workflow.listen();
+        const stopping = handle.stop({ timeoutMs: PERIOD * 2 });
+        await advanceFakeTimers(PERIOD * 2);
+        await stopping;
+
+        expect(
+          warnings.some((warning) => warning.message === "Timed out stopping workflow triggers")
+        ).toBe(true);
+      } finally {
+        restore();
+      }
+    });
+
+    test("a set of triggers that all stop cleanly reports nothing", async () => {
+      const { warnings, restore } = captureWarnings();
+      try {
+        const workflow = createWorkflow();
+        workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "a" }), {
+          input: () => ({ label: "a" }),
+        });
+        workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD, id: "b" }), {
+          input: () => ({ label: "b" }),
+        });
+
+        const handle = await workflow.listen({ stopTimeoutMs: PERIOD * 5 });
+        await advanceFakeTimers(PERIOD);
+        await handle.stop();
+
+        expect(
+          warnings.some((warning) => warning.message === "Timed out stopping workflow triggers")
+        ).toBe(false);
+        // The deadline timer is cleared once the drain wins the race.
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  test("a fire with no input mapping runs the workflow with its declared defaults", async () => {
+    const workflow = createWorkflow();
+    workflow.trigger(new IntervalTrigger({ intervalMs: PERIOD }));
+
+    const handle = await workflow.listen();
+    await advanceFakeTimers(PERIOD);
+
+    expect(executions).toEqual(["default"]);
+
+    await handle.stop();
+  });
+});

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "../storage" },
     { "path": "../job-queue" },
     { "path": "../task-graph" },
+    { "path": "../triggers" },
     { "path": "../knowledge-base" },
     { "path": "../tasks" },
     { "path": "../ai" },

--- a/packages/triggers/LICENSE
+++ b/packages/triggers/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright 2025 Steven Roussey
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/triggers/README.md
+++ b/packages/triggers/README.md
@@ -1,0 +1,146 @@
+# @workglow/triggers
+
+Pure-timer triggers for Workglow, plus the `Workflow` lifecycle methods that
+start a workflow from one. No new dependencies, no host HTTP server, no
+persistence — just `setTimeout` and the calendar, so the package runs unchanged
+in Node, Bun, and the browser.
+
+```sh
+npm install @workglow/triggers
+```
+
+## Triggers
+
+| Trigger           | Fires                                                         |
+| ----------------- | ------------------------------------------------------------- |
+| `IntervalTrigger` | every `intervalMs`, starting one full period after `start()`  |
+| `PollingTrigger`  | only when a poll result is interesting (non-empty by default) |
+| `CronTrigger`     | on the UTC instants matching a 5-field cron expression        |
+
+```ts
+import { CronTrigger, IntervalTrigger, PollingTrigger } from "@workglow/triggers";
+
+const trigger = new CronTrigger({ expression: "0 9 * * 1-5" }); // 09:00 UTC, weekdays
+trigger.on("error", (error) => console.error(error));
+trigger.start(async ({ scheduledAt, signal }) => {
+  await doWork({ signal });
+});
+// ...
+await trigger.stop();
+```
+
+## Driving a workflow
+
+Two forms, same behavior. The free functions always work; the fluent methods
+exist only after `installWorkflowTriggers()`.
+
+```ts
+import { bindWorkflowTrigger, IntervalTrigger, listenWorkflow, PollingTrigger } from "@workglow/triggers";
+import { Workflow } from "@workglow/task-graph";
+
+const workflow = new Workflow().addTask(MyTask);
+
+bindWorkflowTrigger(workflow, new IntervalTrigger({ intervalMs: 60_000 }));
+bindWorkflowTrigger(workflow, new PollingTrigger({ intervalMs: 5_000, poll: () => fetchPendingIds() }), {
+  input: (context) => ({ ids: context.payload }),
+});
+
+await using handle = await listenWorkflow(workflow);
+```
+
+**Importing this package installs nothing.** A module body that patched
+`Workflow.prototype` would make every barrel re-exporting it side-effectful —
+including `workglow`'s, which also reaches `@workglow/duckdb`, `postgres`,
+`sqlite` and `mcp`, none of which declare `sideEffects`, so a bundler would have
+to keep all of them in the app's bundle. Ask for the patch instead:
+
+```ts
+import { installWorkflowTriggers } from "@workglow/triggers";
+
+installWorkflowTriggers(); // once, at startup; idempotent
+
+workflow.trigger(new IntervalTrigger({ intervalMs: 60_000 }));
+await using handle = await workflow.listen();
+```
+
+`import "workglow/auto-bootstrap"` already calls it, so the batteries-included
+path keeps the fluent API. Anything else that bootstraps by hand — including
+`bootstrapWorkglow()` from `workglow/bootstrap` — does not: `workflow.trigger`
+is `undefined` there until you install it, and TypeScript will not warn you,
+because the method declaration is a module augmentation with no way to say
+"after install".
+
+`stopWorkflowListening(workflow)` is the free-function form of
+`workflow.stopListening()`.
+
+`listen()` **resolves as soon as the triggers are scheduled — it does not block
+until the process is interrupted.** It does not, however, leave the process free
+to exit: a scheduled `setTimeout` is a live handle, so under Node or Bun a
+started trigger keeps the process alive until it is stopped. A CLI or a test
+that forgets `stop()` therefore hangs. Pass `unrefTimer: true` to any trigger
+whose schedule should not by itself hold the process open. Stop with
+`handle.stop()`, `workflow.stopListening()`, or by letting an `await using`
+scope exit.
+
+## Behavior worth knowing
+
+- **Abort** — `stop()` aborts the signal handed to handlers and resolves only
+  once in-flight handlers settle; concurrent `stop()` calls join the same drain.
+  A tick that fails because of that abort is not reported on `error` — a
+  graceful shutdown is not a fault. A caller signal passed to `start()` is
+  linked with `AbortSignal.any`. Under the workflow bindings, stopping a trigger
+  aborts only the workflow runs THAT trigger started — the signal is forwarded
+  as `runConfig.signal`, so a second trigger bound to the same workflow keeps
+  running. An `AbortSignal` that is ALREADY aborted when it reaches `listen()`
+  makes `listen()` reject rather than hand back a handle whose triggers were
+  never scheduled.
+- **Bounding the drain** — the wait above is **unbounded by default**, and that
+  default is load-bearing: it is what makes "`await stop()` means no handler of
+  that run is still running" true. A handler that never settles therefore never
+  lets `stop()` resolve, and through the workflow bindings that wedges
+  `handle.stop()`, `workflow.stopListening()` and an `await using` scope exit
+  for every other trigger on the workflow. Opt into a deadline with
+  `stopTimeoutMs` on the trigger, `timeoutMs` on the `stop()` call, or
+  `stopTimeoutMs` on `listen()` (which forwards to each trigger AND bounds the
+  set, so a third-party `ITrigger` that ignores the option cannot wedge its
+  siblings). Past the deadline the still-pending handlers are **abandoned — they
+  keep running** — a `TriggerStopTimeoutError` carrying the count is emitted on
+  `error`, and the trigger is released so it can be started again.
+- **Overlap** — `overlap: "skip" | "queue" | "concurrent"`, default `"skip"`. A
+  tick arriving while the previous handler runs is dropped (and emits `skip`); a
+  trigger is a clock, not a work queue, so a slow handler cannot grow a backlog.
+  The policy governs handler INVOCATION. A handler bound to a workflow still
+  serializes at the workflow — one `Workflow` owns one task graph, and a graph
+  cannot run re-entrantly — so `"concurrent"` plus a workflow binding degrades
+  to queue semantics, bounded by the binding's `maxPendingFires` (default `1`).
+  A fire past that bound is dropped and reported on `error`. When queueing is
+  what you want, ask for it: `overlap: "queue"` with `maxQueuedFires`. A dropped
+  tick emits `skip` every time; the accompanying log is collapsed to the first
+  skip of a contiguous run plus a count when the run ends. `"concurrent"` is
+  unbounded unless you say otherwise — a handler slower than the period gains
+  one more invocation every tick, forever — so pass `maxConcurrentFires` to cap
+  it; ticks past the cap degrade to skips.
+- **Errors** — a handler rejection never stops the loop. It is emitted on
+  `error` as the real `Error` and logged through `getLogger()`. A polling
+  handler that throws does not consume the change: the baseline is restored and
+  the value is offered again on the next poll that still observes it
+  (at-least-once, always with the freshest result — retries are paced by the
+  poll period, not by `errorBackoff`, which counts POLL failures only).
+- **Hung polls** — `poll` gets no deadline by default. Pass `pollTimeoutMs` to
+  bound one poll: exceeding it aborts the signal handed to `poll` and fails the
+  tick with a `TriggerPollTimeoutError`, which counts as a poll failure
+  (reported on `error`, and it drives `errorBackoff`). Without it, a `fetch`
+  against a black-holed host keeps the tick in flight forever, and under the
+  default `"skip"` policy every later tick is dropped — the trigger goes quiet
+  with nothing on `error`, because a hang is not a throw.
+- **Drift** — each tick is scheduled from the previous tick's scheduled instant,
+  not from when its handler finished, so handler duration never accumulates.
+  Waits longer than a timer's ~24.8-day ceiling are chunked.
+- **Cron** — 5 fields, **UTC only**, supporting `*`, `N`, `a,b`, `a-b`, `*/n`,
+  and `a-b/n`. Day-of-month and day-of-week use standard OR semantics only when
+  NEITHER field begins with `*`: `0 0 1 * 1` is "the 1st **or** any Monday",
+  while `0 0 */2 * 1` is "every other day **and** a Monday" — Vixie cron's
+  leading-`*` rule, so a crontab line ported here means what it meant there.
+  Macros (`@daily`), names (`MON`), and `L`/`W`/`#` are rejected rather than
+  guessed at.
+- **Delivery** — in-process and at most once. Nothing survives a restart.

--- a/packages/triggers/package.json
+++ b/packages/triggers/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@workglow/triggers",
+  "type": "module",
+  "version": "0.3.45",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/workglow-dev/libs.git",
+    "directory": "packages/triggers"
+  },
+  "bugs": {
+    "url": "https://github.com/workglow-dev/libs/issues"
+  },
+  "description": "Runtime-agnostic triggers for Workglow \u2014 interval, polling, and cron schedules that start workflows programmatically.",
+  "homepage": "https://workglow.dev",
+  "scripts": {
+    "watch": "concurrently -c 'auto' 'bun:watch-*'",
+    "watch-js": "concurrently -c 'auto' -n 'browser,node' 'bun run watch-browser' 'bun run watch-node'",
+    "watch-browser": "bun build --watch --no-clear-screen --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/browser.ts",
+    "watch-node": "bun build --watch --no-clear-screen --target=node --sourcemap=external --packages=external --outdir ./dist ./src/node.ts",
+    "watch-types": "tsc --watch --preserveWatchOutput",
+    "build-package": "concurrently -c 'auto' -n 'browser,node,types' 'bun run build-browser' 'bun run build-node' 'bun run build-types'",
+    "build-js": "concurrently -m 12 --timings -c 'auto' -n 'browser,node' 'bun run build-browser' 'bun run build-node'",
+    "build-clean": "rm -fr dist/* tsconfig.tsbuildinfo",
+    "build-browser": "bun build --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/browser.ts",
+    "build-node": "bun build --target=node --sourcemap=external --packages=external --outdir ./dist ./src/node.ts",
+    "build-types": "rm -f tsconfig.tsbuildinfo && tsgo",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+  },
+  "exports": {
+    ".": {
+      "react-native": {
+        "types": "./dist/browser.d.ts",
+        "import": "./dist/browser.js"
+      },
+      "browser": {
+        "types": "./dist/browser.d.ts",
+        "import": "./dist/browser.js"
+      },
+      "types": "./dist/node.d.ts",
+      "import": "./dist/node.js"
+    }
+  },
+  "peerDependencies": {
+    "@workglow/task-graph": "workspace:*",
+    "@workglow/util": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@workglow/task-graph": {
+      "optional": false
+    },
+    "@workglow/util": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@workglow/task-graph": "workspace:*",
+    "@workglow/util": "workspace:*"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/triggers/src/browser.ts
+++ b/packages/triggers/src/browser.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./common";

--- a/packages/triggers/src/common.ts
+++ b/packages/triggers/src/common.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This barrel is PURE: nothing here patches `Workflow.prototype`, so a bundler
+// may elide any of it. `installWorkflowTriggers()` is what installs the fluent
+// `.trigger()` / `.listen()` methods, and a consumer calls it (or uses the free
+// functions instead). Do not re-add a bare `import "./workflow/WorkflowTriggers"`:
+// it would make this module side-effectful, and every package re-exporting it —
+// `workglow`'s barrel most of all — would be pinned into consumer bundles along
+// with duckdb, postgres, sqlite and mcp, none of which declare `sideEffects`.
+
+export * from "./cron/CronSchedule";
+export * from "./trigger/BaseTrigger";
+export * from "./trigger/CronTrigger";
+export * from "./trigger/fixedInterval";
+export * from "./trigger/IntervalTrigger";
+export * from "./trigger/ITrigger";
+export * from "./trigger/PollingTrigger";
+export * from "./trigger/TriggerError";
+export * from "./workflow/WorkflowTriggers";

--- a/packages/triggers/src/cron/CronSchedule.ts
+++ b/packages/triggers/src/cron/CronSchedule.ts
@@ -1,0 +1,301 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CronExpressionError, CronUnsatisfiableError } from "../trigger/TriggerError";
+
+/**
+ * A parsed 5-field cron expression: `minute hour day-of-month month day-of-week`.
+ *
+ * Every set is expanded at parse time, and all matching is done in **UTC** —
+ * see {@link parseCronExpression} for the supported syntax and the rationale.
+ */
+export interface CronSchedule {
+  /** The expression this schedule was parsed from, whitespace-normalized. */
+  readonly expression: string;
+  readonly minutes: ReadonlySet<number>;
+  readonly hours: ReadonlySet<number>;
+  readonly daysOfMonth: ReadonlySet<number>;
+  /** 1-12. */
+  readonly months: ReadonlySet<number>;
+  /** 0-6, Sunday = 0. A `7` in the expression is normalized to `0`. */
+  readonly daysOfWeek: ReadonlySet<number>;
+  /**
+   * True when the day-of-month field does NOT begin with `*` — Vixie cron's
+   * `DOM_STAR` flag, inverted. See {@link matchesDay} for what it selects.
+   */
+  readonly dayOfMonthRestricted: boolean;
+  /** True when the day-of-week field does NOT begin with `*`. */
+  readonly dayOfWeekRestricted: boolean;
+}
+
+interface CronFieldSpec {
+  readonly name: string;
+  readonly min: number;
+  readonly max: number;
+}
+
+const MINUTE_FIELD: CronFieldSpec = { name: "minute", min: 0, max: 59 };
+const HOUR_FIELD: CronFieldSpec = { name: "hour", min: 0, max: 23 };
+const DAY_OF_MONTH_FIELD: CronFieldSpec = { name: "day-of-month", min: 1, max: 31 };
+const MONTH_FIELD: CronFieldSpec = { name: "month", min: 1, max: 12 };
+// 7 is accepted as an alias for Sunday and normalized to 0.
+const DAY_OF_WEEK_FIELD: CronFieldSpec = { name: "day-of-week", min: 0, max: 7 };
+
+const CRON_FIELD_COUNT = 5;
+
+const MINUTE_MS = 60_000;
+
+/**
+ * How far ahead {@link nextCronFireTime} searches before declaring an
+ * expression unsatisfiable.
+ *
+ * It has to clear the longest real gap between two matches, and leap day is
+ * that gap: century years divisible by 100 but not 400 are NOT leap years, so
+ * `0 0 29 2 *` jumps from 2096-02-29 straight to 2104-02-29 — just under eight
+ * years. Nine gives that margin without letting a genuinely impossible
+ * expression (`0 0 30 2 *`) search for long: the month and day fast-forwards in
+ * {@link nextCronFireTime} skip whole months and days at a time, so the horizon
+ * costs a few hundred iterations, not years of minutes.
+ */
+const MAX_SEARCH_YEARS = 9;
+
+/**
+ * Parses a 5-field cron expression.
+ *
+ * Supported per field: `*`, `N`, `a,b`, `a-b`, `*&#47;n`, `a-b&#47;n`. Anything
+ * else — macros (`@daily`), month/day NAMES (`JAN`, `MON`), a seconds field, and
+ * the Quartz extensions `L`, `W`, `#`, `?` — is rejected with a
+ * {@link CronExpressionError} rather than silently reinterpreted.
+ *
+ * Fields are matched in **UTC**. A local-time cron needs a timezone database and
+ * an answer for DST-ambiguous instants (a 2:30am daily job runs twice on one day
+ * a year and zero times on another); UTC has no such gaps, so it is the only
+ * dialect this package will guess at.
+ *
+ * Day-of-month and day-of-week use standard cron **OR** semantics: when NEITHER
+ * field begins with `*`, a day matches if EITHER matches — so `0 0 1 * 1` fires
+ * on the 1st of the month AND on every Monday. A field beginning with `*`
+ * (including a step such as `*&#47;2`) switches back to AND, matching Vixie
+ * cron's `DOM_STAR`/`DOW_STAR` rule. See {@link matchesDay}.
+ */
+export function parseCronExpression(expression: string): CronSchedule {
+  if (typeof expression !== "string") {
+    throw new CronExpressionError(
+      `Cron expression must be a string, received ${typeof expression}.`
+    );
+  }
+  const normalized = expression.trim().replace(/\s+/g, " ");
+  if (normalized.length === 0) {
+    throw new CronExpressionError("Cron expression must not be empty.");
+  }
+  const fields = normalized.split(" ");
+  if (fields.length !== CRON_FIELD_COUNT) {
+    throw new CronExpressionError(
+      `Cron expression "${expression}" has ${fields.length} field(s); exactly ${CRON_FIELD_COUNT} ` +
+        `are required (minute hour day-of-month month day-of-week).`
+    );
+  }
+
+  const [minuteRaw, hourRaw, dayOfMonthRaw, monthRaw, dayOfWeekRaw] = fields as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+
+  const daysOfWeek = new Set(
+    [...parseField(dayOfWeekRaw, DAY_OF_WEEK_FIELD, normalized)].map((day) => day % 7)
+  );
+
+  return {
+    expression: normalized,
+    minutes: parseField(minuteRaw, MINUTE_FIELD, normalized),
+    hours: parseField(hourRaw, HOUR_FIELD, normalized),
+    daysOfMonth: parseField(dayOfMonthRaw, DAY_OF_MONTH_FIELD, normalized),
+    months: parseField(monthRaw, MONTH_FIELD, normalized),
+    daysOfWeek,
+    // Vixie tests the LEADING character, not the whole field: `*/2` is still a
+    // "star" field there, so it keeps AND semantics. Comparing against `"*"`
+    // instead made `0 0 */2 * 1` mean "every other day OR every Monday", which
+    // is not what the same crontab line does anywhere else.
+    dayOfMonthRestricted: !dayOfMonthRaw.startsWith("*"),
+    dayOfWeekRestricted: !dayOfWeekRaw.startsWith("*"),
+  };
+}
+
+function parseField(raw: string, spec: CronFieldSpec, expression: string): ReadonlySet<number> {
+  const values = new Set<number>();
+  for (const part of raw.split(",")) {
+    for (const value of parseFieldPart(part, spec, expression)) {
+      values.add(value);
+    }
+  }
+  return values;
+}
+
+function parseFieldPart(part: string, spec: CronFieldSpec, expression: string): number[] {
+  if (part.length === 0) {
+    throw fieldError(part, spec, expression, "it contains an empty list entry");
+  }
+
+  const [rangeText, stepText, ...extra] = part.split("/");
+  if (extra.length > 0 || rangeText === undefined) {
+    throw fieldError(part, spec, expression, "it has more than one step separator");
+  }
+
+  let step = 1;
+  if (stepText !== undefined) {
+    if (!/^\d+$/.test(stepText)) {
+      throw fieldError(part, spec, expression, `"${stepText}" is not a positive step`);
+    }
+    step = Number(stepText);
+    if (step === 0) {
+      throw fieldError(part, spec, expression, "a step of 0 is not a valid increment");
+    }
+  }
+
+  let start: number;
+  let end: number;
+  if (rangeText === "*") {
+    start = spec.min;
+    end = spec.max;
+  } else if (rangeText.includes("-")) {
+    const [startText, endText, ...rest] = rangeText.split("-");
+    if (rest.length > 0 || startText === undefined || endText === undefined) {
+      throw fieldError(part, spec, expression, `"${rangeText}" is not a valid range`);
+    }
+    start = parseNumber(startText, part, spec, expression);
+    end = parseNumber(endText, part, spec, expression);
+    if (start > end) {
+      throw fieldError(part, spec, expression, `range ${start}-${end} is inverted`);
+    }
+  } else if (stepText !== undefined) {
+    // `a/n` (Vixie's open-ended step) is deliberately unsupported: it reads like
+    // "every n starting at a" but means different things across dialects.
+    throw fieldError(
+      part,
+      spec,
+      expression,
+      `a step needs an explicit range — write "${rangeText}-${spec.max}/${step}" or "*/${step}"`
+    );
+  } else {
+    start = parseNumber(rangeText, part, spec, expression);
+    end = start;
+  }
+
+  const values: number[] = [];
+  for (let value = start; value <= end; value += step) {
+    values.push(value);
+  }
+  return values;
+}
+
+function parseNumber(text: string, part: string, spec: CronFieldSpec, expression: string): number {
+  if (!/^\d+$/.test(text)) {
+    throw fieldError(
+      part,
+      spec,
+      expression,
+      `"${text}" is not a number (names such as JAN or MON are not supported)`
+    );
+  }
+  const value = Number(text);
+  if (value < spec.min || value > spec.max) {
+    throw fieldError(part, spec, expression, `${value} is outside ${spec.min}-${spec.max}`);
+  }
+  return value;
+}
+
+function fieldError(
+  part: string,
+  spec: CronFieldSpec,
+  expression: string,
+  reason: string
+): CronExpressionError {
+  return new CronExpressionError(
+    `Invalid ${spec.name} "${part}" in cron expression "${expression}": ${reason}.`
+  );
+}
+
+/**
+ * The first instant matching `schedule` STRICTLY AFTER `afterMs`, in UTC.
+ *
+ * Strictly after is what makes the trigger loop terminate: computing the next
+ * fire from a tick that landed exactly on a boundary must move forward, not
+ * return the same instant again.
+ *
+ * @throws CronUnsatisfiableError when nothing matches within {@link MAX_SEARCH_YEARS}
+ *   (for example `0 0 30 2 *` — February never has a 30th).
+ */
+export function nextCronFireTime(schedule: CronSchedule, afterMs: number): number {
+  const from = new Date(afterMs);
+  // Truncate to the minute, then step one minute: cron has minute resolution,
+  // and the result must be strictly after `afterMs`.
+  let candidate =
+    Date.UTC(
+      from.getUTCFullYear(),
+      from.getUTCMonth(),
+      from.getUTCDate(),
+      from.getUTCHours(),
+      from.getUTCMinutes()
+    ) + MINUTE_MS;
+  const limit = Date.UTC(
+    from.getUTCFullYear() + MAX_SEARCH_YEARS,
+    from.getUTCMonth(),
+    from.getUTCDate(),
+    from.getUTCHours(),
+    from.getUTCMinutes()
+  );
+
+  while (candidate <= limit) {
+    const date = new Date(candidate);
+    const year = date.getUTCFullYear();
+    const monthIndex = date.getUTCMonth();
+
+    if (!schedule.months.has(monthIndex + 1)) {
+      candidate = Date.UTC(year, monthIndex + 1, 1, 0, 0);
+      continue;
+    }
+    if (!matchesDay(schedule, date)) {
+      candidate = Date.UTC(year, monthIndex, date.getUTCDate() + 1, 0, 0);
+      continue;
+    }
+    if (!schedule.hours.has(date.getUTCHours())) {
+      candidate = Date.UTC(year, monthIndex, date.getUTCDate(), date.getUTCHours() + 1, 0);
+      continue;
+    }
+    if (!schedule.minutes.has(date.getUTCMinutes())) {
+      candidate += MINUTE_MS;
+      continue;
+    }
+    return candidate;
+  }
+
+  throw new CronUnsatisfiableError(
+    `Cron expression "${schedule.expression}" has no matching time within ${MAX_SEARCH_YEARS} years ` +
+      `of ${new Date(afterMs).toISOString()}.`
+  );
+}
+
+/**
+ * Vixie cron's day rule: when BOTH day fields are restricted (neither begins
+ * with `*`) a day matches if EITHER set contains it; otherwise both sets must
+ * contain it — which, since `*` expands to every value, reduces to "the
+ * restricted field decides".
+ *
+ * The AND branch consults both sets deliberately. A field like `*&#47;2` is a
+ * star field for the OR/AND decision but still carries a narrowed set, so
+ * `0 0 *&#47;2 * 1` means "every other day of the month AND a Monday".
+ */
+function matchesDay(schedule: CronSchedule, date: Date): boolean {
+  const dayOfMonthMatches = schedule.daysOfMonth.has(date.getUTCDate());
+  const dayOfWeekMatches = schedule.daysOfWeek.has(date.getUTCDay());
+  if (schedule.dayOfMonthRestricted && schedule.dayOfWeekRestricted) {
+    return dayOfMonthMatches || dayOfWeekMatches;
+  }
+  return dayOfMonthMatches && dayOfWeekMatches;
+}

--- a/packages/triggers/src/node.ts
+++ b/packages/triggers/src/node.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./common";

--- a/packages/triggers/src/trigger/BaseTrigger.ts
+++ b/packages/triggers/src/trigger/BaseTrigger.ts
@@ -1,0 +1,651 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TaskAbortedError } from "@workglow/task-graph";
+import { EventEmitter, getLogger, uuid4 } from "@workglow/util";
+import { assertPositiveInteger } from "./assertions";
+import type {
+  ITrigger,
+  ITriggerFireContext,
+  OverlapPolicy,
+  TriggerEventListener,
+  TriggerEventListeners,
+  TriggerEventParameters,
+  TriggerEvents,
+  TriggerHandler,
+  TriggerStartOptions,
+  TriggerStopOptions,
+} from "./ITrigger";
+import { OVERLAP_POLICIES } from "./ITrigger";
+import { TriggerConfigurationError, TriggerStopTimeoutError } from "./TriggerError";
+
+/**
+ * Largest delay a host timer accepts. A larger value overflows the 32-bit
+ * delay and fires immediately, so long waits are scheduled in chunks.
+ */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Largest shortfall at timer expiry still attributable to a host firing a timer a
+ * hair early. Anything larger, on a wait we did not truncate, means the wall clock
+ * moved backwards under a monotonic timer.
+ */
+const EARLY_TIMER_TOLERANCE_MS = 50;
+
+/** A `stop()` drain's deadline: the race arm, its cancellation, and its size. */
+interface StopDeadline {
+  readonly timeoutMs: number;
+  readonly expired: Promise<"expired">;
+  readonly cancel: () => void;
+}
+
+/**
+ * Whether a rejection is a cancellation rather than a fault.
+ *
+ * The three shapes a stopped tick actually rejects with: the signal's own
+ * `reason` (what `throwIfAborted()` re-throws), the platform `AbortError`
+ * (`DOMException`, and the convention every hand-rolled one here follows), and
+ * {@link TaskAbortedError} — what a `Workflow` run raises when its signal
+ * fires, which is the common case since the workflow bindings are what most
+ * handlers wrap. Anything else is a real failure that happened to land during
+ * shutdown, and is reported.
+ */
+function isAbortShaped(error: unknown, signal: AbortSignal): boolean {
+  if (error !== undefined && error === signal.reason) return true;
+  if (error instanceof TaskAbortedError) return true;
+  return error instanceof Error && error.name === "AbortError";
+}
+
+/** Options common to every built-in trigger. */
+export interface TriggerOptions {
+  /** Stable id; a UUID is generated when omitted. */
+  readonly id?: string | undefined;
+  /** See {@link OverlapPolicy}. Defaults to `"skip"`. */
+  readonly overlap?: OverlapPolicy | undefined;
+  /** Backlog bound for the `"queue"` policy. Defaults to `1`. */
+  readonly maxQueuedFires?: number | undefined;
+  /**
+   * Ceiling on handler invocations in flight at once under
+   * `overlap: "concurrent"`. A positive integer; unbounded by default.
+   *
+   * `"concurrent"` otherwise has no bound at all: a handler slower than the
+   * period accumulates one more invocation every tick, forever, and the fan-out
+   * is limited only by whatever the handler itself runs out of. A tick past the
+   * ceiling behaves exactly like a `"skip"` — `skip` event, collapsed warning —
+   * so the trigger stays a clock rather than becoming an unbounded work queue.
+   *
+   * Ignored by the other overlap policies, which already bound themselves.
+   */
+  readonly maxConcurrentFires?: number | undefined;
+  /**
+   * Default deadline for {@link BaseTrigger.stop}'s drain, in milliseconds. A
+   * positive integer; unbounded by default. See
+   * {@link TriggerStopOptions.timeoutMs} — the default MUST stay unbounded, or
+   * the documented meaning of `await stop()` quietly stops being true.
+   */
+  readonly stopTimeoutMs?: number | undefined;
+  /**
+   * Call `unref()` on the scheduled timer where the host supports it (Node and
+   * Bun; a browser's numeric handle has no such method and is left alone).
+   *
+   * A running trigger otherwise keeps a Node process alive, which is the right
+   * default for a server but wrong for a CLI or a test that forgets `stop()`.
+   */
+  readonly unrefTimer?: boolean | undefined;
+}
+
+/**
+ * Everything one {@link BaseTrigger.start} owns: the handler, the abort
+ * plumbing, the pending timer, and the overlap counters.
+ *
+ * The OBJECT IDENTITY is the generation token. Every scheduling and dispatch
+ * path takes its run as a parameter instead of reading `this`, so a chain left
+ * over from a previous `start()` physically cannot see a newer run's counters,
+ * shift its queued ticks, or invoke its handler with a stale (already aborted)
+ * signal. A `stop()` that is still draining therefore cannot disturb a restart.
+ */
+export interface TriggerRun {
+  /** Handler registered by the `start()` that created this run. */
+  readonly handler: TriggerHandler;
+  /** Aborted by `stop()`; the source of {@link TriggerRun.signal}. */
+  readonly controller: AbortController;
+  /** Signal handed to handlers — the controller, linked with any caller signal. */
+  readonly signal: AbortSignal;
+  /** Scheduled instants held back by the `"queue"` overlap policy. */
+  readonly queued: number[];
+  /** Tick chains that have not settled yet; `stop()` awaits these. */
+  readonly pending: Set<Promise<void>>;
+  /** Handle of the pending tick, if one is scheduled. */
+  timer: ReturnType<typeof setTimeout> | undefined;
+  /** Handler invocations currently in flight. */
+  inFlight: number;
+  /** Length of the current contiguous run of skipped ticks; 0 when not skipping. */
+  skipStreak: number;
+  /** False from the moment `stop()` is entered; nothing new is scheduled after. */
+  active: boolean;
+  /** Detaches the caller-signal abort listener, when one was registered. */
+  removeExternalAbort: (() => void) | undefined;
+  /** The in-flight `stop()` for this run, so a second `stop()` joins it. */
+  stopping: Promise<void> | undefined;
+}
+
+/**
+ * Shared lifecycle for the pure-timer triggers: absolute-time scheduling,
+ * overlap gating, abort wiring, and error isolation.
+ *
+ * Subclasses implement {@link computeNextFireTime} and may override
+ * {@link runTick} to resolve a payload before the handler is invoked.
+ *
+ * The next tick is scheduled BEFORE the handler runs and is computed from the
+ * tick's own scheduled instant, so handler duration never accumulates into the
+ * schedule — the recurring `setInterval` drift bug cannot occur here.
+ */
+export abstract class BaseTrigger implements ITrigger {
+  public readonly id: string;
+  public abstract readonly kind: string;
+  public readonly events = new EventEmitter<TriggerEventListeners>();
+
+  protected readonly overlap: OverlapPolicy;
+  protected readonly maxQueuedFires: number;
+  protected readonly maxConcurrentFires: number;
+  protected readonly stopTimeoutMs: number | undefined;
+  protected readonly unrefTimer: boolean;
+
+  /**
+   * How the instants from {@link computeNextFireTime} are meant to be read.
+   *
+   * `"wall"` — a calendar appointment (`CronTrigger`). A timer that expires before
+   * the clock reaches it has not reached the appointment: re-arm for the
+   * remainder, which is what makes a backward NTP correction DELAY the fire rather
+   * than misfire it.
+   *
+   * `"period"` — a bookkeeping anchor for "every N ms" (`IntervalTrigger`,
+   * `PollingTrigger`). The timer, not the clock, measures the period, so an expiry
+   * is a fire whatever the clock reads; re-arming on a backward step would stall
+   * the trigger for the size of the step.
+   */
+  protected readonly clockDomain: "wall" | "period" = "period";
+
+  /** The current run, or `undefined` when the trigger is stopped and drained. */
+  private _run: TriggerRun | undefined;
+
+  constructor(options: TriggerOptions = {}) {
+    this.id = options.id ?? uuid4();
+    this.overlap = options.overlap ?? "skip";
+    if (!(OVERLAP_POLICIES as readonly string[]).includes(this.overlap)) {
+      throw new TriggerConfigurationError(
+        `Unknown overlap policy "${this.overlap}". Expected one of: ${OVERLAP_POLICIES.join(", ")}.`
+      );
+    }
+    this.maxQueuedFires =
+      options.maxQueuedFires === undefined
+        ? 1
+        : assertPositiveInteger(options.maxQueuedFires, "maxQueuedFires");
+    // Infinity, not a large number: the ceiling is genuinely absent by default,
+    // and a sentinel would eventually be reached by a long-lived trigger.
+    this.maxConcurrentFires =
+      options.maxConcurrentFires === undefined
+        ? Number.POSITIVE_INFINITY
+        : assertPositiveInteger(options.maxConcurrentFires, "maxConcurrentFires");
+    this.stopTimeoutMs =
+      options.stopTimeoutMs === undefined
+        ? undefined
+        : assertPositiveInteger(options.stopTimeoutMs, "stopTimeoutMs");
+    this.unrefTimer = options.unrefTimer ?? false;
+  }
+
+  public get running(): boolean {
+    return this._run?.active === true;
+  }
+
+  public on<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.on(name, fn);
+  }
+
+  public off<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.off(name, fn);
+  }
+
+  public once<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void {
+    this.events.once(name, fn);
+  }
+
+  /**
+   * @throws whatever {@link computeNextFireTime} throws (a `CronTrigger` whose
+   *   expression matches no instant within the search horizon raises
+   *   `CronUnsatisfiableError` here). The first fire time is computed BEFORE any
+   *   state is touched, so a throw leaves the trigger exactly as it was — still
+   *   stopped, with nothing scheduled and no listener attached.
+   */
+  public start(handler: TriggerHandler, options: TriggerStartOptions = {}): void {
+    // Validated before anything else: a non-function handler otherwise starts a
+    // trigger that reports `running` and emits a TypeError on `error` once per
+    // period forever, with no way to tell it apart from a failing handler.
+    if (typeof handler !== "function") {
+      throw new TriggerConfigurationError(
+        `start() requires a handler function, received ${typeof handler}.`
+      );
+    }
+    // Starting twice is a no-op rather than an error, so a start/start/stop
+    // sequence leaves no orphaned timer behind.
+    if (this.running) return;
+    // An already-aborted caller signal means "do not schedule anything".
+    if (options.signal?.aborted) return;
+
+    const controller = new AbortController();
+    const run: TriggerRun = {
+      handler,
+      controller,
+      signal: options.signal
+        ? AbortSignal.any([controller.signal, options.signal])
+        : controller.signal,
+      queued: [],
+      pending: new Set(),
+      timer: undefined,
+      inFlight: 0,
+      skipStreak: 0,
+      active: true,
+      removeExternalAbort: undefined,
+      stopping: undefined,
+    };
+
+    // The run is built first so the hook has one to key its state off, but it is
+    // published to `this._run` only after the computation that can throw. Setting
+    // `_run` first would leave the trigger reporting `running` with no timer, and
+    // every later `start()` would be a silent no-op forever.
+    const firstFireAt = this.computeNextFireTime(Date.now(), run);
+    this._run = run;
+
+    if (options.signal) {
+      const externalSignal = options.signal;
+      const onExternalAbort = (): void => {
+        // `.catch` rather than `void`: a `stop` listener that throws would
+        // otherwise reject a floating promise and take a Node host down with an
+        // unhandledRejection. `stop()` reports its own failures.
+        this.stop().catch(() => {});
+      };
+      externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+      run.removeExternalAbort = () => externalSignal.removeEventListener("abort", onExternalAbort);
+    }
+
+    this.scheduleAt(run, firstFireAt);
+    this.safeEmit("start");
+  }
+
+  /**
+   * Cancels the pending tick, aborts the signal handed to handlers, and
+   * resolves once every in-flight handler for this run has settled.
+   *
+   * Concurrent calls join the same drain: the second call returns the first
+   * call's promise rather than resolving early, so `await stop()` always means
+   * "no handler of that run is still running" — and the first call's deadline
+   * is the one in force, since there is only ever one drain.
+   *
+   * Pass {@link TriggerStopOptions.timeoutMs} (or set `stopTimeoutMs` on the
+   * trigger) to bound the drain. The deadline is OPT-IN, and deliberately so: a
+   * bounded default would turn the sentence above into a lie for every caller
+   * that never asked for one. Past the deadline the still-pending handlers are
+   * abandoned — they keep running — and the expiry is reported on `error`.
+   */
+  public stop(options: TriggerStopOptions = {}): Promise<void> {
+    const timeoutMs =
+      options.timeoutMs === undefined
+        ? this.stopTimeoutMs
+        : assertPositiveInteger(options.timeoutMs, "timeoutMs");
+    const run = this._run;
+    if (!run) return Promise.resolve();
+    if (run.stopping) return run.stopping;
+
+    run.active = false;
+    this.flushSkipStreak(run);
+    if (run.timer !== undefined) {
+      clearTimeout(run.timer);
+      run.timer = undefined;
+    }
+    run.queued.length = 0;
+    run.removeExternalAbort?.();
+    run.removeExternalAbort = undefined;
+
+    // Record the drain BEFORE aborting: an abort listener that re-enters
+    // `stop()` must join this drain instead of starting a second one.
+    const stopping = this.releaseWhenIdle(run, timeoutMs);
+    run.stopping = stopping;
+    run.controller.abort();
+    return stopping;
+  }
+
+  /**
+   * Absolute instant (ms since epoch) of the tick following `fromMs`. Must be
+   * strictly greater than `fromMs` so a computation landing exactly on a
+   * boundary advances instead of firing the same tick forever.
+   *
+   * The run whose schedule is being computed is passed explicitly, so a subclass
+   * whose next instant depends on per-generation state (see `PollingTrigger`'s
+   * error backoff) keys that state off the run rather than off `this`.
+   */
+  protected abstract computeNextFireTime(fromMs: number, run: TriggerRun): number;
+
+  /**
+   * Runs one tick. The default invokes the handler with no payload; a subclass
+   * that resolves data first (see `PollingTrigger`) overrides this and may
+   * decline to invoke the handler at all. A throw here is caught by the loop,
+   * reported on the `error` event, and does not stop the trigger.
+   *
+   * The run is passed explicitly — read `run.signal`, never a field on `this` —
+   * so a chain belonging to a superseded generation stays on its own state.
+   */
+  protected async runTick(scheduledAt: number, run: TriggerRun): Promise<void> {
+    await this.invokeHandler(run, {
+      triggerId: this.id,
+      scheduledAt,
+      signal: run.signal,
+      payload: undefined,
+    });
+  }
+
+  /** Emits `fire` and awaits the run's registered handler. */
+  protected async invokeHandler(run: TriggerRun, context: ITriggerFireContext): Promise<void> {
+    this.safeEmit("fire", context);
+    await run.handler(context);
+  }
+
+  /** The run installed by the latest {@link start}, or `undefined` when stopped and drained. */
+  protected get currentRun(): TriggerRun | undefined {
+    return this._run;
+  }
+
+  private async releaseWhenIdle(run: TriggerRun, timeoutMs: number | undefined): Promise<void> {
+    const deadline = timeoutMs === undefined ? undefined : this.createStopDeadline(timeoutMs);
+    try {
+      // A loop, not a single `allSettled`: a chain draining queued ticks may still
+      // be adding work when the first snapshot is taken.
+      while (run.pending.size > 0) {
+        if (deadline === undefined) {
+          await Promise.allSettled([...run.pending]);
+          continue;
+        }
+        const outcome = await Promise.race([
+          Promise.allSettled([...run.pending]).then(() => "settled" as const),
+          deadline.expired,
+        ]);
+        if (outcome === "expired") {
+          this.reportStopTimeout(run, deadline.timeoutMs);
+          break;
+        }
+      }
+    } finally {
+      deadline?.cancel();
+    }
+
+    // Reached on the timeout path too. The abandoned handlers cannot be
+    // recalled, but stranding the run as well would leave the trigger reporting
+    // `running` with nothing scheduled, and every later `start()` a silent
+    // no-op — the caller would have lost the trigger, not just the drain.
+
+    // A `start()` during the drain installed a newer run. Clearing `_run` here
+    // would strand it, and emitting `stop` would report a trigger that is
+    // actively firing as stopped.
+    if (this._run !== run) return;
+    this._run = undefined;
+    this.safeEmit("stop");
+  }
+
+  /**
+   * A timer the drain races against, cancelled in the caller's `finally` — an
+   * un-cleared one keeps a Node host alive for the length of a deadline that
+   * has already been beaten, which is precisely what `stop()` was called to end.
+   */
+  private createStopDeadline(timeoutMs: number): StopDeadline {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const expired = new Promise<"expired">((resolve) => {
+      timer = setTimeout(() => resolve("expired"), timeoutMs);
+      if (this.unrefTimer) {
+        (timer as unknown as { unref?: () => void }).unref?.();
+      }
+    });
+    return {
+      timeoutMs,
+      expired,
+      cancel: () => {
+        if (timer !== undefined) clearTimeout(timer);
+        timer = undefined;
+      },
+    };
+  }
+
+  /**
+   * Reported, not thrown: `stop()` resolves so the caller can finish shutting
+   * down, and the count is what says how much work was left behind.
+   */
+  private reportStopTimeout(run: TriggerRun, timeoutMs: number): void {
+    const pending = run.pending.size;
+    this.safeEmit(
+      "error",
+      new TriggerStopTimeoutError(
+        `stop() gave up after ${timeoutMs}ms with ${pending} handler invocation(s) ` +
+          `still in flight; they were abandoned and are still running.`
+      )
+    );
+    getLogger().warn("Trigger stop deadline expired with handlers still in flight", {
+      triggerId: this.id,
+      kind: this.kind,
+      pending,
+      timeoutMs,
+    });
+  }
+
+  private scheduleAt(run: TriggerRun, targetMs: number): void {
+    const remaining = Math.max(0, targetMs - Date.now());
+    // Decided HERE, while the wall clock is still trustworthy. Re-deciding it at
+    // expiry from `Date.now() < targetMs` cannot tell a chunk apart from a
+    // backward clock step, and serves the step as a wait of the same size.
+    const truncated = remaining > MAX_TIMER_DELAY_MS;
+    const timer = setTimeout(
+      () => {
+        run.timer = undefined;
+        if (!run.active) return;
+        // A chunked wait (or an early host timer) lands before the target.
+        const shortfall = targetMs - Date.now();
+        if (
+          shortfall > 0 &&
+          (truncated || this.clockDomain === "wall" || shortfall <= EARLY_TIMER_TOLERANCE_MS)
+        ) {
+          this.scheduleAt(run, targetMs);
+          return;
+        }
+        this.onTick(run, targetMs);
+      },
+      Math.min(remaining, MAX_TIMER_DELAY_MS)
+    );
+    run.timer = timer;
+    if (this.unrefTimer) {
+      // Node/Bun return a Timeout object; a browser returns a number.
+      (timer as unknown as { unref?: () => void }).unref?.();
+    }
+  }
+
+  private onTick(run: TriggerRun, scheduledAt: number): void {
+    let nextFireAt: number;
+    try {
+      nextFireAt = this.computeNextFireTime(scheduledAt, run);
+    } catch (error) {
+      // Nothing can be scheduled, so there is no half-live state worth keeping:
+      // report and shut down rather than leave a trigger that reports `running`
+      // and will never fire again.
+      this.reportError(error, scheduledAt);
+      this.stop().catch(() => {});
+      return;
+    }
+    this.scheduleAt(run, nextFireAt);
+    this.dispatch(run, scheduledAt);
+  }
+
+  private dispatch(run: TriggerRun, scheduledAt: number): void {
+    if (this.overlap === "concurrent") {
+      // Unbounded by default; a ceiling degrades the excess tick to a skip
+      // rather than letting the fan-out grow one invocation per tick forever.
+      if (run.inFlight >= this.maxConcurrentFires) {
+        this.safeEmit("skip", scheduledAt);
+        this.noteSkip(run, scheduledAt);
+        return;
+      }
+    } else if (run.inFlight > 0 || run.queued.length > 0) {
+      if (this.overlap === "queue" && run.queued.length < this.maxQueuedFires) {
+        this.flushSkipStreak(run);
+        run.queued.push(scheduledAt);
+        return;
+      }
+      this.safeEmit("skip", scheduledAt);
+      this.noteSkip(run, scheduledAt);
+      return;
+    }
+    this.flushSkipStreak(run);
+
+    // The microtask hop is load-bearing, not ceremony. Called directly,
+    // `runTickChain` runs its whole synchronous prefix — the `fire` emit and the
+    // handler's own synchronous head — BEFORE `run.pending.add` below, so a
+    // `stop()` begun from a `fire` listener (or by the handler itself) would see
+    // an empty `pending`, drain instantly, and resolve while that handler was
+    // still running. Deferring by one microtask puts all of `runTickChain`
+    // behind the registration. The schedule is unaffected: the next tick was
+    // already scheduled in `onTick` before this call.
+    const chain = Promise.resolve().then(() => this.runTickChain(run, scheduledAt));
+    run.pending.add(chain);
+    // `catch` before `finally`: `runTickChain` reports handler errors itself,
+    // but an `error` LISTENER that throws rejects the chain, and a bare
+    // `chain.finally(...)` would surface that as an unhandled rejection —
+    // crashing a Node host whose only fault was a noisy listener. `stop()`
+    // still awaits `chain` itself through `allSettled`.
+    void chain.catch(() => {}).finally(() => run.pending.delete(chain));
+  }
+
+  /**
+   * Logs the FIRST skip of a contiguous run only. A handler wedged against a
+   * 1s period otherwise writes 3,600 identical warnings an hour, indefinitely;
+   * the count is reported once by {@link flushSkipStreak} when the run ends.
+   */
+  private noteSkip(run: TriggerRun, scheduledAt: number): void {
+    run.skipStreak += 1;
+    if (run.skipStreak > 1) return;
+    getLogger().warn("Trigger fire skipped; previous handler still running", {
+      triggerId: this.id,
+      kind: this.kind,
+      scheduledAt,
+      overlap: this.overlap,
+    });
+  }
+
+  /** Reports how long a contiguous run of skips lasted, once it ends. */
+  private flushSkipStreak(run: TriggerRun): void {
+    const skipped = run.skipStreak;
+    run.skipStreak = 0;
+    // A lone skip already logged everything there is to say.
+    if (skipped < 2) return;
+    getLogger().warn("Trigger fire skips ended", {
+      triggerId: this.id,
+      kind: this.kind,
+      skipped,
+    });
+  }
+
+  /**
+   * Runs a tick and then drains queued ticks iteratively — a recursive drain
+   * would keep every queued frame alive for the lifetime of the trigger.
+   */
+  private async runTickChain(run: TriggerRun, first: number): Promise<void> {
+    // The chain reaches here one microtask after `dispatch` registered it in
+    // `run.pending`, and a `stop()` in that window clears `run.active` but
+    // still AWAITS this chain through `releaseWhenIdle` — so without this
+    // check the first tick runs anyway, emitting `fire` and invoking the
+    // handler with an already-aborted signal. The loop's own `run.active`
+    // test is at the bottom, after that first tick has happened.
+    //
+    // Returning immediately keeps the drain correct: the chain is still in
+    // `pending`, so `stop()` still awaits it; it simply resolves at once.
+    if (!run.active) return;
+    let scheduledAt: number | undefined = first;
+    while (scheduledAt !== undefined) {
+      run.inFlight += 1;
+      try {
+        await this.runTick(scheduledAt, run);
+      } catch (error) {
+        // A tick that failed BECAUSE we stopped it is the expected shape of a
+        // graceful `stop()`, not a fault: a handler that forwards its signal
+        // rejects with an AbortError, and reporting that on `error` makes every
+        // orderly shutdown look like a failure — loudly enough that callers
+        // install absorbing `error` listeners, which then swallow the real
+        // failures too.
+        //
+        // Both halves are required. `run.signal.aborted` alone is a question
+        // about the RUN, not about this error: once `stop()` aborts, a handler
+        // that throws a genuine bug in the same window is indistinguishable
+        // from a cancellation and would be filed at `debug` — the same
+        // swallowing this branch exists to prevent, just relocated.
+        if (run.signal.aborted && isAbortShaped(error, run.signal)) {
+          getLogger().debug("Trigger tick aborted during stop", {
+            triggerId: this.id,
+            kind: this.kind,
+            scheduledAt,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        } else {
+          this.reportError(error, scheduledAt);
+        }
+      } finally {
+        run.inFlight -= 1;
+      }
+      // Only this run's queue: a superseded chain must never shift a tick a
+      // newer generation queued, nor hand it the newer handler.
+      scheduledAt = run.active ? run.queued.shift() : undefined;
+    }
+  }
+
+  private reportError(error: unknown, scheduledAt: number): void {
+    const wrapped = error instanceof Error ? error : new Error(String(error));
+    this.safeEmit("error", wrapped);
+    getLogger().error("Trigger handler failed", {
+      triggerId: this.id,
+      kind: this.kind,
+      scheduledAt,
+      error: wrapped.message,
+    });
+  }
+
+  /**
+   * Emits without letting a listener's throw escape.
+   *
+   * `EventEmitter.emit` deliberately RE-THROWS what listeners throw, which is
+   * load-bearing elsewhere in the monorepo but fatal here: most of these emits
+   * happen inside a `setTimeout` callback, where a throw is an
+   * uncaughtException that takes the process down — a `metrics.inc(...)` on a
+   * torn-down client is enough. A failing listener is reported on `error`
+   * instead, and an `error` listener that itself throws is only logged, so this
+   * can never recurse.
+   */
+  private safeEmit<Event extends TriggerEvents>(
+    name: Event,
+    ...args: TriggerEventParameters<Event>
+  ): void {
+    try {
+      this.events.emit(name, ...args);
+    } catch (error) {
+      const wrapped = error instanceof Error ? error : new Error(String(error));
+      if (name !== "error") {
+        try {
+          this.events.emit("error", wrapped);
+        } catch {
+          // Nowhere left to report it; the log below is the last word.
+        }
+      }
+      getLogger().error("Trigger event listener failed", {
+        triggerId: this.id,
+        kind: this.kind,
+        event: name,
+        error: wrapped.message,
+      });
+    }
+  }
+}

--- a/packages/triggers/src/trigger/CronTrigger.ts
+++ b/packages/triggers/src/trigger/CronTrigger.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CronSchedule } from "../cron/CronSchedule";
+import { nextCronFireTime, parseCronExpression } from "../cron/CronSchedule";
+import type { TriggerOptions, TriggerRun } from "./BaseTrigger";
+import { BaseTrigger } from "./BaseTrigger";
+import { TRIGGER_KINDS } from "./ITrigger";
+
+export interface CronTriggerOptions extends TriggerOptions {
+  /**
+   * A 5-field cron expression, matched in UTC. See {@link parseCronExpression}
+   * for the supported syntax; it throws on anything it does not support rather
+   * than guessing.
+   */
+  readonly expression: string;
+}
+
+/**
+ * Fires on the UTC instants matching a cron expression.
+ *
+ * The expression is parsed once in the constructor — an invalid expression
+ * fails at construction, not at the first tick — and the next fire time is
+ * recomputed from the calendar after every tick, so month lengths and leap days
+ * are handled exactly rather than approximated by a fixed period.
+ *
+ * A wait longer than a host timer's ~24.8-day ceiling (a monthly schedule, for
+ * instance) is served in chunks by the base class, so `0 0 1 * *` fires once per
+ * month rather than immediately.
+ */
+export class CronTrigger extends BaseTrigger {
+  public readonly kind = TRIGGER_KINDS.cron;
+  public readonly schedule: CronSchedule;
+
+  // A cron instant is an appointment on the wall clock, not a period: a clock
+  // corrected backwards means it has not arrived yet.
+  protected override readonly clockDomain = "wall" as const;
+
+  constructor(options: CronTriggerOptions) {
+    super(options);
+    this.schedule = parseCronExpression(options.expression);
+  }
+
+  /** The whitespace-normalized expression this trigger was built from. */
+  public get expression(): string {
+    return this.schedule.expression;
+  }
+
+  protected computeNextFireTime(fromMs: number, _run: TriggerRun): number {
+    // Anchoring on the later of the tick's own instant and now means a host
+    // that stalled past several cron instants resumes at the next FUTURE one
+    // instead of replaying the missed ones back to back.
+    return nextCronFireTime(this.schedule, Math.max(fromMs, Date.now()));
+  }
+}

--- a/packages/triggers/src/trigger/ITrigger.ts
+++ b/packages/triggers/src/trigger/ITrigger.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { EventEmitter, EventParameters } from "@workglow/util";
+
+/** Built-in trigger kinds. Third-party triggers may report any other string. */
+export const TRIGGER_KINDS = {
+  interval: "interval",
+  polling: "polling",
+  cron: "cron",
+} as const;
+
+export type TriggerKind = (typeof TRIGGER_KINDS)[keyof typeof TRIGGER_KINDS];
+
+/**
+ * What a trigger does when a tick comes due while the previous handler is still
+ * running.
+ *
+ * - `skip` (default) — the tick is dropped. A trigger is a clock, not a work
+ *   queue: a handler that consistently outlasts its period would otherwise grow
+ *   an unbounded backlog. The dropped tick emits `skip` and logs a warning.
+ * - `queue` — the tick is held and run when the in-flight handler settles,
+ *   bounded by `maxQueuedFires`. Ticks past that bound behave like `skip`.
+ * - `concurrent` — the handler is invoked immediately regardless of what is
+ *   still in flight. Overlap becomes the handler's problem.
+ *
+ * The policy governs HANDLER INVOCATION only. A handler bound to a workflow
+ * (`workflow.trigger(...)`) still serializes at the workflow, because one
+ * `Workflow` owns one task graph and a graph cannot run re-entrantly — so
+ * `concurrent` there degrades to queue semantics bounded by
+ * `maxPendingFires`. Prefer `"queue"` with `maxQueuedFires` when queueing is
+ * what you actually want.
+ */
+export const OVERLAP_POLICIES = ["skip", "queue", "concurrent"] as const;
+
+export type OverlapPolicy = (typeof OVERLAP_POLICIES)[number];
+
+/** Payload handed to a {@link TriggerHandler} on each fire. */
+export interface ITriggerFireContext {
+  /** Id of the trigger that fired. */
+  readonly triggerId: string;
+  /**
+   * Wall-clock instant (ms since epoch) the tick was SCHEDULED for, which is
+   * what schedules are computed against. It can predate the actual invocation
+   * when the host event loop is busy — use it, not `Date.now()`, when a handler
+   * needs the logical fire time.
+   */
+  readonly scheduledAt: number;
+  /**
+   * Aborted when the trigger stops. Handlers that do meaningful work should
+   * forward it so an in-flight run can cancel instead of outliving the trigger.
+   */
+  readonly signal: AbortSignal;
+  /**
+   * Trigger-specific data. `undefined` for interval and cron triggers; the poll
+   * result for a polling trigger.
+   */
+  readonly payload: unknown;
+}
+
+/**
+ * Invoked on every fire. A rejection never stops the trigger loop.
+ *
+ * A handler cancelled by {@link ITrigger.stop} should reject with an
+ * `AbortError` (or re-throw `context.signal.reason`, which is what
+ * `throwIfAborted()` does) rather than a plain `Error`. Only those shapes are
+ * recognised as a cancellation and logged at `debug`; anything else is
+ * reported on the `error` event even when a stop is in flight.
+ *
+ * The asymmetry is deliberate. Shutdown is when a handler flushes buffers,
+ * commits and closes connections — the work most likely to fail for real — so
+ * treating every rejection during a stop as graceful would file exactly those
+ * failures at `debug` and report a clean shutdown over the top of them.
+ */
+export type TriggerHandler = (context: ITriggerFireContext) => void | Promise<void>;
+
+export type TriggerEventListeners = {
+  /** The trigger began scheduling. */
+  start: () => void;
+  /**
+   * The trigger stopped and any in-flight handler has settled. Not emitted for a
+   * generation superseded by a `start()` during an un-awaited `stop()` drain —
+   * the trigger is running again, and the newer generation reports its own stop.
+   */
+  stop: () => void;
+  /** A handler invocation is about to begin. */
+  fire: (context: ITriggerFireContext) => void;
+  /**
+   * A due tick was dropped because a handler was still in flight (`skip`
+   * policy, or a `queue` policy past `maxQueuedFires`).
+   */
+  skip: (scheduledAt: number) => void;
+  /**
+   * A handler (or a polling trigger's poll function) threw or rejected.
+   * Carries the REAL Error — not a stringified one — so listeners can do
+   * `instanceof` checks and read `.stack`.
+   */
+  error: (error: Error) => void;
+};
+
+export type TriggerEvents = keyof TriggerEventListeners;
+export type TriggerEventListener<Event extends TriggerEvents> = TriggerEventListeners[Event];
+export type TriggerEventParameters<Event extends TriggerEvents> = EventParameters<
+  TriggerEventListeners,
+  Event
+>;
+
+/** Options accepted by {@link ITrigger.start}. */
+export interface TriggerStartOptions {
+  /**
+   * Caller-owned cancellation. Aborting it stops the trigger exactly as
+   * {@link ITrigger.stop} does; it is linked with the trigger's own controller
+   * via `AbortSignal.any`, so handlers see a single combined signal.
+   */
+  readonly signal?: AbortSignal | undefined;
+}
+
+/** Options accepted by {@link ITrigger.stop}. */
+export interface TriggerStopOptions {
+  /**
+   * Deadline for the drain, in milliseconds. A positive integer.
+   *
+   * Omitted (the default) means NO deadline — `stop()` waits for every
+   * in-flight handler however long that takes, which is what makes
+   * "`await stop()` means no handler of that run is still running" true. A
+   * handler that never settles therefore wedges `stop()` forever, and through
+   * the workflow bindings that wedges every other trigger on the workflow too.
+   *
+   * When set, the drain is abandoned at the deadline: an
+   * {@link TriggerStopTimeoutError} is emitted on `error` with the number of
+   * invocations still pending, the trigger is released so it can be started
+   * again, and THE ABANDONED HANDLERS KEEP RUNNING. Opt in only where a bounded
+   * shutdown matters more than that guarantee.
+   */
+  readonly timeoutMs?: number | undefined;
+}
+
+/**
+ * A source of workflow invocations.
+ *
+ * Implementations are pure in-process schedulers: nothing is persisted, so a
+ * process restart loses the schedule and a fire is delivered at most once, to
+ * this process only. Durable and distributed triggers are a separate concern.
+ */
+export interface ITrigger {
+  /** Stable identifier, used in logs and by the workflow bindings. */
+  readonly id: string;
+  /** Discriminator for the trigger implementation; see {@link TRIGGER_KINDS}. */
+  readonly kind: string;
+  /** True between a successful {@link start} and {@link stop}. */
+  readonly running: boolean;
+  readonly events: EventEmitter<TriggerEventListeners>;
+
+  /**
+   * Begins scheduling. Calling this on an already-running trigger is a no-op,
+   * so a start/start/stop sequence leaves nothing scheduled.
+   *
+   * @throws when the first fire time cannot be computed — a `CronTrigger` whose
+   *   expression matches no instant within the search horizon raises
+   *   `CronUnsatisfiableError`. The computation happens before any state is
+   *   touched, so a throwing `start()` leaves the trigger stopped with nothing
+   *   scheduled; callers that start several triggers should stop the ones they
+   *   already started.
+   */
+  start(handler: TriggerHandler, options?: TriggerStartOptions): void;
+
+  /**
+   * Cancels the pending tick, aborts the signal handed to handlers, and
+   * resolves once any in-flight handler has settled — so a caller that awaits
+   * `stop()` knows no handler is still running. Concurrent calls join the same
+   * drain rather than resolving early, which means the FIRST call's deadline
+   * governs; a later call cannot shorten a drain already under way.
+   *
+   * That guarantee holds only without {@link TriggerStopOptions.timeoutMs},
+   * which is opt-in for exactly this reason: past its deadline `stop()`
+   * abandons whatever is still in flight and resolves anyway.
+   */
+  stop(options?: TriggerStopOptions): Promise<void>;
+
+  on<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void;
+  off<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void;
+  once<Event extends TriggerEvents>(name: Event, fn: TriggerEventListener<Event>): void;
+}

--- a/packages/triggers/src/trigger/IntervalTrigger.ts
+++ b/packages/triggers/src/trigger/IntervalTrigger.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TriggerOptions, TriggerRun } from "./BaseTrigger";
+import { BaseTrigger } from "./BaseTrigger";
+import { assertValidIntervalMs, nextFixedIntervalFireTime } from "./fixedInterval";
+import { TRIGGER_KINDS } from "./ITrigger";
+
+export interface IntervalTriggerOptions extends TriggerOptions {
+  /** Period between fires, in milliseconds. Must be a positive integer. */
+  readonly intervalMs: number;
+}
+
+/**
+ * Fires every `intervalMs`, starting one full period after {@link start} — it
+ * never fires immediately.
+ *
+ * Each tick is scheduled from the previous tick's SCHEDULED instant rather than
+ * from when its handler finished, so the fire times stay on the phase
+ * established at `start()` no matter how long a handler runs. If the host is
+ * suspended past one or more periods, the missed periods are dropped (the
+ * schedule jumps to the next future instant on the same phase) instead of being
+ * replayed as a burst.
+ */
+export class IntervalTrigger extends BaseTrigger {
+  public readonly kind = TRIGGER_KINDS.interval;
+  public readonly intervalMs: number;
+
+  constructor(options: IntervalTriggerOptions) {
+    super(options);
+    this.intervalMs = assertValidIntervalMs(options.intervalMs);
+  }
+
+  protected computeNextFireTime(fromMs: number, _run: TriggerRun): number {
+    return nextFixedIntervalFireTime(fromMs, this.intervalMs);
+  }
+}

--- a/packages/triggers/src/trigger/PollingTrigger.ts
+++ b/packages/triggers/src/trigger/PollingTrigger.ts
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TriggerOptions, TriggerRun } from "./BaseTrigger";
+import { BaseTrigger } from "./BaseTrigger";
+import {
+  assertValidIntervalMs,
+  nextBackoffFireTime,
+  nextFixedIntervalFireTime,
+} from "./fixedInterval";
+import { TRIGGER_KINDS } from "./ITrigger";
+import { TriggerConfigurationError, TriggerPollTimeoutError } from "./TriggerError";
+
+/** Decides whether a poll result should fire the handler. */
+export type PollResultPredicate<Result> = (result: Result, previous: Result | undefined) => boolean;
+
+/**
+ * Default {@link PollResultPredicate}: fires on a NON-EMPTY result. `undefined`,
+ * `null`, an empty array, and an empty string are empty; everything else —
+ * including `0` and `false` — fires.
+ */
+export function isNonEmptyPollResult(result: unknown): boolean {
+  if (result === undefined || result === null) return false;
+  if (Array.isArray(result)) return result.length > 0;
+  if (typeof result === "string") return result.length > 0;
+  return true;
+}
+
+/**
+ * Ready-made {@link PollResultPredicate} for change detection: fires when the
+ * result differs from the previously polled one by `Object.is`. Reference
+ * equality, so supply your own predicate when polling freshly-built objects.
+ * A change whose handler throws is offered again on the next poll that still
+ * observes it.
+ */
+export function firesOnChange<Result>(result: Result, previous: Result | undefined): boolean {
+  return !Object.is(result, previous);
+}
+
+/**
+ * Exponential backoff applied after consecutive poll failures, so a dependency
+ * that is hard down is not hammered at the full poll rate indefinitely.
+ */
+export interface PollErrorBackoff {
+  /** Delay after the first failure, in milliseconds. A positive integer. */
+  readonly initialMs: number;
+  /** Ceiling the doubling stops at, in milliseconds. At least `initialMs`. */
+  readonly maxMs: number;
+}
+
+/**
+ * Change-detection baseline and failure streak for ONE run.
+ *
+ * Both belong to a single `start()`: a restart is a fresh observation window,
+ * and a `firesOnChange` trigger comparing against the previous run's baseline
+ * would swallow the first change after it. Keying them off the run object makes
+ * that structural — a run that ends unnoticed (because a newer `start()` took
+ * over while it was still draining) cannot leave its baseline behind.
+ */
+interface PollRunState<Result> {
+  previous: Result | undefined;
+  failures: number;
+}
+
+export interface PollingTriggerOptions<Result> extends TriggerOptions {
+  /** Period between polls, in milliseconds. Must be a positive integer. */
+  readonly intervalMs: number;
+  /** Called on every tick. Receives the trigger's abort signal. */
+  readonly poll: (signal: AbortSignal) => Result | Promise<Result>;
+  /**
+   * Whether a given poll result fires the handler. Defaults to
+   * {@link isNonEmptyPollResult}; pass {@link firesOnChange} for
+   * change-detection semantics.
+   */
+  readonly shouldFire?: PollResultPredicate<Result> | undefined;
+  /**
+   * Back off after consecutive poll failures instead of polling at the full
+   * rate. Omitted (the default) keeps the fixed period no matter how the poll
+   * fares. The counter resets on the first poll that does not throw.
+   */
+  readonly errorBackoff?: PollErrorBackoff | undefined;
+  /**
+   * Deadline for one poll, in milliseconds. A positive integer.
+   *
+   * Omitted (the default) means NO deadline: a poll that hangs — a `fetch`
+   * against a black-holed host is the usual way — keeps the tick in flight
+   * forever, so under `overlap: "skip"` every later tick is dropped and the
+   * trigger goes quiet with no `error` to show for it. A hang is not a throw,
+   * so `errorBackoff` never engages either.
+   *
+   * When set, exceeding it aborts the signal handed to `poll` and fails the
+   * tick with a {@link TriggerPollTimeoutError}, which counts as a poll failure
+   * — it is reported on `error` and drives `errorBackoff` like any other.
+   */
+  readonly pollTimeoutMs?: number | undefined;
+}
+
+/**
+ * Polls on a fixed period and fires the handler only when the poll result is
+ * interesting — by default when it is non-empty. That conditional fire is the
+ * whole difference from `IntervalTrigger`, which fires on every tick.
+ *
+ * The poll result is handed to the handler as `context.payload`. A poll that
+ * throws is reported on the `error` event and does not stop the loop; the
+ * previous result is left unchanged so the next comparison is against the last
+ * value actually observed. Pass `errorBackoff` to slow the loop down while a
+ * dependency stays down instead of polling it at full rate.
+ *
+ * A handler that throws does not consume the change: the comparison baseline is
+ * restored, so the next poll observing the same value fires again. Delivery is
+ * therefore at-least-once and always carries the freshest poll result — nothing
+ * is queued.
+ */
+export class PollingTrigger<Result = unknown> extends BaseTrigger {
+  public readonly kind = TRIGGER_KINDS.polling;
+  public readonly intervalMs: number;
+
+  private readonly _poll: (signal: AbortSignal) => Result | Promise<Result>;
+  private readonly _shouldFire: PollResultPredicate<Result>;
+  private readonly _errorBackoff: PollErrorBackoff | undefined;
+  private readonly _pollTimeoutMs: number | undefined;
+  private readonly _runState = new WeakMap<TriggerRun, PollRunState<Result>>();
+
+  constructor(options: PollingTriggerOptions<Result>) {
+    super(options);
+    this.intervalMs = assertValidIntervalMs(options.intervalMs);
+    if (typeof options.poll !== "function") {
+      throw new TriggerConfigurationError("poll must be a function.");
+    }
+    this._poll = options.poll;
+    this._shouldFire = options.shouldFire ?? ((result) => isNonEmptyPollResult(result));
+    this._errorBackoff = options.errorBackoff
+      ? assertValidErrorBackoff(options.errorBackoff)
+      : undefined;
+    this._pollTimeoutMs =
+      options.pollTimeoutMs === undefined
+        ? undefined
+        : assertValidPollTimeoutMs(options.pollTimeoutMs);
+  }
+
+  /**
+   * Change-detection baseline of the CURRENT run — the most recent successfully
+   * polled result whose delivery did not fail. `undefined` before the first poll
+   * and while the trigger is stopped.
+   */
+  public get lastResult(): Result | undefined {
+    const run = this.currentRun;
+    return run ? this._runState.get(run)?.previous : undefined;
+  }
+
+  /** Consecutive poll failures of the current run since its last poll that did not throw. */
+  public get consecutiveFailures(): number {
+    const run = this.currentRun;
+    return (run ? this._runState.get(run)?.failures : 0) ?? 0;
+  }
+
+  protected computeNextFireTime(fromMs: number, run: TriggerRun): number {
+    const backoff = this._errorBackoff;
+    const failures = this.stateFor(run).failures;
+    if (backoff && failures > 0) {
+      // The next tick was already scheduled when the failing one started, so the
+      // backoff takes effect from the tick AFTER the first failure.
+      const exponent = Math.min(failures - 1, 31);
+      const delay = Math.min(backoff.maxMs, backoff.initialMs * 2 ** exponent);
+      return nextBackoffFireTime(fromMs, delay);
+    }
+    return nextFixedIntervalFireTime(fromMs, this.intervalMs);
+  }
+
+  protected override async runTick(scheduledAt: number, run: TriggerRun): Promise<void> {
+    const signal = run.signal;
+    const state = this.stateFor(run);
+    let result: Result;
+    try {
+      result = await this.pollOnce(run);
+    } catch (error) {
+      state.failures += 1;
+      throw error;
+    }
+    state.failures = 0;
+    // Bail before recording the result: an aborted tick never fires, so keeping
+    // its value as the baseline would make the NEXT `firesOnChange` comparison
+    // see no change and swallow the very update this tick observed.
+    if (signal.aborted) return;
+    const previous = state.previous;
+    state.previous = result;
+    if (!this._shouldFire(result, previous)) return;
+    try {
+      await this.invokeHandler(run, {
+        triggerId: this.id,
+        scheduledAt,
+        signal,
+        payload: result,
+      });
+    } catch (error) {
+      // A failed delivery must not consume the change: restore the baseline so
+      // the next poll of the same value still counts as one. Skipped when a
+      // later tick already advanced it (`overlap: "concurrent"`), which would
+      // otherwise resurrect a value that has since been delivered.
+      if (Object.is(state.previous, result)) state.previous = previous;
+      throw error;
+    }
+  }
+
+  /**
+   * Races `poll` against its deadline. The race is what makes the timeout
+   * effective: a poll that ignores its signal never settles, so aborting alone
+   * would leave the tick in flight forever.
+   */
+  private async pollOnce(run: TriggerRun): Promise<Result> {
+    const timeoutMs = this._pollTimeoutMs;
+    if (timeoutMs === undefined) return await this._poll(run.signal);
+
+    const controller = new AbortController();
+    const onRunAbort = (): void => controller.abort(run.signal.reason);
+    if (run.signal.aborted) controller.abort(run.signal.reason);
+    else run.signal.addEventListener("abort", onRunAbort, { once: true });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const polled = Promise.resolve(this._poll(controller.signal));
+      // A poll that outlives the race still settles somewhere; without this the
+      // late rejection is an unhandledRejection that takes a Node host down.
+      polled.catch(() => {});
+      const deadline = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          const error = new TriggerPollTimeoutError(`Poll did not settle within ${timeoutMs}ms.`);
+          // Reject BEFORE aborting: a cooperative poll rejects synchronously on
+          // abort and would otherwise win the race with its own error, hiding
+          // the reason the tick failed.
+          reject(error);
+          controller.abort(error);
+        }, timeoutMs);
+        if (this.unrefTimer) {
+          (timer as unknown as { unref?: () => void }).unref?.();
+        }
+      });
+      return await Promise.race([polled, deadline]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+      run.signal.removeEventListener("abort", onRunAbort);
+    }
+  }
+
+  private stateFor(run: TriggerRun): PollRunState<Result> {
+    const existing = this._runState.get(run);
+    if (existing) return existing;
+    const created: PollRunState<Result> = { previous: undefined, failures: 0 };
+    this._runState.set(run, created);
+    return created;
+  }
+}
+
+function assertValidPollTimeoutMs(pollTimeoutMs: number): number {
+  if (!Number.isInteger(pollTimeoutMs) || pollTimeoutMs <= 0) {
+    throw new TriggerConfigurationError(
+      `pollTimeoutMs must be a positive integer, received ${String(pollTimeoutMs)}.`
+    );
+  }
+  return pollTimeoutMs;
+}
+
+function assertValidErrorBackoff(backoff: PollErrorBackoff): PollErrorBackoff {
+  if (!Number.isInteger(backoff.initialMs) || backoff.initialMs < 1) {
+    throw new TriggerConfigurationError(
+      `errorBackoff.initialMs must be a positive integer, received ${String(backoff.initialMs)}.`
+    );
+  }
+  if (!Number.isInteger(backoff.maxMs) || backoff.maxMs < backoff.initialMs) {
+    throw new TriggerConfigurationError(
+      `errorBackoff.maxMs must be an integer >= initialMs (${backoff.initialMs}), ` +
+        `received ${String(backoff.maxMs)}.`
+    );
+  }
+  return backoff;
+}

--- a/packages/triggers/src/trigger/TriggerError.ts
+++ b/packages/triggers/src/trigger/TriggerError.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BaseError } from "@workglow/util";
+
+/** Base class for every error raised by the triggers package. */
+export class TriggerError extends BaseError {
+  public static override type = "TriggerError";
+}
+
+/** Raised when a trigger is constructed or started with invalid options. */
+export class TriggerConfigurationError extends TriggerError {
+  public static override type = "TriggerConfigurationError";
+}
+
+/** Raised when a {@link PollingTrigger}'s poll exceeds `pollTimeoutMs`. */
+export class TriggerPollTimeoutError extends TriggerError {
+  public static override type = "TriggerPollTimeoutError";
+}
+
+/**
+ * Raised when a `stop()` deadline expires with handlers still in flight.
+ *
+ * Reported on the `error` event rather than thrown from `stop()`: the deadline
+ * exists so the caller can get on with shutting down, and rejecting would make
+ * the abandoned work harder to observe, not easier.
+ */
+export class TriggerStopTimeoutError extends TriggerError {
+  public static override type = "TriggerStopTimeoutError";
+}
+
+/** Raised when a cron expression cannot be parsed. */
+export class CronExpressionError extends TriggerError {
+  public static override type = "CronExpressionError";
+}
+
+/**
+ * Raised when a syntactically valid cron expression matches no instant within
+ * the search horizon (for example `0 0 30 2 *` — February never has 30 days).
+ */
+export class CronUnsatisfiableError extends TriggerError {
+  public static override type = "CronUnsatisfiableError";
+}
+
+/** Raised by the `Workflow.trigger()` / `Workflow.listen()` bindings. */
+export class WorkflowTriggerError extends TriggerError {
+  public static override type = "WorkflowTriggerError";
+}

--- a/packages/triggers/src/trigger/assertions.ts
+++ b/packages/triggers/src/trigger/assertions.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TriggerConfigurationError } from "./TriggerError";
+
+/**
+ * Shared numeric-bound guard for every trigger option that is a count or a
+ * duration.
+ *
+ * Deliberately NOT exported from `src/common.ts`: it is an internal invariant
+ * helper, not public API. It lives in its own module rather than in
+ * `BaseTrigger.ts` so the workflow bindings — which validate
+ * `maxPendingFires` but do not extend `BaseTrigger` — report the same
+ * invariant with the same message and the same error type.
+ *
+ * `Number.isInteger` already rejects `NaN`, `±Infinity` and non-integers, so
+ * the `< 1` half only has to rule out zero and negatives.
+ */
+export function assertPositiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new TriggerConfigurationError(
+      `${name} must be a positive integer, received ${String(value)}.`
+    );
+  }
+  return value;
+}

--- a/packages/triggers/src/trigger/fixedInterval.ts
+++ b/packages/triggers/src/trigger/fixedInterval.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TriggerConfigurationError } from "./TriggerError";
+
+/**
+ * The next fire time on a fixed period, measured from the PREVIOUS tick's
+ * scheduled instant so handler duration never accumulates into the schedule.
+ *
+ * If the host was suspended past one or more whole periods, the missed periods
+ * are dropped — the result jumps to the next future instant on the same phase
+ * rather than replaying the backlog as a burst.
+ */
+export function nextFixedIntervalFireTime(fromMs: number, intervalMs: number): number {
+  const next = fromMs + intervalMs;
+  const now = Date.now();
+  // A backward clock step leaves the phase anchor arbitrarily far in the future. A
+  // period trigger must still fire every `intervalMs`, so re-anchor instead of
+  // waiting the jump out; the phase it loses was a wall-clock artifact anyway.
+  if (next > now) return Math.min(next, now + intervalMs);
+  const missedPeriods = Math.floor((now - next) / intervalMs) + 1;
+  return next + missedPeriods * intervalMs;
+}
+
+/**
+ * The next fire time after a backoff `delayMs`, measured from the PREVIOUS tick's
+ * scheduled instant, clamped to `(now, now + delayMs]` exactly as
+ * {@link nextFixedIntervalFireTime} clamps to `(now, now + intervalMs]`.
+ *
+ * An anchor the host slept past would otherwise land in the past and be replayed
+ * as a burst of `setTimeout(0)` ticks; one left in the FUTURE by a backward clock
+ * step would stall the loop for the size of the step.
+ */
+export function nextBackoffFireTime(fromMs: number, delayMs: number): number {
+  const target = fromMs + delayMs;
+  const now = Date.now();
+  return target > now ? Math.min(target, now + delayMs) : now + delayMs;
+}
+
+/** Validates a period shared by the fixed-interval triggers. */
+export function assertValidIntervalMs(intervalMs: number): number {
+  if (!Number.isInteger(intervalMs) || intervalMs <= 0) {
+    throw new TriggerConfigurationError(
+      `intervalMs must be a positive integer, received ${String(intervalMs)}.`
+    );
+  }
+  return intervalMs;
+}

--- a/packages/triggers/src/workflow/WorkflowTriggers.ts
+++ b/packages/triggers/src/workflow/WorkflowTriggers.ts
@@ -1,0 +1,540 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DataPorts, WorkflowRunConfig } from "@workglow/task-graph";
+import { Workflow } from "@workglow/task-graph";
+import { getLogger } from "@workglow/util";
+import { assertPositiveInteger } from "../trigger/assertions";
+import type { ITrigger, ITriggerFireContext, TriggerStopOptions } from "../trigger/ITrigger";
+import { WorkflowTriggerError } from "../trigger/TriggerError";
+
+/** Options for a single {@link Workflow.trigger} binding. */
+export interface WorkflowTriggerOptions {
+  /**
+   * Maps a fire into the workflow's run input. Defaults to an empty object —
+   * a trigger that only needs to start the workflow passes nothing.
+   *
+   * A polling trigger's poll result arrives as `context.payload`, so
+   * `input: (ctx) => ({ items: ctx.payload })` is the usual shape.
+   */
+  readonly input?:
+    | ((context: ITriggerFireContext) => Partial<DataPorts> | Promise<Partial<DataPorts>>)
+    | undefined;
+  /**
+   * Run configuration forwarded to {@link Workflow.run} on every fire.
+   *
+   * `signal` is deliberately excluded, and rejected at bind time rather than
+   * silently dropped: this object is captured ONCE and reused for every fire
+   * for the lifetime of the binding, while an `AbortSignal` is one-shot. Once
+   * the caller aborted it, every subsequent fire would start a run that is
+   * born cancelled while the schedule kept ticking — one error event per
+   * period, indefinitely. Composing it per fire with `AbortSignal.any` would
+   * fix the semantics and leak a composite signal per fire instead, retained
+   * by the long-lived source.
+   *
+   * To cancel the schedule itself, pass `listen({ signal })` — which stops
+   * every bound trigger — or call `handle.stop()`. The trigger's own per-fire
+   * signal is forwarded into each run regardless.
+   */
+  readonly runConfig?: Omit<WorkflowRunConfig, "signal"> | undefined;
+  /**
+   * How many of THIS binding's fires may wait for the workflow's current run
+   * before one is dropped. Defaults to `1`.
+   *
+   * One `Workflow` owns one task graph, which can only be running once, so
+   * fires against a workflow are run one at a time no matter what overlap
+   * policy the trigger uses. This is the bound on that backlog: a fire arriving
+   * past it is dropped and reported on the trigger's `error` event rather than
+   * queued forever behind a handler that cannot keep up.
+   *
+   * Counted per binding, matching where the option lives. A workflow-global
+   * count would let a fast trigger's backlog drop a slow trigger's first-ever
+   * fire against a ceiling the slow trigger never approached — so two bindings
+   * on one workflow do not share this budget, and the aggregate backlog is
+   * bounded by the sum rather than by any single binding's value.
+   */
+  readonly maxPendingFires?: number | undefined;
+}
+
+/** Options for {@link Workflow.listen}. */
+export interface WorkflowListenOptions {
+  /**
+   * Caller-owned cancellation; aborting it stops every bound trigger.
+   *
+   * An ALREADY-aborted signal makes `listen()` reject instead of handing back
+   * an inert handle: nothing would have been scheduled, so returning normally
+   * reports a success that never happened.
+   */
+  readonly signal?: AbortSignal | undefined;
+  /**
+   * Default deadline for {@link ITriggerListenerHandle.stop}, in milliseconds.
+   * Unbounded by default; see {@link TriggerStopOptions.timeoutMs}.
+   *
+   * Forwarded to each trigger's own `stop()` AND applied again around the whole
+   * set, because a trigger is an interface: a third-party `ITrigger` that
+   * ignores the option would otherwise wedge `handle.stop()`,
+   * `workflow.stopListening()` and an `await using` scope exit for every other
+   * trigger bound to this workflow.
+   */
+  readonly stopTimeoutMs?: number | undefined;
+}
+
+/**
+ * Handle returned by {@link Workflow.listen}.
+ *
+ * It is an `AsyncDisposable`, so `await using handle = await wf.listen()` stops
+ * the triggers when the scope exits.
+ */
+export interface ITriggerListenerHandle extends AsyncDisposable {
+  /** The triggers this handle started, in binding order. */
+  readonly triggers: readonly ITrigger[];
+  /**
+   * Stops every trigger and resolves once in-flight runs have settled.
+   *
+   * Pass {@link TriggerStopOptions.timeoutMs} (or `stopTimeoutMs` on
+   * {@link Workflow.listen}) to bound that wait; unbounded by default, so a
+   * handler that never settles never lets this resolve.
+   */
+  stop(options?: TriggerStopOptions): Promise<void>;
+}
+
+interface TriggerBinding {
+  readonly trigger: ITrigger;
+  readonly options: WorkflowTriggerOptions;
+  /**
+   * How many of THIS binding's fires are waiting on the workflow's run chain.
+   *
+   * Deliberately mutable, and deliberately on the binding rather than in a
+   * workflow-keyed map: `maxPendingFires` is a per-binding option, so charging
+   * every binding's backlog against one workflow-global counter let a fast
+   * trigger's queue drop a slow trigger's first-ever fire — and quote the slow
+   * trigger's limit while doing it.
+   */
+  pending: number;
+}
+
+/** Backlog bound applied when a binding does not set {@link WorkflowTriggerOptions.maxPendingFires}. */
+const DEFAULT_MAX_PENDING_FIRES = 1;
+
+// Prototype methods cannot reach Workflow's private fields, so bindings live
+// beside the instance. A WeakMap keeps a discarded workflow collectable.
+const workflowBindings = new WeakMap<Workflow, TriggerBinding[]>();
+const workflowHandles = new WeakMap<Workflow, ITriggerListenerHandle>();
+/**
+ * Tail of the serialized run chain per workflow. Fires against one workflow are
+ * serialized no matter which binding they came from — one `Workflow` owns one
+ * task graph — but the BACKLOG on that chain is counted per binding
+ * ({@link TriggerBinding.pending}). See {@link runWorkflowForFire}.
+ */
+const workflowRunChains = new WeakMap<Workflow, Promise<void>>();
+
+/**
+ * Resolves what `settling` resolved to, or `undefined` once `timeoutMs` passes.
+ *
+ * `settling` is an `allSettled`, so it never rejects and `undefined` is
+ * unambiguously the deadline. The timer is cleared in `finally` — an
+ * un-cleared one keeps a Node host alive past the shutdown it was timing.
+ */
+async function settleWithin<T>(settling: Promise<T>, timeoutMs: number): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      settling,
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/** The triggers bound to `workflow` via {@link Workflow.trigger}, in binding order. */
+export function getWorkflowTriggers(workflow: Workflow): readonly ITrigger[] {
+  return (workflowBindings.get(workflow) ?? []).map((binding) => binding.trigger);
+}
+
+/**
+ * These three methods exist only after {@link installWorkflowTriggers} has run
+ * — importing this package no longer patches the prototype. TypeScript cannot
+ * express that, so the augmentation declares them unconditionally and an app
+ * that never installs them gets a `TypeError` the compiler did not warn about.
+ * `workglow/auto-bootstrap` installs them; the free functions
+ * ({@link bindWorkflowTrigger}, {@link listenWorkflow},
+ * {@link stopWorkflowListening}) need no install at all.
+ */
+declare module "@workglow/task-graph" {
+  interface Workflow {
+    /**
+     * Binds a trigger to this workflow. Bindings accumulate; nothing is
+     * scheduled until {@link Workflow.listen} is called.
+     *
+     * Returns `this`, not `Workflow`: a declared return type would collapse a
+     * `Workflow<Input, Output>` to the default `Workflow<DataPorts, DataPorts>`
+     * on the first chained call and lose both port types.
+     *
+     * @throws {@link WorkflowTriggerError} when this workflow is already
+     *   listening, or when `trigger` is already bound to it — the second
+     *   binding's options would never be used.
+     */
+    trigger(trigger: ITrigger, options?: WorkflowTriggerOptions): this;
+
+    /**
+     * Starts every bound trigger and RESOLVES IMMEDIATELY — it does not block
+     * until the process is interrupted. Keeping the process alive is the host
+     * application's job (a server's own event loop, a `SIGINT` await, a test
+     * runner); this method only owns the schedule.
+     *
+     * Calling it again while already listening returns the same handle rather
+     * than starting a second set of timers.
+     *
+     * @throws the signal's abort reason when `options.signal` is already
+     *   aborted — checked before any state is touched, so the workflow is left
+     *   exactly as it was and stays free to bind and listen later.
+     * @throws {@link WorkflowTriggerError} when a bound trigger is already
+     *   running (it is driving another workflow, and a trigger holds one
+     *   handler). Checked before any state is touched too, so a rejected
+     *   `listen()` leaves BOTH workflows exactly as they were.
+     */
+    listen(options?: WorkflowListenOptions): Promise<ITriggerListenerHandle>;
+
+    /**
+     * Stops every trigger started by {@link Workflow.listen}. A no-op when not
+     * listening. Bounded only if `listen()` was given a `stopTimeoutMs`.
+     */
+    stopListening(): Promise<void>;
+  }
+}
+
+/**
+ * Binds `trigger` to `workflow`. The free-function form of
+ * {@link Workflow.trigger}, and the one that always exists: the method is only
+ * present after {@link installWorkflowTriggers}.
+ *
+ * Returns the workflow it was given, generically, so a chain preserves
+ * `Workflow<Input, Output>` rather than collapsing to the defaults.
+ */
+export function bindWorkflowTrigger<W extends Workflow>(
+  workflow: W,
+  trigger: ITrigger,
+  options: WorkflowTriggerOptions = {}
+): W {
+  if (workflowHandles.has(workflow)) {
+    throw new WorkflowTriggerError(
+      "Cannot bind a trigger while the workflow is listening. Call stopListening() first."
+    );
+  }
+  const bindings = workflowBindings.get(workflow) ?? [];
+  // Rejected HERE rather than at listen(): neither binding is running yet, so a
+  // `trigger.running` check cannot see this. `wf.trigger(t).trigger(t, {input})`
+  // used to be accepted and then silently honour only the first binding's
+  // options — one `ITrigger` holds one handler, so the second `start()` is a
+  // no-op and that input mapper never runs.
+  if (bindings.some((binding) => binding.trigger === trigger)) {
+    throw new WorkflowTriggerError(
+      `Trigger "${trigger.id}" is already bound to this workflow. One trigger drives one ` +
+        `binding: bind a second trigger instance instead of re-binding this one.`
+    );
+  }
+  // Validated with the same helper the five bounds on `BaseTrigger` use, so
+  // the invariant reports identically wherever it is stated. Unvalidated, this
+  // was the one numeric option a caller could break both ways: `NaN` and
+  // `Infinity` make the `waiting >= limit` drop test unreachable (`NaN >= NaN`
+  // and `n >= Infinity` are both false), so the backlog this option exists to
+  // bound grows a chain closure and a captured `input` per fire, forever;
+  // while `0` or a negative makes it always true, dropping every overlapping
+  // fire and quoting the bogus limit back in the error message.
+  if (options.maxPendingFires !== undefined) {
+    assertPositiveInteger(options.maxPendingFires, "maxPendingFires");
+  }
+  // `Omit` stops a `runConfig` literal from carrying a `signal`, but not a
+  // widened variable, and nothing at all in plain JS. See the option's docs
+  // for why bridging it is worse than rejecting it.
+  if ((options.runConfig as WorkflowRunConfig | undefined)?.signal !== undefined) {
+    throw new WorkflowTriggerError(
+      "runConfig.signal is not supported on a trigger binding: runConfig is reused for every " +
+        "fire, so a one-shot signal would abort every later run too. Pass listen({ signal }) to " +
+        "stop the schedule, or call handle.stop()."
+    );
+  }
+  bindings.push({ trigger, options, pending: 0 });
+  workflowBindings.set(workflow, bindings);
+  return workflow;
+}
+
+/**
+ * Starts every trigger bound to `workflow`. The free-function form of
+ * {@link Workflow.listen}; see that declaration for the semantics.
+ */
+export async function listenWorkflow(
+  workflow: Workflow,
+  options: WorkflowListenOptions = {}
+): Promise<ITriggerListenerHandle> {
+  // FIRST, before the handle lookup and before any state is touched. An
+  // already-aborted signal starts nothing (`BaseTrigger.start` bails on one),
+  // so the old path returned a handle that had already been removed from
+  // `workflowHandles` and whose triggers were never scheduled: a listen() that
+  // looked successful and was inert.
+  options.signal?.throwIfAborted();
+
+  const existing = workflowHandles.get(workflow);
+  if (existing) return existing;
+
+  const bindings = workflowBindings.get(workflow) ?? [];
+  if (bindings.length === 0) {
+    throw new WorkflowTriggerError(
+      "listen() requires at least one trigger. Bind one with workflow.trigger(...) first."
+    );
+  }
+
+  // Also before any state is touched, for the same reason the abort check is:
+  // `BaseTrigger.start` is a silent no-op on a running trigger, so a trigger
+  // already listening for ANOTHER workflow would be reported in this handle's
+  // `triggers` while its handler stayed the other workflow's — a listen() that
+  // looks successful and never fires. Worse, this handle's `stop()` would then
+  // stop the other workflow's schedule.
+  //
+  // There is deliberately no ownership map (`WeakMap<ITrigger, Workflow>`): the
+  // trigger is the long-lived object and the workflow the disposable one, so
+  // that mapping is a strong reference from a trigger to every workflow it was
+  // ever bound to. `running` is the property that actually matters, and it is
+  // already on the interface.
+  const running = bindings.filter((binding) => binding.trigger.running);
+  if (running.length > 0) {
+    throw new WorkflowTriggerError(
+      `Cannot listen: trigger(s) ${running.map((binding) => `"${binding.trigger.id}"`).join(", ")} ` +
+        `are already running. A trigger holds one handler, so it drives one workflow at a time — ` +
+        `stop the workflow already listening on it, or bind a separate trigger instance.`
+    );
+  }
+
+  const triggers = bindings.map((binding) => binding.trigger);
+  let detachAbort: (() => void) | undefined;
+
+  const releaseHandle = (): void => {
+    detachAbort?.();
+    detachAbort = undefined;
+    if (workflowHandles.get(workflow) === handle) workflowHandles.delete(workflow);
+  };
+
+  const stop = async (stopOptions: TriggerStopOptions = {}): Promise<void> => {
+    const timeoutMs = stopOptions.timeoutMs ?? options.stopTimeoutMs;
+    const triggerStopOptions: TriggerStopOptions = timeoutMs === undefined ? {} : { timeoutMs };
+
+    // Which triggers are still draining, so an expiry can name them.
+    const outstanding = new Set(triggers);
+    // `allSettled`, not `all`: a trigger whose stop rejects must not leave the
+    // rest of them scheduling forever. The `async` wrapper matters too — an
+    // `ITrigger` whose `stop()` throws synchronously would otherwise take the
+    // whole `map` down before a single sibling was asked to stop.
+    const settling = Promise.allSettled(
+      triggers.map(async (trigger) => {
+        try {
+          await trigger.stop(triggerStopOptions);
+        } finally {
+          outstanding.delete(trigger);
+        }
+      })
+    );
+
+    const results =
+      timeoutMs === undefined ? await settling : await settleWithin(settling, timeoutMs);
+
+    // Released either way: leaving the handle installed after a timed-out stop
+    // locks `workflow.trigger(...)` forever and makes `listen()` keep handing
+    // back triggers that are on their way out.
+    releaseHandle();
+
+    if (results === undefined) {
+      getLogger().warn("Timed out stopping workflow triggers", {
+        timeoutMs,
+        triggerIds: [...outstanding].map((trigger) => trigger.id),
+      });
+      return;
+    }
+    for (const result of results) {
+      if (result.status === "rejected") {
+        getLogger().error("Trigger failed to stop", { error: String(result.reason) });
+      }
+    }
+  };
+  const handle: ITriggerListenerHandle = {
+    triggers,
+    stop,
+    // `AsyncDisposable` passes no arguments, so a scope exit uses the listen()
+    // default rather than picking up whatever the runtime hands the method.
+    [Symbol.asyncDispose]: () => stop(),
+  };
+
+  // Registered BEFORE the triggers start, so the rollback path below (and a
+  // caller-signal abort) can always find the handle to release.
+  workflowHandles.set(workflow, handle);
+
+  if (options.signal) {
+    const signal = options.signal;
+    // Each trigger already stops itself on this signal, but the HANDLE also has
+    // to go: otherwise an aborted listen() leaves `workflow.trigger(...)`
+    // throwing forever and a later listen() returning dead triggers.
+    // `.catch` rather than `void`: `stop()` can reject through a logger whose
+    // `warn`/`error` throws, and this listener has no caller left to observe
+    // that — a floating rejection here takes a Node host down with an
+    // unhandledRejection. `stop()` reports its own failures.
+    const onAbort = (): void => {
+      stop().catch(() => {});
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    detachAbort = () => signal.removeEventListener("abort", onAbort);
+  }
+
+  const started: ITrigger[] = [];
+  try {
+    for (const binding of bindings) {
+      binding.trigger.start(
+        (context) => runWorkflowForFire(workflow, binding, context),
+        options.signal ? { signal: options.signal } : {}
+      );
+      started.push(binding.trigger);
+    }
+  } catch (error) {
+    // A `start()` can throw (an unsatisfiable cron, say). Leaving the earlier
+    // triggers running would drive the workflow forever with no handle to stop
+    // them through.
+    await Promise.allSettled(started.map((trigger) => trigger.stop()));
+    releaseHandle();
+    throw error;
+  }
+
+  return handle;
+}
+
+/**
+ * Stops every trigger {@link listenWorkflow} started for `workflow`. The
+ * free-function form of {@link Workflow.stopListening}; a no-op when the
+ * workflow is not listening.
+ */
+export async function stopWorkflowListening(workflow: Workflow): Promise<void> {
+  await workflowHandles.get(workflow)?.stop();
+}
+
+/**
+ * Installs `trigger()` / `listen()` / `stopListening()` on `Workflow.prototype`,
+ * so the fluent form in this package's README works.
+ *
+ * **Importing this package does not call it.** A module body that patched a
+ * foreign prototype would make every entry point re-exporting it side-effectful,
+ * and the meta-package `workglow` re-exports it from a barrel that also reaches
+ * `@workglow/duckdb`, `postgres`, `sqlite`, `mcp`, `storage`, `task-graph` and
+ * `util` — none of which declare `sideEffects` at all, so a bundler must keep
+ * every one of them once the barrel cannot be elided. Naming the barrel in
+ * `sideEffects` does not help: the flag is consulted per package, and those
+ * dependencies have already forfeited the claim. The patch therefore has to be
+ * something a consumer asks for.
+ *
+ * `workglow/auto-bootstrap` calls it, so the batteries-included path is
+ * unchanged. Everyone else either calls this once at startup, or uses
+ * {@link bindWorkflowTrigger} / {@link listenWorkflow} /
+ * {@link stopWorkflowListening} directly and never patches anything.
+ *
+ * Idempotent, and cheap to call defensively: it returns early once the methods
+ * are own properties of the prototype.
+ */
+export function installWorkflowTriggers(): void {
+  if (Object.prototype.hasOwnProperty.call(Workflow.prototype, "trigger")) return;
+
+  Workflow.prototype.trigger = function (
+    this: Workflow,
+    trigger: ITrigger,
+    options?: WorkflowTriggerOptions
+  ): Workflow {
+    return bindWorkflowTrigger(this, trigger, options);
+  };
+
+  Workflow.prototype.listen = function (
+    this: Workflow,
+    options?: WorkflowListenOptions
+  ): Promise<ITriggerListenerHandle> {
+    return listenWorkflow(this, options);
+  };
+
+  Workflow.prototype.stopListening = function (this: Workflow): Promise<void> {
+    return stopWorkflowListening(this);
+  };
+}
+
+/**
+ * Runs the workflow for one fire, serialized against every other fire on the
+ * SAME workflow.
+ *
+ * A `Workflow` owns exactly one `TaskGraph`, and a graph refuses to be run
+ * re-entrantly, so two fires landing on one workflow at once — two triggers
+ * whose periods share a boundary, or one trigger with `overlap: "concurrent"`
+ * and a handler slower than its period — would lose the second fire to a
+ * "Graph is already running" error. Deriving a fresh graph per fire is not an
+ * option: `TaskGraph` has no clone, `toJSON` cannot carry closures, attached
+ * caches, or user-attached task listeners, and a copy would break the identity
+ * the trigger bindings and `workflow.abort()` are keyed on.
+ */
+async function runWorkflowForFire(
+  workflow: Workflow,
+  binding: TriggerBinding,
+  context: ITriggerFireContext
+): Promise<void> {
+  const input = binding.options.input ? await binding.options.input(context) : {};
+  const predecessor = workflowRunChains.get(workflow);
+
+  if (predecessor !== undefined) {
+    const limit = binding.options.maxPendingFires ?? DEFAULT_MAX_PENDING_FIRES;
+    // This binding's own backlog. The limit and the count must come from the
+    // same binding or the message is a lie: a workflow-global count charged a
+    // fast binding's queue against a slow binding's ceiling and then reported
+    // "5 fire(s) are already waiting ... (maxPendingFires: 1)" for a trigger
+    // that had never queued a fire.
+    const waiting = binding.pending;
+    if (waiting >= limit) {
+      // Thrown rather than dropped in silence: this is the one place the old
+      // "Graph is already running" failure was observable, and a backlog the
+      // workflow cannot work off is worth reporting on the `error` event.
+      throw new WorkflowTriggerError(
+        `Dropped a fire from trigger "${binding.trigger.id}" scheduled for ` +
+          `${new Date(context.scheduledAt).toISOString()}: ${waiting} fire(s) from that trigger ` +
+          `are already waiting for this workflow's run to finish (maxPendingFires: ${limit}).`
+      );
+    }
+    binding.pending = waiting + 1;
+  }
+
+  const chain = (async (): Promise<void> => {
+    if (predecessor !== undefined) {
+      // `catch`, not a bare await: a fire whose run rejected must not take the
+      // fires queued behind it down with it.
+      await predecessor.catch(() => {});
+      binding.pending -= 1;
+      // The wait can outlast the trigger. A fire that queued behind a slow run
+      // must not start a new one after `stop()`.
+      if (context.signal.aborted) return;
+    }
+    // Forward the trigger's signal into the run itself rather than calling
+    // `workflow.abort()`: that aborts the workflow's CURRENT run, which — with
+    // two triggers bound to one workflow — is whichever run started last, so
+    // stopping trigger A would cancel trigger B's in-flight run and leave A's own
+    // older run going. A per-run signal cancels exactly the run this fire started.
+    await workflow.run(input, { ...binding.options.runConfig, signal: context.signal });
+  })();
+
+  workflowRunChains.set(workflow, chain);
+
+  try {
+    await chain;
+  } catch (error) {
+    // A run cancelled by our own stop() is the expected path, not a failure to
+    // report on the trigger's `error` event.
+    if (context.signal.aborted) return;
+    throw error;
+  } finally {
+    // Identity check: a later fire may already have claimed the tail.
+    if (workflowRunChains.get(workflow) === chain) workflowRunChains.delete(workflow);
+  }
+}

--- a/packages/triggers/tsconfig.json
+++ b/packages/triggers/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/common.ts", "src/*/**/*"],
+  "files": ["./src/browser.ts", "./src/node.ts"],
+  "exclude": ["dist", "node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [
+    { "path": "../util" },
+    { "path": "../task-graph" }
+  ]
+}

--- a/packages/workglow/package.json
+++ b/packages/workglow/package.json
@@ -220,6 +220,7 @@
     "@workglow/sqlite": "workspace:*",
     "@workglow/storage": "workspace:*",
     "@workglow/task-graph": "workspace:*",
+    "@workglow/triggers": "workspace:*",
     "@workglow/browser-control": "workspace:*",
     "@workglow/javascript": "workspace:*",
     "@workglow/mcp": "workspace:*",

--- a/packages/workglow/src/auto-bootstrap.ts
+++ b/packages/workglow/src/auto-bootstrap.ts
@@ -6,11 +6,13 @@
 
 /**
  * Convenience subpath that bootstraps the global Workglow runtime with the
- * tslog-backed logger. Equivalent to:
+ * tslog-backed logger and installs the fluent `Workflow` trigger methods.
+ * Equivalent to:
  *
  * ```ts
- * import { bootstrapWorkglow, TsLogLogger } from "workglow";
+ * import { bootstrapWorkglow, installWorkflowTriggers, TsLogLogger } from "workglow";
  * bootstrapWorkglow({ logger: new TsLogLogger() });
+ * installWorkflowTriggers();
  * ```
  *
  * Use it for "import workglow and go" ergonomics:
@@ -21,10 +23,21 @@
  *
  * For library code, multi-tenant servers, tests, or any case needing a
  * configurable or isolated registry, prefer `bootstrapWorkglow()` /
- * `createOrchestrationContext()` from `workglow/bootstrap`.
+ * `createOrchestrationContext()` from `workglow/bootstrap` — and call
+ * `installWorkflowTriggers()` yourself if you want `workflow.trigger(...)`
+ * rather than the free functions `bindWorkflowTrigger` / `listenWorkflow` /
+ * `stopWorkflowListening`.
+ *
+ * This module is the ONLY side-effectful entry point of the package, which is
+ * what `"sideEffects": ["./dist/auto-bootstrap.js"]` in the manifest says: the
+ * barrel stays elidable, so an app importing `{ Workflow } from "workglow"`
+ * does not drag duckdb, postgres, sqlite and mcp into its bundle.
  */
+
+import { installWorkflowTriggers } from "@workglow/triggers";
 
 import { bootstrapWorkglow } from "./bootstrap";
 import { TsLogLogger } from "./logging";
 
 bootstrapWorkglow({ logger: new TsLogLogger() });
+installWorkflowTriggers();

--- a/packages/workglow/src/common.ts
+++ b/packages/workglow/src/common.ts
@@ -16,6 +16,10 @@ export * from "@workglow/postgres/job-queue";
 export * from "@workglow/duckdb/storage";
 export * from "@workglow/storage";
 export * from "@workglow/task-graph";
+// A pure re-export: the triggers package installs nothing on import. It exports
+// `installWorkflowTriggers()`, which `workglow/auto-bootstrap` calls; a consumer
+// bootstrapping manually calls it too, or uses the free functions.
+export * from "@workglow/triggers";
 export * from "@workglow/browser-control/task";
 export * from "@workglow/javascript/task";
 export * from "@workglow/mcp/tasks";

--- a/packages/workglow/tsconfig.json
+++ b/packages/workglow/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "../storage" },
     { "path": "../job-queue" },
     { "path": "../task-graph" },
+    { "path": "../triggers" },
     { "path": "../knowledge-base" },
     { "path": "../tasks" },
     { "path": "../ai" },


### PR DESCRIPTION
Rebuilt of #679 on current `main`, carrying the triggers work and nothing else. Supersedes #679.

## Why a new branch

#679's payload sits inside a squashed PR merge (`7e6ec7f35`, "Validate trigger binding bounds and reject a reused runConfig.signal (#792)") spanning 223 files. So the branch also carried task-graph cache, `ConditionalTask` and `FetchUrlTask` changes unrelated to triggers — **231 unrelated files against 17 real ones**.

That made it unmergeable by either route:

| | rebase | merge |
|---|---|---|
| conflicting files | 96 | 96 (84 mechanical `CHANGELOG`/`package.json`/lock) |
| substantive hunks | — | 29, of which **14 two-sided** |

The two-sided hunks concentrate in `RunPrivateCacheRepo` / `FsFolderTaskOutputRepository` / `TaskOutputRepository` — the `clearRun` blob-ref path `main` reworked in "stop clearRun dangling blob refs". A wrong resolution there is invisible until a crash-resume. None of it belongs to this feature, so none of it is here.

## What this branch contains

- `packages/triggers` — `BaseTrigger`, `CronTrigger`, `IntervalTrigger`, `PollingTrigger`, a UTC `CronSchedule`, and the `Workflow` binding layer.
- Its six test files under `packages/test/src/test/trigger/`.
- Workspace wiring: the dependency and tsconfig project reference in `test` and `workglow`, plus the `workglow` re-export and `auto-bootstrap` install. Vitest projects and test sections are derived, so they need no edit.

## One task-graph change, carried deliberately

`WorkflowRunConfig.signal`, bridged onto the run's own controller by `WorkflowRunContext.linkSignal`. This is a real dependency, not a leftover: a trigger must cancel exactly the run its own fire started, and `Workflow.abort()` trips the single current-run controller — it would cancel whichever run happens to be current, which is the wrong granularity once two triggers drive one workflow.

It is additive (a new optional field, a new method, one line in `run()`), and its two `Workflow.test.ts` cases come with it. `linkSignal` uses a removable listener rather than `AbortSignal.any`, whose composite is retained per fire.

## Verification

| check | result |
|---|---|
| `bun scripts/test.ts trigger vitest` | 180/180 |
| `bun scripts/test.ts graph vitest` | 507/507 (incl. the 2 new `runConfig.signal` cases) |
| `bun scripts/test.ts task-graph vitest` | 981/981 |
| `bun run build:types` | 42/42 |
| `bun run format` | clean |

Diff is 34 files against `main`, with no conflicts.

The stacked review fixes in #812 have been rebased onto this branch (trigger 187/187) and retargeted here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgxtp7mQECdh7F2UT9CVwN)_