### PR TITLE
fix(ai): stop reporting nullable-object schemas as OpenAI strict-compatible

### DIFF
--- a/packages/ai/src/provider-utils/OpenAIShapedJsonSchema.ts
+++ b/packages/ai/src/provider-utils/OpenAIShapedJsonSchema.ts
@@ -5,6 +5,18 @@
  */
 
 /**
+ * The single type a schema declares, reading both the `"object"` spelling and
+ * the `["object","null"]` array that {@link rewriteNullableUnionsForStrict}
+ * emits. `undefined` for a multi-type union, which has no strict spelling.
+ */
+function soleDeclaredType(type: unknown): string | undefined {
+  if (typeof type === "string") return type;
+  if (!Array.isArray(type)) return undefined;
+  const nonNull = type.filter((entry) => entry !== "null");
+  return nonNull.length === 1 && typeof nonNull[0] === "string" ? nonNull[0] : undefined;
+}
+
+/**
  * Whether a JSON schema satisfies the OpenAI-shape `strict` subset — every
  * object has `additionalProperties: false` and lists all of its properties in
  * `required`, recursively. Combinators (`anyOf`/`oneOf`/`allOf`) and `$ref`
@@ -28,7 +40,13 @@ export function isStrictCompatibleSchema(schema: unknown): boolean {
   if (s.$ref !== undefined) return false;
   if (Array.isArray(s.anyOf) || Array.isArray(s.oneOf) || Array.isArray(s.allOf)) return false;
 
-  const isObject = s.type === "object" || (s.type === undefined && s.properties !== undefined);
+  const declaredType = soleDeclaredType(s.type);
+  // A multi-type union (with or without "null") is a combinator by another
+  // name; only `[t, "null"]` has a strict spelling.
+  if (Array.isArray(s.type) && declaredType === undefined) return false;
+
+  const isObject =
+    declaredType === "object" || (s.type === undefined && s.properties !== undefined);
   if (isObject) {
     if (s.additionalProperties !== false) return false;
     const props = (s.properties as Record<string, unknown> | undefined) ?? {};
@@ -40,7 +58,7 @@ export function isStrictCompatibleSchema(schema: unknown): boolean {
     return true;
   }
 
-  const isArray = s.type === "array" || s.items !== undefined;
+  const isArray = declaredType === "array" || s.items !== undefined;
   if (isArray) {
     if (Array.isArray(s.items)) return s.items.every(isStrictCompatibleSchema);
     return isStrictCompatibleSchema(s.items);
@@ -64,7 +82,13 @@ export function firstNonStrictReason(schema: unknown): string | undefined {
   if (Array.isArray(s.oneOf)) return "oneOf";
   if (Array.isArray(s.allOf)) return "allOf";
 
-  const isObject = s.type === "object" || (s.type === undefined && s.properties !== undefined);
+  const declaredType = soleDeclaredType(s.type);
+  if (Array.isArray(s.type) && declaredType === undefined) {
+    return `multi-type union: ${(s.type as unknown[]).join("|")}`;
+  }
+
+  const isObject =
+    declaredType === "object" || (s.type === undefined && s.properties !== undefined);
   if (isObject) {
     if (s.additionalProperties !== false) return "missing additionalProperties:false";
     const props = (s.properties as Record<string, unknown> | undefined) ?? {};
@@ -77,7 +101,7 @@ export function firstNonStrictReason(schema: unknown): string | undefined {
     return undefined;
   }
 
-  const isArray = s.type === "array" || s.items !== undefined;
+  const isArray = declaredType === "array" || s.items !== undefined;
   if (isArray) {
     if (Array.isArray(s.items)) {
       for (let i = 0; i < s.items.length; i++) {
@@ -97,12 +121,16 @@ function isNullTypeSchema(schema: unknown): boolean {
   return (schema as Record<string, unknown>).type === "null";
 }
 
-function withNullType(schema: Record<string, unknown>): Record<string, unknown> {
+function withNullType(schema: Record<string, unknown>): Record<string, unknown> | undefined {
   const t = schema.type;
-  if (t === undefined) return { ...schema, type: ["object", "null"] };
-  if (Array.isArray(t)) {
-    return t.includes("null") ? schema : { ...schema, type: [...t, "null"] };
+  if (t === undefined) {
+    // Infer only from a keyword that already implies the kind; guessing
+    // "object" for a free-form variant sends a type the caller never wrote.
+    const implied =
+      schema.properties !== undefined ? "object" : schema.items !== undefined ? "array" : undefined;
+    return implied === undefined ? undefined : { ...schema, type: [implied, "null"] };
   }
+  if (Array.isArray(t)) return t.includes("null") ? schema : { ...schema, type: [...t, "null"] };
   return { ...schema, type: [t, "null"] };
 }
 
@@ -116,7 +144,11 @@ export function rewriteNullableUnionsForStrict(schema: unknown): unknown {
   if (Array.isArray(schema)) return schema.map(rewriteNullableUnionsForStrict);
 
   const s = schema as Record<string, unknown>;
-  const combinator = Array.isArray(s.anyOf) ? "anyOf" : Array.isArray(s.oneOf) ? "oneOf" : undefined;
+  const combinator = Array.isArray(s.anyOf)
+    ? "anyOf"
+    : Array.isArray(s.oneOf)
+      ? "oneOf"
+      : undefined;
   if (combinator !== undefined) {
     const variants = (s[combinator] as unknown[]).map(rewriteNullableUnionsForStrict);
     if (variants.length === 2) {
@@ -131,7 +163,8 @@ export function rewriteNullableUnionsForStrict(schema: unknown): unknown {
         const rest = { ...s };
         delete rest.anyOf;
         delete rest.oneOf;
-        return withNullType({ ...rest, ...(other as Record<string, unknown>) });
+        const collapsed = withNullType({ ...rest, ...(other as Record<string, unknown>) });
+        if (collapsed !== undefined) return collapsed;
       }
     }
     return { ...s, [combinator]: variants };
@@ -202,7 +235,10 @@ export function jsonModeChatParts(
   options?: { readonly jsonSchemaSupported?: boolean }
 ): JsonModeChatParts {
   if (options?.jsonSchemaSupported === false) {
-    return { prompt: promptWithJsonSchema(prompt, schema), responseFormat: { type: "json_object" } };
+    return {
+      prompt: promptWithJsonSchema(prompt, schema),
+      responseFormat: { type: "json_object" },
+    };
   }
   if (schema === undefined || schema === null) {
     return { prompt, responseFormat: { type: "json_object" } };

--- a/packages/test/src/test/ai-provider-api/Gemini_RequestBody.test.ts
+++ b/packages/test/src/test/ai-provider-api/Gemini_RequestBody.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn } from "@workglow/ai";
+import { _testOnly } from "@workglow/google-gemini/ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { GEMINI_RUN_FNS } = _testOnly;
+
+function findStructuredGenerationRunFn(): AiProviderRunFn {
+  const registration = GEMINI_RUN_FNS.find(
+    ({ serves }) =>
+      (serves as readonly string[]).includes("json-mode") &&
+      (serves as readonly string[]).includes("text.generation")
+  );
+  if (!registration) throw new Error("no Gemini run-fn registered for json-mode,text.generation");
+  return registration.runFn as AiProviderRunFn;
+}
+
+/**
+ * Encode streaming chunks in the SSE wire format `@google/genai` parses:
+ * one `data: {json}` frame per chunk.
+ */
+function sseResponse(chunks: readonly unknown[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(c)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+const model = {
+  model_id: "gemini-x",
+  provider_config: { model_name: "gemini-3-flash-preview", api_key: "test-key" },
+} as never;
+
+/** Both spellings of "a nullable number", which the SDK must normalize alike. */
+const ANYOF_SPELLING = {
+  type: "object",
+  required: ["a"],
+  properties: { a: { anyOf: [{ type: "number" }, { type: "null" }] } },
+};
+
+const TYPE_ARRAY_SPELLING = {
+  type: "object",
+  required: ["a"],
+  properties: { a: { type: ["number", "null"] } },
+};
+
+/**
+ * Wire-level pin on `@google/genai`'s own request converter.
+ *
+ * `rewriteNullableUnionsForStrict` runs in the Gemini structured-generation
+ * run-fn, rewriting `anyOf: [T, null]` to `type: [T, "null"]`. That rewrite is
+ * a strict-mode accommodation for the OpenAI-shaped providers and is
+ * SHAPE-NEUTRAL for Gemini: the SDK's `processJsonSchema` calls
+ * `flattenTypeArrayToAnyOf`, which folds a `"null"` member into
+ * `nullable: true`, so both spellings serialize to the same `responseSchema`.
+ * These tests assert that equivalence against the real serialized body, so an
+ * SDK upgrade that drops `flattenTypeArrayToAnyOf` fails here rather than in
+ * production, where a rewritten schema would reach Gemini as an unrecognized
+ * type array.
+ *
+ * The existing fake-client tests cannot cover this: `fakeGeminiClient` replaces
+ * `ai.models.generateContentStream`, which intercepts ABOVE the SDK's `tSchema`
+ * converter — the code under test here. So this suite uses the REAL SDK client
+ * and spies on `fetch` instead of calling `setGeminiClientForTests`.
+ */
+describe("Gemini request body normalizes both nullable spellings", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  async function capturedResponseSchema(schema: unknown): Promise<unknown> {
+    fetchSpy.mockResolvedValueOnce(
+      sseResponse([{ candidates: [{ content: { parts: [{ text: '{"a":1}' }] } }] }])
+    );
+
+    const runFn = findStructuredGenerationRunFn();
+    await runFn(
+      { prompt: "hi", outputSchema: schema } as never,
+      model,
+      undefined as never,
+      () => {}
+    );
+
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(init.body)) as {
+      generationConfig?: { responseSchema?: unknown };
+    };
+    return body.generationConfig?.responseSchema;
+  }
+
+  const EXPECTED = {
+    type: "OBJECT",
+    required: ["a"],
+    properties: { a: { nullable: true, type: "NUMBER" } },
+  };
+
+  it("serializes an anyOf [T, null] property to nullable:true", async () => {
+    expect(await capturedResponseSchema(ANYOF_SPELLING)).toEqual(EXPECTED);
+  });
+
+  it("serializes a type:[T,'null'] property to the same nullable:true", async () => {
+    expect(await capturedResponseSchema(TYPE_ARRAY_SPELLING)).toEqual(EXPECTED);
+  });
+});

--- a/packages/test/src/test/ai-provider/OpenAIShapedJsonSchema.test.ts
+++ b/packages/test/src/test/ai-provider/OpenAIShapedJsonSchema.test.ts
@@ -21,10 +21,7 @@ const STRICT_OBJECT = {
 
 /** TypeBox `Type.Union([T, Type.Null()])` — the shape that used to force `strict: false`. */
 const NULLABLE_STRING = {
-  anyOf: [
-    { type: "string", maxLength: 200, description: "Proposed target" },
-    { type: "null" },
-  ],
+  anyOf: [{ type: "string", maxLength: 200, description: "Proposed target" }, { type: "null" }],
 };
 
 const LOI_LIKE = {
@@ -86,6 +83,125 @@ describe("rewriteNullableUnionsForStrict", () => {
   });
 });
 
+describe("isStrictCompatibleSchema", () => {
+  it("rejects a nullable object whose inner object omits additionalProperties/required", () => {
+    // `rewriteNullableUnionsForStrict` collapses `anyOf: [T, null]` into a type
+    // ARRAY (`["object","null"]`). The strict check must keep recursing through
+    // that spelling: the inner object here carries neither
+    // `additionalProperties: false` nor `required`, so sending it with
+    // `strict: true` earns a 400 from OpenAI —
+    //   In context=('properties','addr'), 'additionalProperties' is required to
+    //   be supplied and to be false
+    // Reading only the `"object"` string spelling made this schema fall through
+    // to a bare `return true`, so the array-type branch is what stops the bad
+    // request. Do not simplify it away.
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["addr"],
+      properties: {
+        addr: {
+          anyOf: [{ type: "object", properties: { city: { type: "string" } } }, { type: "null" }],
+        },
+      },
+    };
+    const rewritten = rewriteNullableUnionsForStrict(schema);
+    expect(rewritten).toEqual({
+      type: "object",
+      additionalProperties: false,
+      required: ["addr"],
+      properties: { addr: { type: ["object", "null"], properties: { city: { type: "string" } } } },
+    });
+    expect(isStrictCompatibleSchema(rewritten)).toBe(false);
+  });
+
+  it("accepts a nullable object that is itself strict", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["addr"],
+      properties: {
+        addr: {
+          anyOf: [
+            {
+              type: "object",
+              additionalProperties: false,
+              required: ["city"],
+              properties: { city: { type: "string" } },
+            },
+            { type: "null" },
+          ],
+        },
+      },
+    };
+    const rewritten = rewriteNullableUnionsForStrict(schema) as Record<string, unknown>;
+    expect(isStrictCompatibleSchema(rewritten)).toBe(true);
+    expect((rewritten.properties as Record<string, unknown>).addr).toEqual({
+      type: ["object", "null"],
+      additionalProperties: false,
+      required: ["city"],
+      properties: { city: { type: "string" } },
+    });
+  });
+
+  it("rejects a genuine anyOf nested inside a nullable object", () => {
+    // The nullable wrapper is strict; the combinator two levels down is not,
+    // which is only reachable if the array-type branch recurses.
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["addr"],
+      properties: {
+        addr: {
+          anyOf: [
+            {
+              type: "object",
+              additionalProperties: false,
+              required: ["x"],
+              properties: { x: { anyOf: [{ type: "string" }, { type: "number" }] } },
+            },
+            { type: "null" },
+          ],
+        },
+      },
+    };
+    expect(isStrictCompatibleSchema(rewriteNullableUnionsForStrict(schema))).toBe(false);
+  });
+
+  it("rejects a multi-type union", () => {
+    // A type array naming two real types is a combinator by another name —
+    // `["string","number"]` has no strict spelling, with or without "null".
+    expect(isStrictCompatibleSchema({ type: ["string", "number"] })).toBe(false);
+
+    const rewritten = rewriteNullableUnionsForStrict({
+      anyOf: [{ type: ["string", "number"] }, { type: "null" }],
+    });
+    expect(rewritten).toEqual({ type: ["string", "number", "null"] });
+    expect(isStrictCompatibleSchema(rewritten)).toBe(false);
+  });
+
+  it("leaves an untyped nullable variant as anyOf rather than guessing object", () => {
+    // Nothing here implies a kind, so inventing `["object","null"]` would send
+    // a type the caller never wrote. The combinator survives untouched and the
+    // schema honestly reports non-strict.
+    const schema = { anyOf: [{ description: "free" }, { type: "null" }] };
+    expect(rewriteNullableUnionsForStrict(schema)).toEqual(schema);
+    expect(isStrictCompatibleSchema(rewriteNullableUnionsForStrict(schema))).toBe(false);
+  });
+
+  it("infers object from properties / array from items on an untyped variant", () => {
+    expect(
+      rewriteNullableUnionsForStrict({
+        anyOf: [{ properties: { a: { type: "string" } } }, { type: "null" }],
+      })
+    ).toEqual({ properties: { a: { type: "string" } }, type: ["object", "null"] });
+
+    expect(
+      rewriteNullableUnionsForStrict({ anyOf: [{ items: { type: "string" } }, { type: "null" }] })
+    ).toEqual({ items: { type: "string" }, type: ["array", "null"] });
+  });
+});
+
 describe("jsonModeChatParts", () => {
   it("uses json_schema + strict when the provider supports it and the schema is (or rewrites to) strict", () => {
     const parts = jsonModeChatParts("Extract the LOI.", LOI_LIKE);
@@ -106,6 +222,25 @@ describe("jsonModeChatParts", () => {
     });
     expect(parts.responseFormat).toEqual({ type: "json_object" });
     expect(parts.prompt).toBe(promptWithJsonSchema("Extract the LOI.", LOI_LIKE));
+  });
+
+  it("falls back to json_object when a nullable object is not strict-compatible", () => {
+    // The rewrite succeeds (the field collapses to a type array) but the inner
+    // object is not strict, so the request must downshift rather than ship
+    // `strict: true`. The prompt carries the ORIGINAL schema, not the rewrite.
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["addr"],
+      properties: {
+        addr: {
+          anyOf: [{ type: "object", properties: { city: { type: "string" } } }, { type: "null" }],
+        },
+      },
+    };
+    const parts = jsonModeChatParts("n", schema);
+    expect(parts.responseFormat).toEqual({ type: "json_object" });
+    expect(parts.prompt).toBe(promptWithJsonSchema("n", schema));
   });
 
   it("falls back to json_object + prompt schema when a combinator cannot be rewritten", () => {

--- a/packages/test/src/test/ai-provider/OpenAI_StructuredGeneration.request.test.ts
+++ b/packages/test/src/test/ai-provider/OpenAI_StructuredGeneration.request.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn } from "@workglow/ai";
+import { OPENAI, _testOnly } from "@workglow/openai/ai";
+import { _testOnly as runtimeTestOnly } from "@workglow/openai/ai-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const { OPENAI_RUN_FNS, setOpenAIClientForTests } = _testOnly;
+
+function findStructuredGenerationRunFn(): AiProviderRunFn {
+  const registration = OPENAI_RUN_FNS.find(
+    ({ serves }) =>
+      (serves as readonly string[]).includes("json-mode") &&
+      (serves as readonly string[]).includes("text.generation")
+  );
+  expect(registration).toBeDefined();
+  return registration!.runFn as AiProviderRunFn;
+}
+
+const modelConfig = () =>
+  ({
+    model_id: "gpt-5.5",
+    title: "gpt-5.5",
+    description: "",
+    provider: OPENAI,
+    provider_config: { model_name: "gpt-5.5", api_key: "test-key" },
+    capabilities: ["text.generation", "json-mode"],
+    metadata: {},
+  }) as never;
+
+/**
+ * The Responses SDK returns an async-iterable of lifecycle events; the run-fn
+ * only reads `type`/`delta`, so a two-event stream is enough to drive it to a
+ * finish while we inspect the captured request.
+ */
+function fakeStream(text: string): AsyncIterable<unknown> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "response.output_text.delta", delta: text };
+      yield { type: "response.completed", response: {} };
+    },
+  };
+}
+
+describe("OpenAI_StructuredGeneration request shape", () => {
+  let created: Record<string, unknown>[];
+
+  beforeEach(() => {
+    created = [];
+    const fakeClient = {
+      responses: {
+        create: async (params: Record<string, unknown>) => {
+          created.push(params);
+          return fakeStream('{"a":1}');
+        },
+      },
+    };
+    setOpenAIClientForTests(fakeClient);
+    runtimeTestOnly.setOpenAIClientForTests(fakeClient);
+  });
+
+  afterEach(() => {
+    setOpenAIClientForTests(undefined);
+    runtimeTestOnly.setOpenAIClientForTests(undefined);
+  });
+
+  it("sends strict:false and the caller's schema when the schema cannot be made strict", async () => {
+    // The Responses path always sends `json_schema`, with `strict` as a
+    // variable. When the schema cannot satisfy the strict subset the request
+    // must carry the schema AS THE CALLER WROTE IT — the nullable-union rewrite
+    // exists only to satisfy strict mode, so shipping the rewritten type-array
+    // spelling on a downshifted request would send a shape the caller never
+    // asked for while buying nothing.
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["addr"],
+      properties: {
+        addr: {
+          anyOf: [{ type: "object", properties: { city: { type: "string" } } }, { type: "null" }],
+        },
+      },
+    };
+
+    const runFn = findStructuredGenerationRunFn();
+    const model = modelConfig();
+    await runFn(
+      { prompt: "hi", outputSchema: schema } as never,
+      model,
+      undefined as never,
+      () => {}
+    );
+
+    expect(created).toHaveLength(1);
+    const format = (created[0].text as { format: Record<string, unknown> }).format;
+    expect(format.strict).toBe(false);
+    expect(format.schema).toEqual(schema);
+    // The schema also travels in the prompt, since `strict: false` is not
+    // enforcement.
+    expect(String(created[0].input)).toContain("JSON Schema:");
+  });
+
+  it("sends strict:true and the rewritten schema when the rewrite makes it strict", async () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["a"],
+      properties: { a: { anyOf: [{ type: "number" }, { type: "null" }] } },
+    };
+
+    const runFn = findStructuredGenerationRunFn();
+    const model = modelConfig();
+    await runFn(
+      { prompt: "hi", outputSchema: schema } as never,
+      model,
+      undefined as never,
+      () => {}
+    );
+
+    const format = (created[0].text as { format: Record<string, unknown> }).format;
+    expect(format.strict).toBe(true);
+    expect(format.schema).toEqual({
+      type: "object",
+      additionalProperties: false,
+      required: ["a"],
+      properties: { a: { type: ["number", "null"] } },
+    });
+    expect(created[0].input).toBe("hi");
+  });
+});

--- a/packages/test/src/test/ai-provider/OpenAI_TextGeneration.warnings.test.ts
+++ b/packages/test/src/test/ai-provider/OpenAI_TextGeneration.warnings.test.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { firstNonStrictReason, isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
+import {
+  firstNonStrictReason,
+  isStrictCompatibleSchema,
+  rewriteNullableUnionsForStrict,
+} from "@workglow/ai/provider-utils";
 import { _testOnly } from "@workglow/openai/ai";
 import type { ILogger } from "@workglow/util";
 import { setLogger } from "@workglow/util";
@@ -205,5 +209,42 @@ describe("warnStrictDowngradedOnce dedupe", () => {
     warnStrictDowngradedOnce("gpt-5.5", "anyOf");
     warnStrictDowngradedOnce("gpt-5.5-mini", "anyOf");
     expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("names the reason inside a nullable object", () => {
+    // The run-fn reports on the REWRITTEN schema, where the nullable field is a
+    // type array. While `firstNonStrictReason` read only the `"object"` string
+    // spelling it returned undefined here and the run-fn logged "unknown
+    // reason" — the downshift was observable but not diagnosable.
+    const rewritten = rewriteNullableUnionsForStrict({
+      type: "object",
+      additionalProperties: false,
+      required: ["addr"],
+      properties: {
+        addr: {
+          anyOf: [{ type: "object", properties: { city: { type: "string" } } }, { type: "null" }],
+        },
+      },
+    });
+    expect(isStrictCompatibleSchema(rewritten)).toBe(false);
+    const reason = firstNonStrictReason(rewritten);
+    expect(reason).toBe("addr.missing additionalProperties:false");
+
+    warnStrictDowngradedOnce("gpt-5.5", reason!);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("addr.missing additionalProperties:false");
+  });
+
+  it("names a multi-type union", () => {
+    const rewritten = rewriteNullableUnionsForStrict({
+      anyOf: [{ type: ["string", "number"] }, { type: "null" }],
+    });
+    expect(isStrictCompatibleSchema(rewritten)).toBe(false);
+    const reason = firstNonStrictReason(rewritten);
+    expect(reason).toBe("multi-type union: string|number|null");
+
+    warnStrictDowngradedOnce("gpt-5.5", reason!);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("multi-type union: string|number|null");
   });
 });

--- a/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
@@ -28,10 +28,13 @@ import { mapGeminiUsage } from "./Gemini_Usage";
 /**
  * Streaming run-fn for `["text.generation", "json-mode"]`. Gemini uses
  * `responseSchema` + `responseMimeType: "application/json"` to produce
- * structured output. TypeBox `Type.Union([T, Null])` is rewritten to
- * `{type: [t, "null"]}` first so a nullable field is not an `anyOf`;
- * `sanitizeSchemaForGemini` then strips `additionalProperties`. The prompt
- * is left as the caller wrote it — Gemini enforces via `responseSchema`.
+ * structured output. The nullable-union rewrite is shape-neutral here:
+ * `@google/genai` normalizes both `anyOf: [T, {type:"null"}]` and
+ * `type: [T, "null"]` to `{nullable: true, type: T}` in its own request
+ * converter, so the two spellings serialize identically. It is applied only to
+ * keep one schema pipeline across providers. `sanitizeSchemaForGemini` then
+ * strips `additionalProperties`. The prompt is left as the caller wrote it —
+ * Gemini enforces via `responseSchema`.
  * Per the streaming convention exception for json-mode, the `finish` event
  * MUST include the parsed `object` — it is the definitive result
  * `StructuredGenerationTask` validates against the schema.

--- a/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
+++ b/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
@@ -57,7 +57,9 @@ export const OpenAI_StructuredGeneration_Stream: AiProviderRunFn<
       format: {
         type: "json_schema",
         name: "structured_output",
-        schema: rewritten,
+        // The nullable-union rewrite is a strict-mode accommodation; a
+        // downshifted request sends the schema as the caller wrote it.
+        schema: strict ? rewritten : schema,
         strict,
       },
     },


### PR DESCRIPTION
## The regression

`rewriteNullableUnionsForStrict` (added in 34afa1615) collapses `anyOf: [T, null]` into a **type array** — `type: ["object", "null"]`. But `isStrictCompatibleSchema` tested only the string spelling:

```ts
const isObject = s.type === "object" || (s.type === undefined && s.properties !== undefined);  // line 31
const isArray  = s.type === "array"  || s.items !== undefined;                                  // line 43
```

A type array matches neither, so the function fell through to a bare `return true` **without recursing**. Concretely, this input:

```json
{"type":"object","additionalProperties":false,"required":["addr"],
 "properties":{"addr":{"anyOf":[{"type":"object","properties":{"city":{"type":"string"}}},{"type":"null"}]}}}
```

rewrites to

```json
{"type":"object","additionalProperties":false,"required":["addr"],
 "properties":{"addr":{"type":["object","null"],"properties":{"city":{"type":"string"}}}}}
```

and `isStrictCompatibleSchema(rewritten)` returned `true` — even though the inner object carries neither `additionalProperties: false` nor `required`. Sending it with `strict: true` earns a 400:

```
In context=('properties','addr'), 'additionalProperties' is required to be supplied and to be false
```

**The same schema worked before 34afa1615**: it was an `anyOf`, which the predicate classified non-strict, so it took the prompt + `json_object` fallback. The rewrite is what moved it onto the strict path while the strict check stayed blind to the spelling the rewrite emits.

`firstNonStrictReason` had the byte-identical gap at lines 67/80, which is why `OpenAI_StructuredGeneration.ts:49` logged `"unknown reason"` — the downshift was observable but not diagnosable.

Blast radius: `jsonModeChatParts` (xAI, OpenRouter, DeepSeek) and the OpenAI Responses path, which sends `strict` as a variable and so shipped `strict: true` on these schemas.

## The fix

- **`soleDeclaredType`** reads both spellings; a multi-type union (`["string","number"]`, with or without `"null"`) is a combinator by another name and is now rejected outright with a named reason (`multi-type union: string|number`).
- **`withNullType` no longer invents a type.** It previously produced `["object","null"]` for an untyped variant — a type the caller never wrote. It now infers only from `properties` / `items` and otherwise declines, letting the rewrite fall through to the untouched combinator.
- **The Responses path sends the caller's schema, not the rewrite, when `strict` is `false`.** The rewrite exists only to satisfy strict mode; a downshifted request has no reason to carry it.

## A suspected Gemini bug was investigated and DISPROVEN

The rewrite also runs in the Gemini structured-generation run-fn, and its docstring justified it as *needed* ("so a nullable field is not an `anyOf`"). That is false, and it would have led the next reader to "fix" Gemini.

`@google/genai@2.17.1` normalizes both spellings before serializing. `tSchema` → `processJsonSchema` calls `flattenTypeArrayToAnyOf`, which folds a `"null"` member into `nullable: true`:

```js
function flattenTypeArrayToAnyOf(typeList, resultingSchema) {
    if (typeList.includes('null')) { resultingSchema['nullable'] = true; }
    const listWithoutNull = typeList.filter((type) => type !== 'null');
    if (listWithoutNull.length === 1) { resultingSchema['type'] = ... }
```

It runs in **both** `generateContentConfigToMldev` and `generateContentConfigToVertex`. `processJsonSchema` also strips `additionalProperties` itself, and `maybeMoveToResponseJsonSchema` only reroutes when the schema has a top-level `$schema` (ours never do).

**No Gemini behavior is changed here.** The docstring is corrected to state the truth, and a new wire-level test (`packages/test/src/test/ai-provider-api/Gemini_RequestBody.test.ts`) **pins the SDK behavior** so a future `@google/genai` bump that drops `flattenTypeArrayToAnyOf` fails in CI rather than in production. It uses the REAL SDK client with a `fetch` spy, because the existing `fakeGeminiClient` tests replace `ai.models.generateContentStream` — intercepting *above* the `tSchema` converter under test. Verified: both `anyOf:[T,null]` and `type:[T,"null"]` serialize to `{"nullable":true,"type":"NUMBER"}`.

## Risks

- **Strictly fewer schemas take the `strict: true` path.** That is the intent. The fallback is the pre-regression behavior: the schema travels in the prompt and `StructuredGenerationTask` re-validates the parsed object. No schema that was correctly strict before loses it.
- **`firstNonStrictReason` strings in logs will change** — a nullable object that reported nothing now reports e.g. `addr.missing additionalProperties:false`, and a new `multi-type union: …` string exists. Anything grepping these strings needs updating.
- **A schema whose ROOT rewrites to `type: ["object","null"]` is still reported strict**, and OpenAI rejects a nullable root. No current `StructuredGenerationTask` output schema is nullable at the root, so this is a note rather than a guard — flagged here so it is not mistaken for covered.

## Verification

```
$ bun scripts/test.ts provider vitest
Running all tests in sections [provider] — 42 file(s)
 Test Files  42 passed (42)
      Tests  499 passed | 1 skipped (500)
   Duration  198.05s

$ bun scripts/test.ts provider-api vitest
Running all tests in sections [provider-api] — 60 file(s)
 Test Files  57 passed | 3 skipped (60)
      Tests  603 passed | 60 skipped (664)
   Duration  347.67s

$ bun run build:types
 Tasks:    42 successful, 42 total
  Time:    1m58.779s
```

The new and changed test files, verbosely:

```
 ✓ OpenAIShapedJsonSchema.test.ts > isStrictCompatibleSchema > rejects a nullable object whose inner object omits additionalProperties/required
 ✓ OpenAIShapedJsonSchema.test.ts > isStrictCompatibleSchema > accepts a nullable object that is itself strict
 ✓ OpenAIShapedJsonSchema.test.ts > isStrictCompatibleSchema > rejects a genuine anyOf nested inside a nullable object
 ✓ OpenAIShapedJsonSchema.test.ts > isStrictCompatibleSchema > rejects a multi-type union
 ✓ OpenAIShapedJsonSchema.test.ts > isStrictCompatibleSchema > leaves an untyped nullable variant as anyOf rather than guessing object
 ✓ OpenAIShapedJsonSchema.test.ts > isStrictCompatibleSchema > infers object from properties / array from items on an untyped variant
 ✓ OpenAIShapedJsonSchema.test.ts > jsonModeChatParts > falls back to json_object when a nullable object is not strict-compatible
 ✓ OpenAI_StructuredGeneration.request.test.ts > sends strict:false and the caller's schema when the schema cannot be made strict
 ✓ OpenAI_StructuredGeneration.request.test.ts > sends strict:true and the rewritten schema when the rewrite makes it strict
 ✓ OpenAI_TextGeneration.warnings.test.ts > warnStrictDowngradedOnce dedupe > names the reason inside a nullable object
 ✓ OpenAI_TextGeneration.warnings.test.ts > warnStrictDowngradedOnce dedupe > names a multi-type union
 ✓ Gemini_RequestBody.test.ts > serializes an anyOf [T, null] property to nullable:true
 ✓ Gemini_RequestBody.test.ts > serializes a type:[T,'null'] property to the same nullable:true
 Test Files  4 passed (4)
      Tests  39 passed (39)
```

The three previously-committed `rewriteNullableUnionsForStrict` cases (nullable string / integer collapse) pass **unchanged** — that is the feature the regression came bundled with, and it is preserved.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT)_