### PR TITLE
feat(tasks): add FileGrepTask for server-side file grepping

### DIFF
--- a/packages/tasks/src/browser.ts
+++ b/packages/tasks/src/browser.ts
@@ -10,14 +10,17 @@ import "./codec.browser";
 import "./task/image/registerImageTextRenderer.browser";
 
 export * from "./common";
+export * from "./task/FileGrepTask";
 export * from "./task/FileLoaderTask";
 
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";
+import { FileGrepTask } from "./task/FileGrepTask";
 import { FileLoaderTask } from "./task/FileLoaderTask";
 
 export const registerCommonTasks = () => {
   const tasks = registerCommonTasksFn();
+  TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
-  return [...tasks, FileLoaderTask];
+  return [...tasks, FileGrepTask, FileLoaderTask];
 };

--- a/packages/tasks/src/browser.ts
+++ b/packages/tasks/src/browser.ts
@@ -12,15 +12,18 @@ import "./task/image/registerImageTextRenderer.browser";
 export * from "./common";
 export * from "./task/FileGrepTask";
 export * from "./task/FileLoaderTask";
+export * from "./task/FileSedTask";
 
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";
 import { FileGrepTask } from "./task/FileGrepTask";
 import { FileLoaderTask } from "./task/FileLoaderTask";
+import { FileSedTask } from "./task/FileSedTask";
 
 export const registerCommonTasks = () => {
   const tasks = registerCommonTasksFn();
   TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
-  return [...tasks, FileGrepTask, FileLoaderTask];
+  TaskRegistry.registerTask(FileSedTask);
+  return [...tasks, FileGrepTask, FileLoaderTask, FileSedTask];
 };

--- a/packages/tasks/src/common.ts
+++ b/packages/tasks/src/common.ts
@@ -87,6 +87,7 @@ export * from "./task/vector/VectorNormalizeTask";
 export * from "./task/vector/VectorScaleTask";
 export * from "./task/vector/VectorSubtractTask";
 export * from "./task/vector/VectorSumTask";
+export * from "./util/regexSafety";
 export * from "./util/SafeFetch";
 export * from "./util/UrlClassifier";
 export { applyFilter, hasFilterOp, registerFilterOp } from "@workglow/util/media";

--- a/packages/tasks/src/electron.ts
+++ b/packages/tasks/src/electron.ts
@@ -12,6 +12,7 @@ import "./util/SafeFetch.server";
 
 export * from "./common";
 export * from "./task/FileGrepTask.server";
+export { grepLines, linesFromText } from "./task/FileGrepTask";
 export * from "./task/FileLoaderTask.server";
 export * from "./task/FileSedTask.server";
 

--- a/packages/tasks/src/electron.ts
+++ b/packages/tasks/src/electron.ts
@@ -13,15 +13,18 @@ import "./util/SafeFetch.server";
 export * from "./common";
 export * from "./task/FileGrepTask.server";
 export * from "./task/FileLoaderTask.server";
+export * from "./task/FileSedTask.server";
 
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";
 import { FileGrepTask } from "./task/FileGrepTask.server";
 import { FileLoaderTask } from "./task/FileLoaderTask.server";
+import { FileSedTask } from "./task/FileSedTask.server";
 
 export const registerCommonTasks = () => {
   const tasks = registerCommonTasksFn();
   TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
-  return [...tasks, FileGrepTask, FileLoaderTask];
+  TaskRegistry.registerTask(FileSedTask);
+  return [...tasks, FileGrepTask, FileLoaderTask, FileSedTask];
 };

--- a/packages/tasks/src/electron.ts
+++ b/packages/tasks/src/electron.ts
@@ -11,14 +11,17 @@ import "./task/image/registerImageTextRenderer.node";
 import "./util/SafeFetch.server";
 
 export * from "./common";
+export * from "./task/FileGrepTask.server";
 export * from "./task/FileLoaderTask.server";
 
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";
+import { FileGrepTask } from "./task/FileGrepTask.server";
 import { FileLoaderTask } from "./task/FileLoaderTask.server";
 
 export const registerCommonTasks = () => {
   const tasks = registerCommonTasksFn();
+  TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
-  return [...tasks, FileLoaderTask];
+  return [...tasks, FileGrepTask, FileLoaderTask];
 };

--- a/packages/tasks/src/node.ts
+++ b/packages/tasks/src/node.ts
@@ -15,15 +15,18 @@ import "./util/SafeFetch.server";
 export * from "./common";
 export * from "./task/FileGrepTask.server";
 export * from "./task/FileLoaderTask.server";
+export * from "./task/FileSedTask.server";
 
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";
 import { FileGrepTask } from "./task/FileGrepTask.server";
 import { FileLoaderTask } from "./task/FileLoaderTask.server";
+import { FileSedTask } from "./task/FileSedTask.server";
 
 export const registerCommonTasks = () => {
   const tasks = registerCommonTasksFn();
   TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
-  return [...tasks, FileGrepTask, FileLoaderTask];
+  TaskRegistry.registerTask(FileSedTask);
+  return [...tasks, FileGrepTask, FileLoaderTask, FileSedTask];
 };

--- a/packages/tasks/src/node.ts
+++ b/packages/tasks/src/node.ts
@@ -14,6 +14,7 @@ import "./util/SafeFetch.server";
 
 export * from "./common";
 export * from "./task/FileGrepTask.server";
+export { grepLines, linesFromText } from "./task/FileGrepTask";
 export * from "./task/FileLoaderTask.server";
 export * from "./task/FileSedTask.server";
 

--- a/packages/tasks/src/node.ts
+++ b/packages/tasks/src/node.ts
@@ -13,14 +13,17 @@ import "./task/image/registerImageTextRenderer.node";
 import "./util/SafeFetch.server";
 
 export * from "./common";
+export * from "./task/FileGrepTask.server";
 export * from "./task/FileLoaderTask.server";
 
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";
+import { FileGrepTask } from "./task/FileGrepTask.server";
 import { FileLoaderTask } from "./task/FileLoaderTask.server";
 
 export const registerCommonTasks = () => {
   const tasks = registerCommonTasksFn();
+  TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
-  return [...tasks, FileLoaderTask];
+  return [...tasks, FileGrepTask, FileLoaderTask];
 };

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -57,7 +57,7 @@ const inputSchema = {
       format: "uri",
     },
     method: {
-      enum: ["GET", "POST", "PUT", "DELETE", "PATCH"],
+      enum: ["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"],
       title: "Method",
       description: "The HTTP method to use",
       default: "GET",
@@ -594,6 +594,17 @@ export class FetchUrlJob<
     if (!response.ok) {
       await discardBody(response);
       throw buildHttpError(input.url!, response);
+    }
+
+    if ((input.method ?? "GET").toUpperCase() === "HEAD") {
+      // HEAD has no representation body. `response.body` is typically null, and
+      // Content-Length describes what a GET would return — not the (empty)
+      // bytes we receive. Streaming it would throw NO_RESPONSE_BODY or
+      // CONTENT_LENGTH_MISMATCH. Metadata is the whole answer.
+      await discardBody(response);
+      await this.emitStreamEnd(metadata, context);
+      yield { type: "finish", data: { metadata } } as StreamEvent<Output>;
+      return;
     }
 
     const chunks: Uint8Array[] = [];

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -142,6 +142,7 @@ const outputSchema = {
         status: { type: "number" },
         notModified: { type: "boolean" },
       },
+      required: ["contentType", "headers", "status", "notModified"],
       additionalProperties: false,
       title: "Response Metadata",
       description: "HTTP response metadata: content type, headers, status, and 304 state",

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -739,6 +739,44 @@ function toJobFailure(reason: unknown): unknown {
   return new Error(`Queued fetch job rejected without a reason (${String(reason)})`);
 }
 
+/**
+ * Entitlements a fetch of `url` requires. A task that OWNS a `FetchUrlTask`
+ * must declare these itself: the graph snapshot is taken over
+ * `graph.getTasks()` before any `execute()` runs, so an owned child created
+ * inside `execute()` is never in it.
+ *
+ * `url` may be unknown at evaluation time (root-task input is not applied
+ * yet), in which case this fails closed and requires an unscoped
+ * `network:private` rather than under-declaring it.
+ */
+export function fetchUrlEntitlementsFor(url: string | undefined): TaskEntitlements {
+  const base = FetchUrlTask.entitlements();
+  if (typeof url !== "string" || url.length === 0) {
+    return mergeEntitlements(base, {
+      entitlements: [
+        {
+          id: Entitlements.NETWORK_PRIVATE,
+          reason:
+            "Runtime URL is not yet available during entitlement evaluation; private/internal destinations must be explicitly allowed",
+        },
+      ],
+    });
+  }
+  const classification = classifyUrl(url);
+  if (classification.kind !== "private") {
+    return base;
+  }
+  return mergeEntitlements(base, {
+    entitlements: [
+      {
+        id: Entitlements.NETWORK_PRIVATE,
+        reason: `URL targets private/internal host: ${classification.reason ?? classification.host ?? "unknown"}`,
+        resources: [urlResourcePattern(url)],
+      },
+    ],
+  });
+}
+
 export class FetchUrlTask<
   Input extends FetchUrlTaskInput = FetchUrlTaskInput,
   Output extends FetchUrlTaskOutput = FetchUrlTaskOutput,
@@ -798,38 +836,9 @@ export class FetchUrlTask<
    * via the URL's origin so grants can be resource-limited (e.g. a dev-mode
    * grant for `http://localhost:*`). The graph runner evaluates this before
    * `execute()` runs, so a denied private URL never issues a network call.
-   *
-   * Root-task input may not yet be applied when entitlements are evaluated.
-   * If the URL is not available at this point, fail closed and require the
-   * private-network entitlement rather than under-declaring it.
    */
   public override entitlements(): TaskEntitlements {
-    const base = FetchUrlTask.entitlements();
-    const url = this.runInputData?.url;
-    if (typeof url !== "string" || url.length === 0) {
-      return mergeEntitlements(base, {
-        entitlements: [
-          {
-            id: Entitlements.NETWORK_PRIVATE,
-            reason:
-              "Runtime URL is not yet available during entitlement evaluation; private/internal destinations must be explicitly allowed",
-          },
-        ],
-      });
-    }
-    const classification = classifyUrl(url);
-    if (classification.kind !== "private") {
-      return base;
-    }
-    return mergeEntitlements(base, {
-      entitlements: [
-        {
-          id: Entitlements.NETWORK_PRIVATE,
-          reason: `URL targets private/internal host: ${classification.reason ?? classification.host ?? "unknown"}`,
-          resources: [urlResourcePattern(url)],
-        },
-      ],
-    });
+    return fetchUrlEntitlementsFor(this.runInputData?.url);
   }
 
   public static override configSchema(): DataPortSchema {

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -15,9 +15,8 @@ import {
   Workflow,
 } from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
-import { createInterface } from "node:readline";
 
-import { SECURITY_LIMITS } from "@workglow/util";
+import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
@@ -198,6 +197,60 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
   }
 }
 
+/**
+ * Splits a byte stream into lines with a hard per-line cap.
+ *
+ * `readline.createInterface` accumulates an unterminated line without bound: a
+ * 640 MB newline-free stream threw `RangeError: Invalid string length` from a
+ * stream `'data'` listener, which surfaces as an `uncaughtException` rather
+ * than an iterator rejection — so the caller's try/catch could not see it and
+ * the process died.
+ *
+ * A line reaching `maxLineChars` with no terminator yields its first
+ * `maxLineChars` characters, and the rest of that physical line is discarded up
+ * to the next `\n`. `setEncoding` puts a `StringDecoder` in front, so a
+ * multi-byte character split across two reads is not corrupted.
+ */
+async function* linesFromStream(
+  stream: NodeJS.ReadableStream,
+  maxLineChars: number
+): AsyncGenerator<string> {
+  stream.setEncoding("utf8");
+
+  let pending = "";
+  let skipping = false;
+
+  const stripCr = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line);
+
+  for await (const chunk of stream as AsyncIterable<string>) {
+    pending += chunk;
+
+    let newline = pending.indexOf("\n");
+    while (newline !== -1) {
+      const line = pending.slice(0, newline);
+      pending = pending.slice(newline + 1);
+      if (skipping) {
+        skipping = false;
+      } else {
+        yield stripCr(line);
+      }
+      newline = pending.indexOf("\n");
+    }
+
+    if (!skipping && pending.length >= maxLineChars) {
+      yield pending.slice(0, maxLineChars);
+      pending = "";
+      skipping = true;
+    } else if (skipping) {
+      pending = "";
+    }
+  }
+
+  if (!skipping && pending.length > 0) {
+    yield stripCr(pending);
+  }
+}
+
 async function grepFile(
   file: string,
   pattern: string,
@@ -206,20 +259,21 @@ async function grepFile(
   matcher: GrepLineMatcher
 ): Promise<FileGrepTaskOutput> {
   const input = createReadStream(file, { signal });
-  const rl = createInterface({
-    input,
-    crlfDelay: Infinity,
-  });
 
   try {
-    return await grepLines(rl, pattern, options, signal, matcher);
+    return await grepLines(
+      linesFromStream(input, DEFAULT_LIMITS.grepMaxLineChars),
+      pattern,
+      options,
+      signal,
+      matcher
+    );
   } catch (err) {
     if (signal.aborted) {
       throw new TaskAbortedError("Task aborted");
     }
     throw err;
   } finally {
-    rl.close();
     input.destroy();
   }
 }

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -4,13 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph";
+import type { IExecuteContext, TaskConfig, TaskEntitlements } from "@workglow/task-graph";
+import {
+  CreateWorkflow,
+  Entitlements,
+  mergeEntitlements,
+  TaskAbortedError,
+  TaskConfigSchema,
+  Workflow,
+} from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 
 import { SECURITY_LIMITS } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
+import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
 import { compileSafeRegex } from "../util/RegexSafety";
 import type {
   FileGrepTaskInput,
@@ -22,6 +31,30 @@ import { FileGrepTask as BaseFileGrepTask, grepLines } from "./FileGrepTask";
 
 export type { FileGrepTaskInput, FileGrepTaskOutput };
 
+export interface FileGrepTaskConfig extends TaskConfig {
+  /**
+   * Directories a local path must resolve inside, checked after symlinks are
+   * resolved. Omitted means unrestricted: the enforced control is the
+   * `filesystem:read` entitlement, and this is the embedder's extra fence.
+   */
+  readonly roots?: readonly string[] | undefined;
+}
+
+const fileGrepTaskConfigSchema = {
+  type: "object",
+  properties: {
+    ...TaskConfigSchema["properties"],
+    roots: {
+      type: "array",
+      items: { type: "string" },
+      title: "Roots",
+      description: "Directories a local path must resolve inside (after symlink resolution)",
+      "x-ui-hidden": true,
+    },
+  },
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
 /**
  * Server-only task for grepping documents from the filesystem.
  * Streams the file line-by-line rather than loading it into memory.
@@ -29,7 +62,22 @@ export type { FileGrepTaskInput, FileGrepTaskOutput };
  *
  * For cross-platform grep (including browser), use FileGrepTask with URLs.
  */
-export class FileGrepTask extends BaseFileGrepTask {
+export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
+  public static override configSchema(): DataPortSchema {
+    return fileGrepTaskConfigSchema as DataPortSchema;
+  }
+
+  public static override entitlements(): TaskEntitlements {
+    return mergeEntitlements(super.entitlements(), {
+      entitlements: [
+        {
+          id: Entitlements.FILESYSTEM_READ,
+          reason: "Reads a local file or file:// URL from disk",
+        },
+      ],
+    });
+  }
+
   /**
    * Runs regex matching inside a `vm` context under a wall-clock budget, so a
    * catastrophically backtracking pattern fails instead of wedging the event
@@ -53,9 +101,9 @@ export class FileGrepTask extends BaseFileGrepTask {
     input: FileGrepTaskInput,
     context: IExecuteContext
   ): Promise<FileGrepTaskOutput> {
-    let { url, pattern, ...options } = input;
+    const { url, pattern, ...options } = input;
 
-    if (url.startsWith("http://") || url.startsWith("https://")) {
+    if (isHttpUrl(url)) {
       return super.execute(input, context);
     }
 
@@ -64,9 +112,7 @@ export class FileGrepTask extends BaseFileGrepTask {
     }
     await context.updateProgress(0, "Opening file");
 
-    if (url.startsWith("file://")) {
-      url = url.slice(7);
-    }
+    const file = resolveLocalFilePath(url, { roots: this.config.roots });
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
@@ -74,7 +120,7 @@ export class FileGrepTask extends BaseFileGrepTask {
     await context.updateProgress(10, "Searching file");
 
     const result = await grepFile(
-      url,
+      file,
       pattern,
       options,
       context.signal,
@@ -116,13 +162,13 @@ async function grepFile(
   }
 }
 
-export const fileGrep = (input: FileGrepTaskInput, config?: TaskConfig) => {
+export const fileGrep = (input: FileGrepTaskInput, config?: FileGrepTaskConfig) => {
   return new FileGrepTask(config).run(input);
 };
 
 declare module "@workglow/task-graph" {
   interface Workflow {
-    fileGrep: CreateWorkflow<FileGrepTaskInput, FileGrepTaskOutput, TaskConfig>;
+    fileGrep: CreateWorkflow<FileGrepTaskInput, FileGrepTaskOutput, FileGrepTaskConfig>;
   }
 }
 

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -56,11 +56,20 @@ const fileGrepTaskConfigSchema = {
 } as const satisfies DataPortSchema;
 
 /**
- * Server-only task for grepping documents from the filesystem.
- * Streams the file line-by-line rather than loading it into memory.
- * Only available in Node.js and Bun environments.
+ * Server-only task for grepping documents from the filesystem, on top of the
+ * base task's http(s) handling.
  *
- * For cross-platform grep (including browser), use FileGrepTask with URLs.
+ * The file is read as a stream rather than loaded into memory, and split into
+ * lines with a hard per-line cap ({@link DEFAULT_LIMITS.grepMaxLineChars}) — a
+ * longer physical line is truncated to that length and the remainder discarded,
+ * so a file with no line terminator cannot exhaust memory.
+ *
+ * A local path is resolved and realpath'd before it is opened, and constrained
+ * to `config.roots` when the embedder sets them. Reading requires the
+ * `filesystem:read` entitlement, declared scoped to the resolved path.
+ *
+ * Only available in Node.js and Bun environments. For cross-platform grep
+ * (including browser), use FileGrepTask with an http(s) URL.
  */
 export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
   public static override configSchema(): DataPortSchema {

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -20,7 +20,7 @@ import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
-import { compileSafeRegex } from "../util/RegexSafety";
+import { compileSafeRegex } from "../util/regexSafety";
 import type {
   FileGrepTaskConfig,
   FileGrepTaskInput,

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig, TaskEntitlements } from "@workglow/task-graph";
+import type { IExecuteContext, TaskEntitlements } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   Entitlements,
@@ -22,6 +22,7 @@ import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
 import { compileSafeRegex } from "../util/RegexSafety";
 import type {
+  FileGrepTaskConfig,
   FileGrepTaskInput,
   FileGrepTaskOutput,
   GrepLineMatcher,
@@ -29,16 +30,7 @@ import type {
 } from "./FileGrepTask";
 import { FileGrepTask as BaseFileGrepTask, grepLines } from "./FileGrepTask";
 
-export type { FileGrepTaskInput, FileGrepTaskOutput };
-
-export interface FileGrepTaskConfig extends TaskConfig {
-  /**
-   * Directories a local path must resolve inside, checked after symlinks are
-   * resolved. Omitted means unrestricted: the enforced control is the
-   * `filesystem:read` entitlement, and this is the embedder's extra fence.
-   */
-  readonly roots?: readonly string[] | undefined;
-}
+export type { FileGrepTaskConfig, FileGrepTaskInput, FileGrepTaskOutput };
 
 const fileGrepTaskConfigSchema = {
   type: "object",

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -11,6 +11,7 @@ import {
   mergeEntitlements,
   TaskAbortedError,
   TaskConfigSchema,
+  TaskEntitlementError,
   Workflow,
 } from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
@@ -79,6 +80,44 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
   }
 
   /**
+   * Declares whichever half of the surface this url actually uses: the fetch
+   * entitlements for http(s), otherwise `filesystem:read` scoped to the
+   * resolved real path. An unknown url fails closed to both, unscoped.
+   *
+   * Never throws — entitlement evaluation runs before `execute()` and must
+   * produce a declaration for any input, so an unresolvable path degrades to
+   * the unscoped declaration and is refused later, at open time.
+   */
+  public override entitlements(): TaskEntitlements {
+    const url = this.runInputData?.url;
+    const unscopedRead: TaskEntitlements = {
+      entitlements: [{ id: Entitlements.FILESYSTEM_READ, reason: "Reads a local file from disk" }],
+    };
+
+    if (typeof url !== "string" || url.length === 0) {
+      return mergeEntitlements(super.entitlements(), unscopedRead);
+    }
+
+    if (isHttpUrl(url)) {
+      return super.entitlements();
+    }
+
+    try {
+      return {
+        entitlements: [
+          {
+            id: Entitlements.FILESYSTEM_READ,
+            reason: "Reads a local file from disk",
+            resources: [resolveLocalFilePath(url, { roots: this.config.roots })],
+          },
+        ],
+      };
+    } catch {
+      return unscopedRead;
+    }
+  }
+
+  /**
    * Runs regex matching inside a `vm` context under a wall-clock budget, so a
    * catastrophically backtracking pattern fails instead of wedging the event
    * loop. Overriding here covers both branches: the http branch reaches
@@ -97,6 +136,28 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
     return { matchBatch };
   }
 
+  /**
+   * Refuses a path the instance did not declare. Entitlements are evaluated
+   * on the unresolved input, so without this a declare-then-swap would let the
+   * open authorize itself — and a standalone `fileGrep(...)` with no graph and
+   * no enforcer would honour no `roots` at all.
+   */
+  private assertResolvedPathDeclared(file: string): void {
+    const declared = this.entitlements().entitlements.find(
+      (entitlement) => entitlement.id === Entitlements.FILESYSTEM_READ
+    );
+    if (declared?.resources === undefined) {
+      throw new TaskEntitlementError(
+        `Refusing to read ${file}: the path could not be resolved when entitlements were declared`
+      );
+    }
+    if (!declared.resources.includes(file)) {
+      throw new TaskEntitlementError(
+        `Refusing to read ${file}: it differs from the declared path ${declared.resources.join(", ")}`
+      );
+    }
+  }
+
   override async execute(
     input: FileGrepTaskInput,
     context: IExecuteContext
@@ -113,6 +174,7 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
     await context.updateProgress(0, "Opening file");
 
     const file = resolveLocalFilePath(url, { roots: this.config.roots });
+    this.assertResolvedPathDeclared(file);
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -9,7 +9,15 @@ import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 
-import type { FileGrepTaskInput, FileGrepTaskOutput } from "./FileGrepTask";
+import { SECURITY_LIMITS } from "@workglow/util";
+import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
+import { compileSafeRegex } from "../util/RegexSafety";
+import type {
+  FileGrepTaskInput,
+  FileGrepTaskOutput,
+  GrepLineMatcher,
+  GrepOptions,
+} from "./FileGrepTask";
 import { FileGrepTask as BaseFileGrepTask, grepLines } from "./FileGrepTask";
 
 export type { FileGrepTaskInput, FileGrepTaskOutput };
@@ -22,6 +30,25 @@ export type { FileGrepTaskInput, FileGrepTaskOutput };
  * For cross-platform grep (including browser), use FileGrepTask with URLs.
  */
 export class FileGrepTask extends BaseFileGrepTask {
+  /**
+   * Runs regex matching inside a `vm` context under a wall-clock budget, so a
+   * catastrophically backtracking pattern fails instead of wedging the event
+   * loop. Overriding here covers both branches: the http branch reaches
+   * `super.execute`, which uses the matcher this returns.
+   *
+   * `fixedString` never enters `vm` — `String.includes` cannot backtrack, and
+   * the `vm` hop would cost ~20x for nothing.
+   */
+  protected override createLineMatcher(pattern: string, options: GrepOptions): GrepLineMatcher {
+    if (options.fixedString) {
+      return super.createLineMatcher(pattern, options);
+    }
+
+    const regex = compileSafeRegex(pattern, options.ignoreCase ? "i" : "");
+    const matchBatch = createBoundedRegexMatcher(regex, SECURITY_LIMITS.regexMatchBatchTimeoutMs);
+    return { matchBatch };
+  }
+
   override async execute(
     input: FileGrepTaskInput,
     context: IExecuteContext
@@ -46,7 +73,13 @@ export class FileGrepTask extends BaseFileGrepTask {
     }
     await context.updateProgress(10, "Searching file");
 
-    const result = await grepFile(url, pattern, options, context.signal);
+    const result = await grepFile(
+      url,
+      pattern,
+      options,
+      context.signal,
+      this.createLineMatcher(pattern, options)
+    );
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
@@ -60,8 +93,9 @@ export class FileGrepTask extends BaseFileGrepTask {
 async function grepFile(
   file: string,
   pattern: string,
-  options: Omit<FileGrepTaskInput, "url" | "pattern">,
-  signal: AbortSignal
+  options: GrepOptions,
+  signal: AbortSignal,
+  matcher: GrepLineMatcher
 ): Promise<FileGrepTaskOutput> {
   const input = createReadStream(file, { signal });
   const rl = createInterface({
@@ -70,7 +104,7 @@ async function grepFile(
   });
 
   try {
-    return await grepLines(rl, pattern, options, signal);
+    return await grepLines(rl, pattern, options, signal, matcher);
   } catch (err) {
     if (signal.aborted) {
       throw new TaskAbortedError("Task aborted");

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -21,6 +21,7 @@ import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
 import { compileSafeRegex } from "../util/regexSafety";
+import { linesFromStream } from "../util/StreamLines.server";
 import type {
   FileGrepTaskConfig,
   FileGrepTaskInput,
@@ -195,60 +196,6 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
     await context.updateProgress(100, "Search complete");
 
     return result;
-  }
-}
-
-/**
- * Splits a byte stream into lines with a hard per-line cap.
- *
- * `readline.createInterface` accumulates an unterminated line without bound: a
- * 640 MB newline-free stream threw `RangeError: Invalid string length` from a
- * stream `'data'` listener, which surfaces as an `uncaughtException` rather
- * than an iterator rejection — so the caller's try/catch could not see it and
- * the process died.
- *
- * A line reaching `maxLineChars` with no terminator yields its first
- * `maxLineChars` characters, and the rest of that physical line is discarded up
- * to the next `\n`. `setEncoding` puts a `StringDecoder` in front, so a
- * multi-byte character split across two reads is not corrupted.
- */
-async function* linesFromStream(
-  stream: NodeJS.ReadableStream,
-  maxLineChars: number
-): AsyncGenerator<string> {
-  stream.setEncoding("utf8");
-
-  let pending = "";
-  let skipping = false;
-
-  const stripCr = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line);
-
-  for await (const chunk of stream as AsyncIterable<string>) {
-    pending += chunk;
-
-    let newline = pending.indexOf("\n");
-    while (newline !== -1) {
-      const line = pending.slice(0, newline);
-      pending = pending.slice(newline + 1);
-      if (skipping) {
-        skipping = false;
-      } else {
-        yield stripCr(line);
-      }
-      newline = pending.indexOf("\n");
-    }
-
-    if (!skipping && pending.length >= maxLineChars) {
-      yield pending.slice(0, maxLineChars);
-      pending = "";
-      skipping = true;
-    } else if (skipping) {
-      pending = "";
-    }
-  }
-
-  if (!skipping && pending.length > 0) {
-    yield stripCr(pending);
   }
 }
 

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
+import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph";
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+
+import type { FileGrepTaskInput, FileGrepTaskOutput } from "./FileGrepTask";
+import { FileGrepTask as BaseFileGrepTask, grepLines } from "./FileGrepTask";
+
+export type { FileGrepTaskInput, FileGrepTaskOutput };
+
+/**
+ * Server-only task for grepping documents from the filesystem.
+ * Streams the file line-by-line rather than loading it into memory.
+ * Only available in Node.js and Bun environments.
+ *
+ * For cross-platform grep (including browser), use FileGrepTask with URLs.
+ */
+export class FileGrepTask extends BaseFileGrepTask {
+  override async execute(
+    input: FileGrepTaskInput,
+    context: IExecuteContext
+  ): Promise<FileGrepTaskOutput> {
+    let { url, pattern, ...options } = input;
+
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      return super.execute(input, context);
+    }
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(0, "Opening file");
+
+    if (url.startsWith("file://")) {
+      url = url.slice(7);
+    }
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(10, "Searching file");
+
+    const result = await grepFile(url, pattern, options, context.signal);
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(100, "Search complete");
+
+    return result;
+  }
+}
+
+async function grepFile(
+  file: string,
+  pattern: string,
+  options: Omit<FileGrepTaskInput, "url" | "pattern">,
+  signal: AbortSignal
+): Promise<FileGrepTaskOutput> {
+  const input = createReadStream(file, { signal });
+  const rl = createInterface({
+    input,
+    crlfDelay: Infinity,
+  });
+
+  try {
+    return await grepLines(rl, pattern, options, signal);
+  } catch (err) {
+    if (signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    throw err;
+  } finally {
+    rl.close();
+    input.destroy();
+  }
+}
+
+export const fileGrep = (input: FileGrepTaskInput, config?: TaskConfig) => {
+  return new FileGrepTask(config).run(input);
+};
+
+declare module "@workglow/task-graph" {
+  interface Workflow {
+    fileGrep: CreateWorkflow<FileGrepTaskInput, FileGrepTaskOutput, TaskConfig>;
+  }
+}
+
+Workflow.prototype.fileGrep = CreateWorkflow(FileGrepTask);

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -18,7 +18,10 @@ import { createReadStream } from "node:fs";
 
 import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
-import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
+import {
+  createBoundedRegexExtractor,
+  createBoundedRegexMatcher,
+} from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
 import { compileSafeRegex } from "../util/regexSafety";
 import { linesFromStream } from "../util/StreamLines.server";
@@ -124,6 +127,11 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
    * loop. Overriding here covers both branches: the http branch reaches
    * `super.execute`, which uses the matcher this returns.
    *
+   * `matchBatch` (`RegExp.test`) is not the whole cost: `onlyMatching` then
+   * `exec`s each hit to slice out the substring. A pattern whose left
+   * alternative matches quickly can still backtrack on that global pass, so
+   * `extractBatch` is bounded the same way.
+   *
    * `fixedString` never enters `vm` — `String.includes` cannot backtrack, and
    * the `vm` hop would cost ~20x for nothing.
    */
@@ -133,8 +141,15 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
     }
 
     const regex = compileSafeRegex(pattern, options.ignoreCase ? "i" : "");
-    const matchBatch = createBoundedRegexMatcher(regex, SECURITY_LIMITS.regexMatchBatchTimeoutMs);
-    return { matchBatch };
+    const timeoutMs = SECURITY_LIMITS.regexMatchBatchTimeoutMs;
+    const matchBatch = createBoundedRegexMatcher(regex, timeoutMs);
+    const extractBatch = options.onlyMatching
+      ? createBoundedRegexExtractor(
+          new RegExp(regex.source, regex.ignoreCase ? "gi" : "g"),
+          timeoutMs
+        )
+      : undefined;
+    return { matchBatch, extractBatch };
   }
 
   /**

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -367,6 +367,7 @@ export async function grepLines(
 
   const iterator = lines[Symbol.asyncIterator]();
   const deadline = Date.now() + DEFAULT_LIMITS.grepMaxSearchMs;
+  const maxLineChars = DEFAULT_LIMITS.grepMaxLineChars;
   const batch: string[] = [];
   let exhausted = false;
 
@@ -379,7 +380,15 @@ export async function grepLines(
           exhausted = true;
           break;
         }
-        batch.push(next.value);
+        // `>=` rather than `>`: conservative by one character, and it lets the
+        // server's line splitter signal truncation without a side channel.
+        const text = next.value;
+        if (text.length >= maxLineChars) {
+          truncated = true;
+          batch.push(text.slice(0, maxLineChars));
+        } else {
+          batch.push(text);
+        }
       }
 
       if (batch.length === 0) break;

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -13,7 +13,7 @@ import {
   Workflow,
 } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-import { assertSafeRegexPattern } from "../util/regexSafety";
+import { assertSafeRegexPattern, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
 import { FetchUrlTask } from "./FetchUrlTask";
 
@@ -47,6 +47,11 @@ const inputSchema = {
       type: "boolean",
       title: "Invert Match",
       description: "Select lines that do not match (-v)",
+    },
+    onlyMatching: {
+      type: "boolean",
+      title: "Only Matching",
+      description: "Emit the matched substrings instead of whole lines, one per match (-o)",
     },
     afterContext: {
       type: "integer",
@@ -217,6 +222,46 @@ function createMatcher(pattern: string, options: GrepOptions): (text: string) =>
   }
 }
 
+/**
+ * Collects the matched substrings of a line for `onlyMatching`. A literal
+ * pattern is compiled rather than searched with `indexOf` so that an
+ * ignore-case match can be sliced out of the original text: `toLowerCase()`
+ * is not length-preserving for every character, so lowercasing the haystack
+ * to find an offset can misalign the slice back in the original.
+ */
+function createExtractor(pattern: string, options: GrepOptions): (text: string) => string[] {
+  const source = options.fixedString ? escapeRegExp(pattern) : pattern;
+
+  if (!options.fixedString) {
+    assertSafeRegexPattern(pattern);
+  }
+
+  let regex: RegExp;
+  try {
+    regex = new RegExp(source, options.ignoreCase ? "gi" : "g");
+  } catch {
+    throw new TaskInvalidInputError(`Invalid regular expression: ${pattern}`);
+  }
+
+  return (text) => {
+    const matches: string[] = [];
+
+    regex.lastIndex = 0;
+
+    let result: RegExpExecArray | null;
+    while ((result = regex.exec(text)) !== null) {
+      // grep skips a zero-length match; advancing is also what ends the loop.
+      if (result[0].length === 0) {
+        regex.lastIndex++;
+        continue;
+      }
+      matches.push(result[0]);
+    }
+
+    return matches;
+  };
+}
+
 export async function grepLines(
   lines: AsyncIterable<string>,
   pattern: string,
@@ -225,10 +270,17 @@ export async function grepLines(
 ): Promise<FileGrepTaskOutput> {
   validateOptions(options);
 
-  const beforeContext = options.context ?? options.beforeContext ?? 0;
-  const afterContext = options.context ?? options.afterContext ?? 0;
+  // Context is inert under onlyMatching: a context line holds no match, so
+  // grep prints nothing for it, and carrying a window would only let two
+  // matches separated by unprinted lines land in one group.
+  const beforeContext = options.onlyMatching ? 0 : (options.context ?? options.beforeContext ?? 0);
+  const afterContext = options.onlyMatching ? 0 : (options.context ?? options.afterContext ?? 0);
 
   const matcher = createMatcher(pattern, options);
+  const extract =
+    options.onlyMatching && !options.existsOnly && !options.countOnly
+      ? createExtractor(pattern, options)
+      : undefined;
 
   const groups: GrepGroup[] = [];
   const beforeBuffer: BufferedLine[] = [];
@@ -267,7 +319,12 @@ export async function grepLines(
     }
 
     if (currentGroup && entry.line <= currentGroup.endLine + 1) {
-      const existing = currentGroup.lines.find((line) => line.line === entry.line);
+      // De-duplication exists to merge a before-context line already emitted as
+      // after-context. Under onlyMatching one line legitimately yields several
+      // entries, so merging them would collapse repeated matches into one.
+      const existing = options.onlyMatching
+        ? undefined
+        : currentGroup.lines.find((line) => line.line === entry.line);
 
       if (existing) {
         if (entry.match) {
@@ -321,7 +378,21 @@ export async function grepLines(
         };
       }
 
-      if (!options.countOnly) {
+      if (extract) {
+        // An inverted selection reaches here on a line the pattern did NOT
+        // match, so the extractor finds nothing and emits nothing — which is
+        // exactly what `grep -v -o` prints.
+        for (const match of extract(text)) {
+          if (!emitLine({ line: lineNumber, text: match, match: true })) {
+            return {
+              groups,
+              matchCount,
+              exists,
+              truncated: true,
+            };
+          }
+        }
+      } else if (!options.countOnly) {
         for (const previous of beforeBuffer) {
           if (
             !emitLine({

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -539,7 +539,11 @@ export async function grepLines(
  * Works in all environments (browser, Node.js, Bun) by using fetch API.
  * For server-only filesystem path access, see FileGrepTask.server.
  */
-export class FileGrepTask extends Task<FileGrepTaskInput, FileGrepTaskOutput, TaskConfig> {
+export class FileGrepTask<Config extends TaskConfig = TaskConfig> extends Task<
+  FileGrepTaskInput,
+  FileGrepTaskOutput,
+  Config
+> {
   public static override type = "FileGrepTask";
   public static override category = "Document";
   public static override title = "File Grep";

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -12,9 +12,12 @@ import {
   TaskInvalidInputError,
   Workflow,
 } from "@workglow/task-graph";
-import { SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
+import { assertSafeRegexPattern } from "../util/regexSafety";
+import { linesFromText } from "../util/textLines";
 import { FetchUrlTask } from "./FetchUrlTask";
+
+export { linesFromText };
 
 const inputSchema = {
   type: "object",
@@ -174,15 +177,6 @@ interface BufferedLine {
   readonly text: string;
 }
 
-/**
- * Detects regex patterns prone to catastrophic backtracking (ReDoS).
- * Checks for nested quantifiers like (a+)+, (a*)+, (a+)*, etc.
- */
-function hasNestedQuantifiers(pattern: string): boolean {
-  const withoutClasses = pattern.replace(/\[(?:[^\]\\]|\\.)*\]/g, "X");
-  return /\([^)*+]*[*+][^)]*\)[+*?]|\([^)*+]*[*+][^)]*\)\{/.test(withoutClasses);
-}
-
 function validateOptions(options: GrepOptions): void {
   const integerOptions: Array<[keyof GrepOptions, number | undefined]> = [
     ["afterContext", options.afterContext],
@@ -213,39 +207,13 @@ function createMatcher(pattern: string, options: GrepOptions): (text: string) =>
     return (text) => text.includes(pattern);
   }
 
-  const bracketCount = (pattern.match(/\[/g) ?? []).length;
-  if (bracketCount > SECURITY_LIMITS.regexMaxBracketCount) {
-    throw new TaskInvalidInputError(
-      "Regex pattern rejected: too many '[' characters (potential ReDoS). " +
-        "Simplify the pattern to reduce complexity."
-    );
-  }
-
-  if (hasNestedQuantifiers(pattern)) {
-    throw new TaskInvalidInputError(
-      "Regex pattern rejected: nested quantifiers detected (potential ReDoS). " +
-        "Simplify the pattern to avoid catastrophic backtracking."
-    );
-  }
+  assertSafeRegexPattern(pattern);
 
   try {
     const regex = new RegExp(pattern, options.ignoreCase ? "i" : "");
     return (text) => regex.test(text);
   } catch {
     throw new TaskInvalidInputError(`Invalid regular expression: ${pattern}`);
-  }
-}
-
-export async function* linesFromText(text: string): AsyncGenerator<string> {
-  if (text.length === 0) {
-    return;
-  }
-  const lines = text.split(/\r?\n/);
-  if (text.endsWith("\n")) {
-    lines.pop();
-  }
-  for (const line of lines) {
-    yield line;
   }
 }
 

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -670,13 +670,33 @@ export class FileGrepTask<Config extends TaskConfig = TaskConfig> extends Task<
   }
 }
 
-export const fileGrep = (input: FileGrepTaskInput, config?: TaskConfig) => {
+/**
+ * Config for both builds. `roots` is declared here rather than beside the
+ * server subclass because a `declare module` augmentation must state one type
+ * across every file that contributes it, and both files augment `Workflow`
+ * with `fileGrep`. Declaring it only on the server made the two disagree
+ * (TS2717); declaring `TaskConfig` in both would keep them agreeing but drop
+ * `roots` from `workflow.fileGrep(...)`, which is the API most callers use.
+ */
+export interface FileGrepTaskConfig extends TaskConfig {
+  /**
+   * Directories a local path must resolve inside, checked after symlinks are
+   * resolved. Omitted means unrestricted: the enforced control is the
+   * `filesystem:read` entitlement, and this is the embedder's extra fence.
+   *
+   * Honored only by the server build — the cross-platform class reaches
+   * http(s) through `FetchUrlTask` and touches no filesystem.
+   */
+  readonly roots?: readonly string[] | undefined;
+}
+
+export const fileGrep = (input: FileGrepTaskInput, config?: FileGrepTaskConfig) => {
   return new FileGrepTask(config).run(input);
 };
 
 declare module "@workglow/task-graph" {
   interface Workflow {
-    fileGrep: CreateWorkflow<FileGrepTaskInput, FileGrepTaskOutput, TaskConfig>;
+    fileGrep: CreateWorkflow<FileGrepTaskInput, FileGrepTaskOutput, FileGrepTaskConfig>;
   }
 }
 

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
+import type { IExecuteContext, TaskConfig, TaskEntitlements } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   Task,
@@ -16,7 +16,7 @@ import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
-import { FetchUrlTask } from "./FetchUrlTask";
+import { fetchUrlEntitlementsFor, FetchUrlTask } from "./FetchUrlTask";
 
 export { linesFromText };
 
@@ -549,6 +549,21 @@ export class FileGrepTask<Config extends TaskConfig = TaskConfig> extends Task<
   public static override title = "File Grep";
   public static override description = "Search a file for matching lines (grep)";
   public static override cacheable = true;
+  public static override hasDynamicEntitlements: boolean = true;
+
+  /**
+   * The owned `FetchUrlTask` does the network access, but an owned child is
+   * created inside `execute()` and so is absent from the graph-start snapshot
+   * `computeGraphEntitlements` takes over `graph.getTasks()`. Declaring the
+   * fetch's entitlements here is what puts them in front of the enforcer.
+   */
+  public static override entitlements(): TaskEntitlements {
+    return FetchUrlTask.entitlements();
+  }
+
+  public override entitlements(): TaskEntitlements {
+    return fetchUrlEntitlementsFor(this.runInputData?.url);
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -14,7 +14,7 @@ import {
 } from "@workglow/task-graph";
 import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
+import { assertSafeRegexPattern, compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
 import { fetchUrlEntitlementsFor, FetchUrlTask } from "./FetchUrlTask";
 

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -1,0 +1,522 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
+import {
+  CreateWorkflow,
+  Task,
+  TaskAbortedError,
+  TaskInvalidInputError,
+  Workflow,
+} from "@workglow/task-graph";
+import { SECURITY_LIMITS } from "@workglow/util";
+import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
+import { FetchUrlTask } from "./FetchUrlTask";
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    url: {
+      type: "string",
+      title: "URL",
+      description: "URL to search (http://, https://)",
+      format: "uri",
+    },
+    pattern: {
+      type: "string",
+      title: "Pattern",
+      description: "Regular expression, or a literal string when fixedString is set",
+    },
+    ignoreCase: {
+      type: "boolean",
+      title: "Ignore Case",
+      description: "Case-insensitive matching (-i)",
+    },
+    fixedString: {
+      type: "boolean",
+      title: "Fixed String",
+      description: "Treat pattern as a literal string (-F)",
+    },
+    invertMatch: {
+      type: "boolean",
+      title: "Invert Match",
+      description: "Select lines that do not match (-v)",
+    },
+    afterContext: {
+      type: "integer",
+      title: "After Context",
+      description: "Lines after each match (-A)",
+      minimum: 0,
+    },
+    beforeContext: {
+      type: "integer",
+      title: "Before Context",
+      description: "Lines before each match (-B)",
+      minimum: 0,
+    },
+    context: {
+      type: "integer",
+      title: "Context",
+      description: "Lines before and after each match (-C)",
+      minimum: 0,
+    },
+    maxMatches: {
+      type: "integer",
+      title: "Max Matches",
+      description: "Stop after this many matching lines (-m)",
+      minimum: 1,
+    },
+    existsOnly: {
+      type: "boolean",
+      title: "Exists Only",
+      description: "Return only whether a match exists (-q-like behavior)",
+    },
+    countOnly: {
+      type: "boolean",
+      title: "Count Only",
+      description: "Return only the number of matching lines (-c-like behavior)",
+    },
+    maxOutputLines: {
+      type: "integer",
+      title: "Max Output Lines",
+      description: "Maximum number of output lines, including context",
+      minimum: 0,
+    },
+    maxOutputChars: {
+      type: "integer",
+      title: "Max Output Characters",
+      description: "Maximum number of output characters, including newlines",
+      minimum: 0,
+    },
+  },
+  required: ["url", "pattern"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+const grepLineSchema = {
+  type: "object",
+  properties: {
+    line: { type: "integer", title: "Line", description: "1-based line number" },
+    text: { type: "string", title: "Text", description: "Line contents without the terminator" },
+    match: {
+      type: "boolean",
+      title: "Match",
+      description: "Whether this line matched the pattern",
+    },
+  },
+  required: ["line", "text", "match"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+const outputSchema = {
+  type: "object",
+  properties: {
+    groups: {
+      type: "array",
+      title: "Groups",
+      description: "Contiguous match groups, including context lines",
+      items: {
+        type: "object",
+        properties: {
+          startLine: { type: "integer", title: "Start Line" },
+          endLine: { type: "integer", title: "End Line" },
+          lines: {
+            type: "array",
+            items: grepLineSchema,
+          },
+        },
+        required: ["startLine", "endLine", "lines"],
+        additionalProperties: false,
+      },
+    },
+    matchCount: {
+      type: "integer",
+      title: "Match Count",
+      description: "Number of matching lines",
+    },
+    exists: {
+      type: "boolean",
+      title: "Exists",
+      description: "Whether any line matched",
+    },
+    truncated: {
+      type: "boolean",
+      title: "Truncated",
+      description: "Search stopped before EOF because of an output or search limit",
+    },
+  },
+  required: ["groups", "matchCount", "exists", "truncated"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export type FileGrepTaskInput = FromSchema<typeof inputSchema>;
+export type FileGrepTaskOutput = FromSchema<typeof outputSchema>;
+
+interface GrepLine {
+  line: number;
+  text: string;
+  match: boolean;
+}
+
+interface GrepGroup {
+  startLine: number;
+  endLine: number;
+  lines: GrepLine[];
+}
+
+type GrepOptions = Omit<FileGrepTaskInput, "url" | "pattern">;
+
+interface BufferedLine {
+  readonly line: number;
+  readonly text: string;
+}
+
+/**
+ * Detects regex patterns prone to catastrophic backtracking (ReDoS).
+ * Checks for nested quantifiers like (a+)+, (a*)+, (a+)*, etc.
+ */
+function hasNestedQuantifiers(pattern: string): boolean {
+  const withoutClasses = pattern.replace(/\[(?:[^\]\\]|\\.)*\]/g, "X");
+  return /\([^)*+]*[*+][^)]*\)[+*?]|\([^)*+]*[*+][^)]*\)\{/.test(withoutClasses);
+}
+
+function validateOptions(options: GrepOptions): void {
+  const integerOptions: Array<[keyof GrepOptions, number | undefined]> = [
+    ["afterContext", options.afterContext],
+    ["beforeContext", options.beforeContext],
+    ["context", options.context],
+    ["maxMatches", options.maxMatches],
+    ["maxOutputLines", options.maxOutputLines],
+    ["maxOutputChars", options.maxOutputChars],
+  ];
+
+  for (const [name, value] of integerOptions) {
+    if (value !== undefined && (!Number.isInteger(value) || value < 0)) {
+      throw new TaskInvalidInputError(`${String(name)} must be a non-negative integer`);
+    }
+  }
+
+  if (options.maxMatches === 0) {
+    throw new TaskInvalidInputError("maxMatches must be greater than zero when specified");
+  }
+}
+
+function createMatcher(pattern: string, options: GrepOptions): (text: string) => boolean {
+  if (options.fixedString) {
+    if (options.ignoreCase) {
+      const needle = pattern.toLowerCase();
+      return (text) => text.toLowerCase().includes(needle);
+    }
+    return (text) => text.includes(pattern);
+  }
+
+  const bracketCount = (pattern.match(/\[/g) ?? []).length;
+  if (bracketCount > SECURITY_LIMITS.regexMaxBracketCount) {
+    throw new TaskInvalidInputError(
+      "Regex pattern rejected: too many '[' characters (potential ReDoS). " +
+        "Simplify the pattern to reduce complexity."
+    );
+  }
+
+  if (hasNestedQuantifiers(pattern)) {
+    throw new TaskInvalidInputError(
+      "Regex pattern rejected: nested quantifiers detected (potential ReDoS). " +
+        "Simplify the pattern to avoid catastrophic backtracking."
+    );
+  }
+
+  try {
+    const regex = new RegExp(pattern, options.ignoreCase ? "i" : "");
+    return (text) => regex.test(text);
+  } catch {
+    throw new TaskInvalidInputError(`Invalid regular expression: ${pattern}`);
+  }
+}
+
+export async function* linesFromText(text: string): AsyncGenerator<string> {
+  if (text.length === 0) {
+    return;
+  }
+  const lines = text.split(/\r?\n/);
+  if (text.endsWith("\n")) {
+    lines.pop();
+  }
+  for (const line of lines) {
+    yield line;
+  }
+}
+
+export async function grepLines(
+  lines: AsyncIterable<string>,
+  pattern: string,
+  options: GrepOptions = {},
+  signal?: AbortSignal
+): Promise<FileGrepTaskOutput> {
+  validateOptions(options);
+
+  const beforeContext = options.context ?? options.beforeContext ?? 0;
+  const afterContext = options.context ?? options.afterContext ?? 0;
+
+  const matcher = createMatcher(pattern, options);
+
+  const groups: GrepGroup[] = [];
+  const beforeBuffer: BufferedLine[] = [];
+
+  let currentGroup: GrepGroup | undefined;
+
+  let lineNumber = 0;
+  let matchCount = 0;
+  let exists = false;
+  let truncated = false;
+
+  let afterRemaining = 0;
+  let maxMatchesReached = false;
+
+  let outputLines = 0;
+  let outputChars = 0;
+
+  function canEmit(text: string): boolean {
+    if (options.maxOutputLines !== undefined && outputLines >= options.maxOutputLines) {
+      return false;
+    }
+
+    const chars = text.length + 1;
+
+    if (options.maxOutputChars !== undefined && outputChars + chars > options.maxOutputChars) {
+      return false;
+    }
+
+    return true;
+  }
+
+  function emitLine(entry: GrepLine): boolean {
+    if (!canEmit(entry.text)) {
+      truncated = true;
+      return false;
+    }
+
+    if (currentGroup && entry.line <= currentGroup.endLine + 1) {
+      const existing = currentGroup.lines.find((line) => line.line === entry.line);
+
+      if (existing) {
+        if (entry.match) {
+          existing.match = true;
+        }
+
+        return true;
+      }
+
+      currentGroup.lines.push(entry);
+      currentGroup.endLine = entry.line;
+    } else {
+      currentGroup = {
+        startLine: entry.line,
+        endLine: entry.line,
+        lines: [entry],
+      };
+
+      groups.push(currentGroup);
+    }
+
+    outputLines++;
+    outputChars += entry.text.length + 1;
+
+    return true;
+  }
+
+  for await (const text of lines) {
+    if (signal?.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+
+    lineNumber++;
+
+    let matched = matcher(text);
+
+    if (options.invertMatch) {
+      matched = !matched;
+    }
+
+    if (matched && !maxMatchesReached) {
+      matchCount++;
+      exists = true;
+
+      if (options.existsOnly) {
+        return {
+          groups: [],
+          matchCount: 1,
+          exists: true,
+          truncated: false,
+        };
+      }
+
+      if (!options.countOnly) {
+        for (const previous of beforeBuffer) {
+          if (
+            !emitLine({
+              line: previous.line,
+              text: previous.text,
+              match: false,
+            })
+          ) {
+            return {
+              groups,
+              matchCount,
+              exists,
+              truncated: true,
+            };
+          }
+        }
+
+        if (
+          !emitLine({
+            line: lineNumber,
+            text,
+            match: true,
+          })
+        ) {
+          return {
+            groups,
+            matchCount,
+            exists,
+            truncated: true,
+          };
+        }
+      }
+
+      afterRemaining = afterContext;
+
+      if (options.maxMatches !== undefined && matchCount >= options.maxMatches) {
+        maxMatchesReached = true;
+
+        if (afterContext === 0) {
+          truncated = true;
+          break;
+        }
+      }
+    } else if (!options.countOnly && afterRemaining > 0) {
+      if (
+        !emitLine({
+          line: lineNumber,
+          text,
+          match: false,
+        })
+      ) {
+        return {
+          groups,
+          matchCount,
+          exists,
+          truncated: true,
+        };
+      }
+
+      afterRemaining--;
+    }
+
+    beforeBuffer.push({
+      line: lineNumber,
+      text,
+    });
+
+    if (beforeBuffer.length > beforeContext) {
+      beforeBuffer.shift();
+    }
+
+    if (maxMatchesReached) {
+      if (afterRemaining === 0) {
+        truncated = true;
+        break;
+      }
+
+      continue;
+    }
+
+    /*
+     * A non-matching line outside trailing context means any future
+     * match is separated from the current group.
+     */
+    if (!matched && afterRemaining === 0) {
+      currentGroup = undefined;
+    }
+  }
+
+  return {
+    groups: options.countOnly ? [] : groups,
+    matchCount,
+    exists,
+    truncated,
+  };
+}
+
+/**
+ * Task for grepping documents from URLs (including file:// URLs).
+ * Works in all environments (browser, Node.js, Bun) by using fetch API.
+ * For server-only filesystem path access, see FileGrepTask.server.
+ */
+export class FileGrepTask extends Task<FileGrepTaskInput, FileGrepTaskOutput, TaskConfig> {
+  public static override type = "FileGrepTask";
+  public static override category = "Document";
+  public static override title = "File Grep";
+  public static override description = "Search a file for matching lines (grep)";
+  public static override cacheable = true;
+
+  public static override inputSchema(): DataPortSchema {
+    return inputSchema as DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return outputSchema as DataPortSchema;
+  }
+
+  override async execute(
+    input: FileGrepTaskInput,
+    context: IExecuteContext
+  ): Promise<FileGrepTaskOutput> {
+    const { url, pattern, ...options } = input;
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(0, "Fetching file");
+
+    const fetchTask = context.own(new FetchUrlTask({ queue: false }));
+    const response = await fetchTask.run({
+      url,
+      response_type: "text",
+    });
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(60, "Searching file");
+
+    const result = await grepLines(
+      linesFromText(response.text ?? ""),
+      pattern,
+      options,
+      context.signal
+    );
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(100, "Search complete");
+
+    return result;
+  }
+}
+
+export const fileGrep = (input: FileGrepTaskInput, config?: TaskConfig) => {
+  return new FileGrepTask(config).run(input);
+};
+
+declare module "@workglow/task-graph" {
+  interface Workflow {
+    fileGrep: CreateWorkflow<FileGrepTaskInput, FileGrepTaskOutput, TaskConfig>;
+  }
+}
+
+Workflow.prototype.fileGrep = CreateWorkflow(FileGrepTask);

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -332,16 +332,20 @@ export async function grepLines(
     }
 
     if (currentGroup && entry.line <= currentGroup.endLine + 1) {
-      // De-duplication exists to merge a before-context line already emitted as
-      // after-context. Under onlyMatching one line legitimately yields several
-      // entries, so merging them would collapse repeated matches into one.
-      const existing = options.onlyMatching
-        ? undefined
-        : currentGroup.lines.find((line) => line.line === entry.line);
-
-      if (existing) {
-        if (entry.match) {
-          existing.match = true;
+      /*
+       * Entries are appended in strictly increasing line order, so a line at or
+       * below endLine has already been emitted; only the last one can be it.
+       * The scan this replaces existed solely to skip replayed beforeBuffer
+       * entries, and those always carry match: false, so no flag is lost.
+       *
+       * Skipped entirely under onlyMatching, where one line legitimately yields
+       * several entries and merging them would collapse repeated matches
+       * into one.
+       */
+      if (!options.onlyMatching && entry.line <= currentGroup.endLine) {
+        const last = currentGroup.lines[currentGroup.lines.length - 1];
+        if (entry.match && last?.line === entry.line) {
+          last.match = true;
         }
 
         return true;

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -189,6 +189,13 @@ export type GrepOptions = Omit<FileGrepTaskInput, "url" | "pattern">;
  */
 export interface GrepLineMatcher {
   readonly matchBatch: (texts: readonly string[]) => boolean[];
+  /**
+   * Slices matched substrings out of each line, positionally aligned with
+   * `texts`. The server matcher bounds this under the same interruptible
+   * budget as {@link matchBatch}; without it, `onlyMatching` falls back to an
+   * unbounded `exec` on the calling thread.
+   */
+  readonly extractBatch?: (texts: readonly string[]) => string[][];
 }
 
 interface BufferedLine {
@@ -294,8 +301,9 @@ export async function grepLines(
   const afterContext = options.onlyMatching ? 0 : (options.context ?? options.afterContext ?? 0);
 
   const lineMatcher = matcher ?? createMatcher(pattern, options);
+  const wantExtract = Boolean(options.onlyMatching && !options.existsOnly && !options.countOnly);
   const extract =
-    options.onlyMatching && !options.existsOnly && !options.countOnly
+    wantExtract && lineMatcher.extractBatch === undefined
       ? createExtractor(pattern, options)
       : undefined;
 
@@ -419,6 +427,10 @@ export async function grepLines(
       }
 
       const flags = lineMatcher.matchBatch(batch);
+      const extracted =
+        wantExtract && lineMatcher.extractBatch !== undefined
+          ? lineMatcher.extractBatch(batch)
+          : undefined;
 
       for (let i = 0; i < batch.length; i++) {
         const text = batch[i]!;
@@ -442,11 +454,12 @@ export async function grepLines(
             break outer;
           }
 
-          if (extract) {
+          if (wantExtract) {
             // An inverted selection reaches here on a line the pattern did NOT
             // match, so the extractor finds nothing and emits nothing — which is
             // exactly what `grep -v -o` prints.
-            for (const match of extract(text)) {
+            const matches = extracted !== undefined ? (extracted[i] ?? []) : extract!(text);
+            for (const match of matches) {
               if (!emitLine({ line: lineNumber, text: match, match: true })) {
                 return {
                   groups,

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -13,7 +13,7 @@ import {
   Workflow,
 } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-import { assertSafeRegexPattern, escapeRegExp } from "../util/regexSafety";
+import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
 import { FetchUrlTask } from "./FetchUrlTask";
 
@@ -212,14 +212,8 @@ function createMatcher(pattern: string, options: GrepOptions): (text: string) =>
     return (text) => text.includes(pattern);
   }
 
-  assertSafeRegexPattern(pattern);
-
-  try {
-    const regex = new RegExp(pattern, options.ignoreCase ? "i" : "");
-    return (text) => regex.test(text);
-  } catch {
-    throw new TaskInvalidInputError(`Invalid regular expression: ${pattern}`);
-  }
+  const regex = compileSafeRegex(pattern, options.ignoreCase ? "i" : "");
+  return (text) => regex.test(text);
 }
 
 /**

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -91,13 +91,15 @@ const inputSchema = {
     maxOutputLines: {
       type: "integer",
       title: "Max Output Lines",
-      description: "Maximum number of output lines, including context",
+      description:
+        "Maximum number of output lines, including context. Defaults to 10000; set this to override.",
       minimum: 0,
     },
     maxOutputChars: {
       type: "integer",
       title: "Max Output Characters",
-      description: "Maximum number of output characters, including newlines",
+      description:
+        "Maximum number of output characters, including newlines. Defaults to 1000000; set this to override.",
       minimum: 0,
     },
   },
@@ -144,7 +146,8 @@ const outputSchema = {
     matchCount: {
       type: "integer",
       title: "Match Count",
-      description: "Number of matching lines",
+      description:
+        "Number of matching lines. With `existsOnly` the scan stops at the first match, so this is 1 rather than a full count.",
     },
     exists: {
       type: "boolean",
@@ -303,7 +306,6 @@ export async function grepLines(
   let lineNumber = 0;
   let matchCount = 0;
   let exists = false;
-  let truncated = false;
 
   let afterRemaining = 0;
   let maxMatchesReached = false;
@@ -311,14 +313,17 @@ export async function grepLines(
   let outputLines = 0;
   let outputChars = 0;
 
+  // Caps apply whether or not the caller stated them: an unbounded default sent
+  // the whole document back to whoever asked for one line.
+  const maxOutputLines = options.maxOutputLines ?? DEFAULT_LIMITS.grepMaxOutputLines;
+  const maxOutputChars = options.maxOutputChars ?? DEFAULT_LIMITS.grepMaxOutputChars;
+
   function canEmit(text: string): boolean {
-    if (options.maxOutputLines !== undefined && outputLines >= options.maxOutputLines) {
+    if (outputLines >= maxOutputLines) {
       return false;
     }
 
-    const chars = text.length + 1;
-
-    if (options.maxOutputChars !== undefined && outputChars + chars > options.maxOutputChars) {
+    if (outputChars + text.length + 1 > maxOutputChars) {
       return false;
     }
 
@@ -327,7 +332,6 @@ export async function grepLines(
 
   function emitLine(entry: GrepLine): boolean {
     if (!canEmit(entry.text)) {
-      truncated = true;
       return false;
     }
 
@@ -375,6 +379,14 @@ export async function grepLines(
   const batch: string[] = [];
   let exhausted = false;
 
+  // `stopped` says the scan ended early; whether that MEANS truncation depends
+  // on whether anything was left, which is settled once, below.
+  let stopped = false;
+  let stopIndex = -1;
+  let existsOnlyHit = false;
+  let lineCapped = false;
+  let sawMoreInput = false;
+
   try {
     outer: while (!exhausted) {
       batch.length = 0;
@@ -388,7 +400,7 @@ export async function grepLines(
         // server's line splitter signal truncation without a side channel.
         const text = next.value;
         if (text.length >= maxLineChars) {
-          truncated = true;
+          lineCapped = true;
           batch.push(text.slice(0, maxLineChars));
         } else {
           batch.push(text);
@@ -401,7 +413,7 @@ export async function grepLines(
         throw new TaskAbortedError("Task aborted");
       }
       if (Date.now() > deadline) {
-        truncated = true;
+        stopped = true;
         break;
       }
 
@@ -423,12 +435,10 @@ export async function grepLines(
           exists = true;
 
           if (options.existsOnly) {
-            return {
-              groups: [],
-              matchCount: 1,
-              exists: true,
-              truncated: false,
-            };
+            existsOnlyHit = true;
+            stopped = true;
+            stopIndex = i;
+            break outer;
           }
 
           if (extract) {
@@ -454,12 +464,9 @@ export async function grepLines(
                   match: false,
                 })
               ) {
-                return {
-                  groups,
-                  matchCount,
-                  exists,
-                  truncated: true,
-                };
+                stopped = true;
+                stopIndex = i - 1;
+                break outer;
               }
             }
 
@@ -470,12 +477,9 @@ export async function grepLines(
                 match: true,
               })
             ) {
-              return {
-                groups,
-                matchCount,
-                exists,
-                truncated: true,
-              };
+              stopped = true;
+              stopIndex = i - 1;
+              break outer;
             }
           }
 
@@ -485,7 +489,8 @@ export async function grepLines(
             maxMatchesReached = true;
 
             if (afterContext === 0) {
-              truncated = true;
+              stopped = true;
+              stopIndex = i;
               break outer;
             }
           }
@@ -494,15 +499,14 @@ export async function grepLines(
             !emitLine({
               line: lineNumber,
               text,
-              match: false,
+              // `maxMatchesReached` governs whether a match COUNTS toward the
+              // budget, not whether the line IS a match.
+              match: matched,
             })
           ) {
-            return {
-              groups,
-              matchCount,
-              exists,
-              truncated: true,
-            };
+            stopped = true;
+            stopIndex = i - 1;
+            break outer;
           }
 
           afterRemaining--;
@@ -519,7 +523,8 @@ export async function grepLines(
 
         if (maxMatchesReached) {
           if (afterRemaining === 0) {
-            truncated = true;
+            stopped = true;
+            stopIndex = i;
             break outer;
           }
 
@@ -535,8 +540,29 @@ export async function grepLines(
         }
       }
     }
+
+    /*
+     * Truncation is exact because the loop drives the iterator itself: it is
+     * only truncation if something was actually left, either in the current
+     * batch or in the source. That costs one extra element from the source on
+     * an early stop.
+     *
+     * `stopIndex` is the last line fully accounted for. An output cap rejects
+     * the line it stopped on, so those sites record `i - 1` and that line
+     * counts as remaining; a match budget consumed its line, so those record
+     * `i`.
+     */
+    if (stopped) {
+      sawMoreInput = stopIndex + 1 < batch.length ? true : (await iterator.next()).done !== true;
+    }
   } finally {
     await iterator.return?.();
+  }
+
+  const truncated = lineCapped || (stopped && sawMoreInput);
+
+  if (existsOnlyHit) {
+    return { groups: [], matchCount: 1, exists: true, truncated };
   }
 
   return {

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -26,7 +26,8 @@ const inputSchema = {
     url: {
       type: "string",
       title: "URL",
-      description: "URL to search (http://, https://)",
+      description:
+        "URL to search (http://, https://). The Node/Electron build additionally accepts a `file://` URL or an absolute filesystem path, subject to the `filesystem:read` entitlement and any configured `roots`.",
       format: "uri",
     },
     pattern: {
@@ -574,9 +575,13 @@ export async function grepLines(
 }
 
 /**
- * Task for grepping documents from URLs (including file:// URLs).
- * Works in all environments (browser, Node.js, Bun) by using fetch API.
- * For server-only filesystem path access, see FileGrepTask.server.
+ * Task for grepping documents fetched over http(s).
+ *
+ * This build handles http and https only: the fetch routes through
+ * `FetchUrlTask` -> `safeFetch` -> `classifyUrl`, which rejects every other
+ * scheme. `file://` URLs and bare filesystem paths are handled only by the
+ * server build (`FileGrepTask.server`), which requires the `filesystem:read`
+ * entitlement.
  */
 export class FileGrepTask<Config extends TaskConfig = TaskConfig> extends Task<
   FileGrepTaskInput,

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -12,6 +12,7 @@ import {
   TaskInvalidInputError,
   Workflow,
 } from "@workglow/task-graph";
+import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
@@ -175,7 +176,16 @@ interface GrepGroup {
   lines: GrepLine[];
 }
 
-type GrepOptions = Omit<FileGrepTaskInput, "url" | "pattern">;
+export type GrepOptions = Omit<FileGrepTaskInput, "url" | "pattern">;
+
+/**
+ * Matches a batch of lines at once. Batching is what makes an interruptible
+ * matcher affordable — see `createBoundedRegexMatcher` on the server build,
+ * whose per-call cost only amortizes over a batch.
+ */
+export interface GrepLineMatcher {
+  readonly matchBatch: (texts: readonly string[]) => boolean[];
+}
 
 interface BufferedLine {
   readonly line: number;
@@ -203,17 +213,17 @@ function validateOptions(options: GrepOptions): void {
   }
 }
 
-function createMatcher(pattern: string, options: GrepOptions): (text: string) => boolean {
+export function createMatcher(pattern: string, options: GrepOptions): GrepLineMatcher {
   if (options.fixedString) {
     if (options.ignoreCase) {
       const needle = pattern.toLowerCase();
-      return (text) => text.toLowerCase().includes(needle);
+      return { matchBatch: (texts) => texts.map((t) => t.toLowerCase().includes(needle)) };
     }
-    return (text) => text.includes(pattern);
+    return { matchBatch: (texts) => texts.map((t) => t.includes(pattern)) };
   }
 
   const regex = compileSafeRegex(pattern, options.ignoreCase ? "i" : "");
-  return (text) => regex.test(text);
+  return { matchBatch: (texts) => texts.map((t) => regex.test(t)) };
 }
 
 /**
@@ -256,11 +266,20 @@ function createExtractor(pattern: string, options: GrepOptions): (text: string) 
   };
 }
 
+/**
+ * Scans `lines`, matching in batches of {@link SECURITY_LIMITS.regexMatchBatchLines}.
+ *
+ * Abort and the overall search deadline are checked once per BATCH, not per
+ * line: a single `regex.test` is uninterruptible, so per-line checks bought
+ * nothing a hostile pattern could not ignore. The granularity that matters is
+ * therefore the batch, and the matcher itself bounds how long one batch may run.
+ */
 export async function grepLines(
   lines: AsyncIterable<string>,
   pattern: string,
   options: GrepOptions = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  matcher?: GrepLineMatcher | undefined
 ): Promise<FileGrepTaskOutput> {
   validateOptions(options);
 
@@ -270,7 +289,7 @@ export async function grepLines(
   const beforeContext = options.onlyMatching ? 0 : (options.context ?? options.beforeContext ?? 0);
   const afterContext = options.onlyMatching ? 0 : (options.context ?? options.afterContext ?? 0);
 
-  const matcher = createMatcher(pattern, options);
+  const lineMatcher = matcher ?? createMatcher(pattern, options);
   const extract =
     options.onlyMatching && !options.existsOnly && !options.countOnly
       ? createExtractor(pattern, options)
@@ -346,52 +365,122 @@ export async function grepLines(
     return true;
   }
 
-  for await (const text of lines) {
-    if (signal?.aborted) {
-      throw new TaskAbortedError("Task aborted");
-    }
+  const iterator = lines[Symbol.asyncIterator]();
+  const deadline = Date.now() + DEFAULT_LIMITS.grepMaxSearchMs;
+  const batch: string[] = [];
+  let exhausted = false;
 
-    lineNumber++;
-
-    let matched = matcher(text);
-
-    if (options.invertMatch) {
-      matched = !matched;
-    }
-
-    if (matched && !maxMatchesReached) {
-      matchCount++;
-      exists = true;
-
-      if (options.existsOnly) {
-        return {
-          groups: [],
-          matchCount: 1,
-          exists: true,
-          truncated: false,
-        };
+  try {
+    outer: while (!exhausted) {
+      batch.length = 0;
+      while (batch.length < SECURITY_LIMITS.regexMatchBatchLines) {
+        const next = await iterator.next();
+        if (next.done === true) {
+          exhausted = true;
+          break;
+        }
+        batch.push(next.value);
       }
 
-      if (extract) {
-        // An inverted selection reaches here on a line the pattern did NOT
-        // match, so the extractor finds nothing and emits nothing — which is
-        // exactly what `grep -v -o` prints.
-        for (const match of extract(text)) {
-          if (!emitLine({ line: lineNumber, text: match, match: true })) {
+      if (batch.length === 0) break;
+
+      if (signal?.aborted) {
+        throw new TaskAbortedError("Task aborted");
+      }
+      if (Date.now() > deadline) {
+        truncated = true;
+        break;
+      }
+
+      const flags = lineMatcher.matchBatch(batch);
+
+      for (let i = 0; i < batch.length; i++) {
+        const text = batch[i]!;
+
+        lineNumber++;
+
+        let matched = flags[i]!;
+
+        if (options.invertMatch) {
+          matched = !matched;
+        }
+
+        if (matched && !maxMatchesReached) {
+          matchCount++;
+          exists = true;
+
+          if (options.existsOnly) {
             return {
-              groups,
-              matchCount,
-              exists,
-              truncated: true,
+              groups: [],
+              matchCount: 1,
+              exists: true,
+              truncated: false,
             };
           }
-        }
-      } else if (!options.countOnly) {
-        for (const previous of beforeBuffer) {
+
+          if (extract) {
+            // An inverted selection reaches here on a line the pattern did NOT
+            // match, so the extractor finds nothing and emits nothing — which is
+            // exactly what `grep -v -o` prints.
+            for (const match of extract(text)) {
+              if (!emitLine({ line: lineNumber, text: match, match: true })) {
+                return {
+                  groups,
+                  matchCount,
+                  exists,
+                  truncated: true,
+                };
+              }
+            }
+          } else if (!options.countOnly) {
+            for (const previous of beforeBuffer) {
+              if (
+                !emitLine({
+                  line: previous.line,
+                  text: previous.text,
+                  match: false,
+                })
+              ) {
+                return {
+                  groups,
+                  matchCount,
+                  exists,
+                  truncated: true,
+                };
+              }
+            }
+
+            if (
+              !emitLine({
+                line: lineNumber,
+                text,
+                match: true,
+              })
+            ) {
+              return {
+                groups,
+                matchCount,
+                exists,
+                truncated: true,
+              };
+            }
+          }
+
+          afterRemaining = afterContext;
+
+          if (options.maxMatches !== undefined && matchCount >= options.maxMatches) {
+            maxMatchesReached = true;
+
+            if (afterContext === 0) {
+              truncated = true;
+              break outer;
+            }
+          }
+        } else if (!options.countOnly && afterRemaining > 0) {
           if (
             !emitLine({
-              line: previous.line,
-              text: previous.text,
+              line: lineNumber,
+              text,
               match: false,
             })
           ) {
@@ -402,78 +491,39 @@ export async function grepLines(
               truncated: true,
             };
           }
+
+          afterRemaining--;
         }
 
-        if (
-          !emitLine({
-            line: lineNumber,
-            text,
-            match: true,
-          })
-        ) {
-          return {
-            groups,
-            matchCount,
-            exists,
-            truncated: true,
-          };
-        }
-      }
-
-      afterRemaining = afterContext;
-
-      if (options.maxMatches !== undefined && matchCount >= options.maxMatches) {
-        maxMatchesReached = true;
-
-        if (afterContext === 0) {
-          truncated = true;
-          break;
-        }
-      }
-    } else if (!options.countOnly && afterRemaining > 0) {
-      if (
-        !emitLine({
+        beforeBuffer.push({
           line: lineNumber,
           text,
-          match: false,
-        })
-      ) {
-        return {
-          groups,
-          matchCount,
-          exists,
-          truncated: true,
-        };
+        });
+
+        if (beforeBuffer.length > beforeContext) {
+          beforeBuffer.shift();
+        }
+
+        if (maxMatchesReached) {
+          if (afterRemaining === 0) {
+            truncated = true;
+            break outer;
+          }
+
+          continue;
+        }
+
+        /*
+         * A non-matching line outside trailing context means any future
+         * match is separated from the current group.
+         */
+        if (!matched && afterRemaining === 0) {
+          currentGroup = undefined;
+        }
       }
-
-      afterRemaining--;
     }
-
-    beforeBuffer.push({
-      line: lineNumber,
-      text,
-    });
-
-    if (beforeBuffer.length > beforeContext) {
-      beforeBuffer.shift();
-    }
-
-    if (maxMatchesReached) {
-      if (afterRemaining === 0) {
-        truncated = true;
-        break;
-      }
-
-      continue;
-    }
-
-    /*
-     * A non-matching line outside trailing context means any future
-     * match is separated from the current group.
-     */
-    if (!matched && afterRemaining === 0) {
-      currentGroup = undefined;
-    }
+  } finally {
+    await iterator.return?.();
   }
 
   return {
@@ -504,6 +554,16 @@ export class FileGrepTask extends Task<FileGrepTaskInput, FileGrepTaskOutput, Ta
     return outputSchema as DataPortSchema;
   }
 
+  /**
+   * Seam for the matcher the scan runs. The server build overrides it to bound
+   * regex matching with an interruptible time budget; there is no `vm` in a
+   * browser, so a hostile pattern there still blocks that tab (a tab — not the
+   * process hosting a local API).
+   */
+  protected createLineMatcher(pattern: string, options: GrepOptions): GrepLineMatcher {
+    return createMatcher(pattern, options);
+  }
+
   override async execute(
     input: FileGrepTaskInput,
     context: IExecuteContext
@@ -513,6 +573,10 @@ export class FileGrepTask extends Task<FileGrepTaskInput, FileGrepTaskOutput, Ta
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
     }
+
+    // Compiled before the fetch so a rejected pattern costs no network call.
+    const matcher = this.createLineMatcher(pattern, options);
+
     await context.updateProgress(0, "Fetching file");
 
     const fetchTask = context.own(new FetchUrlTask({ queue: false }));
@@ -530,7 +594,8 @@ export class FileGrepTask extends Task<FileGrepTaskInput, FileGrepTaskOutput, Ta
       linesFromText(response.text ?? ""),
       pattern,
       options,
-      context.signal
+      context.signal,
+      matcher
     );
 
     if (context.signal.aborted) {

--- a/packages/tasks/src/task/FileSedTask.server.ts
+++ b/packages/tasks/src/task/FileSedTask.server.ts
@@ -4,14 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph";
+import type { IExecuteContext, TaskEntitlements } from "@workglow/task-graph";
+import {
+  CreateWorkflow,
+  Entitlements,
+  mergeEntitlements,
+  TaskAbortedError,
+  TaskConfigSchema,
+  Workflow,
+} from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 
 import { SECURITY_LIMITS } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexReplacer } from "../util/BoundedRegex.server";
+import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
 import type {
+  FileSedTaskConfig,
   FileSedTaskInput,
   FileSedTaskOutput,
   SedLineSubstituter,
@@ -24,18 +34,53 @@ import {
   sedLines,
 } from "./FileSedTask";
 
-export type { FileSedTaskInput, FileSedTaskOutput };
+export type { FileSedTaskConfig, FileSedTaskInput, FileSedTaskOutput };
+
+const fileSedTaskConfigSchema = {
+  type: "object",
+  properties: {
+    ...TaskConfigSchema["properties"],
+    roots: {
+      type: "array",
+      items: { type: "string" },
+      title: "Roots",
+      description: "Directories a local path must resolve inside (after symlink resolution)",
+      "x-ui-hidden": true,
+    },
+  },
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
 
 /**
- * Server-only task for substituting text in files on the filesystem.
- * Streams the file line-by-line rather than loading it into memory.
- * Only available in Node.js and Bun environments.
+ * Server-only task for substituting text in files on the filesystem, on top of
+ * the base task's http(s) handling.
  *
- * The file on disk is never modified — there is no in-place (`sed -i`) mode.
+ * The file is streamed line-by-line rather than loaded into memory, and the
+ * file on disk is never modified — there is no in-place (`sed -i`) mode.
  *
- * For cross-platform substitution (including browser), use FileSedTask with URLs.
+ * A local path is resolved and realpath'd before it is opened, and constrained
+ * to `config.roots` when the embedder sets them. Reading requires the
+ * `filesystem:read` entitlement.
+ *
+ * Only available in Node.js and Bun environments. For cross-platform
+ * substitution (including browser), use FileSedTask with an http(s) URL.
  */
-export class FileSedTask extends BaseFileSedTask {
+export class FileSedTask extends BaseFileSedTask<FileSedTaskConfig> {
+  public static override configSchema(): DataPortSchema {
+    return fileSedTaskConfigSchema as DataPortSchema;
+  }
+
+  public static override entitlements(): TaskEntitlements {
+    return mergeEntitlements(super.entitlements(), {
+      entitlements: [
+        {
+          id: Entitlements.FILESYSTEM_READ,
+          reason: "Reads a local file or file:// URL from disk",
+        },
+      ],
+    });
+  }
+
   /**
    * Runs the substitution inside a `vm` context under a wall-clock budget, so
    * a catastrophically backtracking pattern fails instead of wedging the event
@@ -67,9 +112,9 @@ export class FileSedTask extends BaseFileSedTask {
     input: FileSedTaskInput,
     context: IExecuteContext
   ): Promise<FileSedTaskOutput> {
-    let { url, pattern, replacement, ...options } = input;
+    const { url, pattern, replacement, ...options } = input;
 
-    if (url.startsWith("http://") || url.startsWith("https://")) {
+    if (isHttpUrl(url)) {
       return super.execute(input, context);
     }
 
@@ -78,9 +123,7 @@ export class FileSedTask extends BaseFileSedTask {
     }
     await context.updateProgress(0, "Opening file");
 
-    if (url.startsWith("file://")) {
-      url = url.slice(7);
-    }
+    const file = resolveLocalFilePath(url, { roots: this.config.roots });
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
@@ -88,7 +131,7 @@ export class FileSedTask extends BaseFileSedTask {
     await context.updateProgress(10, "Substituting text");
 
     const result = await sedFile(
-      url,
+      file,
       pattern,
       replacement,
       options,
@@ -132,13 +175,13 @@ async function sedFile(
   }
 }
 
-export const fileSed = (input: FileSedTaskInput, config?: TaskConfig) => {
+export const fileSed = (input: FileSedTaskInput, config?: FileSedTaskConfig) => {
   return new FileSedTask(config).run(input);
 };
 
 declare module "@workglow/task-graph" {
   interface Workflow {
-    fileSed: CreateWorkflow<FileSedTaskInput, FileSedTaskOutput, TaskConfig>;
+    fileSed: CreateWorkflow<FileSedTaskInput, FileSedTaskOutput, FileSedTaskConfig>;
   }
 }
 

--- a/packages/tasks/src/task/FileSedTask.server.ts
+++ b/packages/tasks/src/task/FileSedTask.server.ts
@@ -11,6 +11,7 @@ import {
   mergeEntitlements,
   TaskAbortedError,
   TaskConfigSchema,
+  TaskEntitlementError,
   Workflow,
 } from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
@@ -82,6 +83,66 @@ export class FileSedTask extends BaseFileSedTask<FileSedTaskConfig> {
   }
 
   /**
+   * Declares whichever half of the surface this url actually uses: the fetch
+   * entitlements for http(s), otherwise `filesystem:read` scoped to the
+   * resolved real path. An unknown url fails closed to both, unscoped.
+   *
+   * Never throws — entitlement evaluation runs before `execute()` and must
+   * produce a declaration for any input, so an unresolvable path degrades to
+   * the unscoped declaration and is refused later, at open time.
+   */
+  public override entitlements(): TaskEntitlements {
+    const url = this.runInputData?.url;
+    const unscopedRead: TaskEntitlements = {
+      entitlements: [{ id: Entitlements.FILESYSTEM_READ, reason: "Reads a local file from disk" }],
+    };
+
+    if (typeof url !== "string" || url.length === 0) {
+      return mergeEntitlements(super.entitlements(), unscopedRead);
+    }
+
+    if (isHttpUrl(url)) {
+      return super.entitlements();
+    }
+
+    try {
+      return {
+        entitlements: [
+          {
+            id: Entitlements.FILESYSTEM_READ,
+            reason: "Reads a local file from disk",
+            resources: [resolveLocalFilePath(url, { roots: this.config.roots })],
+          },
+        ],
+      };
+    } catch {
+      return unscopedRead;
+    }
+  }
+
+  /**
+   * Refuses a path the instance did not declare. Entitlements are evaluated
+   * on the unresolved input, so without this a declare-then-swap would let the
+   * open authorize itself — and a standalone `fileSed(...)` with no graph and
+   * no enforcer would honour no `roots` at all.
+   */
+  private assertResolvedPathDeclared(file: string): void {
+    const declared = this.entitlements().entitlements.find(
+      (entitlement) => entitlement.id === Entitlements.FILESYSTEM_READ
+    );
+    if (declared?.resources === undefined) {
+      throw new TaskEntitlementError(
+        `Refusing to read ${file}: the path could not be resolved when entitlements were declared`
+      );
+    }
+    if (!declared.resources.includes(file)) {
+      throw new TaskEntitlementError(
+        `Refusing to read ${file}: it differs from the declared path ${declared.resources.join(", ")}`
+      );
+    }
+  }
+
+  /**
    * Runs the substitution inside a `vm` context under a wall-clock budget, so
    * a catastrophically backtracking pattern fails instead of wedging the event
    * loop. Overriding here covers both branches: the http branch reaches
@@ -124,6 +185,7 @@ export class FileSedTask extends BaseFileSedTask<FileSedTaskConfig> {
     await context.updateProgress(0, "Opening file");
 
     const file = resolveLocalFilePath(url, { roots: this.config.roots });
+    this.assertResolvedPathDeclared(file);
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");

--- a/packages/tasks/src/task/FileSedTask.server.ts
+++ b/packages/tasks/src/task/FileSedTask.server.ts
@@ -9,8 +9,20 @@ import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 
-import type { FileSedTaskInput, FileSedTaskOutput } from "./FileSedTask";
-import { FileSedTask as BaseFileSedTask, sedLines } from "./FileSedTask";
+import { SECURITY_LIMITS } from "@workglow/util";
+import { createBoundedRegexReplacer } from "../util/BoundedRegex.server";
+import type {
+  FileSedTaskInput,
+  FileSedTaskOutput,
+  SedLineSubstituter,
+  SedOptions,
+} from "./FileSedTask";
+import {
+  FileSedTask as BaseFileSedTask,
+  createSedExpander,
+  createSedRegex,
+  sedLines,
+} from "./FileSedTask";
 
 export type { FileSedTaskInput, FileSedTaskOutput };
 
@@ -24,6 +36,33 @@ export type { FileSedTaskInput, FileSedTaskOutput };
  * For cross-platform substitution (including browser), use FileSedTask with URLs.
  */
 export class FileSedTask extends BaseFileSedTask {
+  /**
+   * Runs the substitution inside a `vm` context under a wall-clock budget, so
+   * a catastrophically backtracking pattern fails instead of wedging the event
+   * loop. Overriding here covers both branches: the http branch reaches
+   * `super.execute`, which uses the substituter this returns.
+   *
+   * `fixedString` never enters `vm` — an escaped literal cannot backtrack, and
+   * the `vm` hop would cost ~4x for nothing.
+   */
+  protected override createSubstituter(
+    pattern: string,
+    replacement: string,
+    options: SedOptions
+  ): SedLineSubstituter {
+    if (options.fixedString) {
+      return super.createSubstituter(pattern, replacement, options);
+    }
+
+    const regex = createSedRegex(pattern, options);
+    const substituteBatch = createBoundedRegexReplacer(
+      regex,
+      createSedExpander(replacement, options),
+      SECURITY_LIMITS.regexMatchBatchTimeoutMs
+    );
+    return { substituteBatch };
+  }
+
   override async execute(
     input: FileSedTaskInput,
     context: IExecuteContext
@@ -48,7 +87,14 @@ export class FileSedTask extends BaseFileSedTask {
     }
     await context.updateProgress(10, "Substituting text");
 
-    const result = await sedFile(url, pattern, replacement, options, context.signal);
+    const result = await sedFile(
+      url,
+      pattern,
+      replacement,
+      options,
+      context.signal,
+      this.createSubstituter(pattern, replacement, options)
+    );
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
@@ -63,8 +109,9 @@ async function sedFile(
   file: string,
   pattern: string,
   replacement: string,
-  options: Omit<FileSedTaskInput, "url" | "pattern" | "replacement">,
-  signal: AbortSignal
+  options: SedOptions,
+  signal: AbortSignal,
+  substituter: SedLineSubstituter
 ): Promise<FileSedTaskOutput> {
   const input = createReadStream(file, { signal });
   const rl = createInterface({
@@ -73,7 +120,7 @@ async function sedFile(
   });
 
   try {
-    return await sedLines(rl, pattern, replacement, options, signal);
+    return await sedLines(rl, pattern, replacement, options, signal, substituter);
   } catch (err) {
     if (signal.aborted) {
       throw new TaskAbortedError("Task aborted");

--- a/packages/tasks/src/task/FileSedTask.server.ts
+++ b/packages/tasks/src/task/FileSedTask.server.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
+import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph";
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+
+import type { FileSedTaskInput, FileSedTaskOutput } from "./FileSedTask";
+import { FileSedTask as BaseFileSedTask, sedLines } from "./FileSedTask";
+
+export type { FileSedTaskInput, FileSedTaskOutput };
+
+/**
+ * Server-only task for substituting text in files on the filesystem.
+ * Streams the file line-by-line rather than loading it into memory.
+ * Only available in Node.js and Bun environments.
+ *
+ * The file on disk is never modified — there is no in-place (`sed -i`) mode.
+ *
+ * For cross-platform substitution (including browser), use FileSedTask with URLs.
+ */
+export class FileSedTask extends BaseFileSedTask {
+  override async execute(
+    input: FileSedTaskInput,
+    context: IExecuteContext
+  ): Promise<FileSedTaskOutput> {
+    let { url, pattern, replacement, ...options } = input;
+
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      return super.execute(input, context);
+    }
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(0, "Opening file");
+
+    if (url.startsWith("file://")) {
+      url = url.slice(7);
+    }
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(10, "Substituting text");
+
+    const result = await sedFile(url, pattern, replacement, options, context.signal);
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(100, "Substitution complete");
+
+    return result;
+  }
+}
+
+async function sedFile(
+  file: string,
+  pattern: string,
+  replacement: string,
+  options: Omit<FileSedTaskInput, "url" | "pattern" | "replacement">,
+  signal: AbortSignal
+): Promise<FileSedTaskOutput> {
+  const input = createReadStream(file, { signal });
+  const rl = createInterface({
+    input,
+    crlfDelay: Infinity,
+  });
+
+  try {
+    return await sedLines(rl, pattern, replacement, options, signal);
+  } catch (err) {
+    if (signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    throw err;
+  } finally {
+    rl.close();
+    input.destroy();
+  }
+}
+
+export const fileSed = (input: FileSedTaskInput, config?: TaskConfig) => {
+  return new FileSedTask(config).run(input);
+};
+
+declare module "@workglow/task-graph" {
+  interface Workflow {
+    fileSed: CreateWorkflow<FileSedTaskInput, FileSedTaskOutput, TaskConfig>;
+  }
+}
+
+Workflow.prototype.fileSed = CreateWorkflow(FileSedTask);

--- a/packages/tasks/src/task/FileSedTask.server.ts
+++ b/packages/tasks/src/task/FileSedTask.server.ts
@@ -15,12 +15,12 @@ import {
   Workflow,
 } from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
-import { createInterface } from "node:readline";
 
-import { SECURITY_LIMITS } from "@workglow/util";
+import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexReplacer } from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
+import { linesFromStream } from "../util/StreamLines.server";
 import type {
   FileSedTaskConfig,
   FileSedTaskInput,
@@ -56,8 +56,11 @@ const fileSedTaskConfigSchema = {
  * Server-only task for substituting text in files on the filesystem, on top of
  * the base task's http(s) handling.
  *
- * The file is streamed line-by-line rather than loaded into memory, and the
- * file on disk is never modified — there is no in-place (`sed -i`) mode.
+ * The file is streamed line-by-line rather than loaded into memory, and split
+ * into lines with a hard per-line cap ({@link DEFAULT_LIMITS.grepMaxLineChars})
+ * — a longer physical line is truncated to that length and the remainder
+ * discarded, so a file with no line terminator cannot exhaust memory. The file
+ * on disk is never modified — there is no in-place (`sed -i`) mode.
  *
  * A local path is resolved and realpath'd before it is opened, and constrained
  * to `config.roots` when the embedder sets them. Reading requires the
@@ -219,20 +222,22 @@ async function sedFile(
   substituter: SedLineSubstituter
 ): Promise<FileSedTaskOutput> {
   const input = createReadStream(file, { signal });
-  const rl = createInterface({
-    input,
-    crlfDelay: Infinity,
-  });
 
   try {
-    return await sedLines(rl, pattern, replacement, options, signal, substituter);
+    return await sedLines(
+      linesFromStream(input, DEFAULT_LIMITS.grepMaxLineChars),
+      pattern,
+      replacement,
+      options,
+      signal,
+      substituter
+    );
   } catch (err) {
     if (signal.aborted) {
       throw new TaskAbortedError("Task aborted");
     }
     throw err;
   } finally {
-    rl.close();
     input.destroy();
   }
 }

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -104,7 +104,8 @@ const outputSchema = {
     truncated: {
       type: "boolean",
       title: "Truncated",
-      description: "Output stopped before EOF because of an output limit",
+      description:
+        "Output stopped before EOF because an output cap was reached or an input line was capped",
     },
   },
   required: ["text", "replacementCount", "linesChanged", "truncated"],
@@ -431,9 +432,10 @@ export async function sedLines(
 }
 
 /**
- * Task for substituting text in documents from URLs (including file:// URLs).
+ * Task for substituting text in documents fetched from URLs.
  * Works in all environments (browser, Node.js, Bun) by using fetch API.
- * For server-only filesystem path access, see FileSedTask.server.
+ * `file://` filesystem access is implemented in the server build only; see
+ * FileSedTask.server.
  *
  * The source is never modified: the transformed document is returned as output.
  */

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -12,7 +12,7 @@ import {
   TaskInvalidInputError,
   Workflow,
 } from "@workglow/task-graph";
-import { SECURITY_LIMITS } from "@workglow/util";
+import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
@@ -341,8 +341,10 @@ export async function sedLines(
   let outputChars = 0;
 
   const iterator = lines[Symbol.asyncIterator]();
+  const maxLineChars = DEFAULT_LIMITS.grepMaxLineChars;
   const batch: string[] = [];
   let exhausted = false;
+  let lineCapped = false;
 
   try {
     outer: while (!exhausted) {
@@ -353,7 +355,15 @@ export async function sedLines(
           exhausted = true;
           break;
         }
-        batch.push(next.value);
+        // `>=` rather than `>`: conservative by one character, and it lets the
+        // server's line splitter signal truncation without a side channel.
+        const text = next.value;
+        if (text.length >= maxLineChars) {
+          lineCapped = true;
+          batch.push(text.slice(0, maxLineChars));
+        } else {
+          batch.push(text);
+        }
       }
 
       if (batch.length === 0) break;
@@ -407,7 +417,10 @@ export async function sedLines(
     text: out.length === 0 ? "" : `${out.join("\n")}\n`,
     replacementCount,
     linesChanged,
-    truncated,
+    // A capped line means the emitted document is missing part of the source,
+    // which is what `truncated` is for — an output cap is not the only way to
+    // stop short of the whole document.
+    truncated: truncated || lineCapped,
   };
 }
 

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
+import type { IExecuteContext, TaskConfig, TaskEntitlements } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   Task,
@@ -16,7 +16,7 @@ import { SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
-import { FetchUrlTask } from "./FetchUrlTask";
+import { fetchUrlEntitlementsFor, FetchUrlTask } from "./FetchUrlTask";
 
 const inputSchema = {
   type: "object",
@@ -428,6 +428,21 @@ export class FileSedTask<Config extends TaskConfig = TaskConfig> extends Task<
   public static override title = "File Sed";
   public static override description = "Substitute matching text in a file (sed)";
   public static override cacheable = true;
+  public static override hasDynamicEntitlements: boolean = true;
+
+  /**
+   * The owned `FetchUrlTask` does the network access, but an owned child is
+   * created inside `execute()` and so is absent from the graph-start snapshot
+   * `computeGraphEntitlements` takes over `graph.getTasks()`. Declaring the
+   * fetch's entitlements here is what puts them in front of the enforcer.
+   */
+  public static override entitlements(): TaskEntitlements {
+    return FetchUrlTask.entitlements();
+  }
+
+  public override entitlements(): TaskEntitlements {
+    return fetchUrlEntitlementsFor(this.runInputData?.url);
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -13,7 +13,7 @@ import {
   Workflow,
 } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-import { assertSafeRegexPattern } from "../util/regexSafety";
+import { assertSafeRegexPattern, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
 import { FetchUrlTask } from "./FetchUrlTask";
 
@@ -134,10 +134,6 @@ function validateOptions(options: SedOptions): void {
   if (options.maxReplacements === 0) {
     throw new TaskInvalidInputError("maxReplacements must be greater than zero when specified");
   }
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -12,8 +12,9 @@ import {
   TaskInvalidInputError,
   Workflow,
 } from "@workglow/task-graph";
+import { SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-import { assertSafeRegexPattern, escapeRegExp } from "../util/regexSafety";
+import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
 import { FetchUrlTask } from "./FetchUrlTask";
 
@@ -111,11 +112,24 @@ const outputSchema = {
 export type FileSedTaskInput = FromSchema<typeof inputSchema>;
 export type FileSedTaskOutput = FromSchema<typeof outputSchema>;
 
-type SedOptions = Omit<FileSedTaskInput, "url" | "pattern" | "replacement">;
+export type SedOptions = Omit<FileSedTaskInput, "url" | "pattern" | "replacement">;
 
-interface LineSubstitution {
-  readonly text: string;
-  readonly replacements: number;
+/** One batch of substituted lines, positionally aligned with the input. */
+export interface SedBatchResult {
+  readonly texts: readonly string[];
+  readonly counts: readonly number[];
+}
+
+/**
+ * Substitutes over a batch of lines at once. Batching is what makes an
+ * interruptible substituter affordable — see `createBoundedRegexReplacer` on
+ * the server build, whose per-call cost only amortizes over a batch.
+ *
+ * `budget` is how many replacements the whole run may still make, so a global
+ * substitution can be cut mid-line and the rest of the document copied verbatim.
+ */
+export interface SedLineSubstituter {
+  readonly substituteBatch: (texts: readonly string[], budget: number) => SedBatchResult;
 }
 
 function validateOptions(options: SedOptions): void {
@@ -136,40 +150,41 @@ function validateOptions(options: SedOptions): void {
   }
 }
 
-/**
- * Builds the per-line substitution. `budget` caps how many replacements the
- * whole run may still make, so a global substitution can be cut mid-line and
- * the rest of the document copied verbatim.
- */
-function createSubstituter(
-  pattern: string,
-  replacement: string,
-  options: SedOptions
-): (text: string, budget: number) => LineSubstitution {
+/** Compiles the substitution pattern, screening it for ReDoS shapes first. */
+export function createSedRegex(pattern: string, options: SedOptions): RegExp {
   const flags = `${options.global ? "g" : ""}${options.ignoreCase ? "i" : ""}`;
-
-  let regex: RegExp;
 
   if (options.fixedString) {
     if (pattern.length === 0) {
       throw new TaskInvalidInputError("pattern must not be empty when fixedString is set");
     }
-    regex = new RegExp(escapeRegExp(pattern), flags);
-  } else {
-    assertSafeRegexPattern(pattern);
-    try {
-      regex = new RegExp(pattern, flags);
-    } catch {
-      throw new TaskInvalidInputError(`Invalid regular expression: ${pattern}`);
-    }
+    return new RegExp(escapeRegExp(pattern), flags);
   }
 
-  // A literal replacement must not be re-read for `$1` / `$&` expansion.
-  const substitute: (args: unknown[]) => string = options.fixedString
-    ? () => replacement
-    : (args) => expandReplacement(replacement, args);
+  return compileSafeRegex(pattern, flags);
+}
 
-  return (text, budget) => {
+/**
+ * The expansion `String.replace` would do itself if it were handed a string.
+ * A literal replacement must not be re-read for `$1` / `$&` expansion.
+ */
+export function createSedExpander(
+  replacement: string,
+  options: SedOptions
+): (args: unknown[]) => string {
+  return options.fixedString ? () => replacement : (args) => expandReplacement(replacement, args);
+}
+
+/** Unbounded substituter; the server build overrides it with a bounded one. */
+export function createSubstituter(
+  pattern: string,
+  replacement: string,
+  options: SedOptions
+): SedLineSubstituter {
+  const regex = createSedRegex(pattern, options);
+  const substitute = createSedExpander(replacement, options);
+
+  const substituteLine = (text: string, budget: number): [string, number] => {
     let replacements = 0;
 
     const result = text.replace(regex, (...args: unknown[]): string => {
@@ -180,7 +195,30 @@ function createSubstituter(
       return substitute(args);
     });
 
-    return { text: result, replacements };
+    return [result, replacements];
+  };
+
+  return {
+    substituteBatch: (lines, budget) => {
+      const texts: string[] = [];
+      const counts: number[] = [];
+
+      let remaining = budget;
+
+      for (const line of lines) {
+        if (remaining <= 0) {
+          texts.push(line);
+          counts.push(0);
+          continue;
+        }
+        const [text, replacements] = substituteLine(line, remaining);
+        texts.push(text);
+        counts.push(replacements);
+        remaining -= replacements;
+      }
+
+      return { texts, counts };
+    },
   };
 }
 
@@ -188,7 +226,7 @@ function createSubstituter(
  * `String.replace` only expands `$n` when handed a string, and a callback is
  * what bounds the substitution count — so the expansion is done here instead.
  */
-function expandReplacement(replacement: string, args: unknown[]): string {
+export function expandReplacement(replacement: string, args: unknown[]): string {
   if (!replacement.includes("$")) {
     return replacement;
   }
@@ -272,16 +310,25 @@ function expandReplacement(replacement: string, args: unknown[]): string {
   return out;
 }
 
+/**
+ * Substitutes over `lines` in batches of {@link SECURITY_LIMITS.regexMatchBatchLines}.
+ *
+ * Abort is checked once per BATCH, not per line: a single `String.replace` is
+ * uninterruptible, so a per-line check bought nothing a hostile pattern could
+ * not ignore. The granularity that matters is therefore the batch, and the
+ * substituter itself bounds how long one batch may run.
+ */
 export async function sedLines(
   lines: AsyncIterable<string>,
   pattern: string,
   replacement: string,
   options: SedOptions = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  substituter?: SedLineSubstituter | undefined
 ): Promise<FileSedTaskOutput> {
   validateOptions(options);
 
-  const substituter = createSubstituter(pattern, replacement, options);
+  const lineSubstituter = substituter ?? createSubstituter(pattern, replacement, options);
 
   const out: string[] = [];
 
@@ -292,43 +339,67 @@ export async function sedLines(
   let outputLines = 0;
   let outputChars = 0;
 
-  for await (const text of lines) {
-    if (signal?.aborted) {
-      throw new TaskAbortedError("Task aborted");
+  const iterator = lines[Symbol.asyncIterator]();
+  const batch: string[] = [];
+  let exhausted = false;
+
+  try {
+    outer: while (!exhausted) {
+      batch.length = 0;
+      while (batch.length < SECURITY_LIMITS.regexMatchBatchLines) {
+        const next = await iterator.next();
+        if (next.done === true) {
+          exhausted = true;
+          break;
+        }
+        batch.push(next.value);
+      }
+
+      if (batch.length === 0) break;
+
+      if (signal?.aborted) {
+        throw new TaskAbortedError("Task aborted");
+      }
+
+      const budget =
+        options.maxReplacements === undefined
+          ? Number.POSITIVE_INFINITY
+          : options.maxReplacements - replacementCount;
+
+      const { texts, counts } = lineSubstituter.substituteBatch(batch, budget);
+
+      for (let i = 0; i < batch.length; i++) {
+        const replaced = texts[i]!;
+        const replacements = counts[i]!;
+
+        replacementCount += replacements;
+        if (replacements > 0) {
+          linesChanged++;
+        }
+
+        if (options.onlyChangedLines && replacements === 0) {
+          continue;
+        }
+
+        if (options.maxOutputLines !== undefined && outputLines >= options.maxOutputLines) {
+          truncated = true;
+          break outer;
+        }
+
+        const chars = replaced.length + 1;
+
+        if (options.maxOutputChars !== undefined && outputChars + chars > options.maxOutputChars) {
+          truncated = true;
+          break outer;
+        }
+
+        out.push(replaced);
+        outputLines++;
+        outputChars += chars;
+      }
     }
-
-    const budget =
-      options.maxReplacements === undefined
-        ? Number.POSITIVE_INFINITY
-        : options.maxReplacements - replacementCount;
-
-    const { text: replaced, replacements } =
-      budget > 0 ? substituter(text, budget) : { text, replacements: 0 };
-
-    replacementCount += replacements;
-    if (replacements > 0) {
-      linesChanged++;
-    }
-
-    if (options.onlyChangedLines && replacements === 0) {
-      continue;
-    }
-
-    if (options.maxOutputLines !== undefined && outputLines >= options.maxOutputLines) {
-      truncated = true;
-      break;
-    }
-
-    const chars = replaced.length + 1;
-
-    if (options.maxOutputChars !== undefined && outputChars + chars > options.maxOutputChars) {
-      truncated = true;
-      break;
-    }
-
-    out.push(replaced);
-    outputLines++;
-    outputChars += chars;
+  } finally {
+    await iterator.return?.();
   }
 
   return {
@@ -361,6 +432,20 @@ export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskC
     return outputSchema as DataPortSchema;
   }
 
+  /**
+   * Seam for the substituter the scan runs. The server build overrides it to
+   * bound matching with an interruptible time budget; there is no `vm` in a
+   * browser, so a hostile pattern there still blocks that tab (a tab — not the
+   * process hosting a local API).
+   */
+  protected createSubstituter(
+    pattern: string,
+    replacement: string,
+    options: SedOptions
+  ): SedLineSubstituter {
+    return createSubstituter(pattern, replacement, options);
+  }
+
   override async execute(
     input: FileSedTaskInput,
     context: IExecuteContext
@@ -370,6 +455,10 @@ export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskC
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
     }
+
+    // Compiled before the fetch so a rejected pattern costs no network call.
+    const substituter = this.createSubstituter(pattern, replacement, options);
+
     await context.updateProgress(0, "Fetching file");
 
     const fetchTask = context.own(new FetchUrlTask({ queue: false }));
@@ -388,7 +477,8 @@ export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskC
       pattern,
       replacement,
       options,
-      context.signal
+      context.signal,
+      substituter
     );
 
     if (context.signal.aborted) {

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -24,7 +24,8 @@ const inputSchema = {
     url: {
       type: "string",
       title: "URL",
-      description: "URL to transform (http://, https://)",
+      description:
+        "URL to transform (http://, https://). The Node/Electron build additionally accepts a `file://` URL or an absolute filesystem path, subject to the `filesystem:read` entitlement and any configured `roots`.",
       format: "uri",
     },
     pattern: {
@@ -417,7 +418,11 @@ export async function sedLines(
  *
  * The source is never modified: the transformed document is returned as output.
  */
-export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskConfig> {
+export class FileSedTask<Config extends TaskConfig = TaskConfig> extends Task<
+  FileSedTaskInput,
+  FileSedTaskOutput,
+  Config
+> {
   public static override type = "FileSedTask";
   public static override category = "Document";
   public static override title = "File Sed";
@@ -490,13 +495,31 @@ export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskC
   }
 }
 
-export const fileSed = (input: FileSedTaskInput, config?: TaskConfig) => {
+/**
+ * Config for both builds. `roots` is declared here rather than beside the
+ * server subclass because a `declare module` augmentation must state one type
+ * across every file that contributes it, and both files augment `Workflow`
+ * with `fileSed`.
+ */
+export interface FileSedTaskConfig extends TaskConfig {
+  /**
+   * Directories a local path must resolve inside, checked after symlinks are
+   * resolved. Omitted means unrestricted: the enforced control is the
+   * `filesystem:read` entitlement, and this is the embedder's extra fence.
+   *
+   * Honored only by the server build — the cross-platform class reaches
+   * http(s) through `FetchUrlTask` and touches no filesystem.
+   */
+  readonly roots?: readonly string[] | undefined;
+}
+
+export const fileSed = (input: FileSedTaskInput, config?: FileSedTaskConfig) => {
   return new FileSedTask(config).run(input);
 };
 
 declare module "@workglow/task-graph" {
   interface Workflow {
-    fileSed: CreateWorkflow<FileSedTaskInput, FileSedTaskOutput, TaskConfig>;
+    fileSed: CreateWorkflow<FileSedTaskInput, FileSedTaskOutput, FileSedTaskConfig>;
   }
 }
 

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -68,13 +68,14 @@ const inputSchema = {
     maxOutputLines: {
       type: "integer",
       title: "Max Output Lines",
-      description: "Maximum number of output lines",
+      description: "Maximum number of output lines. Defaults to 10000; set this to override.",
       minimum: 0,
     },
     maxOutputChars: {
       type: "integer",
       title: "Max Output Characters",
-      description: "Maximum number of output characters, including newlines",
+      description:
+        "Maximum number of output characters, including newlines. Defaults to 1000000; set this to override.",
       minimum: 0,
     },
   },
@@ -340,6 +341,11 @@ export async function sedLines(
   let outputLines = 0;
   let outputChars = 0;
 
+  // Caps apply whether or not the caller stated them: an unbounded default
+  // returned the whole document to whoever asked for one substitution.
+  const maxOutputLines = options.maxOutputLines ?? DEFAULT_LIMITS.grepMaxOutputLines;
+  const maxOutputChars = options.maxOutputChars ?? DEFAULT_LIMITS.grepMaxOutputChars;
+
   const iterator = lines[Symbol.asyncIterator]();
   const maxLineChars = DEFAULT_LIMITS.grepMaxLineChars;
   const batch: string[] = [];
@@ -392,14 +398,14 @@ export async function sedLines(
           continue;
         }
 
-        if (options.maxOutputLines !== undefined && outputLines >= options.maxOutputLines) {
+        if (outputLines >= maxOutputLines) {
           truncated = true;
           break outer;
         }
 
         const chars = replaced.length + 1;
 
-        if (options.maxOutputChars !== undefined && outputChars + chars > options.maxOutputChars) {
+        if (outputChars + chars > maxOutputChars) {
           truncated = true;
           break outer;
         }

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -1,0 +1,417 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
+import {
+  CreateWorkflow,
+  Task,
+  TaskAbortedError,
+  TaskInvalidInputError,
+  Workflow,
+} from "@workglow/task-graph";
+import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
+import { assertSafeRegexPattern } from "../util/regexSafety";
+import { linesFromText } from "../util/textLines";
+import { FetchUrlTask } from "./FetchUrlTask";
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    url: {
+      type: "string",
+      title: "URL",
+      description: "URL to transform (http://, https://)",
+      format: "uri",
+    },
+    pattern: {
+      type: "string",
+      title: "Pattern",
+      description: "Regular expression, or a literal string when fixedString is set",
+    },
+    replacement: {
+      type: "string",
+      title: "Replacement",
+      description:
+        "Text substituted for each match. Supports $1/$& when the pattern is a regular expression; literal when fixedString is set",
+    },
+    ignoreCase: {
+      type: "boolean",
+      title: "Ignore Case",
+      description: "Case-insensitive matching (s///i)",
+    },
+    fixedString: {
+      type: "boolean",
+      title: "Fixed String",
+      description: "Treat pattern and replacement as literal strings",
+    },
+    global: {
+      type: "boolean",
+      title: "Global",
+      description: "Replace every occurrence on a line rather than the first (s///g)",
+    },
+    maxReplacements: {
+      type: "integer",
+      title: "Max Replacements",
+      description: "Stop substituting after this many replacements; later lines pass through",
+      minimum: 1,
+    },
+    onlyChangedLines: {
+      type: "boolean",
+      title: "Only Changed Lines",
+      description: "Emit only the lines that changed (sed -n 's///p')",
+    },
+    maxOutputLines: {
+      type: "integer",
+      title: "Max Output Lines",
+      description: "Maximum number of output lines",
+      minimum: 0,
+    },
+    maxOutputChars: {
+      type: "integer",
+      title: "Max Output Characters",
+      description: "Maximum number of output characters, including newlines",
+      minimum: 0,
+    },
+  },
+  required: ["url", "pattern", "replacement"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+const outputSchema = {
+  type: "object",
+  properties: {
+    text: {
+      type: "string",
+      title: "Text",
+      description: "Transformed document",
+    },
+    replacementCount: {
+      type: "integer",
+      title: "Replacement Count",
+      description: "Number of substitutions performed",
+    },
+    linesChanged: {
+      type: "integer",
+      title: "Lines Changed",
+      description: "Number of lines with at least one substitution",
+    },
+    truncated: {
+      type: "boolean",
+      title: "Truncated",
+      description: "Output stopped before EOF because of an output limit",
+    },
+  },
+  required: ["text", "replacementCount", "linesChanged", "truncated"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export type FileSedTaskInput = FromSchema<typeof inputSchema>;
+export type FileSedTaskOutput = FromSchema<typeof outputSchema>;
+
+type SedOptions = Omit<FileSedTaskInput, "url" | "pattern" | "replacement">;
+
+interface LineSubstitution {
+  readonly text: string;
+  readonly replacements: number;
+}
+
+function validateOptions(options: SedOptions): void {
+  const integerOptions: Array<[keyof SedOptions, number | undefined]> = [
+    ["maxReplacements", options.maxReplacements],
+    ["maxOutputLines", options.maxOutputLines],
+    ["maxOutputChars", options.maxOutputChars],
+  ];
+
+  for (const [name, value] of integerOptions) {
+    if (value !== undefined && (!Number.isInteger(value) || value < 0)) {
+      throw new TaskInvalidInputError(`${String(name)} must be a non-negative integer`);
+    }
+  }
+
+  if (options.maxReplacements === 0) {
+    throw new TaskInvalidInputError("maxReplacements must be greater than zero when specified");
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Builds the per-line substitution. `budget` caps how many replacements the
+ * whole run may still make, so a global substitution can be cut mid-line and
+ * the rest of the document copied verbatim.
+ */
+function createSubstituter(
+  pattern: string,
+  replacement: string,
+  options: SedOptions
+): (text: string, budget: number) => LineSubstitution {
+  const flags = `${options.global ? "g" : ""}${options.ignoreCase ? "i" : ""}`;
+
+  let regex: RegExp;
+
+  if (options.fixedString) {
+    if (pattern.length === 0) {
+      throw new TaskInvalidInputError("pattern must not be empty when fixedString is set");
+    }
+    regex = new RegExp(escapeRegExp(pattern), flags);
+  } else {
+    assertSafeRegexPattern(pattern);
+    try {
+      regex = new RegExp(pattern, flags);
+    } catch {
+      throw new TaskInvalidInputError(`Invalid regular expression: ${pattern}`);
+    }
+  }
+
+  // A literal replacement must not be re-read for `$1` / `$&` expansion.
+  const substitute: (args: unknown[]) => string = options.fixedString
+    ? () => replacement
+    : (args) => expandReplacement(replacement, args);
+
+  return (text, budget) => {
+    let replacements = 0;
+
+    const result = text.replace(regex, (...args: unknown[]): string => {
+      if (replacements >= budget) {
+        return args[0] as string;
+      }
+      replacements++;
+      return substitute(args);
+    });
+
+    return { text: result, replacements };
+  };
+}
+
+/**
+ * `String.replace` only expands `$n` when handed a string, and a callback is
+ * what bounds the substitution count — so the expansion is done here instead.
+ */
+function expandReplacement(replacement: string, args: unknown[]): string {
+  if (!replacement.includes("$")) {
+    return replacement;
+  }
+
+  const match = args[0] as string;
+
+  // Trailing args are the offset, the subject, and optionally the named groups.
+  const hasNamed = typeof args[args.length - 1] === "object";
+  const end = hasNamed ? args.length - 1 : args.length;
+  const groups = args.slice(1, end - 2) as Array<string | undefined>;
+  const named = hasNamed
+    ? (args[args.length - 1] as Record<string, string | undefined>)
+    : undefined;
+
+  let out = "";
+
+  // Latched once no '>' remains: the scan index only grows, so a failed search
+  // can never succeed later, and re-searching would make this quadratic on a
+  // replacement of unterminated `$<`.
+  let mayHaveGroupName = true;
+
+  for (let index = 0; index < replacement.length; index++) {
+    const char = replacement[index];
+    const next = replacement[index + 1];
+
+    if (char !== "$" || next === undefined) {
+      out += char;
+      continue;
+    }
+
+    if (next === "$") {
+      out += "$";
+      index++;
+      continue;
+    }
+
+    if (next === "&") {
+      out += match;
+      index++;
+      continue;
+    }
+
+    if (next === "<") {
+      const close = mayHaveGroupName ? replacement.indexOf(">", index + 2) : -1;
+      if (close === -1) {
+        mayHaveGroupName = false;
+        out += char;
+        continue;
+      }
+      out += named?.[replacement.slice(index + 2, close)] ?? "";
+      index = close;
+      continue;
+    }
+
+    if (next >= "0" && next <= "9") {
+      let selector = next;
+
+      // A two-digit reference wins only when that group actually exists.
+      const after = replacement[index + 2];
+      if (after !== undefined && after >= "0" && after <= "9") {
+        if (Number(next + after) <= groups.length) {
+          selector = next + after;
+        }
+      }
+
+      const group = Number(selector);
+
+      if (group < 1 || group > groups.length) {
+        out += char;
+        continue;
+      }
+
+      out += groups[group - 1] ?? "";
+      index += selector.length;
+      continue;
+    }
+
+    out += char;
+  }
+
+  return out;
+}
+
+export async function sedLines(
+  lines: AsyncIterable<string>,
+  pattern: string,
+  replacement: string,
+  options: SedOptions = {},
+  signal?: AbortSignal
+): Promise<FileSedTaskOutput> {
+  validateOptions(options);
+
+  const substituter = createSubstituter(pattern, replacement, options);
+
+  const out: string[] = [];
+
+  let replacementCount = 0;
+  let linesChanged = 0;
+  let truncated = false;
+
+  let outputLines = 0;
+  let outputChars = 0;
+
+  for await (const text of lines) {
+    if (signal?.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+
+    const budget =
+      options.maxReplacements === undefined
+        ? Number.POSITIVE_INFINITY
+        : options.maxReplacements - replacementCount;
+
+    const { text: replaced, replacements } =
+      budget > 0 ? substituter(text, budget) : { text, replacements: 0 };
+
+    replacementCount += replacements;
+    if (replacements > 0) {
+      linesChanged++;
+    }
+
+    if (options.onlyChangedLines && replacements === 0) {
+      continue;
+    }
+
+    if (options.maxOutputLines !== undefined && outputLines >= options.maxOutputLines) {
+      truncated = true;
+      break;
+    }
+
+    const chars = replaced.length + 1;
+
+    if (options.maxOutputChars !== undefined && outputChars + chars > options.maxOutputChars) {
+      truncated = true;
+      break;
+    }
+
+    out.push(replaced);
+    outputLines++;
+    outputChars += chars;
+  }
+
+  return {
+    text: out.length === 0 ? "" : `${out.join("\n")}\n`,
+    replacementCount,
+    linesChanged,
+    truncated,
+  };
+}
+
+/**
+ * Task for substituting text in documents from URLs (including file:// URLs).
+ * Works in all environments (browser, Node.js, Bun) by using fetch API.
+ * For server-only filesystem path access, see FileSedTask.server.
+ *
+ * The source is never modified: the transformed document is returned as output.
+ */
+export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskConfig> {
+  public static override type = "FileSedTask";
+  public static override category = "Document";
+  public static override title = "File Sed";
+  public static override description = "Substitute matching text in a file (sed)";
+  public static override cacheable = true;
+
+  public static override inputSchema(): DataPortSchema {
+    return inputSchema as DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return outputSchema as DataPortSchema;
+  }
+
+  override async execute(
+    input: FileSedTaskInput,
+    context: IExecuteContext
+  ): Promise<FileSedTaskOutput> {
+    const { url, pattern, replacement, ...options } = input;
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(0, "Fetching file");
+
+    const fetchTask = context.own(new FetchUrlTask({ queue: false }));
+    const response = await fetchTask.run({
+      url,
+      response_type: "text",
+    });
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(60, "Substituting text");
+
+    const result = await sedLines(
+      linesFromText(response.text ?? ""),
+      pattern,
+      replacement,
+      options,
+      context.signal
+    );
+
+    if (context.signal.aborted) {
+      throw new TaskAbortedError("Task aborted");
+    }
+    await context.updateProgress(100, "Substitution complete");
+
+    return result;
+  }
+}
+
+export const fileSed = (input: FileSedTaskInput, config?: TaskConfig) => {
+  return new FileSedTask(config).run(input);
+};
+
+declare module "@workglow/task-graph" {
+  interface Workflow {
+    fileSed: CreateWorkflow<FileSedTaskInput, FileSedTaskOutput, TaskConfig>;
+  }
+}
+
+Workflow.prototype.fileSed = CreateWorkflow(FileSedTask);

--- a/packages/tasks/src/task/RegexTask.ts
+++ b/packages/tasks/src/task/RegexTask.ts
@@ -5,39 +5,15 @@
  */
 
 import type { IExecuteContext, IExecutePreviewContext, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Task, TaskInvalidInputError, Workflow } from "@workglow/task-graph";
-import { SECURITY_LIMITS } from "@workglow/util";
+import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-
-/**
- * Detects regex patterns prone to catastrophic backtracking (ReDoS).
- * Checks for nested quantifiers like (a+)+, (a*)+, (a+)*, etc.
- */
-function hasNestedQuantifiers(pattern: string): boolean {
-  // Strip character classes to avoid false positives on quantifiers inside [...]
-  const withoutClasses = pattern.replace(/\[(?:[^\]\\]|\\.)*\]/g, "X");
-  // Detect group with inner quantifier followed by outer quantifier
-  return /\([^)*+]*[*+][^)]*\)[+*?]|\([^)*+]*[*+][^)]*\)\{/.test(withoutClasses);
-}
+import { assertSafeRegexPattern } from "../util/regexSafety";
 
 function executeRegex(input: { value: string; pattern: string; flags?: string }): {
   match: boolean;
   matches: string[];
 } {
-  const bracketCount = (input.pattern.match(/\[/g) ?? []).length;
-  if (bracketCount > SECURITY_LIMITS.regexMaxBracketCount) {
-    throw new TaskInvalidInputError(
-      "Regex pattern rejected: too many '[' characters (potential ReDoS). " +
-        "Simplify the pattern to reduce complexity."
-    );
-  }
-
-  if (hasNestedQuantifiers(input.pattern)) {
-    throw new TaskInvalidInputError(
-      "Regex pattern rejected: nested quantifiers detected (potential ReDoS). " +
-        "Simplify the pattern to avoid catastrophic backtracking."
-    );
-  }
+  assertSafeRegexPattern(input.pattern);
 
   const flags = input.flags ?? "";
   const regex = new RegExp(input.pattern, flags);

--- a/packages/tasks/src/util/BoundedRegex.server.ts
+++ b/packages/tasks/src/util/BoundedRegex.server.ts
@@ -59,3 +59,110 @@ export function createBoundedRegexMatcher(
     return [...scope.out];
   };
 }
+
+/** One batch of substituted lines, positionally aligned with the input. */
+export interface BoundedReplaceResult {
+  readonly texts: readonly string[];
+  readonly counts: readonly number[];
+}
+
+/**
+ * Substitutes over a batch of lines under the same interruptible budget as
+ * {@link createBoundedRegexMatcher}, and for the same reason: `String.replace`
+ * backtracks exactly like `test` does. Measured on `/(\w|\d)*$/` against
+ * `"1".repeat(n) + "!"`: 25 ms at n=20, 392 ms at n=24, 1538 ms at n=26.
+ *
+ * Batched for the same cost reason as well. Over 100 000 lines with `/foo/g`:
+ * a bare `replace` per line runs 39 ms, one `vm` call per line ~13 650 ms, one
+ * `vm` call per 512-line batch 147 ms.
+ *
+ * `expand` is called from inside the context, once per replaced match, and its
+ * return value is what `String.replace` splices in. Keeping the substitution
+ * itself in the engine is what lets `budget` cap replacements — which needs a
+ * callback, so `$1` / `$&` expansion cannot be left to `replace` — without this
+ * helper reimplementing where a match starts and ends. It also means no
+ * per-match record outlives the call: peak memory is the output, not a
+ * description of every match in the batch.
+ *
+ * `budget` is the number of replacements the whole run may still make; it is
+ * threaded across the batch, so a line that exhausts it leaves the rest of the
+ * batch copied verbatim.
+ */
+export function createBoundedRegexReplacer(
+  regex: RegExp,
+  expand: (args: unknown[]) => string,
+  timeoutMs: number
+): (texts: readonly string[], budget: number) => BoundedReplaceResult {
+  // An `expand` that throws would otherwise surface as a timeout, since a
+  // terminated script and a rejected one are the same rejection out here.
+  let expandError: unknown;
+
+  const context = createContext({
+    re: regex,
+    expand: (args: unknown[]): string => {
+      try {
+        return expand(args);
+      } catch (err) {
+        expandError = err;
+        throw err;
+      }
+    },
+    lines: [] as readonly string[],
+    budget: 0,
+    out: [] as string[],
+    counts: [] as number[],
+  });
+
+  // Wrapped in a function so `remaining` is not redeclared in the context's
+  // global scope on the second call.
+  const script = new Script(`(function () {
+  out.length = 0;
+  counts.length = 0;
+  let remaining = budget;
+  for (let i = 0; i < lines.length; i++) {
+    const text = lines[i];
+    if (remaining <= 0) {
+      out.push(text);
+      counts.push(0);
+      continue;
+    }
+    let n = 0;
+    const replaced = text.replace(re, function () {
+      if (n >= remaining) return arguments[0];
+      n++;
+      return expand(Array.prototype.slice.call(arguments));
+    });
+    out.push(replaced);
+    counts.push(n);
+    remaining -= n;
+  }
+})();`);
+
+  return (texts, budget) => {
+    const scope = context as {
+      lines: readonly string[];
+      budget: number;
+      out: string[];
+      counts: number[];
+    };
+    scope.lines = texts;
+    scope.budget = budget;
+    expandError = undefined;
+
+    try {
+      script.runInContext(context, { timeout: timeoutMs });
+    } catch {
+      if (expandError !== undefined) {
+        throw expandError;
+      }
+      // Deliberately not a TaskTimeoutError: that extends TaskAbortedError and
+      // would report the run as aborted rather than failed by bad input.
+      throw new TaskInvalidInputError(
+        `Regex substitution exceeded its ${timeoutMs}ms budget for pattern /${regex.source}/ — ` +
+          `the pattern backtracks catastrophically on this input. Simplify the pattern.`
+      );
+    }
+
+    return { texts: [...scope.out], counts: [...scope.counts] };
+  };
+}

--- a/packages/tasks/src/util/BoundedRegex.server.ts
+++ b/packages/tasks/src/util/BoundedRegex.server.ts
@@ -60,6 +60,61 @@ export function createBoundedRegexMatcher(
   };
 }
 
+/**
+ * Collects global `exec` matches for each line under the same interruptible
+ * budget as {@link createBoundedRegexMatcher}.
+ *
+ * `test` is not a substitute for this: a pattern whose left alternative
+ * matches quickly (`ok|(\w|\d)*$` against a line that starts with `ok`)
+ * returns from `test` inside budget, then a later `/g` `exec` continues into
+ * the catastrophic right alternative and wedges the event loop. `onlyMatching`
+ * is that second pass. The regex must carry the `g` flag; `lastIndex` is reset
+ * per line.
+ */
+export function createBoundedRegexExtractor(
+  regex: RegExp,
+  timeoutMs: number
+): (texts: readonly string[]) => string[][] {
+  const context = createContext({
+    re: regex,
+    lines: [] as readonly string[],
+    out: [] as string[][],
+  });
+  // Wrapped so `matches` / `result` are not redeclared in the context's global
+  // scope on the second call — same reason as {@link createBoundedRegexReplacer}.
+  const script = new Script(`(function () {
+  out.length = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const matches = [];
+    re.lastIndex = 0;
+    const text = lines[i];
+    let result;
+    while ((result = re.exec(text)) !== null) {
+      if (result[0].length === 0) {
+        re.lastIndex++;
+        continue;
+      }
+      matches.push(result[0]);
+    }
+    out.push(matches);
+  }
+})();`);
+
+  return (texts) => {
+    const scope = context as { lines: readonly string[]; out: string[][] };
+    scope.lines = texts;
+    try {
+      script.runInContext(context, { timeout: timeoutMs });
+    } catch {
+      throw new TaskInvalidInputError(
+        `Regex matching exceeded its ${timeoutMs}ms budget for pattern /${regex.source}/ — ` +
+          `the pattern backtracks catastrophically on this input. Simplify the pattern.`
+      );
+    }
+    return scope.out.map((matches) => [...matches]);
+  };
+}
+
 /** One batch of substituted lines, positionally aligned with the input. */
 export interface BoundedReplaceResult {
   readonly texts: readonly string[];

--- a/packages/tasks/src/util/BoundedRegex.server.ts
+++ b/packages/tasks/src/util/BoundedRegex.server.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TaskInvalidInputError } from "@workglow/task-graph";
+import { createContext, Script } from "node:vm";
+
+/**
+ * Matches lines against a regex under an interruptible wall-clock budget.
+ *
+ * `RegExp.prototype.test` is synchronous and uninterruptible: a catastrophic
+ * pattern against one hostile line blocks the event loop indefinitely, and no
+ * abort signal can reach it. V8's script-execution timeout DOES reach inside
+ * Irregexp backtracking, so matching runs inside a `vm` context where a
+ * `timeout` terminates it. Measured: `/(a|a)*$/` against a 40-character input
+ * terminated at ~210 ms under a 200 ms budget.
+ *
+ * Matching is BATCHED because the `vm` hop is what costs. Over 100 000 lines
+ * with `/foo/`: a bare `regex.test` per line runs 6 ms, one `vm` call per line
+ * 25 051 ms (unusable), one `vm` call per 512-line batch 129 ms.
+ *
+ * The residual: the loop is still blocked for up to one batch budget, which is
+ * bounded and finite where the unguarded call was neither. Bun honours the
+ * timeout more coarsely — a 300 ms budget terminated at ~1025 ms — so treat the
+ * budget as an order of magnitude, not a deadline.
+ *
+ * The `RegExp` is created in the calling realm and passed through the context;
+ * the context is reusable after a timeout, but this returns a fresh matcher per
+ * call site anyway.
+ */
+export function createBoundedRegexMatcher(
+  regex: RegExp,
+  timeoutMs: number
+): (texts: readonly string[]) => boolean[] {
+  const context = createContext({
+    re: regex,
+    lines: [] as readonly string[],
+    out: [] as boolean[],
+  });
+  const script = new Script(
+    "out.length = 0; for (let i = 0; i < lines.length; i++) out.push(re.test(lines[i]));"
+  );
+
+  return (texts) => {
+    const scope = context as { lines: readonly string[]; out: boolean[] };
+    scope.lines = texts;
+    try {
+      script.runInContext(context, { timeout: timeoutMs });
+    } catch {
+      // Deliberately not a TaskTimeoutError: that extends TaskAbortedError and
+      // would report the run as aborted rather than failed by bad input.
+      throw new TaskInvalidInputError(
+        `Regex matching exceeded its ${timeoutMs}ms budget for pattern /${regex.source}/ — ` +
+          `the pattern backtracks catastrophically on this input. Simplify the pattern.`
+      );
+    }
+    return [...scope.out];
+  };
+}

--- a/packages/tasks/src/util/LocalFilePath.server.ts
+++ b/packages/tasks/src/util/LocalFilePath.server.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
+import { realpathSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface LocalFilePathOptions {
+  /**
+   * Directories the path must resolve inside. `undefined` means unrestricted —
+   * the enforced control is the `filesystem:read` entitlement, and this is the
+   * embedder's belt-and-braces on top of it.
+   */
+  readonly roots?: readonly string[] | undefined;
+}
+
+/** True for an http(s) URL, case-insensitively — `HTTP://x` is an http URL. */
+export function isHttpUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+function fileUrlToPath(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new TaskInvalidInputError(`Invalid file URL: ${url}`);
+  }
+  try {
+    // Percent-decodes, rejects a non-empty non-localhost host, and yields
+    // `C:\x` rather than `/c:/x` on Windows.
+    return fileURLToPath(parsed);
+  } catch (err) {
+    throw new TaskInvalidInputError(
+      `Invalid file URL: ${url} (${err instanceof Error ? err.message : String(err)})`
+    );
+  }
+}
+
+/**
+ * Real, absolute path for a local-file input, contained within `roots`.
+ *
+ * Order matters: the containment check runs AFTER `realpathSync`, so a symlink
+ * pointing out of a root is caught rather than followed. Callers must open the
+ * returned path, not the one they passed in.
+ *
+ * Residual TOCTOU: a component of the path can be swapped between this
+ * resolution and the open that follows it. Closing that needs an
+ * openat-with-fd-relative walk, which Node does not expose.
+ */
+export function resolveLocalFilePath(url: string, options: LocalFilePathOptions = {}): string {
+  const raw = /^file:/i.test(url) ? fileUrlToPath(url) : url;
+  const resolved = resolve(raw);
+
+  let real: string;
+  try {
+    real = realpathSync(resolved);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    // A missing file still gets a real DIRECTORY path, so containment is
+    // decided on resolved ground; the open below then fails with ENOENT as it
+    // always did.
+    real = join(realpathSync(dirname(resolved)), basename(resolved));
+  }
+
+  const { roots } = options;
+  if (roots !== undefined) {
+    const allowed = roots.some((root) => {
+      const realRoot = realpathSync(root);
+      return real === realRoot || real.startsWith(realRoot + sep);
+    });
+    if (!allowed) {
+      throw new TaskEntitlementError(
+        `Path ${real} is outside the configured roots: ${roots.join(", ")}`
+      );
+    }
+  }
+
+  // A fifo or a character device (/dev/zero) reads forever with no deadline.
+  let stats;
+  try {
+    stats = statSync(real);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return real;
+    throw err;
+  }
+  if (!stats.isFile()) {
+    throw new TaskInvalidInputError(`Not a regular file: ${real}`);
+  }
+
+  return real;
+}

--- a/packages/tasks/src/util/LocalFilePath.server.ts
+++ b/packages/tasks/src/util/LocalFilePath.server.ts
@@ -70,7 +70,20 @@ export function resolveLocalFilePath(url: string, options: LocalFilePathOptions 
   const { roots } = options;
   if (roots !== undefined) {
     const allowed = roots.some((root) => {
-      const realRoot = realpathSync(root);
+      // A root that cannot be resolved is a misconfiguration, and saying which
+      // one beats an `ENOENT ... lstat` raised from inside the containment
+      // check. It is deliberately NOT treated as "does not contain the path":
+      // that reads as a containment verdict on evidence nobody has.
+      let realRoot: string;
+      try {
+        realRoot = realpathSync(root);
+      } catch (err) {
+        throw new TaskInvalidInputError(
+          `Configured root ${root} could not be resolved: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
       return real === realRoot || real.startsWith(realRoot + sep);
     });
     if (!allowed) {

--- a/packages/tasks/src/util/StreamLines.server.ts
+++ b/packages/tasks/src/util/StreamLines.server.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Splits a byte stream into lines with a hard per-line cap.
+ *
+ * `readline.createInterface` accumulates an unterminated line without bound: a
+ * 640 MB newline-free stream threw `RangeError: Invalid string length` from a
+ * stream `'data'` listener, which surfaces as an `uncaughtException` rather
+ * than an iterator rejection — so the caller's try/catch could not see it and
+ * the process died.
+ *
+ * A line reaching `maxLineChars` with no terminator yields its first
+ * `maxLineChars` characters, and the rest of that physical line is discarded up
+ * to the next `\n`. `setEncoding` puts a `StringDecoder` in front, so a
+ * multi-byte character split across two reads is not corrupted.
+ */
+export async function* linesFromStream(
+  stream: NodeJS.ReadableStream,
+  maxLineChars: number
+): AsyncGenerator<string> {
+  stream.setEncoding("utf8");
+
+  let pending = "";
+  let skipping = false;
+
+  const stripCr = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line);
+
+  for await (const chunk of stream as AsyncIterable<string>) {
+    pending += chunk;
+
+    let newline = pending.indexOf("\n");
+    while (newline !== -1) {
+      const line = pending.slice(0, newline);
+      pending = pending.slice(newline + 1);
+      if (skipping) {
+        skipping = false;
+      } else {
+        yield stripCr(line);
+      }
+      newline = pending.indexOf("\n");
+    }
+
+    if (!skipping && pending.length >= maxLineChars) {
+      yield pending.slice(0, maxLineChars);
+      pending = "";
+      skipping = true;
+    } else if (skipping) {
+      pending = "";
+    }
+  }
+
+  if (!skipping && pending.length > 0) {
+    yield stripCr(pending);
+  }
+}

--- a/packages/tasks/src/util/regexSafety.ts
+++ b/packages/tasks/src/util/regexSafety.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TaskInvalidInputError } from "@workglow/task-graph";
+import { SECURITY_LIMITS } from "@workglow/util";
+
+interface PatternScan {
+  /** Every `[` in the source, including literals inside a class. */
+  readonly bracketCount: number;
+  /** A quantified group whose own body already quantifies, e.g. `(a+)+`. */
+  readonly nestedQuantifiers: boolean;
+}
+
+/**
+ * Walks a regex source once, tracking character classes (so a quantifier
+ * inside `[...]` is not read as one) and group nesting on a stack.
+ *
+ * The scan is hand-written rather than regex-driven on purpose: stripping
+ * classes with `\[(?:[^\]\\]|\\.)*\]` is itself quadratic on a pattern that is
+ * mostly unclosed `[`, since every one of them restarts a scan that runs to
+ * the end of the string. Guarding against ReDoS with a pattern an attacker can
+ * ReDoS defeats the guard.
+ */
+function scanPattern(pattern: string): PatternScan {
+  let bracketCount = 0;
+  let nestedQuantifiers = false;
+  let inClass = false;
+
+  /** One entry per open group; true once that group's body contains `*` or `+`. */
+  const groupHasQuantifier: boolean[] = [];
+
+  for (let index = 0; index < pattern.length; index++) {
+    const char = pattern[index];
+
+    if (char === "\\") {
+      index++;
+      continue;
+    }
+
+    if (inClass) {
+      if (char === "[") {
+        bracketCount++;
+      } else if (char === "]") {
+        inClass = false;
+      }
+      continue;
+    }
+
+    if (char === "[") {
+      bracketCount++;
+      inClass = true;
+      continue;
+    }
+
+    if (char === "(") {
+      groupHasQuantifier.push(false);
+      continue;
+    }
+
+    if (char === ")") {
+      const bodyQuantifies = groupHasQuantifier.pop();
+      if (bodyQuantifies === undefined) {
+        continue;
+      }
+
+      const next = pattern[index + 1];
+      const groupIsQuantified = next === "*" || next === "+" || next === "?" || next === "{";
+
+      if (bodyQuantifies && groupIsQuantified) {
+        nestedQuantifiers = true;
+      }
+
+      // A quantifying group counts as a quantifier for whatever encloses it.
+      if (bodyQuantifies && groupHasQuantifier.length > 0) {
+        groupHasQuantifier[groupHasQuantifier.length - 1] = true;
+      }
+
+      continue;
+    }
+
+    if ((char === "*" || char === "+") && groupHasQuantifier.length > 0) {
+      groupHasQuantifier[groupHasQuantifier.length - 1] = true;
+    }
+  }
+
+  return { bracketCount, nestedQuantifiers };
+}
+
+/**
+ * Rejects regex sources prone to catastrophic backtracking (ReDoS) before they
+ * ever reach `new RegExp`. Throws {@link TaskInvalidInputError} for a pattern
+ * with too many `[` characters or with nested quantifiers like `(a+)+`.
+ */
+export function assertSafeRegexPattern(pattern: string): void {
+  const { bracketCount, nestedQuantifiers } = scanPattern(pattern);
+
+  if (bracketCount > SECURITY_LIMITS.regexMaxBracketCount) {
+    throw new TaskInvalidInputError(
+      "Regex pattern rejected: too many '[' characters (potential ReDoS). " +
+        "Simplify the pattern to reduce complexity."
+    );
+  }
+
+  if (nestedQuantifiers) {
+    throw new TaskInvalidInputError(
+      "Regex pattern rejected: nested quantifiers detected (potential ReDoS). " +
+        "Simplify the pattern to avoid catastrophic backtracking."
+    );
+  }
+}

--- a/packages/tasks/src/util/regexSafety.ts
+++ b/packages/tasks/src/util/regexSafety.ts
@@ -90,6 +90,16 @@ function scanPattern(pattern: string): PatternScan {
 }
 
 /**
+ * Escapes every regex metacharacter, so caller text can be compiled into a
+ * pattern that matches it literally rather than being read as one. The other
+ * half of {@link assertSafeRegexPattern}: that guards text the caller *meant*
+ * as a pattern, this guards text they did not.
+ */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * Rejects regex sources prone to catastrophic backtracking (ReDoS) before they
  * ever reach `new RegExp`. Throws {@link TaskInvalidInputError} for a pattern
  * with too many `[` characters or with nested quantifiers like `(a+)+`.

--- a/packages/tasks/src/util/regexSafety.ts
+++ b/packages/tasks/src/util/regexSafety.ts
@@ -7,6 +7,20 @@
 import { TaskInvalidInputError } from "@workglow/task-graph";
 import { SECURITY_LIMITS } from "@workglow/util";
 
+/**
+ * `{n,}` / `{n,m}` starting exactly at an index. Sticky rather than
+ * `test(pattern.slice(index))`, because slicing per character is the quadratic
+ * shape this module exists to avoid.
+ */
+const UNBOUNDED_REPETITION_RE = /\{\d+,\d*\}/y;
+
+/** True when a counted repetition starts at `index`. */
+function isUnboundedRepetitionAt(pattern: string, index: number): boolean {
+  if (pattern[index] !== "{") return false;
+  UNBOUNDED_REPETITION_RE.lastIndex = index;
+  return UNBOUNDED_REPETITION_RE.test(pattern);
+}
+
 interface PatternScan {
   /** Every `[` in the source, including literals inside a class. */
   readonly bracketCount: number;
@@ -81,7 +95,10 @@ function scanPattern(pattern: string): PatternScan {
       continue;
     }
 
-    if ((char === "*" || char === "+") && groupHasQuantifier.length > 0) {
+    if (
+      (char === "*" || char === "+" || isUnboundedRepetitionAt(pattern, index)) &&
+      groupHasQuantifier.length > 0
+    ) {
       groupHasQuantifier[groupHasQuantifier.length - 1] = true;
     }
   }
@@ -111,7 +128,7 @@ function endOfCharacterClass(pattern: string, index: number): number {
 function isRepetitionAt(pattern: string, index: number): boolean {
   const ch = pattern[index];
   if (ch === "*" || ch === "+") return true;
-  return /^\{\d+,\d*\}/.test(pattern.slice(index));
+  return isUnboundedRepetitionAt(pattern, index);
 }
 
 /** Bodies of every group immediately followed by a repetition quantifier. */

--- a/packages/tasks/src/util/regexSafety.ts
+++ b/packages/tasks/src/util/regexSafety.ts
@@ -89,6 +89,181 @@ function scanPattern(pattern: string): PatternScan {
   return { bracketCount, nestedQuantifiers };
 }
 
+/** Stands in for a whole character class, which is a single atom to the emptiness test. */
+const CLASS_ATOM = "\u0001";
+
+/** An alternative made entirely of optional atoms, so it can match the empty string. */
+const ALL_OPTIONAL_ATOMS_RE = /^(?:(?:\\.|[^\\*+?{}()|])(?:[*?]|\{0,\d*\}))+$/;
+
+/** An alternative containing no regex metacharacters, so prefix comparison is meaningful. */
+const LITERAL_ALTERNATIVE_RE = /^[^\\.*+?()[\]{}|^$]+$/;
+
+/** Index just past the `]` closing the class at `index`, or the end if it never closes. */
+function endOfCharacterClass(pattern: string, index: number): number {
+  let i = index + 1;
+  while (i < pattern.length && pattern[i] !== "]") {
+    i += pattern[i] === "\\" ? 2 : 1;
+  }
+  return i < pattern.length ? i + 1 : pattern.length;
+}
+
+/** Returns true when a repetition quantifier starts at `index`. */
+function isRepetitionAt(pattern: string, index: number): boolean {
+  const ch = pattern[index];
+  if (ch === "*" || ch === "+") return true;
+  return /^\{\d+,\d*\}/.test(pattern.slice(index));
+}
+
+/** Bodies of every group immediately followed by a repetition quantifier. */
+function quantifiedGroupBodies(pattern: string): string[] {
+  const bodies: string[] = [];
+  const open: number[] = [];
+
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === "\\") {
+      i++;
+    } else if (ch === "[") {
+      i = endOfCharacterClass(pattern, i) - 1;
+    } else if (ch === "(") {
+      open.push(i);
+    } else if (ch === ")") {
+      const start = open.pop();
+      if (start !== undefined && isRepetitionAt(pattern, i + 1)) {
+        bodies.push(pattern.slice(start + 1, i));
+      }
+    }
+  }
+
+  return bodies;
+}
+
+/**
+ * Drops a group modifier prefix. Returns undefined for lookarounds, which this
+ * screen does not model.
+ */
+function groupBodyAfterModifier(body: string): string | undefined {
+  if (!body.startsWith("?")) return body;
+  if (body.startsWith("?:")) return body.slice(2);
+  const named = /^\?<[A-Z_$][\w$]*>/i.exec(body);
+  if (named) return body.slice(named[0].length);
+  return undefined;
+}
+
+/** Splits an alternation on `|` at nesting depth zero. */
+function splitTopLevelAlternatives(body: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === "\\") i++;
+    else if (ch === "[") i = endOfCharacterClass(body, i) - 1;
+    else if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    else if (ch === "|" && depth === 0) {
+      parts.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+
+  parts.push(body.slice(start));
+  return parts;
+}
+
+/**
+ * Collapses each character class to one placeholder character, because a class
+ * IS a single atom for the can-it-match-empty question. Only that question uses
+ * this — comparing two alternatives for overlap reads the class text verbatim,
+ * so `[a-z]` and `[A-Z]` stay distinguishable.
+ */
+function collapseCharacterClasses(alternative: string): string {
+  let out = "";
+  let i = 0;
+
+  while (i < alternative.length) {
+    const ch = alternative[i];
+    if (ch === "\\") {
+      out += alternative.slice(i, i + 2);
+      i += 2;
+    } else if (ch === "[") {
+      out += CLASS_ATOM;
+      i = endOfCharacterClass(alternative, i);
+    } else {
+      out += ch;
+      i += 1;
+    }
+  }
+
+  return out;
+}
+
+function alternativeCanMatchEmpty(alternative: string): boolean {
+  if (alternative.length === 0) return true;
+  // A nested group is not modelled; do not claim it can match empty.
+  if (alternative.includes("(")) return false;
+  return ALL_OPTIONAL_ATOMS_RE.test(collapseCharacterClasses(alternative));
+}
+
+/**
+ * True when a quantified alternation has branches that overlap, so the engine
+ * has more than one way to consume the same input: `(a|a)*`, `(?:a|a)*`,
+ * `(a|ab)+`, `(a*|b)+`.
+ *
+ * {@link scanPattern} does not model this — it pops `(a|a)` with a body that
+ * carries no quantifier of its own — yet the family is measurably exponential:
+ * `/(a|a)*$/` against `"a".repeat(n) + "!"` runs 52 ms at n=18, 118 ms at n=22,
+ * 466 ms at n=24 and 1821 ms at n=26, doubling per added character, and
+ * `(a|a|a)+$` at n=20 ran past a 120 s timeout.
+ *
+ * Sharing a first character is NOT enough — `(foo|far)+` is not exponential and
+ * a first-character rule would reject a large class of ordinary patterns.
+ */
+function hasOverlappingAlternation(pattern: string): boolean {
+  for (const rawBody of quantifiedGroupBodies(pattern)) {
+    const body = groupBodyAfterModifier(rawBody);
+    if (body === undefined) continue;
+
+    const alternatives = splitTopLevelAlternatives(body);
+    if (alternatives.length < 2) continue;
+
+    if (alternatives.some(alternativeCanMatchEmpty)) return true;
+
+    for (let i = 0; i < alternatives.length; i++) {
+      for (let j = i + 1; j < alternatives.length; j++) {
+        const a = alternatives[i]!;
+        const b = alternatives[j]!;
+        if (a === b) return true;
+        if (
+          LITERAL_ALTERNATIVE_RE.test(a) &&
+          LITERAL_ALTERNATIVE_RE.test(b) &&
+          (a.startsWith(b) || b.startsWith(a))
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Screen for the catastrophic-backtracking shapes this module models, without
+ * throwing.
+ *
+ * A `false` is not a safety guarantee, only the absence of a modelled shape:
+ * the screen is a heuristic, not a decision procedure. What is actually
+ * ENFORCED is the match budget applied at match time — see
+ * `createBoundedRegexMatcher`, which interrupts a running match after a fixed
+ * wall-clock budget. Treat this as a fast, friendly rejection of obviously
+ * dangerous input, never as the containment.
+ */
+export function hasUnsafeRegexShape(pattern: string): boolean {
+  return scanPattern(pattern).nestedQuantifiers || hasOverlappingAlternation(pattern);
+}
+
 /**
  * Escapes every regex metacharacter, so caller text can be compiled into a
  * pattern that matches it literally rather than being read as one. The other
@@ -102,7 +277,10 @@ export function escapeRegExp(value: string): string {
 /**
  * Rejects regex sources prone to catastrophic backtracking (ReDoS) before they
  * ever reach `new RegExp`. Throws {@link TaskInvalidInputError} for a pattern
- * with too many `[` characters or with nested quantifiers like `(a+)+`.
+ * with too many `[` characters, with nested quantifiers like `(a+)+`, or with a
+ * quantified alternation whose branches overlap like `(a|a)*`.
+ *
+ * This is a screen, not the containment — see {@link hasUnsafeRegexShape}.
  */
 export function assertSafeRegexPattern(pattern: string): void {
   const { bracketCount, nestedQuantifiers } = scanPattern(pattern);
@@ -119,5 +297,22 @@ export function assertSafeRegexPattern(pattern: string): void {
       "Regex pattern rejected: nested quantifiers detected (potential ReDoS). " +
         "Simplify the pattern to avoid catastrophic backtracking."
     );
+  }
+
+  if (hasOverlappingAlternation(pattern)) {
+    throw new TaskInvalidInputError(
+      "Regex pattern rejected: a repeated alternation has overlapping branches " +
+        "(potential ReDoS). Make the branches mutually exclusive."
+    );
+  }
+}
+
+/** Screens a pattern, then compiles it. */
+export function compileSafeRegex(pattern: string, flags: string): RegExp {
+  assertSafeRegexPattern(pattern);
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    throw new TaskInvalidInputError(`Invalid regular expression: ${pattern}`);
   }
 }

--- a/packages/tasks/src/util/textLines.ts
+++ b/packages/tasks/src/util/textLines.ts
@@ -6,18 +6,24 @@
 
 /**
  * Splits already-materialized text into lines without their terminators,
- * matching how `readline` feeds the streaming server tasks: CRLF and LF are
+ * matching how the streaming server tasks feed their scan: CRLF and LF are
  * equivalent, and a trailing newline does not produce a final empty line.
+ *
+ * Walks the text with `indexOf` rather than `split(/\r?\n/)`, which materializes
+ * an array holding every line of the document before the first is yielded — on
+ * a large document that is a second full copy of it in memory, and the consumer
+ * cannot begin until the whole split completes.
  */
 export async function* linesFromText(text: string): AsyncGenerator<string> {
-  if (text.length === 0) {
-    return;
-  }
-  const lines = text.split(/\r?\n/);
-  if (text.endsWith("\n")) {
-    lines.pop();
-  }
-  for (const line of lines) {
-    yield line;
+  let start = 0;
+  while (start < text.length) {
+    const newline = text.indexOf("\n", start);
+    if (newline === -1) {
+      yield text.slice(start);
+      return;
+    }
+    const end = newline > start && text[newline - 1] === "\r" ? newline - 1 : newline;
+    yield text.slice(start, end);
+    start = newline + 1;
   }
 }

--- a/packages/tasks/src/util/textLines.ts
+++ b/packages/tasks/src/util/textLines.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Splits already-materialized text into lines without their terminators,
+ * matching how `readline` feeds the streaming server tasks: CRLF and LF are
+ * equivalent, and a trailing newline does not produce a final empty line.
+ */
+export async function* linesFromText(text: string): AsyncGenerator<string> {
+  if (text.length === 0) {
+    return;
+  }
+  const lines = text.split(/\r?\n/);
+  if (text.endsWith("\n")) {
+    lines.pop();
+  }
+  for (const line of lines) {
+    yield line;
+  }
+}

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -1149,6 +1149,70 @@ describe("FetchUrlTask", () => {
     });
   });
 
+  describe("HEAD requests", () => {
+    // The schema enum is what the UI and validateInput both read. Without HEAD
+    // in it a caller that asks for metadata-only is rejected before any request
+    // is issued, and the method never reaches SafeFetch.
+    test("validateInput accepts method HEAD", async () => {
+      const task = new FetchUrlTask();
+      await expect(
+        task.validateInput({
+          url: "https://example.com/big.zip",
+          method: "HEAD",
+          response_type: "stream",
+        })
+      ).resolves.toBe(true);
+    });
+
+    // A real HEAD 200 has no body: `Response.body` is null, and Content-Length
+    // describes the representation a GET would return, not the (empty) bytes
+    // we receive. Streaming that as a GET would throw NO_RESPONSE_BODY or
+    // CONTENT_LENGTH_MISMATCH. HEAD exists to read status and headers.
+    test("a HEAD 200 with no body finishes with metadata and does not stream bytes", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(null, {
+            status: 200,
+            headers: {
+              "Content-Type": "application/zip",
+              "Content-Length": "12345",
+              ETag: '"v1"',
+            },
+          })
+        )
+      );
+
+      const result = await fetchUrl({
+        url: "https://example.com/big.zip",
+        method: "HEAD",
+        response_type: "stream",
+      });
+
+      const options = mockFetch.mock.calls.at(-1)?.[1] as { method?: string } | undefined;
+      expect(options?.method).toBe("HEAD");
+      expect(result.metadata?.status).toBe(200);
+      expect(result.metadata?.contentType).toBe("application/zip");
+      expect(result.metadata?.headers.etag).toBe('"v1"');
+      expect(result.metadata?.headers["content-length"]).toBe("12345");
+      expect(result.text).toBeUndefined();
+      expect(result.json).toBeUndefined();
+      expect(result.blob).toBeUndefined();
+    });
+
+    test("a HEAD error status still throws", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(null, { status: 404, statusText: "Not Found" }))
+      );
+      await expect(
+        fetchUrl({
+          url: "https://example.com/missing.zip",
+          method: "HEAD",
+          response_type: "stream",
+        })
+      ).rejects.toThrow();
+    });
+  });
+
   // -------------------------------------------------------------------------
   // C1 regression: SafeFetch throws permanent FETCH_* errors (SSRF deny, DNS
   // failure, invalid URL, etc). The outer catches in the old fetch helper /

--- a/packages/test/src/test/task/FileGrepEntitlements.test.ts
+++ b/packages/test/src/test/task/FileGrepEntitlements.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createPolicyEnforcer,
+  createProfilePolicy,
+  ENTITLEMENT_ENFORCER,
+  Entitlements,
+  TaskEntitlementError,
+  TaskGraph,
+  TaskGraphRunner,
+  TaskRegistry,
+  type IEntitlementEnforcer,
+} from "@workglow/task-graph";
+import { FileGrepTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
+import { Container, ServiceRegistry, setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+const METADATA_URL = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
+
+describe("FileGrepTask entitlement enforcement", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+
+  let prevSafeFetch: SafeFetchFn;
+  let testDir: string;
+
+  beforeAll(() => {
+    // The enforcer is what is under test, not the network layer.
+    prevSafeFetch = registerSafeFetch(() =>
+      Promise.resolve(
+        new Response("alpha\nbravo foo\n", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        })
+      )
+    );
+    TaskRegistry.registerTask(FileGrepTask);
+  });
+
+  afterAll(() => {
+    registerSafeFetch(prevSafeFetch);
+  });
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `filegrep-ent-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function makeRegistry(enforcer: IEntitlementEnforcer): ServiceRegistry {
+    const registry = new ServiceRegistry(new Container());
+    registry.register(ENTITLEMENT_ENFORCER, () => enforcer);
+    return registry;
+  }
+
+  function makeGraph(url: string, roots?: readonly string[]): TaskGraph {
+    const graph = new TaskGraph();
+    graph.addTask(new FileGrepTask({ id: "grep-node", roots, defaults: { url, pattern: "foo" } }));
+    return graph;
+  }
+
+  /**
+   * The scenario that motivated the declaration. Pre-fix the task declared
+   * nothing at all: `computeGraphEntitlements` runs over `graph.getTasks()` at
+   * graph start and saw an empty set, and the `FetchUrlTask` the task owns
+   * inside `execute()` is not in that snapshot — so it reached the metadata
+   * endpoint with `allowPrivate: true`, its own resolved-destination check
+   * satisfied because the child's input url IS the private one.
+   */
+  test("a profile without network:private denies a metadata-endpoint grep", async () => {
+    const enforcer = createPolicyEnforcer(createProfilePolicy("browser"));
+    const runner = new TaskGraphRunner(makeGraph(METADATA_URL));
+
+    await expect(
+      runner.runGraph({}, { registry: makeRegistry(enforcer), enforceEntitlements: true })
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("the same profile allows a public grep", async () => {
+    const enforcer = createPolicyEnforcer(createProfilePolicy("browser"));
+    const runner = new TaskGraphRunner(makeGraph("https://example.com/log.txt"));
+
+    await expect(
+      runner.runGraph({}, { registry: makeRegistry(enforcer), enforceEntitlements: true })
+    ).resolves.toBeDefined();
+  });
+
+  test("a profile granting filesystem:read only under /tmp denies /etc", async () => {
+    const browserPolicy = createProfilePolicy("browser");
+    const scopedPolicy = {
+      deny: browserPolicy.deny,
+      grant: [
+        ...browserPolicy.grant,
+        { id: Entitlements.FILESYSTEM_READ, resources: [`${testDir}/*`] },
+      ],
+      ask: browserPolicy.ask,
+    };
+
+    const allowed = join(testDir, "notes.txt");
+    writeFileSync(allowed, "alpha\nbravo foo\n", "utf-8");
+
+    const permitted = new TaskGraphRunner(makeGraph(allowed));
+    await expect(
+      permitted.runGraph(
+        {},
+        { registry: makeRegistry(createPolicyEnforcer(scopedPolicy)), enforceEntitlements: true }
+      )
+    ).resolves.toBeDefined();
+
+    const denied = new TaskGraphRunner(makeGraph("/etc/passwd"));
+    await expect(
+      denied.runGraph(
+        {},
+        { registry: makeRegistry(createPolicyEnforcer(scopedPolicy)), enforceEntitlements: true }
+      )
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("declares filesystem:read scoped to the resolved path, and no network", () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "bravo foo\n", "utf-8");
+
+    const declared = new FileGrepTask({
+      defaults: { url: filePath, pattern: "foo" },
+    }).entitlements().entitlements;
+
+    expect(declared.map((e) => e.id)).toEqual([Entitlements.FILESYSTEM_READ]);
+    expect(declared[0].resources).toEqual([filePath]);
+  });
+
+  test("declares the fetch entitlements for an http url, and no filesystem:read", () => {
+    const declared = new FileGrepTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo" },
+    }).entitlements().entitlements;
+
+    expect(declared.map((e) => e.id)).toContain(Entitlements.NETWORK_HTTP);
+    expect(declared.map((e) => e.id)).not.toContain(Entitlements.FILESYSTEM_READ);
+  });
+
+  test("declares fail-closed entitlements when the url is unknown", () => {
+    const declared = new FileGrepTask({ defaults: { pattern: "foo" } as never }).entitlements()
+      .entitlements;
+    const ids = declared.map((e) => e.id);
+
+    expect(ids).toContain(Entitlements.FILESYSTEM_READ);
+    expect(ids).toContain(Entitlements.NETWORK_PRIVATE);
+    // Unscoped: nothing is known about the destination yet.
+    expect(declared.find((e) => e.id === Entitlements.NETWORK_PRIVATE)?.resources).toBeUndefined();
+    expect(declared.find((e) => e.id === Entitlements.FILESYSTEM_READ)?.resources).toBeUndefined();
+  });
+});

--- a/packages/test/src/test/task/FileGrepTask.server.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.server.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FileGrepTask } from "@workglow/tasks";
+import { setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+describe("FileGrepTask (server - local files)", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `filegrep-test-${Date.now()}`);
+    if (!existsSync(testDir)) {
+      mkdirSync(testDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("greps a filesystem path", async () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "alpha\nbravo foo\ncharlie\n", "utf-8");
+
+    const result = await new FileGrepTask({
+      defaults: { url: filePath, pattern: "foo" },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 2,
+        lines: [{ line: 2, text: "bravo foo", match: true }],
+      },
+    ]);
+  });
+
+  test("greps a file:// URL", async () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "keep\nskip foo\nkeep too\n", "utf-8");
+
+    const result = await new FileGrepTask({
+      defaults: { url: `file://${filePath}`, pattern: "foo" },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+    expect(result.groups[0].lines[0].text).toBe("skip foo");
+  });
+
+  test("streams CRLF files from disk", async () => {
+    const filePath = join(testDir, "windows.txt");
+    writeFileSync(filePath, "one\r\ntwo foo\r\nthree\r\n", "utf-8");
+
+    const result = await new FileGrepTask({
+      defaults: { url: filePath, pattern: "foo" },
+    }).run();
+
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 2,
+        lines: [{ line: 2, text: "two foo", match: true }],
+      },
+    ]);
+  });
+
+  test("throws for a missing file", async () => {
+    const filePath = join(testDir, "missing.txt");
+
+    await expect(
+      new FileGrepTask({
+        defaults: { url: filePath, pattern: "foo" },
+      }).run()
+    ).rejects.toThrow();
+  });
+});

--- a/packages/test/src/test/task/FileGrepTask.server.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.server.test.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FileGrepTask } from "@workglow/tasks";
+import { TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
+import { FileGrepTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
 import { setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -85,5 +86,136 @@ describe("FileGrepTask (server - local files)", () => {
         defaults: { url: filePath, pattern: "foo" },
       }).run()
     ).rejects.toThrow();
+  });
+
+  test("refuses a path outside the configured roots", async () => {
+    const outside = join(tmpdir(), `filegrep-outside-${Date.now()}.txt`);
+    writeFileSync(outside, "bravo foo\n", "utf-8");
+
+    try {
+      await expect(
+        new FileGrepTask({
+          roots: [testDir],
+          defaults: { url: outside, pattern: "foo" },
+        }).run()
+      ).rejects.toThrow(TaskEntitlementError);
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
+  /**
+   * The containment check runs AFTER `realpathSync`. A pre-realpath check
+   * passes here — the link itself sits inside the root — and then opens the
+   * target, which is the whole escape.
+   */
+  test("refuses a symlink that escapes the configured roots", async () => {
+    const link = join(testDir, "escape.txt");
+    symlinkSync("/etc/passwd", link);
+
+    await expect(
+      new FileGrepTask({
+        roots: [testDir],
+        defaults: { url: link, pattern: "root" },
+      }).run()
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("allows a symlink that stays inside the roots", async () => {
+    const target = join(testDir, "target.txt");
+    const link = join(testDir, "link.txt");
+    writeFileSync(target, "alpha\nbravo foo\n", "utf-8");
+    symlinkSync(target, link);
+
+    const result = await new FileGrepTask({
+      roots: [testDir],
+      defaults: { url: link, pattern: "foo" },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+  });
+
+  /**
+   * `slice(7)` left the path percent-encoded, so a filer-authored name with a
+   * space or a `%` addressed a file that does not exist.
+   */
+  test("parses file:// URLs rather than slicing the scheme", async () => {
+    const filePath = join(testDir, "a b%c.txt");
+    writeFileSync(filePath, "alpha\nbravo foo\n", "utf-8");
+
+    const result = await new FileGrepTask({
+      defaults: { url: `file://${testDir}/a%20b%25c.txt`, pattern: "foo" },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+  });
+
+  test("rejects a file:// URL carrying a remote host", async () => {
+    await expect(
+      new FileGrepTask({
+        defaults: { url: "file://evil.example/etc/passwd", pattern: "root" },
+      }).run()
+    ).rejects.toThrow(TaskInvalidInputError);
+  });
+
+  /**
+   * The scheme test was case-sensitive, so `HTTP://x` fell through to the
+   * filesystem branch and was opened as a relative path against the process
+   * cwd. It must route to the fetch branch instead.
+   */
+  describe("uppercase schemes", () => {
+    let prevSafeFetch: SafeFetchFn;
+
+    beforeEach(() => {
+      prevSafeFetch = registerSafeFetch(() =>
+        Promise.resolve(
+          new Response("alpha\nbravo foo\n", {
+            status: 200,
+            headers: { "Content-Type": "text/plain" },
+          })
+        )
+      );
+    });
+
+    afterEach(() => {
+      registerSafeFetch(prevSafeFetch);
+    });
+
+    test("treats HTTP:// case-insensitively", async () => {
+      const result = await new FileGrepTask({
+        defaults: { url: "HTTP://example.com/log.txt", pattern: "foo" },
+      }).run();
+
+      expect(result.matchCount).toBe(1);
+      expect(result.groups[0].lines[0].text).toBe("bravo foo");
+    });
+  });
+
+  describe.skipIf(!existsSync("/dev/zero"))("non-regular files", () => {
+    test("refuses a character device", async () => {
+      await expect(
+        new FileGrepTask({
+          defaults: { url: "/dev/zero", pattern: "foo" },
+        }).run()
+      ).rejects.toThrow(TaskInvalidInputError);
+    });
+  });
+
+  /**
+   * The budget applies on the local path too, not only through the fetch
+   * branch. `((a)*)*$` bypasses the shape screen and takes 8_234 ms at n=26,
+   * doubling per character.
+   */
+  test("a catastrophic pattern over a local file fails on the budget", async () => {
+    const filePath = join(testDir, "evil.txt");
+    writeFileSync(filePath, "a".repeat(40) + "!\n", "utf-8");
+
+    const started = Date.now();
+    await expect(
+      new FileGrepTask({
+        defaults: { url: filePath, pattern: "((a)*)*$" },
+      }).run()
+    ).rejects.toThrow(/budget/);
+    expect(Date.now() - started).toBeLessThan(5_000);
   });
 });

--- a/packages/test/src/test/task/FileGrepTask.server.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.server.test.ts
@@ -248,17 +248,18 @@ describe("FileGrepTask (server - local files)", () => {
 
   /**
    * The budget applies on the local path too, not only through the fetch
-   * branch. `((a)*)*$` bypasses the shape screen and takes 8_234 ms at n=26,
-   * doubling per character.
+   * branch. `(\w|\d)*$` bypasses the shape screen — its branches overlap on the
+   * digits both accept, which comparing branch text cannot see — and takes
+   * 657 ms at n=26, doubling per added character.
    */
   test("a catastrophic pattern over a local file fails on the budget", async () => {
     const filePath = join(testDir, "evil.txt");
-    writeFileSync(filePath, "a".repeat(40) + "!\n", "utf-8");
+    writeFileSync(filePath, "1".repeat(40) + "!\n", "utf-8");
 
     const started = Date.now();
     await expect(
       new FileGrepTask({
-        defaults: { url: filePath, pattern: "((a)*)*$" },
+        defaults: { url: filePath, pattern: "(\\w|\\d)*$" },
       }).run()
     ).rejects.toThrow(/budget/);
     expect(Date.now() - started).toBeLessThan(5_000);

--- a/packages/test/src/test/task/FileGrepTask.server.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.server.test.ts
@@ -6,7 +6,7 @@
 
 import { TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
 import { FileGrepTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
-import { setLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
@@ -86,6 +86,51 @@ describe("FileGrepTask (server - local files)", () => {
         defaults: { url: filePath, pattern: "foo" },
       }).run()
     ).rejects.toThrow();
+  });
+
+  /**
+   * Reproduced pre-fix with a 640 MB newline-free stream: `createInterface`
+   * accumulated the whole thing and threw `RangeError: Invalid string length`
+   * from a stream `'data'` listener. That surfaces as an `uncaughtException`,
+   * not an iterator rejection, so `grepFile`'s try/catch never saw it and the
+   * process died. 1 MB here is enough to exercise the cap without the memory.
+   */
+  test("a file with no line terminator does not crash the process", async () => {
+    const filePath = join(testDir, "oneline.bin");
+    writeFileSync(filePath, "x".repeat(1_000_000), "utf-8");
+
+    const uncaught: unknown[] = [];
+    const spy = (err: unknown): void => {
+      uncaught.push(err);
+    };
+    process.on("uncaughtException", spy);
+
+    try {
+      const result = await new FileGrepTask({
+        defaults: { url: filePath, pattern: "x" },
+      }).run();
+
+      expect(uncaught).toEqual([]);
+      expect(result.matchCount).toBe(1);
+      expect(result.groups[0].lines[0].text).toHaveLength(DEFAULT_LIMITS.grepMaxLineChars);
+    } finally {
+      process.off("uncaughtException", spy);
+    }
+  });
+
+  test("caps an over-long line and reports truncation", async () => {
+    const filePath = join(testDir, "long.txt");
+    const long = "y".repeat(DEFAULT_LIMITS.grepMaxLineChars + 5_000);
+    writeFileSync(filePath, `short\n${long}\ntail foo\n`, "utf-8");
+
+    const result = await new FileGrepTask({
+      defaults: { url: filePath, pattern: "y" },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    const matched = result.groups.flatMap((g) => g.lines.filter((l) => l.match));
+    expect(matched).toHaveLength(1);
+    expect(matched[0].text).toHaveLength(DEFAULT_LIMITS.grepMaxLineChars);
   });
 
   test("refuses a path outside the configured roots", async () => {

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -640,6 +640,30 @@ describe("FileGrepTask", () => {
     expect(Date.now() - started).toBeLessThan(5_000);
   });
 
+  /**
+   * The group de-duplication used to scan `currentGroup.lines` linearly on
+   * every emit, so a run of contiguous matches was quadratic. Measured on the
+   * pre-fix shape: 10 000 lines -> 126 ms, 20 000 -> 286 ms, 40 000 -> 1576 ms,
+   * 80 000 -> 6390 ms — a clean 4x per doubling, which puts 200 000 at roughly
+   * 40 s. The bound below is that curve's cost, not an arbitrary number.
+   */
+  test("greps 200k contiguous matching lines in bounded time", { timeout: 30_000 }, async () => {
+    mockText("foo\n".repeat(200_000));
+
+    const started = Date.now();
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        maxOutputLines: 200_000,
+        maxOutputChars: 10_000_000,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(200_000);
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
   test("empty file has no matches", async () => {
     mockText("");
 

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -367,6 +367,199 @@ describe("FileGrepTask", () => {
     ).rejects.toThrow(/afterContext/);
   });
 
+  test("onlyMatching emits the matched substring instead of the line", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        onlyMatching: true,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(2);
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 2,
+        lines: [{ line: 2, text: "foo", match: true }],
+      },
+      {
+        startLine: 5,
+        endLine: 5,
+        lines: [{ line: 5, text: "foo", match: true }],
+      },
+    ]);
+  });
+
+  test("onlyMatching emits one entry per match on a line", async () => {
+    mockText("foo bar foo\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        onlyMatching: true,
+      },
+    }).run();
+
+    // matchCount counts matching LINES, as `grep -c` does even with -o.
+    expect(result.matchCount).toBe(1);
+    expect(result.groups).toEqual([
+      {
+        startLine: 1,
+        endLine: 1,
+        lines: [
+          { line: 1, text: "foo", match: true },
+          { line: 1, text: "foo", match: true },
+        ],
+      },
+    ]);
+  });
+
+  test("onlyMatching emits the matched text, not the pattern", async () => {
+    mockText("id=alpha\nid=bravo\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "id=\\w+",
+        onlyMatching: true,
+      },
+    }).run();
+
+    expect(result.groups[0].lines.map((l) => l.text)).toEqual(["id=alpha", "id=bravo"]);
+  });
+
+  test("onlyMatching with ignoreCase keeps the original casing", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        ignoreCase: true,
+        onlyMatching: true,
+      },
+    }).run();
+
+    expect(result.groups.flatMap((g) => g.lines.map((l) => l.text))).toEqual(["foo", "FOO", "foo"]);
+  });
+
+  test("onlyMatching with fixedString emits the literal occurrences", async () => {
+    mockText("cost is $5.00 and $5X00\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "$5.00",
+        fixedString: true,
+        onlyMatching: true,
+      },
+    }).run();
+
+    expect(result.groups[0].lines.map((l) => l.text)).toEqual(["$5.00"]);
+  });
+
+  test("onlyMatching suppresses context lines", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "charlie",
+        context: 1,
+        onlyMatching: true,
+      },
+    }).run();
+
+    expect(result.groups).toEqual([
+      {
+        startLine: 3,
+        endLine: 3,
+        lines: [{ line: 3, text: "charlie", match: true }],
+      },
+    ]);
+  });
+
+  test("onlyMatching with invertMatch emits nothing", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        invertMatch: true,
+        onlyMatching: true,
+      },
+    }).run();
+
+    expect(result.exists).toBe(true);
+    expect(result.matchCount).toBe(4);
+    expect(result.groups).toEqual([]);
+  });
+
+  test("onlyMatching skips zero-length matches", async () => {
+    mockText("abc\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "x*",
+        onlyMatching: true,
+      },
+    }).run();
+
+    expect(result.exists).toBe(true);
+    expect(result.groups).toEqual([]);
+  });
+
+  test("onlyMatching still counts lines under countOnly", async () => {
+    mockText("foo bar foo\nfoo again\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        onlyMatching: true,
+        countOnly: true,
+      },
+    }).run();
+
+    expect(result).toEqual({
+      groups: [],
+      matchCount: 2,
+      exists: true,
+      truncated: false,
+    });
+  });
+
+  test("onlyMatching keeps every match of the line maxMatches stops on", async () => {
+    mockText("foo bar foo\nfoo again\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        onlyMatching: true,
+        maxMatches: 1,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+    expect(result.truncated).toBe(true);
+    expect(result.groups[0].lines.map((l) => l.text)).toEqual(["foo", "foo"]);
+  });
+
+  test("onlyMatching truncates on maxOutputLines mid-line", async () => {
+    mockText("foo foo foo\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        onlyMatching: true,
+        maxOutputLines: 2,
+      },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.groups[0].lines).toHaveLength(2);
+  });
+
   test("splits CRLF the same as LF", async () => {
     mockText("one\r\ntwo foo\r\nthree\r\n");
 

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FileGrepTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
+import { TaskAbortedError } from "@workglow/task-graph";
+import { FileGrepTask, grepLines, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
 import { setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
@@ -574,6 +575,69 @@ describe("FileGrepTask", () => {
         lines: [{ line: 2, text: "two foo", match: true }],
       },
     ]);
+  });
+
+  test("rejects a catastrophic pattern before reading the document", async () => {
+    await expect(
+      new FileGrepTask({
+        defaults: { url: "https://example.com/log.txt", pattern: "(a+)+$" },
+      }).run()
+    ).rejects.toThrow(/nested quantifiers/);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * `((a)*)*$` walks straight past the shape screen — the screen only looks for
+   * a quantifier before the group's first `)`, and here the inner one sits
+   * behind a nested group — and it is exponential all the same: against
+   * `"a".repeat(n) + "!"` V8 takes 8_234 ms at n=26, doubling per added
+   * character. At n=40 that is roughly 2^40 backtracking steps, on the order of
+   * days. Unbounded, this run never returns and no abort can interrupt the one
+   * synchronous `test()` it is stuck inside; the match budget is what turns it
+   * into a rejection. This is exactly why the screen is documented as a
+   * heuristic and the budget as the enforced bound.
+   */
+  test("a guard-bypassing pattern fails on the match budget instead of hanging", async () => {
+    mockText("a".repeat(40) + "!");
+
+    const started = Date.now();
+    await expect(
+      new FileGrepTask({
+        defaults: { url: "https://example.com/log.txt", pattern: "((a)*)*$" },
+      }).run()
+    ).rejects.toThrow(/budget/);
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  /**
+   * Pre-fix the abort check ran between lines, which bought nothing: a single
+   * `regex.test()` is uninterruptible, so a hostile line blocked forever with
+   * the check sitting unreachable above it. It now runs between batches, and
+   * how long one batch may run is what the matcher's budget bounds.
+   *
+   * Driven through `grepLines` rather than the task because an async generator
+   * resolves on the MICROTASK queue: a purely in-memory source starves the
+   * timer phase entirely, so a `setTimeout` abort would not fire until the scan
+   * had already finished. The source below yields to the macrotask queue
+   * periodically, which is what a real file stream does on every read.
+   */
+  test("aborts between batches", async () => {
+    const controller = new AbortController();
+
+    async function* source(): AsyncGenerator<string> {
+      for (let i = 0; i < 200_000; i++) {
+        if (i % 1_000 === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+        yield "foo";
+      }
+    }
+
+    const started = Date.now();
+    const running = grepLines(source(), "foo", { countOnly: true }, controller.signal);
+    setTimeout(() => controller.abort(), 5);
+
+    await expect(running).rejects.toThrow(TaskAbortedError);
+    expect(Date.now() - started).toBeLessThan(5_000);
   });
 
   test("empty file has no matches", async () => {

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -652,23 +652,26 @@ describe("FileGrepTask", () => {
   });
 
   /**
-   * `((a)*)*$` walks straight past the shape screen — the screen only looks for
-   * a quantifier before the group's first `)`, and here the inner one sits
-   * behind a nested group — and it is exponential all the same: against
-   * `"a".repeat(n) + "!"` V8 takes 8_234 ms at n=26, doubling per added
-   * character. At n=40 that is roughly 2^40 backtracking steps, on the order of
-   * days. Unbounded, this run never returns and no abort can interrupt the one
-   * synchronous `test()` it is stuck inside; the match budget is what turns it
-   * into a rejection. This is exactly why the screen is documented as a
+   * `(\w|\d)*$` walks straight past the shape screen and is exponential all the
+   * same: against `"1".repeat(n) + "!"` V8 takes 1 ms at n=16, 14 ms at n=20,
+   * 218 ms at n=24 and 657 ms at n=26 — doubling per added character. At n=40
+   * that is roughly 2^40 backtracking steps, on the order of days. Unbounded,
+   * this run never returns and no abort can interrupt the one synchronous
+   * `test()` it is stuck inside; the match budget is what turns it into a
+   * rejection.
+   *
+   * The bypass is structural rather than an oversight: the two branches overlap
+   * on the digits they both accept, and the screen compares branch TEXT, which
+   * cannot see that. This is exactly why the screen is documented as a
    * heuristic and the budget as the enforced bound.
    */
   test("a guard-bypassing pattern fails on the match budget instead of hanging", async () => {
-    mockText("a".repeat(40) + "!");
+    mockText("1".repeat(40) + "!");
 
     const started = Date.now();
     await expect(
       new FileGrepTask({
-        defaults: { url: "https://example.com/log.txt", pattern: "((a)*)*$" },
+        defaults: { url: "https://example.com/log.txt", pattern: "(\\w|\\d)*$" },
       }).run()
     ).rejects.toThrow(/budget/);
     expect(Date.now() - started).toBeLessThan(5_000);

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -678,6 +678,31 @@ describe("FileGrepTask", () => {
   });
 
   /**
+   * The server budget wraps `matchBatch` (`RegExp.test` in `vm`). `onlyMatching`
+   * then runs `createExtractor`, whose global `exec` loop is on the main thread
+   * and unbounded. `test` can return quickly via a left alternative while the
+   * later `/g` pass still walks into the catastrophic right one: `ok|(\w|\d)*$`
+   * against `"ok" + "1".repeat(n) + "!"` matches `ok` immediately, then `exec`
+   * continues into the digits and backtracks the same way `(\w|\d)*$` alone
+   * does. Pre-fix this never returned; the budget has to cover `exec` too.
+   */
+  test("onlyMatching still fails on the match budget when test() matched via a fast alternative", async () => {
+    mockText("ok" + "1".repeat(40) + "!");
+
+    const started = Date.now();
+    await expect(
+      new FileGrepTask({
+        defaults: {
+          url: "https://example.com/log.txt",
+          pattern: "ok|(\\w|\\d)*$",
+          onlyMatching: true,
+        },
+      }).run()
+    ).rejects.toThrow(/budget/);
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  /**
    * Pre-fix the abort check ran between lines, which bought nothing: a single
    * `regex.test()` is uninterruptible, so a hostile line blocked forever with
    * the check sitting unreachable above it. It now runs between batches, and

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -1,0 +1,400 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FileGrepTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
+import { setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mock = vi.fn;
+
+const mockFetch = mock((_url: string, _options: RequestInit & { allowPrivate?: boolean }) =>
+  Promise.resolve(new Response("test", { status: 200 }))
+);
+const mockSafeFetch: SafeFetchFn = (url, options) => mockFetch(url, options);
+
+const SAMPLE = ["alpha", "bravo foo", "charlie", "FOO delta", "echo foo bar", "foxtrot"].join("\n");
+
+function mockText(content: string): void {
+  mockFetch.mockImplementation(() =>
+    Promise.resolve(
+      new Response(content, {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      })
+    )
+  );
+}
+
+describe("FileGrepTask", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+  let prevSafeFetch: SafeFetchFn;
+
+  beforeAll(() => {
+    prevSafeFetch = registerSafeFetch(mockSafeFetch);
+  });
+
+  afterAll(() => {
+    registerSafeFetch(prevSafeFetch);
+  });
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    mockText(SAMPLE);
+  });
+
+  test("has Document category and FileGrepTask type", () => {
+    expect(FileGrepTask.type).toBe("FileGrepTask");
+    expect(FileGrepTask.category).toBe("Document");
+  });
+
+  test("returns matching lines with 1-based numbers", async () => {
+    const result = await new FileGrepTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo" },
+    }).run();
+
+    expect(result.exists).toBe(true);
+    expect(result.matchCount).toBe(2);
+    expect(result.truncated).toBe(false);
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 2,
+        lines: [{ line: 2, text: "bravo foo", match: true }],
+      },
+      {
+        startLine: 5,
+        endLine: 5,
+        lines: [{ line: 5, text: "echo foo bar", match: true }],
+      },
+    ]);
+  });
+
+  test("returns empty groups when nothing matches", async () => {
+    const result = await new FileGrepTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "zzz" },
+    }).run();
+
+    expect(result).toEqual({
+      groups: [],
+      matchCount: 0,
+      exists: false,
+      truncated: false,
+    });
+  });
+
+  test("ignoreCase matches regardless of case", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        ignoreCase: true,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(3);
+    expect(
+      result.groups.flatMap((g) => g.lines.filter((line) => line.match).map((line) => line.text))
+    ).toEqual(["bravo foo", "FOO delta", "echo foo bar"]);
+  });
+
+  test("fixedString treats regex metacharacters as literals", async () => {
+    mockText("cost is $5.00\ncost is $50\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "$5.00",
+        fixedString: true,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+    expect(result.groups[0].lines[0].text).toBe("cost is $5.00");
+  });
+
+  test("regex pattern matches without fixedString", async () => {
+    mockText("fooXbar\nfoo\nbar\nfoo--bar\n");
+
+    const result = await new FileGrepTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo.*bar" },
+    }).run();
+
+    expect(result.matchCount).toBe(2);
+    expect(result.groups.map((g) => g.lines[0].text)).toEqual(["fooXbar", "foo--bar"]);
+  });
+
+  test("invertMatch returns lines that do not match", async () => {
+    mockText("keep\nskip foo\nkeep too\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        invertMatch: true,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(2);
+    expect(result.groups.map((g) => g.lines[0].text)).toEqual(["keep", "keep too"]);
+  });
+
+  test("beforeContext includes preceding lines", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "echo foo",
+        beforeContext: 1,
+      },
+    }).run();
+
+    expect(result.groups).toEqual([
+      {
+        startLine: 4,
+        endLine: 5,
+        lines: [
+          { line: 4, text: "FOO delta", match: false },
+          { line: 5, text: "echo foo bar", match: true },
+        ],
+      },
+    ]);
+  });
+
+  test("afterContext includes following lines", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "bravo foo",
+        afterContext: 1,
+      },
+    }).run();
+
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 3,
+        lines: [
+          { line: 2, text: "bravo foo", match: true },
+          { line: 3, text: "charlie", match: false },
+        ],
+      },
+    ]);
+  });
+
+  test("context is both before and after", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "charlie",
+        context: 1,
+      },
+    }).run();
+
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 4,
+        lines: [
+          { line: 2, text: "bravo foo", match: false },
+          { line: 3, text: "charlie", match: true },
+          { line: 4, text: "FOO delta", match: false },
+        ],
+      },
+    ]);
+  });
+
+  test("consecutive matches stay in one group", async () => {
+    mockText("alpha\nfoo one\nfoo two\nbravo\n");
+
+    const result = await new FileGrepTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo" },
+    }).run();
+
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 3,
+        lines: [
+          { line: 2, text: "foo one", match: true },
+          { line: 3, text: "foo two", match: true },
+        ],
+      },
+    ]);
+  });
+
+  test("a match inside afterContext extends the current group", async () => {
+    mockText("alpha\nfoo\nbravo\nfoo\ncharlie\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        afterContext: 2,
+      },
+    }).run();
+
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 5,
+        lines: [
+          { line: 2, text: "foo", match: true },
+          { line: 3, text: "bravo", match: false },
+          { line: 4, text: "foo", match: true },
+          { line: 5, text: "charlie", match: false },
+        ],
+      },
+    ]);
+  });
+
+  test("maxMatches stops after N matching lines", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        maxMatches: 1,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+    expect(result.truncated).toBe(true);
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 2,
+        lines: [{ line: 2, text: "bravo foo", match: true }],
+      },
+    ]);
+  });
+
+  test("existsOnly returns whether a match exists without groups", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        existsOnly: true,
+      },
+    }).run();
+
+    expect(result).toEqual({
+      groups: [],
+      matchCount: 1,
+      exists: true,
+      truncated: false,
+    });
+  });
+
+  test("countOnly returns the match count without groups", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        countOnly: true,
+      },
+    }).run();
+
+    expect(result).toEqual({
+      groups: [],
+      matchCount: 2,
+      exists: true,
+      truncated: false,
+    });
+  });
+
+  test("maxOutputLines truncates emitted lines including context", async () => {
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        afterContext: 1,
+        maxOutputLines: 2,
+      },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 3,
+        lines: [
+          { line: 2, text: "bravo foo", match: true },
+          { line: 3, text: "charlie", match: false },
+        ],
+      },
+    ]);
+  });
+
+  test("maxOutputChars truncates when the next line would exceed the budget", async () => {
+    mockText("ab\ncd\nef\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: ".",
+        maxOutputChars: 6,
+      },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.groups[0].lines.map((l) => l.text)).toEqual(["ab", "cd"]);
+  });
+
+  test("rejects maxMatches of zero", async () => {
+    await expect(
+      new FileGrepTask({
+        defaults: {
+          url: "https://example.com/log.txt",
+          pattern: "foo",
+          maxMatches: 0,
+        },
+      }).run()
+    ).rejects.toThrow(/maxMatches/);
+  });
+
+  test("rejects a negative context window", async () => {
+    await expect(
+      new FileGrepTask({
+        defaults: {
+          url: "https://example.com/log.txt",
+          pattern: "foo",
+          afterContext: -1,
+        },
+      }).run()
+    ).rejects.toThrow(/afterContext/);
+  });
+
+  test("splits CRLF the same as LF", async () => {
+    mockText("one\r\ntwo foo\r\nthree\r\n");
+
+    const result = await new FileGrepTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo" },
+    }).run();
+
+    expect(result.groups).toEqual([
+      {
+        startLine: 2,
+        endLine: 2,
+        lines: [{ line: 2, text: "two foo", match: true }],
+      },
+    ]);
+  });
+
+  test("empty file has no matches", async () => {
+    mockText("");
+
+    const result = await new FileGrepTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo" },
+    }).run();
+
+    expect(result).toEqual({
+      groups: [],
+      matchCount: 0,
+      exists: false,
+      truncated: false,
+    });
+  });
+});

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -6,7 +6,7 @@
 
 import { TaskAbortedError } from "@workglow/task-graph";
 import { FileGrepTask, grepLines, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
-import { setLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -272,6 +272,12 @@ describe("FileGrepTask", () => {
     ]);
   });
 
+  /**
+   * `truncated` is now computed rather than hard-coded: the match is on line 2
+   * of 6, so four lines were never scanned and the scan really did stop early.
+   * `matchCount` stays 1 — `existsOnly` stops at the first match, and 0 would
+   * contradict `exists: true`.
+   */
   test("existsOnly returns whether a match exists without groups", async () => {
     const result = await new FileGrepTask({
       defaults: {
@@ -285,8 +291,66 @@ describe("FileGrepTask", () => {
       groups: [],
       matchCount: 1,
       exists: true,
-      truncated: false,
+      truncated: true,
     });
+  });
+
+  test("existsOnly reports no truncation when the match is the last line", async () => {
+    mockText("alpha\nbravo\ncharlie foo\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        existsOnly: true,
+      },
+    }).run();
+
+    expect(result.truncated).toBe(false);
+  });
+
+  test("truncated is false when the last line is the final match", async () => {
+    mockText("alpha\nfoo one\nbravo\nfoo two\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        maxMatches: 2,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(2);
+    expect(result.truncated).toBe(false);
+  });
+
+  test("maxMatches with afterContext still labels later matching lines as matches", async () => {
+    mockText("foo a\nfoo b\nfoo c\ntail\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        maxMatches: 1,
+        afterContext: 2,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+    const byLine = new Map(result.groups.flatMap((g) => g.lines).map((l) => [l.line, l.match]));
+    expect(byLine.get(2)).toBe(true);
+    expect(byLine.get(3)).toBe(true);
+  });
+
+  test("applies default output caps when the caller states none", async () => {
+    mockText("foo\n".repeat(DEFAULT_LIMITS.grepMaxOutputLines + 500));
+
+    const result = await new FileGrepTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo" },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.groups.flatMap((g) => g.lines)).toHaveLength(DEFAULT_LIMITS.grepMaxOutputLines);
   });
 
   test("countOnly returns the match count without groups", async () => {

--- a/packages/test/src/test/task/FileSedEntitlements.test.ts
+++ b/packages/test/src/test/task/FileSedEntitlements.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createPolicyEnforcer,
+  createProfilePolicy,
+  ENTITLEMENT_ENFORCER,
+  Entitlements,
+  TaskEntitlementError,
+  TaskGraph,
+  TaskGraphRunner,
+  TaskRegistry,
+  type IEntitlementEnforcer,
+} from "@workglow/task-graph";
+import { FileSedTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
+import { Container, ServiceRegistry, setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+const METADATA_URL = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
+
+describe("FileSedTask entitlement enforcement", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+
+  let prevSafeFetch: SafeFetchFn;
+  let testDir: string;
+
+  beforeAll(() => {
+    // The enforcer is what is under test, not the network layer.
+    prevSafeFetch = registerSafeFetch(() =>
+      Promise.resolve(
+        new Response("alpha\nbravo foo\n", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        })
+      )
+    );
+    TaskRegistry.registerTask(FileSedTask);
+  });
+
+  afterAll(() => {
+    registerSafeFetch(prevSafeFetch);
+  });
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `filesed-ent-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function makeRegistry(enforcer: IEntitlementEnforcer): ServiceRegistry {
+    const registry = new ServiceRegistry(new Container());
+    registry.register(ENTITLEMENT_ENFORCER, () => enforcer);
+    return registry;
+  }
+
+  function makeGraph(url: string, roots?: readonly string[]): TaskGraph {
+    const graph = new TaskGraph();
+    graph.addTask(
+      new FileSedTask({
+        id: "sed-node",
+        roots,
+        defaults: { url, pattern: "foo", replacement: "bar" },
+      })
+    );
+    return graph;
+  }
+
+  /**
+   * The scenario that motivated the declaration. Pre-fix the task declared
+   * nothing at all: `computeGraphEntitlements` runs over `graph.getTasks()` at
+   * graph start and saw an empty set, and the `FetchUrlTask` the task owns
+   * inside `execute()` is not in that snapshot — so it reached the metadata
+   * endpoint with `allowPrivate: true`, its own resolved-destination check
+   * satisfied because the child's input url IS the private one.
+   */
+  test("a profile without network:private denies a metadata-endpoint substitution", async () => {
+    const enforcer = createPolicyEnforcer(createProfilePolicy("browser"));
+    const runner = new TaskGraphRunner(makeGraph(METADATA_URL));
+
+    await expect(
+      runner.runGraph({}, { registry: makeRegistry(enforcer), enforceEntitlements: true })
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("the same profile allows a public substitution", async () => {
+    const enforcer = createPolicyEnforcer(createProfilePolicy("browser"));
+    const runner = new TaskGraphRunner(makeGraph("https://example.com/log.txt"));
+
+    await expect(
+      runner.runGraph({}, { registry: makeRegistry(enforcer), enforceEntitlements: true })
+    ).resolves.toBeDefined();
+  });
+
+  test("a profile granting filesystem:read only under /tmp denies /etc", async () => {
+    const browserPolicy = createProfilePolicy("browser");
+    const scopedPolicy = {
+      deny: browserPolicy.deny,
+      grant: [
+        ...browserPolicy.grant,
+        { id: Entitlements.FILESYSTEM_READ, resources: [`${testDir}/*`] },
+      ],
+      ask: browserPolicy.ask,
+    };
+
+    const allowed = join(testDir, "notes.txt");
+    writeFileSync(allowed, "alpha\nbravo foo\n", "utf-8");
+
+    const permitted = new TaskGraphRunner(makeGraph(allowed));
+    await expect(
+      permitted.runGraph(
+        {},
+        { registry: makeRegistry(createPolicyEnforcer(scopedPolicy)), enforceEntitlements: true }
+      )
+    ).resolves.toBeDefined();
+
+    const denied = new TaskGraphRunner(makeGraph("/etc/passwd"));
+    await expect(
+      denied.runGraph(
+        {},
+        { registry: makeRegistry(createPolicyEnforcer(scopedPolicy)), enforceEntitlements: true }
+      )
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("declares filesystem:read scoped to the resolved path, and no network", () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "bravo foo\n", "utf-8");
+
+    const declared = new FileSedTask({
+      defaults: { url: filePath, pattern: "foo", replacement: "bar" },
+    }).entitlements().entitlements;
+
+    expect(declared.map((e) => e.id)).toEqual([Entitlements.FILESYSTEM_READ]);
+    expect(declared[0].resources).toEqual([filePath]);
+  });
+
+  test("declares the fetch entitlements for an http url, and no filesystem:read", () => {
+    const declared = new FileSedTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo", replacement: "bar" },
+    }).entitlements().entitlements;
+
+    expect(declared.map((e) => e.id)).toContain(Entitlements.NETWORK_HTTP);
+    expect(declared.map((e) => e.id)).not.toContain(Entitlements.FILESYSTEM_READ);
+  });
+
+  test("declares fail-closed entitlements when the url is unknown", () => {
+    const declared = new FileSedTask({
+      defaults: { pattern: "foo", replacement: "bar" } as never,
+    }).entitlements().entitlements;
+    const ids = declared.map((e) => e.id);
+
+    expect(ids).toContain(Entitlements.FILESYSTEM_READ);
+    expect(ids).toContain(Entitlements.NETWORK_PRIVATE);
+    // Unscoped: nothing is known about the destination yet.
+    expect(declared.find((e) => e.id === Entitlements.NETWORK_PRIVATE)?.resources).toBeUndefined();
+    expect(declared.find((e) => e.id === Entitlements.FILESYSTEM_READ)?.resources).toBeUndefined();
+  });
+
+  /**
+   * The declaration must name the path that will actually be OPENED, not the
+   * url as written: a policy scoped to a directory is worthless if a symlink
+   * inside it can be declared under its own name and then followed elsewhere.
+   */
+  test("declares the resolved real path, not the url as given", () => {
+    const target = join(testDir, "target.txt");
+    const link = join(testDir, "link.txt");
+    writeFileSync(target, "bravo foo\n", "utf-8");
+    symlinkSync(target, link);
+
+    const declared = new FileSedTask({
+      defaults: { url: `file://${link}`, pattern: "foo", replacement: "bar" },
+    }).entitlements().entitlements;
+
+    expect(declared[0].resources).toEqual([target]);
+  });
+});

--- a/packages/test/src/test/task/FileSedEntitlements.test.ts
+++ b/packages/test/src/test/task/FileSedEntitlements.test.ts
@@ -12,6 +12,7 @@ import {
   TaskEntitlementError,
   TaskGraph,
   TaskGraphRunner,
+  TaskInvalidInputError,
   TaskRegistry,
   type IEntitlementEnforcer,
 } from "@workglow/task-graph";
@@ -183,5 +184,29 @@ describe("FileSedTask entitlement enforcement", () => {
     }).entitlements().entitlements;
 
     expect(declared[0].resources).toEqual([target]);
+  });
+
+  /**
+   * A misconfigured root (or one cleaned up mid-run) must not escape as a raw
+   * `ENOENT ... lstat` from deep inside the resolver. It names the root, and
+   * the read is refused either way — the declaration degrades to an UNSCOPED
+   * `filesystem:read`, which `execute()` never reaches because resolution
+   * throws there too.
+   */
+  test("names a configured root that does not exist, and still fails closed", async () => {
+    const missingRoot = join(testDir, "nope");
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "bravo foo\n", "utf-8");
+
+    const task = new FileSedTask({
+      roots: [missingRoot],
+      defaults: { url: filePath, pattern: "foo", replacement: "bar" },
+    });
+
+    const declared = task.entitlements().entitlements;
+    expect(declared.find((e) => e.id === Entitlements.FILESYSTEM_READ)?.resources).toBeUndefined();
+
+    await expect(task.run()).rejects.toThrow(TaskInvalidInputError);
+    await expect(task.run()).rejects.toThrow(missingRoot);
   });
 });

--- a/packages/test/src/test/task/FileSedTask.server.test.ts
+++ b/packages/test/src/test/task/FileSedTask.server.test.ts
@@ -84,4 +84,46 @@ describe("FileSedTask (server - local files)", () => {
       }).run()
     ).rejects.toThrow();
   });
+
+  /**
+   * `String.replace` backtracks exactly like `test` does, and the shape screen
+   * is a heuristic rather than a decision procedure — so the enforced bound is
+   * the wall-clock budget the substitution runs under.
+   *
+   * `(\w|\d)*$` bypasses the screen: its branches overlap on the digits both
+   * accept, which comparing branch text cannot see. Measured here: 1 ms at
+   * n=16, 25 ms at n=20, 392 ms at n=24, 1538 ms at n=26 — doubling per added
+   * character, so the n=40 below is on the order of 2^40 steps. Unbounded it
+   * blocks the event loop with no abort able to reach it; the run must instead
+   * be REJECTED, and quickly.
+   */
+  test("a catastrophic pattern over a local file fails on the budget", async () => {
+    const filePath = join(testDir, "evil.txt");
+    writeFileSync(filePath, "1".repeat(40) + "!\n", "utf-8");
+
+    const started = Date.now();
+    await expect(
+      new FileSedTask({
+        defaults: { url: filePath, pattern: "(\\w|\\d)*$", replacement: "X" },
+      }).run()
+    ).rejects.toThrow(/budget/);
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  test("the budget does not disturb an ordinary substitution", async () => {
+    const filePath = join(testDir, "groups.txt");
+    writeFileSync(filePath, "2026-08-17\nname: ada\n", "utf-8");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: filePath,
+        pattern: "(\\d{4})-(\\d{2})-(\\d{2})|name: (?<who>\\w+)",
+        replacement: "[$3/$2/$1 $<who> $&]",
+        global: true,
+      },
+    }).run();
+
+    expect(result.replacementCount).toBe(2);
+    expect(result.text).toBe("[17/08/2026  2026-08-17]\n[// ada name: ada]\n");
+  });
 });

--- a/packages/test/src/test/task/FileSedTask.server.test.ts
+++ b/packages/test/src/test/task/FileSedTask.server.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FileSedTask } from "@workglow/tasks";
+import { setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+describe("FileSedTask (server - local files)", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `filesed-test-${Date.now()}`);
+    if (!existsSync(testDir)) {
+      mkdirSync(testDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("substitutes in a filesystem path", async () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "alpha\nbravo foo\ncharlie\n", "utf-8");
+
+    const result = await new FileSedTask({
+      defaults: { url: filePath, pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.replacementCount).toBe(1);
+    expect(result.text).toBe("alpha\nbravo bar\ncharlie\n");
+  });
+
+  test("leaves the source file unmodified", async () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "alpha\nbravo foo\n", "utf-8");
+
+    await new FileSedTask({
+      defaults: { url: filePath, pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(readFileSync(filePath, "utf-8")).toBe("alpha\nbravo foo\n");
+  });
+
+  test("substitutes in a file:// URL", async () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "keep\nskip foo\nkeep too\n", "utf-8");
+
+    const result = await new FileSedTask({
+      defaults: { url: `file://${filePath}`, pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.text).toBe("keep\nskip bar\nkeep too\n");
+  });
+
+  test("streams CRLF files from disk", async () => {
+    const filePath = join(testDir, "windows.txt");
+    writeFileSync(filePath, "one\r\ntwo foo\r\nthree\r\n", "utf-8");
+
+    const result = await new FileSedTask({
+      defaults: { url: filePath, pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.text).toBe("one\ntwo bar\nthree\n");
+  });
+
+  test("throws for a missing file", async () => {
+    const filePath = join(testDir, "missing.txt");
+
+    await expect(
+      new FileSedTask({
+        defaults: { url: filePath, pattern: "foo", replacement: "bar" },
+      }).run()
+    ).rejects.toThrow();
+  });
+});

--- a/packages/test/src/test/task/FileSedTask.server.test.ts
+++ b/packages/test/src/test/task/FileSedTask.server.test.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FileSedTask } from "@workglow/tasks";
+import { TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
+import { FileSedTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
 import { setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -83,6 +84,140 @@ describe("FileSedTask (server - local files)", () => {
         defaults: { url: filePath, pattern: "foo", replacement: "bar" },
       }).run()
     ).rejects.toThrow();
+  });
+
+  test("refuses a path outside the configured roots", async () => {
+    const outside = join(tmpdir(), `filesed-outside-${Date.now()}.txt`);
+    writeFileSync(outside, "bravo foo\n", "utf-8");
+
+    try {
+      await expect(
+        new FileSedTask({
+          roots: [testDir],
+          defaults: { url: outside, pattern: "foo", replacement: "bar" },
+        }).run()
+      ).rejects.toThrow(TaskEntitlementError);
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
+  /**
+   * The containment check runs AFTER `realpathSync`. A pre-realpath check
+   * passes here — the link itself sits inside the root — and then opens the
+   * target, which is the whole escape.
+   */
+  test("refuses a symlink that escapes the configured roots", async () => {
+    const link = join(testDir, "escape.txt");
+    symlinkSync("/etc/passwd", link);
+
+    await expect(
+      new FileSedTask({
+        roots: [testDir],
+        defaults: { url: link, pattern: "root", replacement: "x" },
+      }).run()
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("allows a symlink that stays inside the roots", async () => {
+    const target = join(testDir, "target.txt");
+    const link = join(testDir, "link.txt");
+    writeFileSync(target, "alpha\nbravo foo\n", "utf-8");
+    symlinkSync(target, link);
+
+    const result = await new FileSedTask({
+      roots: [testDir],
+      defaults: { url: link, pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.text).toBe("alpha\nbravo bar\n");
+  });
+
+  /**
+   * `slice(7)` left the path percent-encoded, so a filer-authored name with a
+   * space or a `%` addressed a file that does not exist.
+   */
+  test("parses file:// URLs rather than slicing the scheme", async () => {
+    const filePath = join(testDir, "a b%c.txt");
+    writeFileSync(filePath, "alpha\nbravo foo\n", "utf-8");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: `file://${testDir}/a%20b%25c.txt`,
+        pattern: "foo",
+        replacement: "bar",
+      },
+    }).run();
+
+    expect(result.text).toBe("alpha\nbravo bar\n");
+  });
+
+  test("rejects a file:// URL carrying a remote host", async () => {
+    await expect(
+      new FileSedTask({
+        defaults: { url: "file://evil.example/etc/passwd", pattern: "root", replacement: "x" },
+      }).run()
+    ).rejects.toThrow(TaskInvalidInputError);
+  });
+
+  /**
+   * `url.slice(7)` on a relative path opened it against the process cwd, so a
+   * bare `package.json` was readable with no root, no containment and no
+   * declaration.
+   */
+  test("resolves a relative path rather than reading it from the process cwd", async () => {
+    await expect(
+      new FileSedTask({
+        roots: [testDir],
+        defaults: { url: "package.json", pattern: "name", replacement: "x" },
+      }).run()
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  /**
+   * The scheme test was case-sensitive, so `HTTP://x` fell through to the
+   * filesystem branch and was opened as a relative path against the process
+   * cwd. It must route to the fetch branch instead.
+   */
+  describe("uppercase schemes", () => {
+    let prevSafeFetch: SafeFetchFn;
+
+    beforeEach(() => {
+      prevSafeFetch = registerSafeFetch(() =>
+        Promise.resolve(
+          new Response("alpha\nbravo foo\n", {
+            status: 200,
+            headers: { "Content-Type": "text/plain" },
+          })
+        )
+      );
+    });
+
+    afterEach(() => {
+      registerSafeFetch(prevSafeFetch);
+    });
+
+    test("treats HTTP:// case-insensitively", async () => {
+      const result = await new FileSedTask({
+        defaults: {
+          url: "HTTP://example.com/log.txt",
+          pattern: "foo",
+          replacement: "bar",
+        },
+      }).run();
+
+      expect(result.text).toBe("alpha\nbravo bar\n");
+    });
+  });
+
+  describe.skipIf(!existsSync("/dev/zero"))("non-regular files", () => {
+    test("refuses a character device", async () => {
+      await expect(
+        new FileSedTask({
+          defaults: { url: "/dev/zero", pattern: "foo", replacement: "bar" },
+        }).run()
+      ).rejects.toThrow(TaskInvalidInputError);
+    });
   });
 
   /**

--- a/packages/test/src/test/task/FileSedTask.server.test.ts
+++ b/packages/test/src/test/task/FileSedTask.server.test.ts
@@ -6,7 +6,7 @@
 
 import { TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
 import { FileSedTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
-import { setLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
@@ -84,6 +84,52 @@ describe("FileSedTask (server - local files)", () => {
         defaults: { url: filePath, pattern: "foo", replacement: "bar" },
       }).run()
     ).rejects.toThrow();
+  });
+
+  /**
+   * Reproduced pre-fix with a 640 MB newline-free stream: `createInterface`
+   * accumulated the whole thing and threw `RangeError: Invalid string length`
+   * from a stream `'data'` listener. That surfaces as an `uncaughtException`,
+   * not an iterator rejection, so `sedFile`'s try/catch never saw it and the
+   * process died. 1 MB here is enough to exercise the cap without the memory.
+   */
+  test("a file with no line terminator does not crash the process", async () => {
+    const filePath = join(testDir, "oneline.bin");
+    writeFileSync(filePath, "x".repeat(1_000_000), "utf-8");
+
+    const uncaught: unknown[] = [];
+    const spy = (err: unknown): void => {
+      uncaught.push(err);
+    };
+    process.on("uncaughtException", spy);
+
+    try {
+      const result = await new FileSedTask({
+        defaults: { url: filePath, pattern: "x", replacement: "y", global: true },
+      }).run();
+
+      expect(uncaught).toEqual([]);
+      expect(result.replacementCount).toBe(DEFAULT_LIMITS.grepMaxLineChars);
+      expect(result.text).toHaveLength(DEFAULT_LIMITS.grepMaxLineChars + 1);
+    } finally {
+      process.off("uncaughtException", spy);
+    }
+  });
+
+  test("caps an over-long line and reports truncation", async () => {
+    const filePath = join(testDir, "long.txt");
+    const long = "y".repeat(DEFAULT_LIMITS.grepMaxLineChars + 5_000);
+    writeFileSync(filePath, `short\n${long}\ntail foo\n`, "utf-8");
+
+    const result = await new FileSedTask({
+      defaults: { url: filePath, pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    const lines = result.text.split("\n");
+    expect(lines[1]).toHaveLength(DEFAULT_LIMITS.grepMaxLineChars);
+    // The rest of the physical line is discarded, not folded into a new one.
+    expect(lines[2]).toBe("tail bar");
   });
 
   test("refuses a path outside the configured roots", async () => {

--- a/packages/test/src/test/task/FileSedTask.test.ts
+++ b/packages/test/src/test/task/FileSedTask.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { FileSedTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
-import { setLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -288,6 +288,41 @@ describe("FileSedTask", () => {
 
     expect(result.truncated).toBe(true);
     expect(result.text).toBe("ab\ncd\n");
+  });
+
+  /**
+   * The caps were enforced only when the caller STATED them, so omitting them
+   * meant no cap at all: a workflow substituting one word in a large document
+   * got the whole document back, and `truncated: false` said that was the
+   * complete answer.
+   */
+  test("caps output lines even when the caller states no limit", async () => {
+    const lines = DEFAULT_LIMITS.grepMaxOutputLines + 500;
+    mockText(`${Array.from({ length: lines }, (_, i) => `line ${i} foo`).join("\n")}\n`);
+
+    const result = await new FileSedTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.text.split("\n").filter((l) => l.length > 0)).toHaveLength(
+      DEFAULT_LIMITS.grepMaxOutputLines
+    );
+  });
+
+  test("caps output characters even when the caller states no limit", async () => {
+    // Few enough lines to stay under the line cap, wide enough to pass the
+    // character one — so this can only be the character cap firing.
+    const wide = "z".repeat(20_000);
+    mockText(`${Array.from({ length: 100 }, () => `${wide} foo`).join("\n")}\n`);
+
+    const result = await new FileSedTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.text.length).toBeLessThanOrEqual(DEFAULT_LIMITS.grepMaxOutputChars);
+    expect(result.text.split("\n").filter((l) => l.length > 0).length).toBeLessThan(100);
   });
 
   test("rejects maxReplacements of zero", async () => {

--- a/packages/test/src/test/task/FileSedTask.test.ts
+++ b/packages/test/src/test/task/FileSedTask.test.ts
@@ -1,0 +1,388 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FileSedTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
+import { setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mock = vi.fn;
+
+const mockFetch = mock((_url: string, _options: RequestInit & { allowPrivate?: boolean }) =>
+  Promise.resolve(new Response("test", { status: 200 }))
+);
+const mockSafeFetch: SafeFetchFn = (url, options) => mockFetch(url, options);
+
+const SAMPLE = ["alpha", "bravo foo", "charlie", "FOO delta", "echo foo bar", "foxtrot"].join("\n");
+
+function mockText(content: string): void {
+  mockFetch.mockImplementation(() =>
+    Promise.resolve(
+      new Response(content, {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      })
+    )
+  );
+}
+
+describe("FileSedTask", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+  let prevSafeFetch: SafeFetchFn;
+
+  beforeAll(() => {
+    prevSafeFetch = registerSafeFetch(mockSafeFetch);
+  });
+
+  afterAll(() => {
+    registerSafeFetch(prevSafeFetch);
+  });
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    mockText(SAMPLE);
+  });
+
+  test("has Document category and FileSedTask type", () => {
+    expect(FileSedTask.type).toBe("FileSedTask");
+    expect(FileSedTask.category).toBe("Document");
+  });
+
+  test("substitutes the first occurrence on each matching line", async () => {
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        replacement: "bar",
+      },
+    }).run();
+
+    expect(result.replacementCount).toBe(2);
+    expect(result.linesChanged).toBe(2);
+    expect(result.truncated).toBe(false);
+    expect(result.text).toBe("alpha\nbravo bar\ncharlie\nFOO delta\necho bar bar\nfoxtrot\n");
+  });
+
+  test("leaves the document untouched when nothing matches", async () => {
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "zzz",
+        replacement: "bar",
+      },
+    }).run();
+
+    expect(result.replacementCount).toBe(0);
+    expect(result.linesChanged).toBe(0);
+    expect(result.text).toBe(`${SAMPLE}\n`);
+  });
+
+  test("global replaces every occurrence on a line", async () => {
+    mockText("foo foo foo\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        replacement: "bar",
+        global: true,
+      },
+    }).run();
+
+    expect(result.replacementCount).toBe(3);
+    expect(result.linesChanged).toBe(1);
+    expect(result.text).toBe("bar bar bar\n");
+  });
+
+  test("without global only the first occurrence on a line changes", async () => {
+    mockText("foo foo foo\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        replacement: "bar",
+      },
+    }).run();
+
+    expect(result.replacementCount).toBe(1);
+    expect(result.text).toBe("bar foo foo\n");
+  });
+
+  test("ignoreCase substitutes regardless of case", async () => {
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        replacement: "bar",
+        ignoreCase: true,
+      },
+    }).run();
+
+    expect(result.replacementCount).toBe(3);
+    expect(result.text).toContain("bar delta");
+  });
+
+  test("expands $1 capture groups", async () => {
+    mockText("2026-08-17\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "(\\d{4})-(\\d{2})-(\\d{2})",
+        replacement: "$3/$2/$1",
+      },
+    }).run();
+
+    expect(result.text).toBe("17/08/2026\n");
+  });
+
+  test("expands $& and $$", async () => {
+    mockText("price 42\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "\\d+",
+        replacement: "$$$&",
+      },
+    }).run();
+
+    expect(result.text).toBe("price $42\n");
+  });
+
+  test("expands named groups", async () => {
+    mockText("name: ada\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "name: (?<who>\\w+)",
+        replacement: "hello $<who>",
+      },
+    }).run();
+
+    expect(result.text).toBe("hello ada\n");
+  });
+
+  test("leaves an unterminated $< and an out-of-range $n literal", async () => {
+    mockText("x\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "(x)",
+        replacement: "$<who $2 $1",
+      },
+    }).run();
+
+    expect(result.text).toBe("$<who $2 x\n");
+  });
+
+  test("prefers a two-digit group reference when that group exists", async () => {
+    mockText("abcdefghijk\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)",
+        replacement: "$11-$1-$12",
+      },
+    }).run();
+
+    expect(result.text).toBe("k-a-a2\n");
+  });
+
+  test("fixedString treats pattern and replacement as literals", async () => {
+    mockText("cost is $5.00\ncost is $50\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "$5.00",
+        replacement: "$1 free",
+        fixedString: true,
+      },
+    }).run();
+
+    expect(result.replacementCount).toBe(1);
+    expect(result.text).toBe("cost is $1 free\ncost is $50\n");
+  });
+
+  test("maxReplacements stops substituting and passes the rest through", async () => {
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        replacement: "bar",
+        maxReplacements: 1,
+      },
+    }).run();
+
+    expect(result.replacementCount).toBe(1);
+    expect(result.linesChanged).toBe(1);
+    expect(result.truncated).toBe(false);
+    expect(result.text).toBe("alpha\nbravo bar\ncharlie\nFOO delta\necho foo bar\nfoxtrot\n");
+  });
+
+  test("maxReplacements bounds a global substitution mid-line", async () => {
+    mockText("foo foo foo\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        replacement: "bar",
+        global: true,
+        maxReplacements: 2,
+      },
+    }).run();
+
+    expect(result.replacementCount).toBe(2);
+    expect(result.text).toBe("bar bar foo\n");
+  });
+
+  test("onlyChangedLines emits just the substituted lines", async () => {
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        replacement: "bar",
+        onlyChangedLines: true,
+      },
+    }).run();
+
+    expect(result.linesChanged).toBe(2);
+    expect(result.text).toBe("bravo bar\necho bar bar\n");
+  });
+
+  test("maxOutputLines truncates the emitted document", async () => {
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        replacement: "bar",
+        maxOutputLines: 2,
+      },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.text).toBe("alpha\nbravo bar\n");
+  });
+
+  test("maxOutputChars truncates when the next line would exceed the budget", async () => {
+    mockText("ab\ncd\nef\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "z",
+        replacement: "y",
+        maxOutputChars: 6,
+      },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.text).toBe("ab\ncd\n");
+  });
+
+  test("rejects maxReplacements of zero", async () => {
+    await expect(
+      new FileSedTask({
+        defaults: {
+          url: "https://example.com/log.txt",
+          pattern: "foo",
+          replacement: "bar",
+          maxReplacements: 0,
+        },
+      }).run()
+    ).rejects.toThrow(/maxReplacements/);
+  });
+
+  test("rejects a negative output limit", async () => {
+    await expect(
+      new FileSedTask({
+        defaults: {
+          url: "https://example.com/log.txt",
+          pattern: "foo",
+          replacement: "bar",
+          maxOutputLines: -1,
+        },
+      }).run()
+    ).rejects.toThrow(/maxOutputLines/);
+  });
+
+  test("rejects an invalid regular expression", async () => {
+    await expect(
+      new FileSedTask({
+        defaults: {
+          url: "https://example.com/log.txt",
+          pattern: "foo(",
+          replacement: "bar",
+        },
+      }).run()
+    ).rejects.toThrow(/Invalid regular expression/);
+  });
+
+  test("rejects a nested-quantifier pattern", async () => {
+    await expect(
+      new FileSedTask({
+        defaults: {
+          url: "https://example.com/log.txt",
+          pattern: "(a+)+",
+          replacement: "bar",
+        },
+      }).run()
+    ).rejects.toThrow(/nested quantifiers/);
+  });
+
+  test("rejects an empty fixed string", async () => {
+    await expect(
+      new FileSedTask({
+        defaults: {
+          url: "https://example.com/log.txt",
+          pattern: "",
+          replacement: "bar",
+          fixedString: true,
+        },
+      }).run()
+    ).rejects.toThrow(/fixedString/);
+  });
+
+  test("splits CRLF the same as LF", async () => {
+    mockText("one\r\ntwo foo\r\nthree\r\n");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        replacement: "bar",
+      },
+    }).run();
+
+    expect(result.text).toBe("one\ntwo bar\nthree\n");
+  });
+
+  test("empty file yields empty output", async () => {
+    mockText("");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        replacement: "bar",
+      },
+    }).run();
+
+    expect(result).toEqual({
+      text: "",
+      replacementCount: 0,
+      linesChanged: 0,
+      truncated: false,
+    });
+  });
+});

--- a/packages/test/src/test/task/RegexSafety.test.ts
+++ b/packages/test/src/test/task/RegexSafety.test.ts
@@ -128,6 +128,15 @@ describe("hasUnsafeRegexShape", () => {
     expect(hasUnsafeRegexShape("([a-z]|[a-z])*")).toBe(true);
   });
 
+  /**
+   * The class-stripping regex this scanner replaced matched `\\[` as a class
+   * opener, so it stripped this whole pattern to `\\X` and called the nested
+   * quantifier inside it safe. Reading the escape is what fixes that.
+   */
+  it("does not let an escaped bracket hide a nested quantifier", () => {
+    expect(hasUnsafeRegexShape("\\[(a+)+]")).toBe(true);
+  });
+
   it("still catches a class branch that can match empty", () => {
     expect(hasUnsafeRegexShape("([a-z]*|[A-Z])+")).toBe(true);
   });

--- a/packages/test/src/test/task/RegexSafety.test.ts
+++ b/packages/test/src/test/task/RegexSafety.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { assertSafeRegexPattern } from "@workglow/tasks";
+import { assertSafeRegexPattern, hasUnsafeRegexShape } from "@workglow/tasks";
 import { SECURITY_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { describe, expect, it } from "vitest";
@@ -50,5 +50,85 @@ describe("assertSafeRegexPattern", () => {
     const started = performance.now();
     expect(() => assertSafeRegexPattern(pattern)).toThrow(/too many/);
     expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  it("rejects a repeated alternation with overlapping branches", () => {
+    expect(() => assertSafeRegexPattern("(a|a)*")).toThrow(/overlapping branches/);
+  });
+});
+
+/**
+ * The shape screen behind {@link assertSafeRegexPattern}, exercised directly so
+ * each modelled family is pinned independently of which error text it produces.
+ */
+describe("hasUnsafeRegexShape", () => {
+  it.each(["(a+)+$", "(a*)*$", "(x+x+)+y", "([a-z]+)+$", "((a)*)*$", "((b|c+))+"])(
+    "rejects the nested quantifier %s",
+    (pattern) => {
+      expect(hasUnsafeRegexShape(pattern)).toBe(true);
+    }
+  );
+
+  /**
+   * These were MEASURED as exponential under V8 and are invisible to the
+   * nested-quantifier scan, which pops `(a|a)` with a body carrying no
+   * quantifier of its own: `/(a|a)*$/` against `"a".repeat(n) + "!"` runs 52 ms
+   * at n=18, 118 ms at n=22, 466 ms at n=24 and 1821 ms at n=26 — a clean
+   * doubling per added character — and `(a|a|a)+$` at n=20 ran past a 120 s
+   * timeout. The alternation branches overlap, so the engine has more than one
+   * way to consume the same input.
+   */
+  it.each(["(a|a)*$", "(?:a|a)*$", "(a|a|a)+$"])(
+    "rejects the overlapping alternation %s",
+    (pattern) => {
+      expect(hasUnsafeRegexShape(pattern)).toBe(true);
+    }
+  );
+
+  it("rejects an alternation where one branch prefixes the other", () => {
+    expect(hasUnsafeRegexShape("^(a|ab)+$")).toBe(true);
+  });
+
+  it("rejects an alternation whose branch can match empty", () => {
+    expect(hasUnsafeRegexShape("(a*|b)+$")).toBe(true);
+  });
+
+  it("rejects an unbounded counted quantifier nested under a quantifier", () => {
+    expect(hasUnsafeRegexShape("(a{2,})*$")).toBe(true);
+  });
+
+  it.each(["foo.*bar", "^\\d{3}-\\d{4}$", "[a-z]+", "(a\\+)+", "([*+])+"])(
+    "accepts the ordinary pattern %s",
+    (pattern) => {
+      expect(hasUnsafeRegexShape(pattern)).toBe(false);
+    }
+  );
+
+  /**
+   * The negative control for the alternation rule. `(foo|far)+` shares a first
+   * character but neither branch prefixes the other, and it is verifiably not
+   * exponential. A first-character-overlap rule would reject it — and a large
+   * class of ordinary patterns with it. The screen is shared with RegexTask and
+   * FileSedTask, so over-rejection here breaks callers that work today.
+   */
+  it("accepts an alternation that merely shares a first character", () => {
+    expect(hasUnsafeRegexShape("(foo|far)+")).toBe(false);
+  });
+
+  /**
+   * Two different classes are two different branches. Collapsing every class to
+   * one placeholder would make these compare equal and reject an ordinary
+   * pattern, so overlap is judged on the class text as written.
+   */
+  it("distinguishes two different character classes in an alternation", () => {
+    expect(hasUnsafeRegexShape("([a-z]|[A-Z])*")).toBe(false);
+  });
+
+  it("still catches an alternation of two identical character classes", () => {
+    expect(hasUnsafeRegexShape("([a-z]|[a-z])*")).toBe(true);
+  });
+
+  it("still catches a class branch that can match empty", () => {
+    expect(hasUnsafeRegexShape("([a-z]*|[A-Z])+")).toBe(true);
   });
 });

--- a/packages/test/src/test/task/RegexSafety.test.ts
+++ b/packages/test/src/test/task/RegexSafety.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { assertSafeRegexPattern } from "@workglow/tasks";
+import { SECURITY_LIMITS, setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { describe, expect, it } from "vitest";
+
+describe("assertSafeRegexPattern", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+
+  it("accepts ordinary patterns", () => {
+    for (const pattern of ["foo", "foo.*bar", "^\\s+$", "(\\d{4})-(\\d{2})-(\\d{2})", "[a-z]+"]) {
+      expect(() => assertSafeRegexPattern(pattern)).not.toThrow();
+    }
+  });
+
+  it("rejects nested quantifiers", () => {
+    for (const pattern of ["(a+)+", "(a*)+", "(a+)*", "(a+)?", "(a+){2}", "((b|c+))+"]) {
+      expect(() => assertSafeRegexPattern(pattern)).toThrow(/nested quantifiers/);
+    }
+  });
+
+  it("does not read a quantifier inside a character class as one", () => {
+    expect(() => assertSafeRegexPattern("([*+])+")).not.toThrow();
+  });
+
+  it("does not read an escaped quantifier as one", () => {
+    expect(() => assertSafeRegexPattern("(a\\+)+")).not.toThrow();
+  });
+
+  it("rejects too many brackets", () => {
+    const pattern = "[a]".repeat(SECURITY_LIMITS.regexMaxBracketCount + 1);
+    expect(() => assertSafeRegexPattern(pattern)).toThrow(/too many/);
+  });
+
+  it("allows brackets right up to the limit", () => {
+    const pattern = "[a]".repeat(SECURITY_LIMITS.regexMaxBracketCount);
+    expect(() => assertSafeRegexPattern(pattern)).not.toThrow();
+  });
+
+  it("stays linear on an unclosed-bracket pattern", () => {
+    // The regex-based class stripper this guard replaced was quadratic here:
+    // every '[' restarted a scan that ran to the end of the string.
+    const pattern = "[".repeat(50_000);
+    const started = performance.now();
+    expect(() => assertSafeRegexPattern(pattern)).toThrow(/too many/);
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+});

--- a/packages/util/src/limits.ts
+++ b/packages/util/src/limits.ts
@@ -48,6 +48,10 @@ export const DEFAULT_LIMITS = {
   grepMaxSearchMs: 30_000,
   /** Max characters of one FileGrepTask line; the rest of that physical line is discarded. */
   grepMaxLineChars: 64_000,
+  /** Default max FileGrepTask output lines (including context) when the caller states none. */
+  grepMaxOutputLines: 10_000,
+  /** Default max FileGrepTask output characters when the caller states none. */
+  grepMaxOutputChars: 1_000_000,
 } as const satisfies Record<string, number>;
 
 /**

--- a/packages/util/src/limits.ts
+++ b/packages/util/src/limits.ts
@@ -44,6 +44,8 @@ export const DEFAULT_LIMITS = {
   structuredGenMaxRetries: 2,
   /** Default absolute TTL (ms) for OtpPassphraseCache. */
   otpCacheHardTtlMs: 6 * 60 * 60 * 1000,
+  /** Default wall-clock budget (ms) for a whole FileGrepTask scan. */
+  grepMaxSearchMs: 30_000,
 } as const satisfies Record<string, number>;
 
 /**
@@ -66,4 +68,13 @@ export const SECURITY_LIMITS = {
   safeFetchMaxRedirectHops: 20,
   /** Max accepted length (characters) of an encoded tabular storage pagination cursor. */
   tabularMaxCursorLength: 8 * 1024,
+  /** Lines matched per interruptible regex batch (ReDoS defence, see below). */
+  regexMatchBatchLines: 512,
+  /**
+   * Wall-clock budget (ms) for one interruptible regex batch. A shape screen
+   * cannot decide backtracking, so this is the bound that is actually enforced:
+   * matching runs where it can be interrupted, and a batch that overruns fails
+   * the task instead of blocking forever.
+   */
+  regexMatchBatchTimeoutMs: 1_000,
 } as const satisfies Record<string, number>;

--- a/packages/util/src/limits.ts
+++ b/packages/util/src/limits.ts
@@ -46,6 +46,8 @@ export const DEFAULT_LIMITS = {
   otpCacheHardTtlMs: 6 * 60 * 60 * 1000,
   /** Default wall-clock budget (ms) for a whole FileGrepTask scan. */
   grepMaxSearchMs: 30_000,
+  /** Max characters of one FileGrepTask line; the rest of that physical line is discarded. */
+  grepMaxLineChars: 64_000,
 } as const satisfies Record<string, number>;
 
 /**

--- a/packages/util/src/utilities/__tests__/Limits.test.ts
+++ b/packages/util/src/utilities/__tests__/Limits.test.ts
@@ -24,6 +24,7 @@ describe("DEFAULT_LIMITS", () => {
     expect(DEFAULT_LIMITS.structuredGenMaxRetries).toBe(2);
     expect(DEFAULT_LIMITS.otpCacheHardTtlMs).toBe(6 * 60 * 60 * 1000);
     expect(DEFAULT_LIMITS.grepMaxSearchMs).toBe(30_000);
+    expect(DEFAULT_LIMITS.grepMaxLineChars).toBe(64_000);
   });
 
   it("is a frozen object shape (const assertion) with only number values", () => {

--- a/packages/util/src/utilities/__tests__/Limits.test.ts
+++ b/packages/util/src/utilities/__tests__/Limits.test.ts
@@ -25,6 +25,8 @@ describe("DEFAULT_LIMITS", () => {
     expect(DEFAULT_LIMITS.otpCacheHardTtlMs).toBe(6 * 60 * 60 * 1000);
     expect(DEFAULT_LIMITS.grepMaxSearchMs).toBe(30_000);
     expect(DEFAULT_LIMITS.grepMaxLineChars).toBe(64_000);
+    expect(DEFAULT_LIMITS.grepMaxOutputLines).toBe(10_000);
+    expect(DEFAULT_LIMITS.grepMaxOutputChars).toBe(1_000_000);
   });
 
   it("is a frozen object shape (const assertion) with only number values", () => {

--- a/packages/util/src/utilities/__tests__/Limits.test.ts
+++ b/packages/util/src/utilities/__tests__/Limits.test.ts
@@ -23,6 +23,7 @@ describe("DEFAULT_LIMITS", () => {
     expect(DEFAULT_LIMITS.aiChatMaxIterations).toBe(100);
     expect(DEFAULT_LIMITS.structuredGenMaxRetries).toBe(2);
     expect(DEFAULT_LIMITS.otpCacheHardTtlMs).toBe(6 * 60 * 60 * 1000);
+    expect(DEFAULT_LIMITS.grepMaxSearchMs).toBe(30_000);
   });
 
   it("is a frozen object shape (const assertion) with only number values", () => {
@@ -40,6 +41,8 @@ describe("SECURITY_LIMITS", () => {
     expect(SECURITY_LIMITS.imageMaxInputBytesBrowser).toBe(32 * 1024 * 1024);
     expect(SECURITY_LIMITS.safeFetchMaxRedirectHops).toBe(20);
     expect(SECURITY_LIMITS.tabularMaxCursorLength).toBe(8 * 1024);
+    expect(SECURITY_LIMITS.regexMatchBatchLines).toBe(512);
+    expect(SECURITY_LIMITS.regexMatchBatchTimeoutMs).toBe(1_000);
   });
 
   it("is a frozen object shape (const assertion) with only number values", () => {


### PR DESCRIPTION
- Introduced FileGrepTask to enable grepping of local files in Node.js and Bun environments.
- Updated browser, electron, and node task registration to include FileGrepTask.
- Enhanced task registration to return both FileGrepTask and FileLoaderTask.
- Added comprehensive tests for FileGrepTask functionality, including handling of local file paths and streaming CRLF files.
- Implemented input validation and error handling for various edge cases in the grepping process.