### PR TITLE
fix(storage): scope InMemory column constraints to a backend mode and document the nullable-column DDL change

### DIFF
--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -261,6 +261,49 @@ const userRepo = new InMemoryTabularStorage<typeof UserSchema, ["id"]>(
 );
 ```
 
+#### Nullable columns and generated DDL
+
+A nullable column can be written two ways, and both are recognized:
+
+```typescript
+{
+  input: {
+    anyOf: [{ type: "integer" }, { type: "null" }];
+  }
+} // anyOf form
+{
+  input: {
+    type: ["integer", "null"];
+  }
+} // type-array form
+```
+
+As of this release the **type-array form maps to the underlying type's column
+type** (`INTEGER`, `VARCHAR(n)`, …) instead of falling through to
+`TEXT /* unknown type */`. Only the DDL generated for _new_ tables changes —
+`CREATE TABLE IF NOT EXISTS` never alters an existing one, so a Postgres
+database created before this keeps its `TEXT` columns and reads those values
+back as `string` where a freshly created database returns `number`.
+
+No migration ships for this: the declarative migration op set has no
+column-type-change op, migrations are supplied per storage instance by whoever
+constructs it, and no table in this repository is built from an affected schema.
+Bringing an existing deployment in line is an operator action:
+
+```sql
+ALTER TABLE run_usage
+  ALTER COLUMN input  TYPE INTEGER USING input::integer,
+  ALTER COLUMN output TYPE INTEGER USING output::integer;
+-- string columns additionally take a width; truncation policy is the operator's call
+ALTER TABLE run_usage
+  ALTER COLUMN "modelId" TYPE VARCHAR(255) USING left("modelId", 255);
+```
+
+The `USING left(...)` clause **truncates** any value already wider than the new
+width. That is a choice about your data, not a recommendation — inspect the
+column first and decide whether to widen the schema, clean the rows, or accept
+the truncation.
+
 #### Auto-Generated Primary Keys
 
 TabularStorage supports automatic ID generation by marking schema properties with `x-auto-generated: true`:

--- a/packages/storage/src/tabular/InMemoryTabularStorage.ts
+++ b/packages/storage/src/tabular/InMemoryTabularStorage.ts
@@ -14,7 +14,7 @@ import { safeEmit } from "../events/safeEmit";
 import { type ITabularMigration, type ITabularMigrationApplier } from "../migrations";
 import type { ClientProvidedKeysOption, KeyGenerationStrategy } from "./BaseTabularStorage";
 import { BaseTabularStorage } from "./BaseTabularStorage";
-import type { TabularColumnConstraint } from "./columnConstraints";
+import type { TabularColumnConstraint, TabularConstraintMode } from "./columnConstraints";
 import { assertColumnConstraints, buildColumnConstraints } from "./columnConstraints";
 import { pickCoveringIndex } from "./coveringIndexPicker";
 import { InMemoryTabularMigrationApplier } from "./InMemoryTabularMigrationApplier";
@@ -126,7 +126,8 @@ export class InMemoryTabularStorage<
     clientProvidedKeys: ClientProvidedKeysOption = "if-missing",
     tabularMigrations?: ReadonlyArray<ITabularMigration>,
     migrationName: string = "inmemory",
-    uniqueIndexes: readonly (readonly (keyof NoInfer<Entity>)[])[] = []
+    uniqueIndexes: readonly (readonly (keyof NoInfer<Entity>)[])[] = [],
+    constraintMode: TabularConstraintMode = "postgres"
   ) {
     super(
       schema,
@@ -137,16 +138,26 @@ export class InMemoryTabularStorage<
       migrationName,
       uniqueIndexes
     );
-    this.columnConstraints = buildColumnConstraints(this.primaryKeySchema, this.valueSchema);
+    this.columnConstraints = buildColumnConstraints(
+      this.primaryKeySchema,
+      this.valueSchema,
+      constraintMode
+    );
   }
 
   /**
-   * Enforce the DB-equivalent column constraints — `NOT NULL` (including the
-   * presence of every `required` column) and `VARCHAR(n)` width — at the
-   * in-memory tier, for the same reason {@link assertUniqueIndexes} exists:
-   * a store used as a test double or a dev-mode backend should reject the rows
-   * Postgres/SQLite would reject, rather than accepting them and deferring the
-   * failure to the first real deployment.
+   * Enforce the backend-equivalent column constraints at the in-memory tier,
+   * for the same reason {@link assertUniqueIndexes} exists: a store used as a
+   * test double or a dev-mode backend should reject the rows the real backend
+   * would reject, rather than accepting them and deferring the failure to the
+   * first real deployment.
+   *
+   * Presence of every `required` column and `NOT NULL` are what every backend
+   * enforces. `VARCHAR(n)` width, integer column range and the schema's own
+   * numeric bounds are Postgres-shaped — SQLite enforces none of them, and the
+   * bounds are stricter than any database. A consumer targeting SQLite passes
+   * `"sqlite"` as the constructor's `constraintMode` so its double matches its
+   * real backend.
    */
   private assertColumnConstraints(entityToStore: Entity): void {
     assertColumnConstraints(entityToStore as Record<string, unknown>, this.columnConstraints);

--- a/packages/storage/src/tabular/__tests__/InMemoryTabularStorage.constraints.test.ts
+++ b/packages/storage/src/tabular/__tests__/InMemoryTabularStorage.constraints.test.ts
@@ -298,6 +298,116 @@ describe("InMemoryTabularStorage column constraints", () => {
     });
   });
 
+  describe("constraint mode", () => {
+    /**
+     * The 8th constructor parameter is the constraint mode. Everything before
+     * it is spelled out so the mode lands in the right position.
+     */
+    function makeStorage<
+      S extends DataPortSchemaObject,
+      PK extends readonly (keyof S["properties"])[],
+    >(
+      schema: S,
+      primaryKeyNames: PK,
+      mode: "postgres" | "sqlite" | "off"
+    ): InMemoryTabularStorage<S, PK> {
+      return new InMemoryTabularStorage<S, PK>(
+        schema,
+        primaryKeyNames,
+        [],
+        "if-missing",
+        undefined,
+        "inmemory",
+        [],
+        mode
+      );
+    }
+
+    it("postgres is the default mode", async () => {
+      // Constructed with the pre-existing 7-argument call: the new parameter is
+      // additive, so an untouched caller keeps the Postgres-shaped rules.
+      const storage = new InMemoryTabularStorage(
+        ConstraintSchema,
+        ConstraintPK,
+        [],
+        "if-missing",
+        undefined,
+        "inmemory",
+        []
+      );
+      await storage.setupDatabase();
+      await expect(storage.put({ ...validRow, name: "Ada Lovelace!" } as never)).rejects.toThrow(
+        StorageValidationError
+      );
+    });
+
+    it("sqlite mode accepts a value wider than maxLength, as a SQLite TEXT column does", async () => {
+      // `SqliteTabularStorage.mapTypeToSQL` emits `TEXT /* VARCHAR(n) */` — the
+      // width is a COMMENT, and SQLite enforces no character width at all. A
+      // double that rejects the value is stricter than the backend it stands in
+      // for.
+      const storage = makeStorage(ConstraintSchema, ConstraintPK, "sqlite");
+      await storage.setupDatabase();
+      await storage.put({ ...validRow, name: "Ada Lovelace!" } as never);
+      expect((await storage.get({ id: "row-1" }))?.name).toBe("Ada Lovelace!");
+    });
+
+    it("sqlite mode accepts an integer outside the Postgres column range", async () => {
+      // `score` maps to SMALLINT on Postgres (max 32767). SQLite emits a bare
+      // `INTEGER` with no width selection, so 40000 stores fine there.
+      const storage = makeStorage(NumericSchema, NumericPK, "sqlite");
+      await storage.setupDatabase();
+      await storage.put({ ...validNumericRow, score: 40000 } as never);
+      expect((await storage.get({ id: "n-1" }))?.score).toBe(40000);
+    });
+
+    it("sqlite mode accepts a value outside the schema's declared bounds", async () => {
+      // Schema bounds are emitted as a CHECK by no backend at all, so they are
+      // the first thing a backend-scoped mode drops.
+      const storage = makeStorage(NumericSchema, NumericPK, "sqlite");
+      await storage.setupDatabase();
+      await storage.put({ ...validNumericRow, ratio: 42 } as never);
+      expect((await storage.get({ id: "n-1" }))?.ratio).toBe(42);
+    });
+
+    it("sqlite mode still rejects a missing required column", async () => {
+      const storage = makeStorage(ConstraintSchema, ConstraintPK, "sqlite");
+      await storage.setupDatabase();
+      const { name: _dropped, ...withoutName } = validRow;
+      await expect(storage.put(withoutName as never)).rejects.toThrow(
+        "Missing required value field: name"
+      );
+    });
+
+    it("sqlite mode still rejects an explicit null in a NOT NULL column", async () => {
+      const storage = makeStorage(ConstraintSchema, ConstraintPK, "sqlite");
+      await storage.setupDatabase();
+      await expect(storage.put({ ...validRow, name: null } as never)).rejects.toThrow(
+        "NOT NULL constraint failed: name"
+      );
+
+      // `note` is required but nullable, so an explicit null stays legal — the
+      // presence and NOT NULL halves are still two separate checks here.
+      await storage.put({ ...validRow, note: null } as never);
+      expect((await storage.get({ id: "row-1" }))?.note).toBeNull();
+    });
+
+    it("off mode accepts a row postgres mode rejects", async () => {
+      // One row failing width (name), integer range (count overflows INTEGER)
+      // and NOT NULL (email) simultaneously.
+      const offending = { ...validRow, name: "Ada Lovelace!", email: null, count: 3_000_000_000 };
+
+      const postgres = makeStorage(ConstraintSchema, ConstraintPK, "postgres");
+      await postgres.setupDatabase();
+      await expect(postgres.put(offending as never)).rejects.toThrow(StorageValidationError);
+
+      const off = makeStorage(ConstraintSchema, ConstraintPK, "off");
+      await off.setupDatabase();
+      await off.put(offending as never);
+      expect(await off.size()).toBe(1);
+    });
+  });
+
   describe("write atomicity", () => {
     it("stores nothing when a single put is rejected", async () => {
       await expect(storage.put({ ...validRow, name: null } as never)).rejects.toThrow();

--- a/packages/storage/src/tabular/__tests__/columnConstraints.test.ts
+++ b/packages/storage/src/tabular/__tests__/columnConstraints.test.ts
@@ -114,6 +114,24 @@ describe("the `type: [T, null]` spelling derives the same constraints as anyOf",
     expect(numericBounds(arrayForm)).toEqual(numericBounds(anyOfForm));
     expect(isNullableSchema(arrayForm)).toBe(true);
   });
+
+  it("a genuine multi-type union stays in the unknown-type branch", () => {
+    // Collapsing applies only when ONE non-null type remains. Two real types
+    // have no single SQL type, so the honest answer is still the unknown-type
+    // branch — not a guess at whichever came first.
+    const union = { type: ["string", "integer", "null"] } as JsonSchema;
+    expect(mapPostgresType(union, { getNonNullType: getNonNullSchema })).toBe(
+      "TEXT /* unknown type */"
+    );
+    expect(varcharWidth(union)).toBeUndefined();
+    expect(sqlIntegerTypeFor(union)).toBeUndefined();
+
+    expect(
+      mapPostgresType({ type: ["string", "integer"] } as JsonSchema, {
+        getNonNullType: getNonNullSchema,
+      })
+    ).toBe("TEXT /* unknown type */");
+  });
 });
 
 describe("varcharWidth", () => {
@@ -332,6 +350,69 @@ describe("buildColumnConstraints", () => {
       notNull: false,
       maxLength: undefined,
     });
+  });
+
+  it("drops width, range and bounds in sqlite mode but keeps required and notNull", () => {
+    // SQLite emits `TEXT /* VARCHAR(n) */` and a single `INTEGER` type, so it
+    // enforces neither width nor column range; schema bounds are emitted as a
+    // CHECK by no backend at all. Presence and NOT NULL survive.
+    const numericValueSchema = {
+      type: "object",
+      properties: {
+        name: { type: "string", maxLength: 10 },
+        score: { type: "integer", minimum: 0, maximum: 100 },
+      },
+      required: ["name", "score"],
+      additionalProperties: false,
+    } as unknown as DataPortSchemaObject;
+
+    const postgres = Object.fromEntries(
+      buildColumnConstraints(primaryKeySchema, numericValueSchema, "postgres").map((c) => [
+        c.column,
+        c,
+      ])
+    );
+    expect(postgres.name.maxLength).toBe(10);
+    expect(postgres.score.integerType).toBe("SMALLINT");
+    expect(postgres.score.bounds).toEqual({
+      minimum: 0,
+      maximum: 100,
+      exclusiveMinimum: undefined,
+      exclusiveMaximum: undefined,
+    });
+
+    const sqlite = Object.fromEntries(
+      buildColumnConstraints(primaryKeySchema, numericValueSchema, "sqlite").map((c) => [
+        c.column,
+        c,
+      ])
+    );
+    expect(sqlite.id).toMatchObject({
+      isPrimaryKey: true,
+      required: true,
+      notNull: true,
+      maxLength: undefined,
+      bounds: undefined,
+      integerType: undefined,
+    });
+    expect(sqlite.name).toMatchObject({
+      required: true,
+      notNull: true,
+      maxLength: undefined,
+      bounds: undefined,
+      integerType: undefined,
+    });
+    expect(sqlite.score).toMatchObject({
+      required: true,
+      notNull: true,
+      maxLength: undefined,
+      bounds: undefined,
+      integerType: undefined,
+    });
+  });
+
+  it("returns no constraints in off mode", () => {
+    expect(buildColumnConstraints(primaryKeySchema, valueSchema, "off")).toEqual([]);
   });
 });
 

--- a/packages/storage/src/tabular/columnConstraints.ts
+++ b/packages/storage/src/tabular/columnConstraints.ts
@@ -152,6 +152,12 @@ export function isNullableSchema(typeDef: JsonSchema): boolean {
  * its unknown-type branch. That made `mapPostgresType` emit
  * `TEXT /* unknown type *\/` for what should be an INTEGER column, and left
  * such columns with no derived width or range at all.
+ *
+ * Collapsing the array form therefore CHANGES the generated DDL for those
+ * columns. `CREATE TABLE IF NOT EXISTS` never alters an existing table, so a
+ * database created before this reads back `string` where a fresh one returns
+ * `number`. See "Nullable columns and generated DDL" in the package README for
+ * the operator-side `ALTER TABLE`.
  */
 export function getNonNullSchema(typeDef: JsonSchema): JsonSchema {
   if (typeof typeDef === "boolean") return typeDef;
@@ -208,6 +214,19 @@ export function varcharWidth(typeDef: JsonSchema): number | undefined {
   return typeof actualType.maxLength === "number" ? actualType.maxLength : undefined;
 }
 
+/**
+ * Which backend's write rules the schemaless stores enforce.
+ *
+ * - `"postgres"` (default): everything the Postgres DDL declares — NOT NULL,
+ *   `VARCHAR(n)` width, integer column range — plus the schema's own numeric
+ *   bounds, which no backend emits a CHECK for.
+ * - `"sqlite"`: only what SQLite enforces. It emits `TEXT` with the width in a
+ *   comment and a single `INTEGER` type, so neither width nor range is a
+ *   constraint there; presence and NOT NULL still are.
+ * - `"off"`: no write-time checking.
+ */
+export type TabularConstraintMode = "postgres" | "sqlite" | "off";
+
 /** The write-time constraints a single column imposes on every stored row. */
 export interface TabularColumnConstraint {
   readonly column: string;
@@ -227,7 +246,7 @@ export interface TabularColumnConstraint {
 
 /**
  * Derives the per-column write constraints implied by a storage's schema,
- * mirroring the DDL the SQL backends emit:
+ * mirroring the DDL the Postgres-shaped backends emit:
  *
  * - Primary-key columns are `NOT NULL` (see `constructPrimaryKeyColumns`).
  * - A value column is `NOT NULL` when it is listed in `required` *and* its
@@ -247,10 +266,14 @@ export interface TabularColumnConstraint {
  *
  * Computed once per storage instance; the result is a plain array so the
  * per-write check is a straight loop with no schema walking.
+ *
+ * `mode` narrows the set to what the target backend really enforces — see
+ * {@link TabularConstraintMode}.
  */
 export function buildColumnConstraints(
   primaryKeySchema: DataPortSchemaObject,
-  valueSchema: DataPortSchemaObject
+  valueSchema: DataPortSchemaObject,
+  mode: TabularConstraintMode = "postgres"
 ): ReadonlyArray<TabularColumnConstraint> {
   const constraints: TabularColumnConstraint[] = [];
 
@@ -278,6 +301,18 @@ export function buildColumnConstraints(
       bounds: numericBounds(typeDef),
       integerType: sqlIntegerTypeFor(typeDef),
     });
+  }
+
+  if (mode === "off") return [];
+  if (mode === "sqlite") {
+    // Width, range and schema bounds have no SQLite counterpart; presence and
+    // NOT NULL do. Stripped once here so the per-write loop stays a straight scan.
+    return constraints.map((c) => ({
+      ...c,
+      maxLength: undefined,
+      bounds: undefined,
+      integerType: undefined,
+    }));
   }
 
   return constraints;
@@ -365,9 +400,16 @@ function assertNumericConstraints(value: number, constraint: TabularColumnConstr
 
 /**
  * Throws when `row` violates any of `constraints`. Lets the schemaless
- * backends (InMemory and the storages layered on it) fail on a row that a
- * SQL backend would have rejected, instead of silently accepting a missing
- * `NOT NULL` column or an over-long `VARCHAR` and only failing in production.
+ * backends (InMemory and the storages layered on it) fail on a row that the
+ * real backend would have rejected, instead of silently accepting it and
+ * deferring the failure to the first real deployment.
+ *
+ * Only the presence / NOT NULL half of that claim holds on every backend. The
+ * width, integer-range and schema-bounds checks are Postgres-shaped: SQLite
+ * emits `TEXT` with the width in a comment and a single `INTEGER` type, so it
+ * enforces neither, and the schema's own numeric bounds are emitted as a CHECK
+ * by no backend at all — stricter than any database. Pick what to enforce with
+ * {@link TabularConstraintMode}.
  *
  * Error messages deliberately echo the SQL backends' wording so a test that
  * asserts on the message reads the same across backends.

--- a/packages/task-graph/src/storage/__tests__/RunUsageSchema.ddl.test.ts
+++ b/packages/task-graph/src/storage/__tests__/RunUsageSchema.ddl.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getNonNullSchema, mapPostgresType } from "@workglow/storage";
+import type { JsonSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+import { RunUsageSchema } from "../RunUsageSchema";
+
+/**
+ * Every token counter on {@link RunUsageSchema} is declared nullable in the
+ * `type: ["integer", "null"]` array spelling, which `getNonNullSchema` collapses
+ * to `{type: "integer"}` before `mapPostgresType` reads it.
+ *
+ * This pins the resulting DDL because the mapping is what makes these columns
+ * `INTEGER` rather than `TEXT /* unknown type *\/`, and `CREATE TABLE IF NOT
+ * EXISTS` never alters an existing table — so a change here silently splits
+ * fresh databases from pre-existing ones (a counter read back as `string`
+ * instead of `number`) with nothing else failing. If this test moves, the
+ * README's "Nullable columns and generated DDL" operator note moves with it.
+ */
+const COUNTER_COLUMNS = ["input", "output", "cached", "cacheWrite", "reasoning", "total"] as const;
+
+describe("RunUsageSchema generated DDL", () => {
+  const ddl = (schema: JsonSchema): string =>
+    mapPostgresType(schema, { getNonNullType: getNonNullSchema });
+
+  it.each(COUNTER_COLUMNS)("every RunUsage counter maps to an INTEGER column (%s)", (column) => {
+    const typeDef = (RunUsageSchema.properties as Record<string, JsonSchema>)[column];
+    expect(typeDef).toBeDefined();
+    expect(ddl(typeDef)).toBe("INTEGER");
+  });
+
+  it("declares each counter in the nullable type-array spelling", () => {
+    for (const column of COUNTER_COLUMNS) {
+      const typeDef = (RunUsageSchema.properties as Record<string, { type?: unknown }>)[column];
+      expect(typeDef.type).toEqual(["integer", "null"]);
+    }
+  });
+});


### PR DESCRIPTION
## Only half the check is universal

`InMemoryTabularStorage.assertColumnConstraints` said the store rejects the rows "Postgres/SQLite would reject", and `columnConstraints.ts` said "a SQL backend would have rejected". Only the **presence / NOT NULL** half of that is true on every backend.

`providers/sqlite/src/storage/SqliteTabularStorage.ts:436`:

```ts
return `TEXT /* VARCHAR(${actualType.maxLength}) */`;
```

The width is a **comment**. SQLite enforces no character width. Line 450 likewise emits a bare `INTEGER` with no SMALLINT/INTEGER/BIGINT selection, so the integer column-range check has no SQLite counterpart either. And `columnConstraints.ts:244-246` already conceded that the schema's own `minimum`/`maximum`/`exclusive*` bounds are emitted as a CHECK by **no** backend — stricter than any database.

There was no opt-out: constraints were built unconditionally and enforced in `put` and `updateWhere`. A SQLite-targeting consumer's in-memory double was therefore strictly stricter than its real backend, with no way to say so.

### The change

`buildColumnConstraints` gains a `TabularConstraintMode` parameter — `"postgres"` (default, unchanged behavior), `"sqlite"` (strips width, range and bounds; keeps presence and NOT NULL), `"off"` — surfaced as an additive, defaulted 8th constructor parameter on `InMemoryTabularStorage`. Docstrings now say which half is universal and which is Postgres-shaped.

`InMemoryVectorStorage` is unchanged and keeps the default. The `InMemoryVectorStorage.validation.test.ts` bypass of the public write path was reviewed and deliberately **left as-is**: `metadata` is required and non-nullable, so rejecting an explicit null is what every backend does — that test constructs a row no backend could produce, on purpose, to exercise read-path robustness. It is not evidence of over-strictness.

## The DDL split — documented, not migrated

`getNonNullSchema` now collapses `type: ["integer", "null"]` → `{type: "integer"}`, which flows to `BaseSqlTabularStorage.getNonNullType` → `mapPostgresType` and moves those columns from `TEXT /* unknown type */` to `INTEGER` / `VARCHAR(n)`. `RunUsageSchema` declares seven such columns (`modelId`, `input`, `output`, `cached`, `cacheWrite`, `reasoning`, `total`, `extra`).

`CREATE TABLE IF NOT EXISTS` never alters an existing table, so **a Postgres database created earlier keeps its TEXT columns and reads those counters back as `string` where a fresh one returns `number`.**

**No migration ships, and that is not an oversight.** Three independent reasons:

1. `TabularMigrationOp` (`packages/storage/src/migrations/TabularMigration.ts:19-41`) has `addColumn` / `dropColumn` / `renameColumn` / `addIndex` / `dropIndex` / `backfill` — there is **no column-type-change op**.
2. Migrations are supplied **per storage instance** by whoever constructs it; libs cannot inject one into a table it does not construct.
3. Nothing in libs builds a SQL table from any affected schema — the affected tables live in downstream deployments only.

So the README carries the operator-side `ALTER TABLE` instead (`packages/storage/README.md`, new *Nullable columns and generated DDL* subsection), including an explicit warning that the `USING left(...)` clause **truncates** and is the operator's call, not a recommendation. A new cheap test (`packages/task-graph/src/storage/__tests__/RunUsageSchema.ddl.test.ts`) pins the scenario so a future `getNonNullSchema` change that moves those columns again fails loudly.

The changelog line is carried in the commit body rather than hand-edited into `packages/storage/CHANGELOG.md` — entries mirror conventional-commit subjects and versions are generated.

## Things worth knowing before merging

- **The 8th constructor parameter is additive and defaulted**, so every existing call site is unaffected (a test pins that `postgres` is what a 7-arg call gets). But the constructor is now **8 positionals deep**. Converting it to an options object is a strictly larger refactor across every caller and every subclass, and is deliberately **not** smuggled into this change.
- **`"sqlite"` mode makes a double MORE permissive than the schema.** That is the point — it aligns the double with SQLite — but it costs the early warning: a consumer that later migrates to Postgres will discover width and range violations at the database instead of in tests. The mode is opt-in for exactly that reason, and `"postgres"` stays the default.
- `buildColumnConstraints` / `assertColumnConstraints` are used **only** by `InMemoryTabularStorage` (verified by grep across `packages/` and `providers/`), so no SQL backend's write path is touched.

## Verification

```
$ npx vitest run --project storage --project task-graph \
    packages/storage/src/tabular/__tests__/columnConstraints.test.ts \
    packages/storage/src/tabular/__tests__/InMemoryTabularStorage.constraints.test.ts \
    packages/storage/src/vector/__tests__/InMemoryVectorStorage.validation.test.ts \
    packages/task-graph/src/storage/__tests__/RunUsageSchema.ddl.test.ts

 Test Files  4 passed (4)
      Tests  143 passed (143)
   Duration  51.30s
```

That covers the new `constraint mode` block, the new `columnConstraints` cases, the new `RunUsageSchema.ddl` test, the pre-existing `InMemoryTabularStorage.constraints.test.ts` blocks, and the two workaround tests — **which stay unchanged**.

```
$ bun run build:types
 Tasks:    42 successful, 42 total
  Time:    18m21.529s
```

### Full-section run: pre-existing environmental failures, disclosed

`bun scripts/test.ts storage vitest` (71 files) reported failures in four files:

```
 ❯ src/test/storage-tabular/uniqueIndexes.contract.test.ts (21 tests | 1 failed) 96533ms
 ❯ src/test/storage-tabular/PostgresTabularStorage.integration.test.ts (164 tests | 6 failed | 1 skipped) 565456ms
 ❯ src/test/storage-tabular/PostgresTabularDateTime.test.ts (5 tests | 3 failed) 212975ms
 ❯ src/test/tabular-migrations/PostgresTabular.smoke.test.ts (1 test | 1 failed) 94130ms
```

Every one is a PGlite/Postgres integration test timing out (`Test timed out in 15000ms`) on a heavily loaded machine — individual tests took 74–565 s. I verified they are **not** caused by this change, two ways:

1. **Reproduced on clean `origin/main`** (`git stash -u`, same two worst files): `Test Files 2 failed (2) | Tests 2 failed | 4 passed (6)`, same 15000 ms timeout.
2. **`uniqueIndexes.contract.test.ts` passes 21/21 on this branch** when run in isolation — including the Postgres variant, which took 22 s instead of 91 s once the machine was free.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT)_