### PR TITLE
Run the dist stub guard in a plugin hook; widen it; anchor the coverage globs

### DIFF
--- a/packages/test/src/test/util/PublishedEntryExportParity.test.ts
+++ b/packages/test/src/test/util/PublishedEntryExportParity.test.ts
@@ -128,6 +128,16 @@ const { pairs, unmapped } = collectEntryPairs();
 const checkable = pairs.filter((pair) => !(pair.specifier in UNCHECKABLE));
 
 /**
+ * Whether this run exercises the built bundles.
+ *
+ * The VALIDATED target handed down by `vitest.config.ts`'s `test.env`, not
+ * re-derived: `packages/test` is a composite program rooted at `./src` and
+ * cannot import `scripts/lib/*`, so a second `=== "dist"` comparison here would
+ * be exactly the silent-typo bug `resolveTestTarget` exists to remove.
+ */
+const RUNS_AGAINST_BUNDLES = process.env.WORKGLOW_TEST_TARGET === "dist";
+
+/**
  * Every published entry, imported twice — once by the specifier a consumer
  * writes, once by the source file it was built from — with the export NAME sets
  * compared.
@@ -139,11 +149,18 @@ const checkable = pairs.filter((pair) => !(pair.specifier in UNCHECKABLE));
  * the only observable that says the entry point is intact, and the source file
  * is the only available statement of what it should be.
  *
- * Under the default `source` target both sides resolve to the same module, so
- * this passes trivially — a green source run is not a bundle check. The run
- * that means something is `test-vitest-dist` (`WORKGLOW_TEST_TARGET=dist`),
- * where the left side is the real bundle; hence a unit-tier file, since that is
- * the tier the dist job runs.
+ * Under the default `source` target the source-resolving plugin rewrites
+ * `import(specifier)` to exactly the path `sourceCounterpart()` computes, so
+ * both sides ARE the same module and every case asserts `X === X`. Those cases
+ * are therefore SKIPPED under source, so the report distinguishes "checked"
+ * from "not applicable" rather than showing ~90 green rows that compared
+ * nothing. The run that means something is `test-vitest-dist`
+ * (`WORKGLOW_TEST_TARGET=dist`), where the left side is the real bundle; hence
+ * a unit-tier file, since that is the tier the dist job runs.
+ *
+ * Skipping loses no loading: `PublishedEntryImports.test.ts` imports every
+ * published specifier unconditionally, and that file DOES carry signal under
+ * source — it is what proves each entry resolves and evaluates at all.
  */
 describe("published entry export parity", () => {
   it("enumerates every workspace manifest, so an empty sweep cannot pass", () => {
@@ -169,7 +186,16 @@ describe("published entry export parity", () => {
     }
   });
 
-  it.each(checkable.map((pair) => [pair.specifier, pair.sourcePath] as const))(
+  it("is handed a validated target, so the skip cannot swallow the dist sweep", () => {
+    // If the `test.env` plumbing broke, `RUNS_AGAINST_BUNDLES` would be false
+    // in every job: every case below would report skipped and
+    // `test-vitest-dist` would go green having compared nothing at all.
+    expect(["source", "dist"]).toContain(process.env.WORKGLOW_TEST_TARGET);
+  });
+
+  it
+    .skipIf(!RUNS_AGAINST_BUNDLES)
+    .each(checkable.map((pair) => [pair.specifier, pair.sourcePath] as const))(
     "%s exports the same names as its source",
     async (specifier, sourcePath) => {
       const [published, source] = await Promise.all([

--- a/scripts/lib/sourceStubs.ts
+++ b/scripts/lib/sourceStubs.ts
@@ -91,7 +91,8 @@ function specFor(distTarget: string, kind: StubKind): StubSpec {
   return { target: distTarget, source: sourceCounterpart(distTarget), kind };
 }
 
-function collectBinTargets(bin: unknown): string[] {
+/** Every `./dist/...` string a manifest's `bin` field names. */
+export function collectBinTargets(bin: unknown): string[] {
   if (typeof bin === "string") return bin.startsWith("./dist/") ? [bin] : [];
   if (bin !== null && typeof bin === "object") {
     return Object.values(bin as Record<string, unknown>).filter(
@@ -159,26 +160,51 @@ export async function writeSourceStubs(
 const SENTINEL_PROBE_BYTES = 512;
 
 /**
+ * What a probe of one dist entry found.
+ *
+ * Three states rather than a boolean, because the two callers fail safe in
+ * OPPOSITE directions: stub REMOVAL must not delete an artifact it could not
+ * read, while the `dist` target's guard must not accept one as a real bundle.
+ * A single "false" collapses those into one answer that is wrong for one of
+ * them.
+ */
+export type SourceStubProbe = "stub" | "not-stub" | "unreadable";
+
+/**
  * Whether a file is a `use-source` stub, using `node:fs` only.
  *
  * Node-portable on purpose: `vitest.config.ts` needs this answer, and Vite
- * loads that config under NODE, where `Bun.file` does not exist. The async
- * {@link isSourceStub} delegates here so the two can never disagree about what
- * a stub is.
+ * loads that config under NODE, where `Bun.file` does not exist.
+ *
+ * A path that does not exist is `not-stub` — an absent entry is nobody's stub.
+ * Every other failure (EACCES, EISDIR, EIO) is `unreadable`: the file may be
+ * anything, and only the caller knows which way to resolve that.
  */
-export function containsSourceStubSentinel(file: string): boolean {
-  if (!TEXT_ENTRY_EXTENSIONS.some((ext) => file.endsWith(ext))) return false;
+export function probeSourceStub(file: string): SourceStubProbe {
+  if (!TEXT_ENTRY_EXTENSIONS.some((ext) => file.endsWith(ext))) return "not-stub";
   let fd: number | undefined;
   try {
     fd = openSync(file, "r");
     const buffer = Buffer.alloc(SENTINEL_PROBE_BYTES);
     const read = readSync(fd, buffer, 0, SENTINEL_PROBE_BYTES, 0);
-    return buffer.subarray(0, read).toString("utf8").includes(SOURCE_STUB_SENTINEL);
-  } catch {
-    return false;
+    return buffer.subarray(0, read).toString("utf8").includes(SOURCE_STUB_SENTINEL)
+      ? "stub"
+      : "not-stub";
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") return "not-stub";
+    return "unreadable";
   } finally {
     if (fd !== undefined) closeSync(fd);
   }
+}
+
+/**
+ * Whether a file is definitely a stub. The async {@link isSourceStub} delegates
+ * here so the two can never disagree about what a stub is; an entry that could
+ * not be read is NOT one, which is the safe answer on the removal path.
+ */
+export function containsSourceStubSentinel(file: string): boolean {
+  return probeSourceStub(file) === "stub";
 }
 
 export async function isSourceStub(file: string): Promise<boolean> {

--- a/scripts/lib/workspaceGroups.ts
+++ b/scripts/lib/workspaceGroups.ts
@@ -75,14 +75,28 @@ export function workspaceGroups(root: string): readonly string[] {
 }
 
 /**
- * The coverage `include` globs for a set of groups.
+ * The coverage `include` globs for a set of groups, ABSOLUTE.
  *
  * The denominator is every workspace package's own `src`, so it has to be
  * derived from the same groups everything else walks: a group present in the
  * scan but absent here has its source rewritten to `src`, executed by its own
  * tests, and then left out of the report entirely — invisible, because a
  * coverage report shows a shorter file list rather than an error.
+ *
+ * Anchored at `root` for the same reason every path-shaped entry in the shared
+ * project options is: a `--project` run — the shape of every package's own
+ * `test` script, and of `turbo run test -- --coverage` — starts in a package
+ * directory, and a relative pattern's meaning there depends on which directory
+ * the provider happens to resolve it against. That is an implementation detail
+ * nothing pins: a relative pattern was measured to give the same denominator on
+ * `@vitest/coverage-v8` 4.1.10 from both the repo root and a package directory,
+ * so this is defensive rather than a fix for an observed miss — but a
+ * denominator that silently drops the untested half reads as a BETTER number,
+ * not as an error, so it is not worth resting on that detail.
+ *
+ * The coverage `exclude` entries that subtract individual packages must be
+ * anchored the same way, or they subtract from nothing.
  */
-export function coverageIncludeGlobs(groups: readonly string[]): string[] {
-  return groups.map((group) => `${group}/*/src/**/*.{ts,tsx}`);
+export function coverageIncludeGlobs(root: string, groups: readonly string[]): string[] {
+  return groups.map((group) => `${root}/${group}/*/src/**/*.{ts,tsx}`);
 }

--- a/scripts/lib/workspaceSource.ts
+++ b/scripts/lib/workspaceSource.ts
@@ -34,7 +34,7 @@ import { join } from "node:path";
 import type { Plugin } from "vite";
 // Extensions required on both: this module is in `vitest.config.ts`'s graph,
 // which Vite's native config loader resolves without extension inference.
-import { collectDistTargets, containsSourceStubSentinel } from "./sourceStubs.ts";
+import { collectBinTargets, collectDistTargets, probeSourceStub } from "./sourceStubs.ts";
 import { workspaceGroups } from "./workspaceGroups.ts";
 
 /** Source extensions a dist entry can have come from, in resolution order. */
@@ -87,6 +87,15 @@ export interface WorkspacePackage {
    * has to re-read it would be one more thing to keep in step.
    */
   readonly exports: unknown;
+  /**
+   * The manifest's `bin` field, verbatim, or `undefined` when it declares none.
+   *
+   * `use-source` stubs `bin` targets too, and two of them are named by no
+   * `exports` entry at all (`examples/eval` declares no `exports`; `examples/cli`'s
+   * bin is not among its export targets), so a guard reading only `exports`
+   * looked straight past them.
+   */
+  readonly bin: unknown;
   /** Every name this package lists in any dependency block. */
   readonly dependencies: ReadonlySet<string>;
   /**
@@ -139,7 +148,7 @@ export function listWorkspacePackages(root: string): WorkspacePackage[] {
     for (const entry of entries) {
       const dir = join(root, group, entry);
       const manifestPath = join(dir, "package.json");
-      let manifest: { name?: unknown; exports?: unknown; publishConfig?: unknown };
+      let manifest: { name?: unknown; exports?: unknown; bin?: unknown; publishConfig?: unknown };
       try {
         manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as typeof manifest;
       } catch (error) {
@@ -164,6 +173,7 @@ export function listWorkspacePackages(root: string): WorkspacePackage[] {
         name: manifest.name,
         dir,
         exports: manifest.exports,
+        bin: manifest.bin,
         dependencies: declaredDependencies(manifest as Record<string, unknown>),
         publishes: access !== "none",
       });
@@ -188,19 +198,57 @@ export function listWorkspacePackages(root: string): WorkspacePackage[] {
  */
 export function assertNoSourceStubs(packages: readonly WorkspacePackage[]): void {
   const stubs: string[] = [];
+  const unreadable: string[] = [];
   for (const pkg of packages) {
-    for (const target of collectDistTargets(pkg.exports)) {
+    for (const target of guardedDistTargets(pkg)) {
       const file = join(pkg.dir, target);
-      if (existsSync(file) && containsSourceStubSentinel(file)) stubs.push(file);
+      if (!existsSync(file)) continue;
+      const probe = probeSourceStub(file);
+      if (probe === "stub") stubs.push(file);
+      else if (probe === "unreadable") unreadable.push(file);
     }
   }
-  if (stubs.length === 0) return;
+  if (stubs.length === 0 && unreadable.length === 0) return;
+
+  const sections: string[] = [];
+  if (stubs.length > 0) {
+    sections.push(
+      `${stubs.length} published entr${stubs.length === 1 ? "y is" : "ies are"} a ` +
+        `\`use-source\` stub re-exporting src. Every bundle-identity assertion would pass ` +
+        `vacuously.\n${stubs.join("\n")}`
+    );
+  }
+  if (unreadable.length > 0) {
+    sections.push(
+      `${unreadable.length} published entr${unreadable.length === 1 ? "y" : "ies"} could not ` +
+        `be read, so ${unreadable.length === 1 ? "it" : "they"} cannot be proved to be a real ` +
+        `bundle — and an entry that cannot be proved to be one is not one. Treating it as ` +
+        `built is exactly how the vacuous pass this guard exists to prevent gets ` +
+        `through.\n${unreadable.join("\n")}`
+    );
+  }
   throw new Error(
-    `WORKGLOW_TEST_TARGET="dist" exercises the built bundles, but ${stubs.length} published ` +
-      `entr${stubs.length === 1 ? "y is" : "ies are"} a \`use-source\` stub re-exporting src. ` +
-      `Every bundle-identity assertion would pass vacuously. Run \`bun run use-dist\` to ` +
-      `restore the real build.\n${stubs.join("\n")}`
+    `WORKGLOW_TEST_TARGET="dist" exercises the built bundles. Run \`bun run use-dist\` to ` +
+      `restore the real build.\n\n${sections.join("\n\n")}`
   );
+}
+
+/**
+ * Every dist entry `use-source` writes a stub into, for guard purposes: the
+ * `exports` targets plus any `bin` target they do not already name.
+ *
+ * Deliberately NOT `stubSpecsFor`, which additionally maps each target to a
+ * source counterpart and THROWS for one that is neither `.js` nor `.d.ts`. All
+ * 338 dist targets across the 41 manifests are one of those today, but the
+ * guard has no use for the mapping and should not acquire a new way to fail
+ * during config resolution.
+ */
+export function guardedDistTargets(pkg: WorkspacePackage): string[] {
+  const targets = collectDistTargets(pkg.exports);
+  for (const binTarget of collectBinTargets(pkg.bin)) {
+    if (!targets.includes(binTarget)) targets.push(binTarget);
+  }
+  return targets;
 }
 
 /** The guard plugin's name, so a test can assert attachment without a literal. */
@@ -219,8 +267,11 @@ export const DIST_STUB_GUARD_PLUGIN_NAME = "workglow:dist-stub-guard";
  * assertion in `configResolved` still kills the run before any suite can report
  * a pass over stubs.
  *
- * The verdict is computed once and re-thrown: one scan serves all twelve
- * projects, and a 41-entry message printed twelve times is unreadable.
+ * The verdict is computed once and re-thrown, so one scan of the tree serves
+ * every project rather than one per project. Every project still throws, so
+ * none can be initialized past a stubbed tree; vitest's own startup
+ * `AggregateError` then lists that single Error object once per project it
+ * failed to set up, which is its reporting rather than a repeated scan.
  */
 export function sourceStubGuardPlugin(packages: readonly WorkspacePackage[]): Plugin {
   let verdict: { error: Error | undefined } | undefined;

--- a/scripts/lib/workspaceSource.ts
+++ b/scripts/lib/workspaceSource.ts
@@ -203,6 +203,44 @@ export function assertNoSourceStubs(packages: readonly WorkspacePackage[]): void
   );
 }
 
+/** The guard plugin's name, so a test can assert attachment without a literal. */
+export const DIST_STUB_GUARD_PLUGIN_NAME = "workglow:dist-stub-guard";
+
+/**
+ * {@link assertNoSourceStubs} as a plugin hook rather than a side effect of
+ * loading `vitest.config.ts`.
+ *
+ * That module is ordinarily importable — `scripts/workspaceSource.test.ts`
+ * imports it with `WORKGLOW_TEST_TARGET` stubbed to `dist` to check plugin
+ * attachment, and `scripts/*.test.ts` is unit-tier — so scanning at module
+ * scope made an ordinary `bun run test:vitest:unit` on a `use-source` tree die
+ * with advice to run `use-dist`, undoing the no-build dev mode the run never
+ * left. Vitest resolves EVERY project's config at startup, so running the
+ * assertion in `configResolved` still kills the run before any suite can report
+ * a pass over stubs.
+ *
+ * The verdict is computed once and re-thrown: one scan serves all twelve
+ * projects, and a 41-entry message printed twelve times is unreadable.
+ */
+export function sourceStubGuardPlugin(packages: readonly WorkspacePackage[]): Plugin {
+  let verdict: { error: Error | undefined } | undefined;
+  return {
+    name: DIST_STUB_GUARD_PLUGIN_NAME,
+    enforce: "pre",
+    configResolved() {
+      if (verdict === undefined) {
+        try {
+          assertNoSourceStubs(packages);
+          verdict = { error: undefined };
+        } catch (error) {
+          verdict = { error: error instanceof Error ? error : new Error(String(error)) };
+        }
+      }
+      if (verdict.error !== undefined) throw verdict.error;
+    },
+  };
+}
+
 /**
  * The source file a built entry came from, or `undefined` when there is none.
  *

--- a/scripts/workspaceSource.test.ts
+++ b/scripts/workspaceSource.test.ts
@@ -8,7 +8,13 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SOURCE_STUB_SENTINEL, stubSpecsFor, type PackageManifest } from "./lib/sourceStubs";
+import {
+  containsSourceStubSentinel,
+  probeSourceStub,
+  SOURCE_STUB_SENTINEL,
+  stubSpecsFor,
+  type PackageManifest,
+} from "./lib/sourceStubs";
 import { ROOT } from "./lib/testDiscovery";
 import { coverageIncludeGlobs, workspaceGroups } from "./lib/workspaceGroups";
 import type {
@@ -22,6 +28,7 @@ import {
   assertNoSourceStubs,
   DIST_STUB_GUARD_PLUGIN_NAME,
   distToSource,
+  guardedDistTargets,
   listWorkspacePackages,
   ownerOf,
   resolveTestTarget,
@@ -137,8 +144,31 @@ describe("workspace source resolution", () => {
         default: { test?: { coverage?: { include?: string[] } } };
       };
       expect(mod.default.test?.coverage?.include).toEqual(
-        coverageIncludeGlobs(workspaceGroups(ROOT))
+        coverageIncludeGlobs(ROOT, workspaceGroups(ROOT))
       );
+    });
+
+    it("states the denominator in absolute globs", async () => {
+      // A `--project` run — every package's own `test` script, and
+      // `turbo run test -- --coverage` — starts in a package directory, so a
+      // relative pattern's meaning depends on which directory the coverage
+      // provider resolves it against. Measured on `@vitest/coverage-v8` 4.1.10
+      // the two forms agree, so anchoring is defensive rather than a fix for an
+      // observed miss; it is worth pinning anyway because a denominator that
+      // silently loses its untested half reads as a BETTER number rather than
+      // as an error. The two halves must agree: a relative `/src/**` exclusion
+      // subtracts from nothing once the include is absolute.
+      const mod = (await import("../vitest.config.ts")) as {
+        default: { test?: { coverage?: { include?: string[]; exclude?: string[] } } };
+      };
+      const include = mod.default.test?.coverage?.include ?? [];
+      expect(include.length).toBeGreaterThan(0);
+      expect(include.filter((glob) => !glob.startsWith("/"))).toEqual([]);
+      const packageExcludes = (mod.default.test?.coverage?.exclude ?? []).filter((glob) =>
+        glob.endsWith("/src/**")
+      );
+      expect(packageExcludes.length).toBeGreaterThan(0);
+      expect(packageExcludes.filter((glob) => !glob.startsWith("/"))).toEqual([]);
     });
 
     /**
@@ -212,7 +242,7 @@ describe("workspace source resolution", () => {
 
     it("keeps packages that publish nothing out of the denominator", async () => {
       const exclude = await coverageExclude();
-      expect(exclude).toContain("examples/web/src/**");
+      expect(exclude).toContain(join(ROOT, "examples/web/src/**"));
 
       // Pinned to the PROPERTY that justifies the exclusion, re-read from the
       // manifest, so the exception dies with its reason: publish `@workglow/web`
@@ -231,7 +261,7 @@ describe("workspace source resolution", () => {
       const exclude = await coverageExclude();
       const wronglyExcluded = packages
         .filter((pkg) => pkg.publishes)
-        .map((pkg) => `${pkg.dir.slice(ROOT.length + 1)}/src/**`)
+        .map((pkg) => `${pkg.dir}/src/**`)
         .filter((glob) => exclude.includes(glob));
       expect(wronglyExcluded).toEqual([]);
     });
@@ -484,6 +514,7 @@ describe("workspace source resolution", () => {
             name: "@workglow/ai",
             dir: "/repo/packages/ai",
             exports: undefined,
+            bin: undefined,
             dependencies: new Set(),
             publishes: true,
           },
@@ -524,6 +555,7 @@ describe("workspace source resolution", () => {
       name: "@workglow/ai",
       dir: "/repo/packages/ai",
       exports: { ".": "./dist/node.js", "./worker": "./dist/worker.js" },
+      bin: undefined,
       dependencies: new Set<string>(),
       publishes: true,
     };
@@ -531,6 +563,7 @@ describe("workspace source resolution", () => {
       name: "@workglow/huggingface-transformers",
       dir: "/repo/providers/hft",
       exports: { "./ai": "./dist/ai.js" },
+      bin: undefined,
       dependencies: new Set(["@workglow/ai"]),
       publishes: true,
     };
@@ -697,6 +730,7 @@ describe("workspace source resolution", () => {
           name: "@workglow/fixture",
           dir,
           exports: Object.fromEntries(Object.keys(entries).map((t, i) => [i === 0 ? "." : t, t])),
+          bin: undefined,
           dependencies: new Set<string>(),
           publishes: true,
         },
@@ -759,13 +793,81 @@ describe("workspace source resolution", () => {
       }
     });
 
+    it("guards every entry `use-source` writes a stub into", () => {
+      /**
+       * The guard read only `exports`, but `use-source` also stubs `bin`
+       * targets — and two of those are named by no export entry at all:
+       * `examples/eval` declares NO `exports`, only a `bin`, and
+       * `examples/cli`'s `bin` is not among its export targets. So `use-source`
+       * stubbed two published entries the dist guard never looked at, while
+       * `publish-workspaces.ts` (which walks the whole `dist` tree) did refuse
+       * them.
+       *
+       * Derived from `stubSpecsFor`, the same enumeration `use-source` stubs
+       * from, so the two cannot drift into disagreeing about what a package's
+       * entries are.
+       */
+      const unguarded: string[] = [];
+      for (const pkg of packages) {
+        const manifest = JSON.parse(
+          readFileSync(join(pkg.dir, "package.json"), "utf8")
+        ) as PackageManifest;
+        const guarded = new Set(guardedDistTargets(pkg));
+        for (const spec of stubSpecsFor(manifest)) {
+          if (!guarded.has(spec.target)) unguarded.push(`${pkg.name} ${spec.target}`);
+        }
+      }
+      expect(unguarded).toEqual([]);
+    });
+
+    it("treats an entry it cannot read as unproven, not as a real bundle", () => {
+      /**
+       * The two probe callers fail safe in OPPOSITE directions: stub removal
+       * must not delete what it could not read, while this guard must not
+       * accept it as a built bundle.
+       *
+       * A DIRECTORY named like a dist entry reproduces that without `chmod`,
+       * which proves nothing when the suite runs as root (as it does in a
+       * container): `open` succeeds and `read` fails EISDIR.
+       */
+      const root = mkdtempSync(join(tmpdir(), "workglow-stubs-"));
+      try {
+        mkdirSync(join(root, "dist", "node.js"), { recursive: true });
+        const pkg: WorkspacePackage = {
+          name: "@workglow/fixture",
+          dir: root,
+          exports: { ".": "./dist/node.js" },
+          bin: undefined,
+          dependencies: new Set<string>(),
+          publishes: true,
+        };
+        expect(() => assertNoSourceStubs([pkg])).toThrow("could not be read");
+        expect(() => assertNoSourceStubs([pkg])).toThrow(join(root, "dist", "node.js"));
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it("still answers `false` for an unreadable entry on the removal path", () => {
+      // The opposite safe direction, pinned so a later "unreadable is
+      // suspicious" change cannot start DELETING artifacts it never read.
+      const root = mkdtempSync(join(tmpdir(), "workglow-stubs-"));
+      try {
+        mkdirSync(join(root, "node.js"), { recursive: true });
+        expect(containsSourceStubSentinel(join(root, "node.js"))).toBe(false);
+        expect(probeSourceStub(join(root, "node.js"))).toBe("unreadable");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
     it("still kills the run through the guard plugin, once per scan", () => {
       /**
        * The assertion moved out of `vitest.config.ts`'s module scope and into a
        * hook, so the property that matters — a stubbed tree cannot run under
        * the dist target — now depends on the plugin. `configResolved` fires
-       * once per project, and a 41-entry message printed twelve times is
-       * unreadable, so the verdict is computed once and re-thrown.
+       * once per project, so the verdict is computed once and re-thrown: one
+       * scan of the tree, and every project still fatal.
        */
       const root = mkdtempSync(join(tmpdir(), "workglow-stubs-"));
       try {

--- a/scripts/workspaceSource.test.ts
+++ b/scripts/workspaceSource.test.ts
@@ -20,11 +20,13 @@ import type {
 } from "./lib/workspaceSource";
 import {
   assertNoSourceStubs,
+  DIST_STUB_GUARD_PLUGIN_NAME,
   distToSource,
   listWorkspacePackages,
   ownerOf,
   resolveTestTarget,
   resolveWorkspaceSourceId,
+  sourceStubGuardPlugin,
   TEST_TARGETS,
   unresolvedWorkspaceMessage,
   WORKSPACE_SOURCE_PLUGIN_NAME,
@@ -399,6 +401,9 @@ describe("workspace source resolution", () => {
     const carriesPlugin = (project: ConfiguredProject): boolean =>
       (project.plugins ?? []).some((plugin) => plugin?.name === WORKSPACE_SOURCE_PLUGIN_NAME);
 
+    const carriesGuard = (project: ConfiguredProject): boolean =>
+      (project.plugins ?? []).some((plugin) => plugin?.name === DIST_STUB_GUARD_PLUGIN_NAME);
+
     it("attaches the source rewrite to every project under the default target", async () => {
       const projects = await projectsForTarget("source");
       expect(projects.filter((project) => !carriesPlugin(project))).toEqual([]);
@@ -407,6 +412,52 @@ describe("workspace source resolution", () => {
     it("attaches it to no project when the target is dist", async () => {
       const projects = await projectsForTarget("dist");
       expect(projects.filter(carriesPlugin)).toEqual([]);
+    });
+
+    it("loads under the dist target without probing the tree for stubs", async () => {
+      /**
+       * The stub check used to run as a MODULE-LEVEL side effect of loading the
+       * config, and this very describe imports the config with the target
+       * stubbed to `dist`. `scripts/*.test.ts` is unit-tier, so on a
+       * `use-source` tree an ordinary `bun run test:vitest:unit` died right
+       * here, advising the developer to run `use-dist` and undo the documented
+       * no-build dev mode the run had never left. CI never saw it because CI
+       * trees are really built.
+       *
+       * Mocked rather than driven off a genuinely stubbed tree: stubbing all 41
+       * workspaces from a test would write into every package's `dist`, and the
+       * assertion that matters is not "no stubs were found" but "the config
+       * never asked". A throwing spy makes any probe at import time fatal.
+       */
+      vi.resetModules();
+      const probe = vi.fn(() => {
+        throw new Error("assertNoSourceStubs must not run at config load");
+      });
+      vi.doMock("./lib/workspaceSource.ts", async () => {
+        const actual = await vi.importActual<typeof import("./lib/workspaceSource")>(
+          "./lib/workspaceSource.ts"
+        );
+        return { ...actual, assertNoSourceStubs: probe };
+      });
+      try {
+        const projects = await projectsForTarget("dist");
+        expect(projects.length).toBeGreaterThan(0);
+        expect(probe).not.toHaveBeenCalled();
+      } finally {
+        vi.doUnmock("./lib/workspaceSource.ts");
+        vi.resetModules();
+      }
+    });
+
+    it("attaches the stub guard under dist, and to no project under source", async () => {
+      // The guard replaces the import-time scan, so it has to reach every
+      // project: vitest resolves each project's config at startup, which is
+      // what makes a hook fire before any suite can report a pass over stubs.
+      const dist = await projectsForTarget("dist");
+      expect(dist.filter((project) => !carriesGuard(project))).toEqual([]);
+
+      const source = await projectsForTarget("source");
+      expect(source.filter(carriesGuard)).toEqual([]);
     });
 
     it("attaches one plugin instance to every project", async () => {
@@ -703,6 +754,35 @@ describe("workspace source resolution", () => {
         }
         expect(message).toContain(a.files["./dist/node.js"]!);
         expect(message).toContain(b.files["./dist/browser.js"]!);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it("still kills the run through the guard plugin, once per scan", () => {
+      /**
+       * The assertion moved out of `vitest.config.ts`'s module scope and into a
+       * hook, so the property that matters — a stubbed tree cannot run under
+       * the dist target — now depends on the plugin. `configResolved` fires
+       * once per project, and a 41-entry message printed twelve times is
+       * unreadable, so the verdict is computed once and re-thrown.
+       */
+      const root = mkdtempSync(join(tmpdir(), "workglow-stubs-"));
+      try {
+        const { pkg, files } = fixturePackage(root, {
+          "./dist/node.js": `// ${SOURCE_STUB_SENTINEL}\nexport * from "../src/node.ts";\n`,
+        });
+        const plugin = sourceStubGuardPlugin([pkg]);
+        // Vite's hook type also allows an object form (`{ handler }`); a
+        // refactor to it would silently stop the guard ever running.
+        expect(typeof plugin.configResolved).toBe("function");
+        const fire = (): void => {
+          (plugin.configResolved as () => void)();
+        };
+        expect(fire).toThrow(files["./dist/node.js"]!);
+        expect(fire).toThrow("use-dist");
+        // Cached verdict, still fatal for the second project that resolves.
+        expect(fire).toThrow("use-dist");
       } finally {
         rmSync(root, { recursive: true, force: true });
       }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -182,7 +182,7 @@ export default defineConfig({
        * every exception carries its own reason instead of being hidden in a
        * shortened glob.
        */
-      include: coverageIncludeGlobs(workspaceGroups(__dirname)),
+      include: coverageIncludeGlobs(__dirname, workspaceGroups(__dirname)),
       exclude: [
         // `coverageConfigDefaults`, not `configDefaults`: the latter is
         // vitest's TEST-FILE exclude list, spliced in here for a question it
@@ -221,9 +221,7 @@ export default defineConfig({
          * globs above, so the group list stays derived and this exception
          * carries its own reason.
          */
-        ...workspacePackages
-          .filter((pkg) => !pkg.publishes)
-          .map((pkg) => `${path.relative(__dirname, pkg.dir)}/src/**`),
+        ...workspacePackages.filter((pkg) => !pkg.publishes).map((pkg) => `${pkg.dir}/src/**`),
         // Tests, fixtures and typing-only files: counting them inflates every
         // package by the coverage of code that exists to be run.
         //

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,9 +6,9 @@ import { configDefaults, coverageConfigDefaults, defineConfig } from "vitest/con
 import { discoverTestFiles, listTestProjects } from "./scripts/lib/testDiscovery.ts";
 import { coverageIncludeGlobs, workspaceGroups } from "./scripts/lib/workspaceGroups.ts";
 import {
-  assertNoSourceStubs,
   listWorkspacePackages,
   resolveTestTarget,
+  sourceStubGuardPlugin,
   workspaceSourcePlugin,
 } from "./scripts/lib/workspaceSource.ts";
 
@@ -108,15 +108,23 @@ const workspacePackages = listWorkspacePackages(__dirname);
 const sourcePlugin = workspaceSourcePlugin(__dirname, workspacePackages);
 
 /**
- * Under the `dist` target, refuse to run at all against a stubbed `dist`.
+ * What every project's `plugins` gets, decided once.
  *
- * At CONFIG LOAD deliberately, not in a test: this kills the whole run before
- * any suite can pass vacuously, and it covers the export-name parity sweep the
- * same way it covers the identity ones. A test-shaped guard would have to be
- * imported by every file it protects, and the one that forgot would be the one
- * reporting a false pass.
+ * Under the `dist` target the guard refuses to run at all against a stubbed
+ * `dist`: a stub re-exports `src`, so every bundle-shaped assertion passes for
+ * the wrong reason and the job reports a clean sweep over bundles it never
+ * loaded. That check is a plugin HOOK rather than a side effect of loading this
+ * module, because this module is ordinarily importable —
+ * `scripts/workspaceSource.test.ts` imports it with `WORKGLOW_TEST_TARGET`
+ * stubbed to `dist` to check attachment, and `scripts/*.test.ts` is unit-tier,
+ * so scanning at import time made an ordinary unit run on a `use-source` tree
+ * die with advice to run `use-dist` and undo the dev mode it never left. Vitest
+ * resolves every project's config at startup, so the hook still fires before
+ * any suite can report a false pass.
  */
-if (!testsRunAgainstSource) assertNoSourceStubs(workspacePackages);
+const projectPlugins = testsRunAgainstSource
+  ? [sourcePlugin]
+  : [sourceStubGuardPlugin(workspacePackages)];
 
 /**
  * One project per workspace that actually holds tests, derived from the same
@@ -140,7 +148,7 @@ const projects = listTestProjects(discovered).map((p) => {
   return {
     // Projects are standalone Vite configs, so a root-level `plugins` entry
     // would never reach them — the resolver has to be attached per project.
-    plugins: testsRunAgainstSource ? [sourcePlugin] : [],
+    plugins: [...projectPlugins],
     test: { ...shared, name: p.name, root, exclude: [...shared.exclude, ...bunOnly] },
   };
 });


### PR DESCRIPTION
Follow-ups to #741. The PR itself is sound — the `dist→src` mapping is TOTAL over all 153 runtime targets of all 41 workspaces, the coverage `include`/`exclude` semantics were verified against unpacked `vitest@4.1.10` and `@vitest/coverage-v8@4.1.10`, and there are no security issues. These are two follow-up commits.

## Commit 1 — the stub guard runs in a hook, not on config import

`vitest.config.ts` called `assertNoSourceStubs(workspacePackages)` as a **module-level side effect** whenever the target was `dist`, and `scripts/workspaceSource.test.ts` deliberately re-imports that module with `vi.stubEnv("WORKGLOW_TEST_TARGET","dist")`. `scripts/*.test.ts` is unit-tier, so **on a `use-source` tree an ordinary `bun run test:vitest:unit` died there**, advising the developer to run `use-dist` — undoing the documented no-build dev mode the run had never left. CI stayed green because CI trees are really built. Worse than reported: two further call sites in the same file import the config with **ambient** env, so under `test:vitest:dist` they re-ran the whole scan too.

Reproduced and fixed, on a genuinely stubbed tree:

```
$ bun run use-source && bun scripts/test.ts scripts vitest
# BEFORE (module-level scan restored):
 FAIL  workspaceSource.test.ts > plugin attachment > attaches it to no project when the target is dist
 Error: WORKGLOW_TEST_TARGET="dist" exercises the built bundles. Run `bun run use-dist` ...
 Tests  3 failed | 56 passed (59)

# AFTER:
 Test Files  5 passed (5)
      Tests  59 passed (59)
```

**Why a hook over the three alternatives.** `buildStart` — vitest does not reliably drive build hooks for a test-only server, while `configResolved` is guaranteed by `resolveConfig` per project. Exporting `buildProjects(target)` — leaves the config module itself un-exercised, which is what makes the attachment test worth having. An early check in `scripts/test.ts` — misses `vitest run --project <n>` and adds a second place that knows the rule.

The guard still kills a stubbed dist run **at startup, before any test result prints**:

```
$ WORKGLOW_TEST_TARGET=dist bun scripts/test.ts util vitest
⎯⎯⎯ Startup Error ⎯⎯⎯
AggregateError: Failed to initialize projects.
  Error: WORKGLOW_TEST_TARGET="dist" exercises the built bundles. Run `bun run use-dist` ...
  280 published entries are a `use-source` stub re-exporting src. ...
  .../examples/cli/dist/workglow.js
  .../examples/eval/dist/workglow-eval.js
```

No `Test Files` / `Tests` line anywhere in the output.

**`vi.doMock` reach was verified by inversion** rather than assumed. Against the pre-fix config the new test fails with the stack pointing at `vitest.config.ts:126`, so the mock genuinely intercepts the config's own transitive import and the test is not passing for the wrong reason.

## Commit 2 — three follow-ups

**The parity sweep is skipped under `source`.** The resolving plugin rewrites `import(specifier)` to exactly the path `sourceCounterpart()` computes, so both sides are the same module and ~90 cases assert `X === X`. Now: 4 passed / 97 skipped under source, **101 passed under dist** — the rows execute where they mean something. Nothing stops being loaded, because `PublishedEntryImports.test.ts` imports every published specifier unconditionally and does carry signal under source. An anti-vacuity test asserts the target is one of the two known values, so broken `test.env` plumbing cannot make every case skip and leave `test-vitest-dist` green having compared nothing. `PublishedEntryIdentity.test.ts` is out of scope (not reviewed).

**The guard now covers every entry `use-source` writes.** It read only `exports`, but `use-source` also stubs `bin` targets — and two are named by no export entry at all: `examples/eval` declares **no** `exports`, only `"bin": {"workglow-eval": "./dist/workglow-eval.js"}`, and `examples/cli`'s `"bin": "./dist/workglow.js"` is not among its export targets. `publish-workspaces.ts` (a full dist walk) *did* refuse them; the dist guard looked straight past them. The new `guards every entry \`use-source\` writes a stub into` test fails pre-fix with exactly:

```
["@workglow/cli ./dist/workglow.js", "@workglow/eval ./dist/workglow-eval.js"]
```

`guardedDistTargets` is deliberately not `stubSpecsFor`, which additionally maps each target to a source counterpart and throws for one that is neither `.js` nor `.d.ts`. The guard has no use for the mapping and should not acquire a new way to fail during config resolution.

**An unreadable entry is unproven, not built.** `probeSourceStub` returns three states because the two callers fail safe in opposite directions: removal must not delete an artifact it could not read, while the dist guard must not accept one as a real bundle. Tested with a *directory* named like a dist entry (open succeeds, read fails EISDIR) rather than `chmod`, which proves nothing when the suite runs as root, as it does in a container.

## The tinyglobby check — Option A shipped, with the claim corrected

The plan's mandatory empirical check ran on a real build. **Neither the pass nor the fail criterion was met, and the reason is worth stating.**

| run | absolute globs | relative globs |
|---|---|---|
| `--project util`, cwd = repo root | `8.52% (292/3427)` | `8.52% (292/3427)` |
| `--project util`, cwd = `packages/util` | `8.52% (292/3427)` | `8.52% (292/3427)` |
| `--project scripts` | `0/0` | `0/0` |

The absolute pattern does **not** error and does **not** shrink the report to loaded files only — untested directories (`src/compress` at 0%) stay in the denominator in every configuration. So Option A is safe and Option B was not needed.

But the pass criterion as written (a `--project util` run reaching `packages/ai/src/**`) is not achievable with **either** form: vitest 4 scopes the coverage denominator by project root regardless of the include glob. **The premise that the relative form silently loses the untested half is therefore not reproducible on `@vitest/coverage-v8` 4.1.10**, and the docstring and test comment say so rather than asserting a failure I did not observe. Anchoring is shipped as defensive — consistent with the config's own "anything path-shaped must be ABSOLUTE" rule for the shared project options, and removing a dependency on an implementation detail nothing pins — not as a fix for a measured miss. The per-package `/src/**` exclusions are anchored to match, since a relative exclusion subtracts from nothing once the include is absolute.

## Dropped finding: Windows path normalisation

`slash()`, `distToSource`'s `[\\/]`, and `importerPackageOf` were dropped in planning and are **not** in this PR. The repo has no Windows CI (`test.yml` is `ubuntu-latest` throughout), the root scripts are POSIX shell, and `sourceStubs.ts:127` writes `#!/usr/bin/env bun` shebangs — it buys nothing. Its POSIX-visible half (the `path.relative`-derived coverage exclusion) is folded into the glob anchoring above.

## Verification

```
bun i
bun scripts/test.ts scripts vitest                 →  5 files, 59 tests passed
bun scripts/test.ts util vitest                    →  55/56 files, 867 passed, 107 skipped
bun run build && WORKGLOW_TEST_TARGET=dist \
  vitest run --project test PublishedEntryExportParity  →  101 passed (0 skipped)
                          (source target)               →    4 passed | 97 skipped
bun run typecheck:scripts                          →  clean
```

The one `util` failure is `packages/util/src/utilities/__tests__/TestCredentialPreload.test.ts` — a 15 s timeout in a KDF under heavy parallel load, **unrelated to these changes and confirmed environmental**: it passes in isolation (`5 passed`). `git status` stayed clean through the whole `use-source` / `use-dist` cycle, as designed.

## Risks

- `configResolved` timing rests on vitest resolving every project's config at startup. If a future vitest defers project init the guard fires later than config load (still before that project's tests). The stubbed-tree `WORKGLOW_TEST_TARGET=dist` run above is the check; if any test result ever prints before the error, escalate to *also* calling `assertNoSourceStubs` from `scripts/test.ts` when the resolved target is `dist`.
- The guard message appears once per project in vitest's startup `AggregateError`. The **scan** runs once (asserted); the repetition is vitest listing one cached `Error` object per project it failed to initialize, and the docstring says so rather than claiming the message prints once.
- `WorkspacePackage.bin` is **required**, not optional, so every construction site must set `bin: undefined` explicitly rather than the field quietly defaulting — TS finds them all.
- Skipping the parity sweep under source narrows what a local run checks, mitigated by `PublishedEntryImports` staying unconditional plus the anti-vacuity test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT)_