### PR TITLE
fix(tasks): harden FileGrepTask — bounded regex matching, path containment, entitlements, output caps

### DIFF
--- a/packages/tasks/src/electron.ts
+++ b/packages/tasks/src/electron.ts
@@ -12,6 +12,7 @@ import "./util/SafeFetch.server";
 
 export * from "./common";
 export * from "./task/FileGrepTask.server";
+export { grepLines, linesFromText } from "./task/FileGrepTask";
 export * from "./task/FileLoaderTask.server";
 export * from "./task/FileSedTask.server";
 

--- a/packages/tasks/src/node.ts
+++ b/packages/tasks/src/node.ts
@@ -14,6 +14,7 @@ import "./util/SafeFetch.server";
 
 export * from "./common";
 export * from "./task/FileGrepTask.server";
+export { grepLines, linesFromText } from "./task/FileGrepTask";
 export * from "./task/FileLoaderTask.server";
 export * from "./task/FileSedTask.server";
 

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -739,6 +739,44 @@ function toJobFailure(reason: unknown): unknown {
   return new Error(`Queued fetch job rejected without a reason (${String(reason)})`);
 }
 
+/**
+ * Entitlements a fetch of `url` requires. A task that OWNS a `FetchUrlTask`
+ * must declare these itself: the graph snapshot is taken over
+ * `graph.getTasks()` before any `execute()` runs, so an owned child created
+ * inside `execute()` is never in it.
+ *
+ * `url` may be unknown at evaluation time (root-task input is not applied
+ * yet), in which case this fails closed and requires an unscoped
+ * `network:private` rather than under-declaring it.
+ */
+export function fetchUrlEntitlementsFor(url: string | undefined): TaskEntitlements {
+  const base = FetchUrlTask.entitlements();
+  if (typeof url !== "string" || url.length === 0) {
+    return mergeEntitlements(base, {
+      entitlements: [
+        {
+          id: Entitlements.NETWORK_PRIVATE,
+          reason:
+            "Runtime URL is not yet available during entitlement evaluation; private/internal destinations must be explicitly allowed",
+        },
+      ],
+    });
+  }
+  const classification = classifyUrl(url);
+  if (classification.kind !== "private") {
+    return base;
+  }
+  return mergeEntitlements(base, {
+    entitlements: [
+      {
+        id: Entitlements.NETWORK_PRIVATE,
+        reason: `URL targets private/internal host: ${classification.reason ?? classification.host ?? "unknown"}`,
+        resources: [urlResourcePattern(url)],
+      },
+    ],
+  });
+}
+
 export class FetchUrlTask<
   Input extends FetchUrlTaskInput = FetchUrlTaskInput,
   Output extends FetchUrlTaskOutput = FetchUrlTaskOutput,
@@ -798,38 +836,9 @@ export class FetchUrlTask<
    * via the URL's origin so grants can be resource-limited (e.g. a dev-mode
    * grant for `http://localhost:*`). The graph runner evaluates this before
    * `execute()` runs, so a denied private URL never issues a network call.
-   *
-   * Root-task input may not yet be applied when entitlements are evaluated.
-   * If the URL is not available at this point, fail closed and require the
-   * private-network entitlement rather than under-declaring it.
    */
   public override entitlements(): TaskEntitlements {
-    const base = FetchUrlTask.entitlements();
-    const url = this.runInputData?.url;
-    if (typeof url !== "string" || url.length === 0) {
-      return mergeEntitlements(base, {
-        entitlements: [
-          {
-            id: Entitlements.NETWORK_PRIVATE,
-            reason:
-              "Runtime URL is not yet available during entitlement evaluation; private/internal destinations must be explicitly allowed",
-          },
-        ],
-      });
-    }
-    const classification = classifyUrl(url);
-    if (classification.kind !== "private") {
-      return base;
-    }
-    return mergeEntitlements(base, {
-      entitlements: [
-        {
-          id: Entitlements.NETWORK_PRIVATE,
-          reason: `URL targets private/internal host: ${classification.reason ?? classification.host ?? "unknown"}`,
-          resources: [urlResourcePattern(url)],
-        },
-      ],
-    });
+    return fetchUrlEntitlementsFor(this.runInputData?.url);
   }
 
   public static override configSchema(): DataPortSchema {

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -15,9 +15,8 @@ import {
   Workflow,
 } from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
-import { createInterface } from "node:readline";
 
-import { SECURITY_LIMITS } from "@workglow/util";
+import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
@@ -198,6 +197,60 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
   }
 }
 
+/**
+ * Splits a byte stream into lines with a hard per-line cap.
+ *
+ * `readline.createInterface` accumulates an unterminated line without bound: a
+ * 640 MB newline-free stream threw `RangeError: Invalid string length` from a
+ * stream `'data'` listener, which surfaces as an `uncaughtException` rather
+ * than an iterator rejection — so the caller's try/catch could not see it and
+ * the process died.
+ *
+ * A line reaching `maxLineChars` with no terminator yields its first
+ * `maxLineChars` characters, and the rest of that physical line is discarded up
+ * to the next `\n`. `setEncoding` puts a `StringDecoder` in front, so a
+ * multi-byte character split across two reads is not corrupted.
+ */
+async function* linesFromStream(
+  stream: NodeJS.ReadableStream,
+  maxLineChars: number
+): AsyncGenerator<string> {
+  stream.setEncoding("utf8");
+
+  let pending = "";
+  let skipping = false;
+
+  const stripCr = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line);
+
+  for await (const chunk of stream as AsyncIterable<string>) {
+    pending += chunk;
+
+    let newline = pending.indexOf("\n");
+    while (newline !== -1) {
+      const line = pending.slice(0, newline);
+      pending = pending.slice(newline + 1);
+      if (skipping) {
+        skipping = false;
+      } else {
+        yield stripCr(line);
+      }
+      newline = pending.indexOf("\n");
+    }
+
+    if (!skipping && pending.length >= maxLineChars) {
+      yield pending.slice(0, maxLineChars);
+      pending = "";
+      skipping = true;
+    } else if (skipping) {
+      pending = "";
+    }
+  }
+
+  if (!skipping && pending.length > 0) {
+    yield stripCr(pending);
+  }
+}
+
 async function grepFile(
   file: string,
   pattern: string,
@@ -206,20 +259,21 @@ async function grepFile(
   matcher: GrepLineMatcher
 ): Promise<FileGrepTaskOutput> {
   const input = createReadStream(file, { signal });
-  const rl = createInterface({
-    input,
-    crlfDelay: Infinity,
-  });
 
   try {
-    return await grepLines(rl, pattern, options, signal, matcher);
+    return await grepLines(
+      linesFromStream(input, DEFAULT_LIMITS.grepMaxLineChars),
+      pattern,
+      options,
+      signal,
+      matcher
+    );
   } catch (err) {
     if (signal.aborted) {
       throw new TaskAbortedError("Task aborted");
     }
     throw err;
   } finally {
-    rl.close();
     input.destroy();
   }
 }

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -4,13 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph";
+import type { IExecuteContext, TaskConfig, TaskEntitlements } from "@workglow/task-graph";
+import {
+  CreateWorkflow,
+  Entitlements,
+  mergeEntitlements,
+  TaskAbortedError,
+  TaskConfigSchema,
+  Workflow,
+} from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 
 import { SECURITY_LIMITS } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
+import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
 import { compileSafeRegex } from "../util/RegexSafety";
 import type {
   FileGrepTaskInput,
@@ -22,6 +31,30 @@ import { FileGrepTask as BaseFileGrepTask, grepLines } from "./FileGrepTask";
 
 export type { FileGrepTaskInput, FileGrepTaskOutput };
 
+export interface FileGrepTaskConfig extends TaskConfig {
+  /**
+   * Directories a local path must resolve inside, checked after symlinks are
+   * resolved. Omitted means unrestricted: the enforced control is the
+   * `filesystem:read` entitlement, and this is the embedder's extra fence.
+   */
+  readonly roots?: readonly string[] | undefined;
+}
+
+const fileGrepTaskConfigSchema = {
+  type: "object",
+  properties: {
+    ...TaskConfigSchema["properties"],
+    roots: {
+      type: "array",
+      items: { type: "string" },
+      title: "Roots",
+      description: "Directories a local path must resolve inside (after symlink resolution)",
+      "x-ui-hidden": true,
+    },
+  },
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
 /**
  * Server-only task for grepping documents from the filesystem.
  * Streams the file line-by-line rather than loading it into memory.
@@ -29,7 +62,22 @@ export type { FileGrepTaskInput, FileGrepTaskOutput };
  *
  * For cross-platform grep (including browser), use FileGrepTask with URLs.
  */
-export class FileGrepTask extends BaseFileGrepTask {
+export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
+  public static override configSchema(): DataPortSchema {
+    return fileGrepTaskConfigSchema as DataPortSchema;
+  }
+
+  public static override entitlements(): TaskEntitlements {
+    return mergeEntitlements(super.entitlements(), {
+      entitlements: [
+        {
+          id: Entitlements.FILESYSTEM_READ,
+          reason: "Reads a local file or file:// URL from disk",
+        },
+      ],
+    });
+  }
+
   /**
    * Runs regex matching inside a `vm` context under a wall-clock budget, so a
    * catastrophically backtracking pattern fails instead of wedging the event
@@ -53,9 +101,9 @@ export class FileGrepTask extends BaseFileGrepTask {
     input: FileGrepTaskInput,
     context: IExecuteContext
   ): Promise<FileGrepTaskOutput> {
-    let { url, pattern, ...options } = input;
+    const { url, pattern, ...options } = input;
 
-    if (url.startsWith("http://") || url.startsWith("https://")) {
+    if (isHttpUrl(url)) {
       return super.execute(input, context);
     }
 
@@ -64,9 +112,7 @@ export class FileGrepTask extends BaseFileGrepTask {
     }
     await context.updateProgress(0, "Opening file");
 
-    if (url.startsWith("file://")) {
-      url = url.slice(7);
-    }
+    const file = resolveLocalFilePath(url, { roots: this.config.roots });
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
@@ -74,7 +120,7 @@ export class FileGrepTask extends BaseFileGrepTask {
     await context.updateProgress(10, "Searching file");
 
     const result = await grepFile(
-      url,
+      file,
       pattern,
       options,
       context.signal,
@@ -116,13 +162,13 @@ async function grepFile(
   }
 }
 
-export const fileGrep = (input: FileGrepTaskInput, config?: TaskConfig) => {
+export const fileGrep = (input: FileGrepTaskInput, config?: FileGrepTaskConfig) => {
   return new FileGrepTask(config).run(input);
 };
 
 declare module "@workglow/task-graph" {
   interface Workflow {
-    fileGrep: CreateWorkflow<FileGrepTaskInput, FileGrepTaskOutput, TaskConfig>;
+    fileGrep: CreateWorkflow<FileGrepTaskInput, FileGrepTaskOutput, FileGrepTaskConfig>;
   }
 }
 

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -56,11 +56,20 @@ const fileGrepTaskConfigSchema = {
 } as const satisfies DataPortSchema;
 
 /**
- * Server-only task for grepping documents from the filesystem.
- * Streams the file line-by-line rather than loading it into memory.
- * Only available in Node.js and Bun environments.
+ * Server-only task for grepping documents from the filesystem, on top of the
+ * base task's http(s) handling.
  *
- * For cross-platform grep (including browser), use FileGrepTask with URLs.
+ * The file is read as a stream rather than loaded into memory, and split into
+ * lines with a hard per-line cap ({@link DEFAULT_LIMITS.grepMaxLineChars}) — a
+ * longer physical line is truncated to that length and the remainder discarded,
+ * so a file with no line terminator cannot exhaust memory.
+ *
+ * A local path is resolved and realpath'd before it is opened, and constrained
+ * to `config.roots` when the embedder sets them. Reading requires the
+ * `filesystem:read` entitlement, declared scoped to the resolved path.
+ *
+ * Only available in Node.js and Bun environments. For cross-platform grep
+ * (including browser), use FileGrepTask with an http(s) URL.
  */
 export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
   public static override configSchema(): DataPortSchema {

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -20,7 +20,7 @@ import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
-import { compileSafeRegex } from "../util/RegexSafety";
+import { compileSafeRegex } from "../util/regexSafety";
 import type {
   FileGrepTaskConfig,
   FileGrepTaskInput,

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig, TaskEntitlements } from "@workglow/task-graph";
+import type { IExecuteContext, TaskEntitlements } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   Entitlements,
@@ -22,6 +22,7 @@ import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
 import { compileSafeRegex } from "../util/RegexSafety";
 import type {
+  FileGrepTaskConfig,
   FileGrepTaskInput,
   FileGrepTaskOutput,
   GrepLineMatcher,
@@ -29,16 +30,7 @@ import type {
 } from "./FileGrepTask";
 import { FileGrepTask as BaseFileGrepTask, grepLines } from "./FileGrepTask";
 
-export type { FileGrepTaskInput, FileGrepTaskOutput };
-
-export interface FileGrepTaskConfig extends TaskConfig {
-  /**
-   * Directories a local path must resolve inside, checked after symlinks are
-   * resolved. Omitted means unrestricted: the enforced control is the
-   * `filesystem:read` entitlement, and this is the embedder's extra fence.
-   */
-  readonly roots?: readonly string[] | undefined;
-}
+export type { FileGrepTaskConfig, FileGrepTaskInput, FileGrepTaskOutput };
 
 const fileGrepTaskConfigSchema = {
   type: "object",

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -11,6 +11,7 @@ import {
   mergeEntitlements,
   TaskAbortedError,
   TaskConfigSchema,
+  TaskEntitlementError,
   Workflow,
 } from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
@@ -79,6 +80,44 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
   }
 
   /**
+   * Declares whichever half of the surface this url actually uses: the fetch
+   * entitlements for http(s), otherwise `filesystem:read` scoped to the
+   * resolved real path. An unknown url fails closed to both, unscoped.
+   *
+   * Never throws — entitlement evaluation runs before `execute()` and must
+   * produce a declaration for any input, so an unresolvable path degrades to
+   * the unscoped declaration and is refused later, at open time.
+   */
+  public override entitlements(): TaskEntitlements {
+    const url = this.runInputData?.url;
+    const unscopedRead: TaskEntitlements = {
+      entitlements: [{ id: Entitlements.FILESYSTEM_READ, reason: "Reads a local file from disk" }],
+    };
+
+    if (typeof url !== "string" || url.length === 0) {
+      return mergeEntitlements(super.entitlements(), unscopedRead);
+    }
+
+    if (isHttpUrl(url)) {
+      return super.entitlements();
+    }
+
+    try {
+      return {
+        entitlements: [
+          {
+            id: Entitlements.FILESYSTEM_READ,
+            reason: "Reads a local file from disk",
+            resources: [resolveLocalFilePath(url, { roots: this.config.roots })],
+          },
+        ],
+      };
+    } catch {
+      return unscopedRead;
+    }
+  }
+
+  /**
    * Runs regex matching inside a `vm` context under a wall-clock budget, so a
    * catastrophically backtracking pattern fails instead of wedging the event
    * loop. Overriding here covers both branches: the http branch reaches
@@ -97,6 +136,28 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
     return { matchBatch };
   }
 
+  /**
+   * Refuses a path the instance did not declare. Entitlements are evaluated
+   * on the unresolved input, so without this a declare-then-swap would let the
+   * open authorize itself — and a standalone `fileGrep(...)` with no graph and
+   * no enforcer would honour no `roots` at all.
+   */
+  private assertResolvedPathDeclared(file: string): void {
+    const declared = this.entitlements().entitlements.find(
+      (entitlement) => entitlement.id === Entitlements.FILESYSTEM_READ
+    );
+    if (declared?.resources === undefined) {
+      throw new TaskEntitlementError(
+        `Refusing to read ${file}: the path could not be resolved when entitlements were declared`
+      );
+    }
+    if (!declared.resources.includes(file)) {
+      throw new TaskEntitlementError(
+        `Refusing to read ${file}: it differs from the declared path ${declared.resources.join(", ")}`
+      );
+    }
+  }
+
   override async execute(
     input: FileGrepTaskInput,
     context: IExecuteContext
@@ -113,6 +174,7 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
     await context.updateProgress(0, "Opening file");
 
     const file = resolveLocalFilePath(url, { roots: this.config.roots });
+    this.assertResolvedPathDeclared(file);
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -9,7 +9,15 @@ import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 
-import type { FileGrepTaskInput, FileGrepTaskOutput } from "./FileGrepTask";
+import { SECURITY_LIMITS } from "@workglow/util";
+import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
+import { compileSafeRegex } from "../util/RegexSafety";
+import type {
+  FileGrepTaskInput,
+  FileGrepTaskOutput,
+  GrepLineMatcher,
+  GrepOptions,
+} from "./FileGrepTask";
 import { FileGrepTask as BaseFileGrepTask, grepLines } from "./FileGrepTask";
 
 export type { FileGrepTaskInput, FileGrepTaskOutput };
@@ -22,6 +30,25 @@ export type { FileGrepTaskInput, FileGrepTaskOutput };
  * For cross-platform grep (including browser), use FileGrepTask with URLs.
  */
 export class FileGrepTask extends BaseFileGrepTask {
+  /**
+   * Runs regex matching inside a `vm` context under a wall-clock budget, so a
+   * catastrophically backtracking pattern fails instead of wedging the event
+   * loop. Overriding here covers both branches: the http branch reaches
+   * `super.execute`, which uses the matcher this returns.
+   *
+   * `fixedString` never enters `vm` — `String.includes` cannot backtrack, and
+   * the `vm` hop would cost ~20x for nothing.
+   */
+  protected override createLineMatcher(pattern: string, options: GrepOptions): GrepLineMatcher {
+    if (options.fixedString) {
+      return super.createLineMatcher(pattern, options);
+    }
+
+    const regex = compileSafeRegex(pattern, options.ignoreCase ? "i" : "");
+    const matchBatch = createBoundedRegexMatcher(regex, SECURITY_LIMITS.regexMatchBatchTimeoutMs);
+    return { matchBatch };
+  }
+
   override async execute(
     input: FileGrepTaskInput,
     context: IExecuteContext
@@ -46,7 +73,13 @@ export class FileGrepTask extends BaseFileGrepTask {
     }
     await context.updateProgress(10, "Searching file");
 
-    const result = await grepFile(url, pattern, options, context.signal);
+    const result = await grepFile(
+      url,
+      pattern,
+      options,
+      context.signal,
+      this.createLineMatcher(pattern, options)
+    );
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
@@ -60,8 +93,9 @@ export class FileGrepTask extends BaseFileGrepTask {
 async function grepFile(
   file: string,
   pattern: string,
-  options: Omit<FileGrepTaskInput, "url" | "pattern">,
-  signal: AbortSignal
+  options: GrepOptions,
+  signal: AbortSignal,
+  matcher: GrepLineMatcher
 ): Promise<FileGrepTaskOutput> {
   const input = createReadStream(file, { signal });
   const rl = createInterface({
@@ -70,7 +104,7 @@ async function grepFile(
   });
 
   try {
-    return await grepLines(rl, pattern, options, signal);
+    return await grepLines(rl, pattern, options, signal, matcher);
   } catch (err) {
     if (signal.aborted) {
       throw new TaskAbortedError("Task aborted");

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -367,6 +367,7 @@ export async function grepLines(
 
   const iterator = lines[Symbol.asyncIterator]();
   const deadline = Date.now() + DEFAULT_LIMITS.grepMaxSearchMs;
+  const maxLineChars = DEFAULT_LIMITS.grepMaxLineChars;
   const batch: string[] = [];
   let exhausted = false;
 
@@ -379,7 +380,15 @@ export async function grepLines(
           exhausted = true;
           break;
         }
-        batch.push(next.value);
+        // `>=` rather than `>`: conservative by one character, and it lets the
+        // server's line splitter signal truncation without a side channel.
+        const text = next.value;
+        if (text.length >= maxLineChars) {
+          truncated = true;
+          batch.push(text.slice(0, maxLineChars));
+        } else {
+          batch.push(text);
+        }
       }
 
       if (batch.length === 0) break;

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -539,7 +539,11 @@ export async function grepLines(
  * Works in all environments (browser, Node.js, Bun) by using fetch API.
  * For server-only filesystem path access, see FileGrepTask.server.
  */
-export class FileGrepTask extends Task<FileGrepTaskInput, FileGrepTaskOutput, TaskConfig> {
+export class FileGrepTask<Config extends TaskConfig = TaskConfig> extends Task<
+  FileGrepTaskInput,
+  FileGrepTaskOutput,
+  Config
+> {
   public static override type = "FileGrepTask";
   public static override category = "Document";
   public static override title = "File Grep";

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -670,13 +670,33 @@ export class FileGrepTask<Config extends TaskConfig = TaskConfig> extends Task<
   }
 }
 
-export const fileGrep = (input: FileGrepTaskInput, config?: TaskConfig) => {
+/**
+ * Config for both builds. `roots` is declared here rather than beside the
+ * server subclass because a `declare module` augmentation must state one type
+ * across every file that contributes it, and both files augment `Workflow`
+ * with `fileGrep`. Declaring it only on the server made the two disagree
+ * (TS2717); declaring `TaskConfig` in both would keep them agreeing but drop
+ * `roots` from `workflow.fileGrep(...)`, which is the API most callers use.
+ */
+export interface FileGrepTaskConfig extends TaskConfig {
+  /**
+   * Directories a local path must resolve inside, checked after symlinks are
+   * resolved. Omitted means unrestricted: the enforced control is the
+   * `filesystem:read` entitlement, and this is the embedder's extra fence.
+   *
+   * Honored only by the server build — the cross-platform class reaches
+   * http(s) through `FetchUrlTask` and touches no filesystem.
+   */
+  readonly roots?: readonly string[] | undefined;
+}
+
+export const fileGrep = (input: FileGrepTaskInput, config?: FileGrepTaskConfig) => {
   return new FileGrepTask(config).run(input);
 };
 
 declare module "@workglow/task-graph" {
   interface Workflow {
-    fileGrep: CreateWorkflow<FileGrepTaskInput, FileGrepTaskOutput, TaskConfig>;
+    fileGrep: CreateWorkflow<FileGrepTaskInput, FileGrepTaskOutput, FileGrepTaskConfig>;
   }
 }
 

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
+import type { IExecuteContext, TaskConfig, TaskEntitlements } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   Task,
@@ -16,7 +16,7 @@ import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
-import { FetchUrlTask } from "./FetchUrlTask";
+import { fetchUrlEntitlementsFor, FetchUrlTask } from "./FetchUrlTask";
 
 export { linesFromText };
 
@@ -549,6 +549,21 @@ export class FileGrepTask<Config extends TaskConfig = TaskConfig> extends Task<
   public static override title = "File Grep";
   public static override description = "Search a file for matching lines (grep)";
   public static override cacheable = true;
+  public static override hasDynamicEntitlements: boolean = true;
+
+  /**
+   * The owned `FetchUrlTask` does the network access, but an owned child is
+   * created inside `execute()` and so is absent from the graph-start snapshot
+   * `computeGraphEntitlements` takes over `graph.getTasks()`. Declaring the
+   * fetch's entitlements here is what puts them in front of the enforcer.
+   */
+  public static override entitlements(): TaskEntitlements {
+    return FetchUrlTask.entitlements();
+  }
+
+  public override entitlements(): TaskEntitlements {
+    return fetchUrlEntitlementsFor(this.runInputData?.url);
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -14,7 +14,7 @@ import {
 } from "@workglow/task-graph";
 import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
+import { assertSafeRegexPattern, compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
 import { fetchUrlEntitlementsFor, FetchUrlTask } from "./FetchUrlTask";
 

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -332,16 +332,20 @@ export async function grepLines(
     }
 
     if (currentGroup && entry.line <= currentGroup.endLine + 1) {
-      // De-duplication exists to merge a before-context line already emitted as
-      // after-context. Under onlyMatching one line legitimately yields several
-      // entries, so merging them would collapse repeated matches into one.
-      const existing = options.onlyMatching
-        ? undefined
-        : currentGroup.lines.find((line) => line.line === entry.line);
-
-      if (existing) {
-        if (entry.match) {
-          existing.match = true;
+      /*
+       * Entries are appended in strictly increasing line order, so a line at or
+       * below endLine has already been emitted; only the last one can be it.
+       * The scan this replaces existed solely to skip replayed beforeBuffer
+       * entries, and those always carry match: false, so no flag is lost.
+       *
+       * Skipped entirely under onlyMatching, where one line legitimately yields
+       * several entries and merging them would collapse repeated matches
+       * into one.
+       */
+      if (!options.onlyMatching && entry.line <= currentGroup.endLine) {
+        const last = currentGroup.lines[currentGroup.lines.length - 1];
+        if (entry.match && last?.line === entry.line) {
+          last.match = true;
         }
 
         return true;

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -13,7 +13,7 @@ import {
   Workflow,
 } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-import { assertSafeRegexPattern, escapeRegExp } from "../util/regexSafety";
+import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
 import { FetchUrlTask } from "./FetchUrlTask";
 
@@ -212,14 +212,8 @@ function createMatcher(pattern: string, options: GrepOptions): (text: string) =>
     return (text) => text.includes(pattern);
   }
 
-  assertSafeRegexPattern(pattern);
-
-  try {
-    const regex = new RegExp(pattern, options.ignoreCase ? "i" : "");
-    return (text) => regex.test(text);
-  } catch {
-    throw new TaskInvalidInputError(`Invalid regular expression: ${pattern}`);
-  }
+  const regex = compileSafeRegex(pattern, options.ignoreCase ? "i" : "");
+  return (text) => regex.test(text);
 }
 
 /**

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -91,13 +91,15 @@ const inputSchema = {
     maxOutputLines: {
       type: "integer",
       title: "Max Output Lines",
-      description: "Maximum number of output lines, including context",
+      description:
+        "Maximum number of output lines, including context. Defaults to 10000; set this to override.",
       minimum: 0,
     },
     maxOutputChars: {
       type: "integer",
       title: "Max Output Characters",
-      description: "Maximum number of output characters, including newlines",
+      description:
+        "Maximum number of output characters, including newlines. Defaults to 1000000; set this to override.",
       minimum: 0,
     },
   },
@@ -144,7 +146,8 @@ const outputSchema = {
     matchCount: {
       type: "integer",
       title: "Match Count",
-      description: "Number of matching lines",
+      description:
+        "Number of matching lines. With `existsOnly` the scan stops at the first match, so this is 1 rather than a full count.",
     },
     exists: {
       type: "boolean",
@@ -303,7 +306,6 @@ export async function grepLines(
   let lineNumber = 0;
   let matchCount = 0;
   let exists = false;
-  let truncated = false;
 
   let afterRemaining = 0;
   let maxMatchesReached = false;
@@ -311,14 +313,17 @@ export async function grepLines(
   let outputLines = 0;
   let outputChars = 0;
 
+  // Caps apply whether or not the caller stated them: an unbounded default sent
+  // the whole document back to whoever asked for one line.
+  const maxOutputLines = options.maxOutputLines ?? DEFAULT_LIMITS.grepMaxOutputLines;
+  const maxOutputChars = options.maxOutputChars ?? DEFAULT_LIMITS.grepMaxOutputChars;
+
   function canEmit(text: string): boolean {
-    if (options.maxOutputLines !== undefined && outputLines >= options.maxOutputLines) {
+    if (outputLines >= maxOutputLines) {
       return false;
     }
 
-    const chars = text.length + 1;
-
-    if (options.maxOutputChars !== undefined && outputChars + chars > options.maxOutputChars) {
+    if (outputChars + text.length + 1 > maxOutputChars) {
       return false;
     }
 
@@ -327,7 +332,6 @@ export async function grepLines(
 
   function emitLine(entry: GrepLine): boolean {
     if (!canEmit(entry.text)) {
-      truncated = true;
       return false;
     }
 
@@ -375,6 +379,14 @@ export async function grepLines(
   const batch: string[] = [];
   let exhausted = false;
 
+  // `stopped` says the scan ended early; whether that MEANS truncation depends
+  // on whether anything was left, which is settled once, below.
+  let stopped = false;
+  let stopIndex = -1;
+  let existsOnlyHit = false;
+  let lineCapped = false;
+  let sawMoreInput = false;
+
   try {
     outer: while (!exhausted) {
       batch.length = 0;
@@ -388,7 +400,7 @@ export async function grepLines(
         // server's line splitter signal truncation without a side channel.
         const text = next.value;
         if (text.length >= maxLineChars) {
-          truncated = true;
+          lineCapped = true;
           batch.push(text.slice(0, maxLineChars));
         } else {
           batch.push(text);
@@ -401,7 +413,7 @@ export async function grepLines(
         throw new TaskAbortedError("Task aborted");
       }
       if (Date.now() > deadline) {
-        truncated = true;
+        stopped = true;
         break;
       }
 
@@ -423,12 +435,10 @@ export async function grepLines(
           exists = true;
 
           if (options.existsOnly) {
-            return {
-              groups: [],
-              matchCount: 1,
-              exists: true,
-              truncated: false,
-            };
+            existsOnlyHit = true;
+            stopped = true;
+            stopIndex = i;
+            break outer;
           }
 
           if (extract) {
@@ -454,12 +464,9 @@ export async function grepLines(
                   match: false,
                 })
               ) {
-                return {
-                  groups,
-                  matchCount,
-                  exists,
-                  truncated: true,
-                };
+                stopped = true;
+                stopIndex = i - 1;
+                break outer;
               }
             }
 
@@ -470,12 +477,9 @@ export async function grepLines(
                 match: true,
               })
             ) {
-              return {
-                groups,
-                matchCount,
-                exists,
-                truncated: true,
-              };
+              stopped = true;
+              stopIndex = i - 1;
+              break outer;
             }
           }
 
@@ -485,7 +489,8 @@ export async function grepLines(
             maxMatchesReached = true;
 
             if (afterContext === 0) {
-              truncated = true;
+              stopped = true;
+              stopIndex = i;
               break outer;
             }
           }
@@ -494,15 +499,14 @@ export async function grepLines(
             !emitLine({
               line: lineNumber,
               text,
-              match: false,
+              // `maxMatchesReached` governs whether a match COUNTS toward the
+              // budget, not whether the line IS a match.
+              match: matched,
             })
           ) {
-            return {
-              groups,
-              matchCount,
-              exists,
-              truncated: true,
-            };
+            stopped = true;
+            stopIndex = i - 1;
+            break outer;
           }
 
           afterRemaining--;
@@ -519,7 +523,8 @@ export async function grepLines(
 
         if (maxMatchesReached) {
           if (afterRemaining === 0) {
-            truncated = true;
+            stopped = true;
+            stopIndex = i;
             break outer;
           }
 
@@ -535,8 +540,29 @@ export async function grepLines(
         }
       }
     }
+
+    /*
+     * Truncation is exact because the loop drives the iterator itself: it is
+     * only truncation if something was actually left, either in the current
+     * batch or in the source. That costs one extra element from the source on
+     * an early stop.
+     *
+     * `stopIndex` is the last line fully accounted for. An output cap rejects
+     * the line it stopped on, so those sites record `i - 1` and that line
+     * counts as remaining; a match budget consumed its line, so those record
+     * `i`.
+     */
+    if (stopped) {
+      sawMoreInput = stopIndex + 1 < batch.length ? true : (await iterator.next()).done !== true;
+    }
   } finally {
     await iterator.return?.();
+  }
+
+  const truncated = lineCapped || (stopped && sawMoreInput);
+
+  if (existsOnlyHit) {
+    return { groups: [], matchCount: 1, exists: true, truncated };
   }
 
   return {

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -26,7 +26,8 @@ const inputSchema = {
     url: {
       type: "string",
       title: "URL",
-      description: "URL to search (http://, https://)",
+      description:
+        "URL to search (http://, https://). The Node/Electron build additionally accepts a `file://` URL or an absolute filesystem path, subject to the `filesystem:read` entitlement and any configured `roots`.",
       format: "uri",
     },
     pattern: {
@@ -574,9 +575,13 @@ export async function grepLines(
 }
 
 /**
- * Task for grepping documents from URLs (including file:// URLs).
- * Works in all environments (browser, Node.js, Bun) by using fetch API.
- * For server-only filesystem path access, see FileGrepTask.server.
+ * Task for grepping documents fetched over http(s).
+ *
+ * This build handles http and https only: the fetch routes through
+ * `FetchUrlTask` -> `safeFetch` -> `classifyUrl`, which rejects every other
+ * scheme. `file://` URLs and bare filesystem paths are handled only by the
+ * server build (`FileGrepTask.server`), which requires the `filesystem:read`
+ * entitlement.
  */
 export class FileGrepTask<Config extends TaskConfig = TaskConfig> extends Task<
   FileGrepTaskInput,

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -12,6 +12,7 @@ import {
   TaskInvalidInputError,
   Workflow,
 } from "@workglow/task-graph";
+import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
@@ -175,7 +176,16 @@ interface GrepGroup {
   lines: GrepLine[];
 }
 
-type GrepOptions = Omit<FileGrepTaskInput, "url" | "pattern">;
+export type GrepOptions = Omit<FileGrepTaskInput, "url" | "pattern">;
+
+/**
+ * Matches a batch of lines at once. Batching is what makes an interruptible
+ * matcher affordable — see `createBoundedRegexMatcher` on the server build,
+ * whose per-call cost only amortizes over a batch.
+ */
+export interface GrepLineMatcher {
+  readonly matchBatch: (texts: readonly string[]) => boolean[];
+}
 
 interface BufferedLine {
   readonly line: number;
@@ -203,17 +213,17 @@ function validateOptions(options: GrepOptions): void {
   }
 }
 
-function createMatcher(pattern: string, options: GrepOptions): (text: string) => boolean {
+export function createMatcher(pattern: string, options: GrepOptions): GrepLineMatcher {
   if (options.fixedString) {
     if (options.ignoreCase) {
       const needle = pattern.toLowerCase();
-      return (text) => text.toLowerCase().includes(needle);
+      return { matchBatch: (texts) => texts.map((t) => t.toLowerCase().includes(needle)) };
     }
-    return (text) => text.includes(pattern);
+    return { matchBatch: (texts) => texts.map((t) => t.includes(pattern)) };
   }
 
   const regex = compileSafeRegex(pattern, options.ignoreCase ? "i" : "");
-  return (text) => regex.test(text);
+  return { matchBatch: (texts) => texts.map((t) => regex.test(t)) };
 }
 
 /**
@@ -256,11 +266,20 @@ function createExtractor(pattern: string, options: GrepOptions): (text: string) 
   };
 }
 
+/**
+ * Scans `lines`, matching in batches of {@link SECURITY_LIMITS.regexMatchBatchLines}.
+ *
+ * Abort and the overall search deadline are checked once per BATCH, not per
+ * line: a single `regex.test` is uninterruptible, so per-line checks bought
+ * nothing a hostile pattern could not ignore. The granularity that matters is
+ * therefore the batch, and the matcher itself bounds how long one batch may run.
+ */
 export async function grepLines(
   lines: AsyncIterable<string>,
   pattern: string,
   options: GrepOptions = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  matcher?: GrepLineMatcher | undefined
 ): Promise<FileGrepTaskOutput> {
   validateOptions(options);
 
@@ -270,7 +289,7 @@ export async function grepLines(
   const beforeContext = options.onlyMatching ? 0 : (options.context ?? options.beforeContext ?? 0);
   const afterContext = options.onlyMatching ? 0 : (options.context ?? options.afterContext ?? 0);
 
-  const matcher = createMatcher(pattern, options);
+  const lineMatcher = matcher ?? createMatcher(pattern, options);
   const extract =
     options.onlyMatching && !options.existsOnly && !options.countOnly
       ? createExtractor(pattern, options)
@@ -346,52 +365,122 @@ export async function grepLines(
     return true;
   }
 
-  for await (const text of lines) {
-    if (signal?.aborted) {
-      throw new TaskAbortedError("Task aborted");
-    }
+  const iterator = lines[Symbol.asyncIterator]();
+  const deadline = Date.now() + DEFAULT_LIMITS.grepMaxSearchMs;
+  const batch: string[] = [];
+  let exhausted = false;
 
-    lineNumber++;
-
-    let matched = matcher(text);
-
-    if (options.invertMatch) {
-      matched = !matched;
-    }
-
-    if (matched && !maxMatchesReached) {
-      matchCount++;
-      exists = true;
-
-      if (options.existsOnly) {
-        return {
-          groups: [],
-          matchCount: 1,
-          exists: true,
-          truncated: false,
-        };
+  try {
+    outer: while (!exhausted) {
+      batch.length = 0;
+      while (batch.length < SECURITY_LIMITS.regexMatchBatchLines) {
+        const next = await iterator.next();
+        if (next.done === true) {
+          exhausted = true;
+          break;
+        }
+        batch.push(next.value);
       }
 
-      if (extract) {
-        // An inverted selection reaches here on a line the pattern did NOT
-        // match, so the extractor finds nothing and emits nothing — which is
-        // exactly what `grep -v -o` prints.
-        for (const match of extract(text)) {
-          if (!emitLine({ line: lineNumber, text: match, match: true })) {
+      if (batch.length === 0) break;
+
+      if (signal?.aborted) {
+        throw new TaskAbortedError("Task aborted");
+      }
+      if (Date.now() > deadline) {
+        truncated = true;
+        break;
+      }
+
+      const flags = lineMatcher.matchBatch(batch);
+
+      for (let i = 0; i < batch.length; i++) {
+        const text = batch[i]!;
+
+        lineNumber++;
+
+        let matched = flags[i]!;
+
+        if (options.invertMatch) {
+          matched = !matched;
+        }
+
+        if (matched && !maxMatchesReached) {
+          matchCount++;
+          exists = true;
+
+          if (options.existsOnly) {
             return {
-              groups,
-              matchCount,
-              exists,
-              truncated: true,
+              groups: [],
+              matchCount: 1,
+              exists: true,
+              truncated: false,
             };
           }
-        }
-      } else if (!options.countOnly) {
-        for (const previous of beforeBuffer) {
+
+          if (extract) {
+            // An inverted selection reaches here on a line the pattern did NOT
+            // match, so the extractor finds nothing and emits nothing — which is
+            // exactly what `grep -v -o` prints.
+            for (const match of extract(text)) {
+              if (!emitLine({ line: lineNumber, text: match, match: true })) {
+                return {
+                  groups,
+                  matchCount,
+                  exists,
+                  truncated: true,
+                };
+              }
+            }
+          } else if (!options.countOnly) {
+            for (const previous of beforeBuffer) {
+              if (
+                !emitLine({
+                  line: previous.line,
+                  text: previous.text,
+                  match: false,
+                })
+              ) {
+                return {
+                  groups,
+                  matchCount,
+                  exists,
+                  truncated: true,
+                };
+              }
+            }
+
+            if (
+              !emitLine({
+                line: lineNumber,
+                text,
+                match: true,
+              })
+            ) {
+              return {
+                groups,
+                matchCount,
+                exists,
+                truncated: true,
+              };
+            }
+          }
+
+          afterRemaining = afterContext;
+
+          if (options.maxMatches !== undefined && matchCount >= options.maxMatches) {
+            maxMatchesReached = true;
+
+            if (afterContext === 0) {
+              truncated = true;
+              break outer;
+            }
+          }
+        } else if (!options.countOnly && afterRemaining > 0) {
           if (
             !emitLine({
-              line: previous.line,
-              text: previous.text,
+              line: lineNumber,
+              text,
               match: false,
             })
           ) {
@@ -402,78 +491,39 @@ export async function grepLines(
               truncated: true,
             };
           }
+
+          afterRemaining--;
         }
 
-        if (
-          !emitLine({
-            line: lineNumber,
-            text,
-            match: true,
-          })
-        ) {
-          return {
-            groups,
-            matchCount,
-            exists,
-            truncated: true,
-          };
-        }
-      }
-
-      afterRemaining = afterContext;
-
-      if (options.maxMatches !== undefined && matchCount >= options.maxMatches) {
-        maxMatchesReached = true;
-
-        if (afterContext === 0) {
-          truncated = true;
-          break;
-        }
-      }
-    } else if (!options.countOnly && afterRemaining > 0) {
-      if (
-        !emitLine({
+        beforeBuffer.push({
           line: lineNumber,
           text,
-          match: false,
-        })
-      ) {
-        return {
-          groups,
-          matchCount,
-          exists,
-          truncated: true,
-        };
+        });
+
+        if (beforeBuffer.length > beforeContext) {
+          beforeBuffer.shift();
+        }
+
+        if (maxMatchesReached) {
+          if (afterRemaining === 0) {
+            truncated = true;
+            break outer;
+          }
+
+          continue;
+        }
+
+        /*
+         * A non-matching line outside trailing context means any future
+         * match is separated from the current group.
+         */
+        if (!matched && afterRemaining === 0) {
+          currentGroup = undefined;
+        }
       }
-
-      afterRemaining--;
     }
-
-    beforeBuffer.push({
-      line: lineNumber,
-      text,
-    });
-
-    if (beforeBuffer.length > beforeContext) {
-      beforeBuffer.shift();
-    }
-
-    if (maxMatchesReached) {
-      if (afterRemaining === 0) {
-        truncated = true;
-        break;
-      }
-
-      continue;
-    }
-
-    /*
-     * A non-matching line outside trailing context means any future
-     * match is separated from the current group.
-     */
-    if (!matched && afterRemaining === 0) {
-      currentGroup = undefined;
-    }
+  } finally {
+    await iterator.return?.();
   }
 
   return {
@@ -504,6 +554,16 @@ export class FileGrepTask extends Task<FileGrepTaskInput, FileGrepTaskOutput, Ta
     return outputSchema as DataPortSchema;
   }
 
+  /**
+   * Seam for the matcher the scan runs. The server build overrides it to bound
+   * regex matching with an interruptible time budget; there is no `vm` in a
+   * browser, so a hostile pattern there still blocks that tab (a tab — not the
+   * process hosting a local API).
+   */
+  protected createLineMatcher(pattern: string, options: GrepOptions): GrepLineMatcher {
+    return createMatcher(pattern, options);
+  }
+
   override async execute(
     input: FileGrepTaskInput,
     context: IExecuteContext
@@ -513,6 +573,10 @@ export class FileGrepTask extends Task<FileGrepTaskInput, FileGrepTaskOutput, Ta
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
     }
+
+    // Compiled before the fetch so a rejected pattern costs no network call.
+    const matcher = this.createLineMatcher(pattern, options);
+
     await context.updateProgress(0, "Fetching file");
 
     const fetchTask = context.own(new FetchUrlTask({ queue: false }));
@@ -530,7 +594,8 @@ export class FileGrepTask extends Task<FileGrepTaskInput, FileGrepTaskOutput, Ta
       linesFromText(response.text ?? ""),
       pattern,
       options,
-      context.signal
+      context.signal,
+      matcher
     );
 
     if (context.signal.aborted) {

--- a/packages/tasks/src/util/BoundedRegex.server.ts
+++ b/packages/tasks/src/util/BoundedRegex.server.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TaskInvalidInputError } from "@workglow/task-graph";
+import { createContext, Script } from "node:vm";
+
+/**
+ * Matches lines against a regex under an interruptible wall-clock budget.
+ *
+ * `RegExp.prototype.test` is synchronous and uninterruptible: a catastrophic
+ * pattern against one hostile line blocks the event loop indefinitely, and no
+ * abort signal can reach it. V8's script-execution timeout DOES reach inside
+ * Irregexp backtracking, so matching runs inside a `vm` context where a
+ * `timeout` terminates it. Measured: `/(a|a)*$/` against a 40-character input
+ * terminated at ~210 ms under a 200 ms budget.
+ *
+ * Matching is BATCHED because the `vm` hop is what costs. Over 100 000 lines
+ * with `/foo/`: a bare `regex.test` per line runs 6 ms, one `vm` call per line
+ * 25 051 ms (unusable), one `vm` call per 512-line batch 129 ms.
+ *
+ * The residual: the loop is still blocked for up to one batch budget, which is
+ * bounded and finite where the unguarded call was neither. Bun honours the
+ * timeout more coarsely — a 300 ms budget terminated at ~1025 ms — so treat the
+ * budget as an order of magnitude, not a deadline.
+ *
+ * The `RegExp` is created in the calling realm and passed through the context;
+ * the context is reusable after a timeout, but this returns a fresh matcher per
+ * call site anyway.
+ */
+export function createBoundedRegexMatcher(
+  regex: RegExp,
+  timeoutMs: number
+): (texts: readonly string[]) => boolean[] {
+  const context = createContext({
+    re: regex,
+    lines: [] as readonly string[],
+    out: [] as boolean[],
+  });
+  const script = new Script(
+    "out.length = 0; for (let i = 0; i < lines.length; i++) out.push(re.test(lines[i]));"
+  );
+
+  return (texts) => {
+    const scope = context as { lines: readonly string[]; out: boolean[] };
+    scope.lines = texts;
+    try {
+      script.runInContext(context, { timeout: timeoutMs });
+    } catch {
+      // Deliberately not a TaskTimeoutError: that extends TaskAbortedError and
+      // would report the run as aborted rather than failed by bad input.
+      throw new TaskInvalidInputError(
+        `Regex matching exceeded its ${timeoutMs}ms budget for pattern /${regex.source}/ — ` +
+          `the pattern backtracks catastrophically on this input. Simplify the pattern.`
+      );
+    }
+    return [...scope.out];
+  };
+}

--- a/packages/tasks/src/util/LocalFilePath.server.ts
+++ b/packages/tasks/src/util/LocalFilePath.server.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
+import { realpathSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface LocalFilePathOptions {
+  /**
+   * Directories the path must resolve inside. `undefined` means unrestricted —
+   * the enforced control is the `filesystem:read` entitlement, and this is the
+   * embedder's belt-and-braces on top of it.
+   */
+  readonly roots?: readonly string[] | undefined;
+}
+
+/** True for an http(s) URL, case-insensitively — `HTTP://x` is an http URL. */
+export function isHttpUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+function fileUrlToPath(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new TaskInvalidInputError(`Invalid file URL: ${url}`);
+  }
+  try {
+    // Percent-decodes, rejects a non-empty non-localhost host, and yields
+    // `C:\x` rather than `/c:/x` on Windows.
+    return fileURLToPath(parsed);
+  } catch (err) {
+    throw new TaskInvalidInputError(
+      `Invalid file URL: ${url} (${err instanceof Error ? err.message : String(err)})`
+    );
+  }
+}
+
+/**
+ * Real, absolute path for a local-file input, contained within `roots`.
+ *
+ * Order matters: the containment check runs AFTER `realpathSync`, so a symlink
+ * pointing out of a root is caught rather than followed. Callers must open the
+ * returned path, not the one they passed in.
+ *
+ * Residual TOCTOU: a component of the path can be swapped between this
+ * resolution and the open that follows it. Closing that needs an
+ * openat-with-fd-relative walk, which Node does not expose.
+ */
+export function resolveLocalFilePath(url: string, options: LocalFilePathOptions = {}): string {
+  const raw = /^file:/i.test(url) ? fileUrlToPath(url) : url;
+  const resolved = resolve(raw);
+
+  let real: string;
+  try {
+    real = realpathSync(resolved);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    // A missing file still gets a real DIRECTORY path, so containment is
+    // decided on resolved ground; the open below then fails with ENOENT as it
+    // always did.
+    real = join(realpathSync(dirname(resolved)), basename(resolved));
+  }
+
+  const { roots } = options;
+  if (roots !== undefined) {
+    const allowed = roots.some((root) => {
+      const realRoot = realpathSync(root);
+      return real === realRoot || real.startsWith(realRoot + sep);
+    });
+    if (!allowed) {
+      throw new TaskEntitlementError(
+        `Path ${real} is outside the configured roots: ${roots.join(", ")}`
+      );
+    }
+  }
+
+  // A fifo or a character device (/dev/zero) reads forever with no deadline.
+  let stats;
+  try {
+    stats = statSync(real);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return real;
+    throw err;
+  }
+  if (!stats.isFile()) {
+    throw new TaskInvalidInputError(`Not a regular file: ${real}`);
+  }
+
+  return real;
+}

--- a/packages/tasks/src/util/regexSafety.ts
+++ b/packages/tasks/src/util/regexSafety.ts
@@ -7,6 +7,20 @@
 import { TaskInvalidInputError } from "@workglow/task-graph";
 import { SECURITY_LIMITS } from "@workglow/util";
 
+/**
+ * `{n,}` / `{n,m}` starting exactly at an index. Sticky rather than
+ * `test(pattern.slice(index))`, because slicing per character is the quadratic
+ * shape this module exists to avoid.
+ */
+const UNBOUNDED_REPETITION_RE = /\{\d+,\d*\}/y;
+
+/** True when a counted repetition starts at `index`. */
+function isUnboundedRepetitionAt(pattern: string, index: number): boolean {
+  if (pattern[index] !== "{") return false;
+  UNBOUNDED_REPETITION_RE.lastIndex = index;
+  return UNBOUNDED_REPETITION_RE.test(pattern);
+}
+
 interface PatternScan {
   /** Every `[` in the source, including literals inside a class. */
   readonly bracketCount: number;
@@ -81,7 +95,10 @@ function scanPattern(pattern: string): PatternScan {
       continue;
     }
 
-    if ((char === "*" || char === "+") && groupHasQuantifier.length > 0) {
+    if (
+      (char === "*" || char === "+" || isUnboundedRepetitionAt(pattern, index)) &&
+      groupHasQuantifier.length > 0
+    ) {
       groupHasQuantifier[groupHasQuantifier.length - 1] = true;
     }
   }
@@ -111,7 +128,7 @@ function endOfCharacterClass(pattern: string, index: number): number {
 function isRepetitionAt(pattern: string, index: number): boolean {
   const ch = pattern[index];
   if (ch === "*" || ch === "+") return true;
-  return /^\{\d+,\d*\}/.test(pattern.slice(index));
+  return isUnboundedRepetitionAt(pattern, index);
 }
 
 /** Bodies of every group immediately followed by a repetition quantifier. */

--- a/packages/tasks/src/util/regexSafety.ts
+++ b/packages/tasks/src/util/regexSafety.ts
@@ -89,6 +89,181 @@ function scanPattern(pattern: string): PatternScan {
   return { bracketCount, nestedQuantifiers };
 }
 
+/** Stands in for a whole character class, which is a single atom to the emptiness test. */
+const CLASS_ATOM = "\u0001";
+
+/** An alternative made entirely of optional atoms, so it can match the empty string. */
+const ALL_OPTIONAL_ATOMS_RE = /^(?:(?:\\.|[^\\*+?{}()|])(?:[*?]|\{0,\d*\}))+$/;
+
+/** An alternative containing no regex metacharacters, so prefix comparison is meaningful. */
+const LITERAL_ALTERNATIVE_RE = /^[^\\.*+?()[\]{}|^$]+$/;
+
+/** Index just past the `]` closing the class at `index`, or the end if it never closes. */
+function endOfCharacterClass(pattern: string, index: number): number {
+  let i = index + 1;
+  while (i < pattern.length && pattern[i] !== "]") {
+    i += pattern[i] === "\\" ? 2 : 1;
+  }
+  return i < pattern.length ? i + 1 : pattern.length;
+}
+
+/** Returns true when a repetition quantifier starts at `index`. */
+function isRepetitionAt(pattern: string, index: number): boolean {
+  const ch = pattern[index];
+  if (ch === "*" || ch === "+") return true;
+  return /^\{\d+,\d*\}/.test(pattern.slice(index));
+}
+
+/** Bodies of every group immediately followed by a repetition quantifier. */
+function quantifiedGroupBodies(pattern: string): string[] {
+  const bodies: string[] = [];
+  const open: number[] = [];
+
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === "\\") {
+      i++;
+    } else if (ch === "[") {
+      i = endOfCharacterClass(pattern, i) - 1;
+    } else if (ch === "(") {
+      open.push(i);
+    } else if (ch === ")") {
+      const start = open.pop();
+      if (start !== undefined && isRepetitionAt(pattern, i + 1)) {
+        bodies.push(pattern.slice(start + 1, i));
+      }
+    }
+  }
+
+  return bodies;
+}
+
+/**
+ * Drops a group modifier prefix. Returns undefined for lookarounds, which this
+ * screen does not model.
+ */
+function groupBodyAfterModifier(body: string): string | undefined {
+  if (!body.startsWith("?")) return body;
+  if (body.startsWith("?:")) return body.slice(2);
+  const named = /^\?<[A-Z_$][\w$]*>/i.exec(body);
+  if (named) return body.slice(named[0].length);
+  return undefined;
+}
+
+/** Splits an alternation on `|` at nesting depth zero. */
+function splitTopLevelAlternatives(body: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === "\\") i++;
+    else if (ch === "[") i = endOfCharacterClass(body, i) - 1;
+    else if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    else if (ch === "|" && depth === 0) {
+      parts.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+
+  parts.push(body.slice(start));
+  return parts;
+}
+
+/**
+ * Collapses each character class to one placeholder character, because a class
+ * IS a single atom for the can-it-match-empty question. Only that question uses
+ * this — comparing two alternatives for overlap reads the class text verbatim,
+ * so `[a-z]` and `[A-Z]` stay distinguishable.
+ */
+function collapseCharacterClasses(alternative: string): string {
+  let out = "";
+  let i = 0;
+
+  while (i < alternative.length) {
+    const ch = alternative[i];
+    if (ch === "\\") {
+      out += alternative.slice(i, i + 2);
+      i += 2;
+    } else if (ch === "[") {
+      out += CLASS_ATOM;
+      i = endOfCharacterClass(alternative, i);
+    } else {
+      out += ch;
+      i += 1;
+    }
+  }
+
+  return out;
+}
+
+function alternativeCanMatchEmpty(alternative: string): boolean {
+  if (alternative.length === 0) return true;
+  // A nested group is not modelled; do not claim it can match empty.
+  if (alternative.includes("(")) return false;
+  return ALL_OPTIONAL_ATOMS_RE.test(collapseCharacterClasses(alternative));
+}
+
+/**
+ * True when a quantified alternation has branches that overlap, so the engine
+ * has more than one way to consume the same input: `(a|a)*`, `(?:a|a)*`,
+ * `(a|ab)+`, `(a*|b)+`.
+ *
+ * {@link scanPattern} does not model this — it pops `(a|a)` with a body that
+ * carries no quantifier of its own — yet the family is measurably exponential:
+ * `/(a|a)*$/` against `"a".repeat(n) + "!"` runs 52 ms at n=18, 118 ms at n=22,
+ * 466 ms at n=24 and 1821 ms at n=26, doubling per added character, and
+ * `(a|a|a)+$` at n=20 ran past a 120 s timeout.
+ *
+ * Sharing a first character is NOT enough — `(foo|far)+` is not exponential and
+ * a first-character rule would reject a large class of ordinary patterns.
+ */
+function hasOverlappingAlternation(pattern: string): boolean {
+  for (const rawBody of quantifiedGroupBodies(pattern)) {
+    const body = groupBodyAfterModifier(rawBody);
+    if (body === undefined) continue;
+
+    const alternatives = splitTopLevelAlternatives(body);
+    if (alternatives.length < 2) continue;
+
+    if (alternatives.some(alternativeCanMatchEmpty)) return true;
+
+    for (let i = 0; i < alternatives.length; i++) {
+      for (let j = i + 1; j < alternatives.length; j++) {
+        const a = alternatives[i]!;
+        const b = alternatives[j]!;
+        if (a === b) return true;
+        if (
+          LITERAL_ALTERNATIVE_RE.test(a) &&
+          LITERAL_ALTERNATIVE_RE.test(b) &&
+          (a.startsWith(b) || b.startsWith(a))
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Screen for the catastrophic-backtracking shapes this module models, without
+ * throwing.
+ *
+ * A `false` is not a safety guarantee, only the absence of a modelled shape:
+ * the screen is a heuristic, not a decision procedure. What is actually
+ * ENFORCED is the match budget applied at match time — see
+ * `createBoundedRegexMatcher`, which interrupts a running match after a fixed
+ * wall-clock budget. Treat this as a fast, friendly rejection of obviously
+ * dangerous input, never as the containment.
+ */
+export function hasUnsafeRegexShape(pattern: string): boolean {
+  return scanPattern(pattern).nestedQuantifiers || hasOverlappingAlternation(pattern);
+}
+
 /**
  * Escapes every regex metacharacter, so caller text can be compiled into a
  * pattern that matches it literally rather than being read as one. The other
@@ -102,7 +277,10 @@ export function escapeRegExp(value: string): string {
 /**
  * Rejects regex sources prone to catastrophic backtracking (ReDoS) before they
  * ever reach `new RegExp`. Throws {@link TaskInvalidInputError} for a pattern
- * with too many `[` characters or with nested quantifiers like `(a+)+`.
+ * with too many `[` characters, with nested quantifiers like `(a+)+`, or with a
+ * quantified alternation whose branches overlap like `(a|a)*`.
+ *
+ * This is a screen, not the containment — see {@link hasUnsafeRegexShape}.
  */
 export function assertSafeRegexPattern(pattern: string): void {
   const { bracketCount, nestedQuantifiers } = scanPattern(pattern);
@@ -119,5 +297,22 @@ export function assertSafeRegexPattern(pattern: string): void {
       "Regex pattern rejected: nested quantifiers detected (potential ReDoS). " +
         "Simplify the pattern to avoid catastrophic backtracking."
     );
+  }
+
+  if (hasOverlappingAlternation(pattern)) {
+    throw new TaskInvalidInputError(
+      "Regex pattern rejected: a repeated alternation has overlapping branches " +
+        "(potential ReDoS). Make the branches mutually exclusive."
+    );
+  }
+}
+
+/** Screens a pattern, then compiles it. */
+export function compileSafeRegex(pattern: string, flags: string): RegExp {
+  assertSafeRegexPattern(pattern);
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    throw new TaskInvalidInputError(`Invalid regular expression: ${pattern}`);
   }
 }

--- a/packages/tasks/src/util/textLines.ts
+++ b/packages/tasks/src/util/textLines.ts
@@ -6,18 +6,24 @@
 
 /**
  * Splits already-materialized text into lines without their terminators,
- * matching how `readline` feeds the streaming server tasks: CRLF and LF are
+ * matching how the streaming server tasks feed their scan: CRLF and LF are
  * equivalent, and a trailing newline does not produce a final empty line.
+ *
+ * Walks the text with `indexOf` rather than `split(/\r?\n/)`, which materializes
+ * an array holding every line of the document before the first is yielded — on
+ * a large document that is a second full copy of it in memory, and the consumer
+ * cannot begin until the whole split completes.
  */
 export async function* linesFromText(text: string): AsyncGenerator<string> {
-  if (text.length === 0) {
-    return;
-  }
-  const lines = text.split(/\r?\n/);
-  if (text.endsWith("\n")) {
-    lines.pop();
-  }
-  for (const line of lines) {
-    yield line;
+  let start = 0;
+  while (start < text.length) {
+    const newline = text.indexOf("\n", start);
+    if (newline === -1) {
+      yield text.slice(start);
+      return;
+    }
+    const end = newline > start && text[newline - 1] === "\r" ? newline - 1 : newline;
+    yield text.slice(start, end);
+    start = newline + 1;
   }
 }

--- a/packages/test/src/test/task/FileGrepEntitlements.test.ts
+++ b/packages/test/src/test/task/FileGrepEntitlements.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createPolicyEnforcer,
+  createProfilePolicy,
+  ENTITLEMENT_ENFORCER,
+  Entitlements,
+  TaskEntitlementError,
+  TaskGraph,
+  TaskGraphRunner,
+  TaskRegistry,
+  type IEntitlementEnforcer,
+} from "@workglow/task-graph";
+import { FileGrepTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
+import { Container, ServiceRegistry, setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+const METADATA_URL = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
+
+describe("FileGrepTask entitlement enforcement", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+
+  let prevSafeFetch: SafeFetchFn;
+  let testDir: string;
+
+  beforeAll(() => {
+    // The enforcer is what is under test, not the network layer.
+    prevSafeFetch = registerSafeFetch(() =>
+      Promise.resolve(
+        new Response("alpha\nbravo foo\n", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        })
+      )
+    );
+    TaskRegistry.registerTask(FileGrepTask);
+  });
+
+  afterAll(() => {
+    registerSafeFetch(prevSafeFetch);
+  });
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `filegrep-ent-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function makeRegistry(enforcer: IEntitlementEnforcer): ServiceRegistry {
+    const registry = new ServiceRegistry(new Container());
+    registry.register(ENTITLEMENT_ENFORCER, () => enforcer);
+    return registry;
+  }
+
+  function makeGraph(url: string, roots?: readonly string[]): TaskGraph {
+    const graph = new TaskGraph();
+    graph.addTask(new FileGrepTask({ id: "grep-node", roots, defaults: { url, pattern: "foo" } }));
+    return graph;
+  }
+
+  /**
+   * The scenario that motivated the declaration. Pre-fix the task declared
+   * nothing at all: `computeGraphEntitlements` runs over `graph.getTasks()` at
+   * graph start and saw an empty set, and the `FetchUrlTask` the task owns
+   * inside `execute()` is not in that snapshot — so it reached the metadata
+   * endpoint with `allowPrivate: true`, its own resolved-destination check
+   * satisfied because the child's input url IS the private one.
+   */
+  test("a profile without network:private denies a metadata-endpoint grep", async () => {
+    const enforcer = createPolicyEnforcer(createProfilePolicy("browser"));
+    const runner = new TaskGraphRunner(makeGraph(METADATA_URL));
+
+    await expect(
+      runner.runGraph({}, { registry: makeRegistry(enforcer), enforceEntitlements: true })
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("the same profile allows a public grep", async () => {
+    const enforcer = createPolicyEnforcer(createProfilePolicy("browser"));
+    const runner = new TaskGraphRunner(makeGraph("https://example.com/log.txt"));
+
+    await expect(
+      runner.runGraph({}, { registry: makeRegistry(enforcer), enforceEntitlements: true })
+    ).resolves.toBeDefined();
+  });
+
+  test("a profile granting filesystem:read only under /tmp denies /etc", async () => {
+    const browserPolicy = createProfilePolicy("browser");
+    const scopedPolicy = {
+      deny: browserPolicy.deny,
+      grant: [
+        ...browserPolicy.grant,
+        { id: Entitlements.FILESYSTEM_READ, resources: [`${testDir}/*`] },
+      ],
+      ask: browserPolicy.ask,
+    };
+
+    const allowed = join(testDir, "notes.txt");
+    writeFileSync(allowed, "alpha\nbravo foo\n", "utf-8");
+
+    const permitted = new TaskGraphRunner(makeGraph(allowed));
+    await expect(
+      permitted.runGraph(
+        {},
+        { registry: makeRegistry(createPolicyEnforcer(scopedPolicy)), enforceEntitlements: true }
+      )
+    ).resolves.toBeDefined();
+
+    const denied = new TaskGraphRunner(makeGraph("/etc/passwd"));
+    await expect(
+      denied.runGraph(
+        {},
+        { registry: makeRegistry(createPolicyEnforcer(scopedPolicy)), enforceEntitlements: true }
+      )
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("declares filesystem:read scoped to the resolved path, and no network", () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "bravo foo\n", "utf-8");
+
+    const declared = new FileGrepTask({
+      defaults: { url: filePath, pattern: "foo" },
+    }).entitlements().entitlements;
+
+    expect(declared.map((e) => e.id)).toEqual([Entitlements.FILESYSTEM_READ]);
+    expect(declared[0].resources).toEqual([filePath]);
+  });
+
+  test("declares the fetch entitlements for an http url, and no filesystem:read", () => {
+    const declared = new FileGrepTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo" },
+    }).entitlements().entitlements;
+
+    expect(declared.map((e) => e.id)).toContain(Entitlements.NETWORK_HTTP);
+    expect(declared.map((e) => e.id)).not.toContain(Entitlements.FILESYSTEM_READ);
+  });
+
+  test("declares fail-closed entitlements when the url is unknown", () => {
+    const declared = new FileGrepTask({ defaults: { pattern: "foo" } as never }).entitlements()
+      .entitlements;
+    const ids = declared.map((e) => e.id);
+
+    expect(ids).toContain(Entitlements.FILESYSTEM_READ);
+    expect(ids).toContain(Entitlements.NETWORK_PRIVATE);
+    // Unscoped: nothing is known about the destination yet.
+    expect(declared.find((e) => e.id === Entitlements.NETWORK_PRIVATE)?.resources).toBeUndefined();
+    expect(declared.find((e) => e.id === Entitlements.FILESYSTEM_READ)?.resources).toBeUndefined();
+  });
+});

--- a/packages/test/src/test/task/FileGrepTask.server.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.server.test.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FileGrepTask } from "@workglow/tasks";
+import { TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
+import { FileGrepTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
 import { setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -85,5 +86,136 @@ describe("FileGrepTask (server - local files)", () => {
         defaults: { url: filePath, pattern: "foo" },
       }).run()
     ).rejects.toThrow();
+  });
+
+  test("refuses a path outside the configured roots", async () => {
+    const outside = join(tmpdir(), `filegrep-outside-${Date.now()}.txt`);
+    writeFileSync(outside, "bravo foo\n", "utf-8");
+
+    try {
+      await expect(
+        new FileGrepTask({
+          roots: [testDir],
+          defaults: { url: outside, pattern: "foo" },
+        }).run()
+      ).rejects.toThrow(TaskEntitlementError);
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
+  /**
+   * The containment check runs AFTER `realpathSync`. A pre-realpath check
+   * passes here — the link itself sits inside the root — and then opens the
+   * target, which is the whole escape.
+   */
+  test("refuses a symlink that escapes the configured roots", async () => {
+    const link = join(testDir, "escape.txt");
+    symlinkSync("/etc/passwd", link);
+
+    await expect(
+      new FileGrepTask({
+        roots: [testDir],
+        defaults: { url: link, pattern: "root" },
+      }).run()
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("allows a symlink that stays inside the roots", async () => {
+    const target = join(testDir, "target.txt");
+    const link = join(testDir, "link.txt");
+    writeFileSync(target, "alpha\nbravo foo\n", "utf-8");
+    symlinkSync(target, link);
+
+    const result = await new FileGrepTask({
+      roots: [testDir],
+      defaults: { url: link, pattern: "foo" },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+  });
+
+  /**
+   * `slice(7)` left the path percent-encoded, so a filer-authored name with a
+   * space or a `%` addressed a file that does not exist.
+   */
+  test("parses file:// URLs rather than slicing the scheme", async () => {
+    const filePath = join(testDir, "a b%c.txt");
+    writeFileSync(filePath, "alpha\nbravo foo\n", "utf-8");
+
+    const result = await new FileGrepTask({
+      defaults: { url: `file://${testDir}/a%20b%25c.txt`, pattern: "foo" },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+  });
+
+  test("rejects a file:// URL carrying a remote host", async () => {
+    await expect(
+      new FileGrepTask({
+        defaults: { url: "file://evil.example/etc/passwd", pattern: "root" },
+      }).run()
+    ).rejects.toThrow(TaskInvalidInputError);
+  });
+
+  /**
+   * The scheme test was case-sensitive, so `HTTP://x` fell through to the
+   * filesystem branch and was opened as a relative path against the process
+   * cwd. It must route to the fetch branch instead.
+   */
+  describe("uppercase schemes", () => {
+    let prevSafeFetch: SafeFetchFn;
+
+    beforeEach(() => {
+      prevSafeFetch = registerSafeFetch(() =>
+        Promise.resolve(
+          new Response("alpha\nbravo foo\n", {
+            status: 200,
+            headers: { "Content-Type": "text/plain" },
+          })
+        )
+      );
+    });
+
+    afterEach(() => {
+      registerSafeFetch(prevSafeFetch);
+    });
+
+    test("treats HTTP:// case-insensitively", async () => {
+      const result = await new FileGrepTask({
+        defaults: { url: "HTTP://example.com/log.txt", pattern: "foo" },
+      }).run();
+
+      expect(result.matchCount).toBe(1);
+      expect(result.groups[0].lines[0].text).toBe("bravo foo");
+    });
+  });
+
+  describe.skipIf(!existsSync("/dev/zero"))("non-regular files", () => {
+    test("refuses a character device", async () => {
+      await expect(
+        new FileGrepTask({
+          defaults: { url: "/dev/zero", pattern: "foo" },
+        }).run()
+      ).rejects.toThrow(TaskInvalidInputError);
+    });
+  });
+
+  /**
+   * The budget applies on the local path too, not only through the fetch
+   * branch. `((a)*)*$` bypasses the shape screen and takes 8_234 ms at n=26,
+   * doubling per character.
+   */
+  test("a catastrophic pattern over a local file fails on the budget", async () => {
+    const filePath = join(testDir, "evil.txt");
+    writeFileSync(filePath, "a".repeat(40) + "!\n", "utf-8");
+
+    const started = Date.now();
+    await expect(
+      new FileGrepTask({
+        defaults: { url: filePath, pattern: "((a)*)*$" },
+      }).run()
+    ).rejects.toThrow(/budget/);
+    expect(Date.now() - started).toBeLessThan(5_000);
   });
 });

--- a/packages/test/src/test/task/FileGrepTask.server.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.server.test.ts
@@ -248,17 +248,18 @@ describe("FileGrepTask (server - local files)", () => {
 
   /**
    * The budget applies on the local path too, not only through the fetch
-   * branch. `((a)*)*$` bypasses the shape screen and takes 8_234 ms at n=26,
-   * doubling per character.
+   * branch. `(\w|\d)*$` bypasses the shape screen — its branches overlap on the
+   * digits both accept, which comparing branch text cannot see — and takes
+   * 657 ms at n=26, doubling per added character.
    */
   test("a catastrophic pattern over a local file fails on the budget", async () => {
     const filePath = join(testDir, "evil.txt");
-    writeFileSync(filePath, "a".repeat(40) + "!\n", "utf-8");
+    writeFileSync(filePath, "1".repeat(40) + "!\n", "utf-8");
 
     const started = Date.now();
     await expect(
       new FileGrepTask({
-        defaults: { url: filePath, pattern: "((a)*)*$" },
+        defaults: { url: filePath, pattern: "(\\w|\\d)*$" },
       }).run()
     ).rejects.toThrow(/budget/);
     expect(Date.now() - started).toBeLessThan(5_000);

--- a/packages/test/src/test/task/FileGrepTask.server.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.server.test.ts
@@ -6,7 +6,7 @@
 
 import { TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
 import { FileGrepTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
-import { setLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
@@ -86,6 +86,51 @@ describe("FileGrepTask (server - local files)", () => {
         defaults: { url: filePath, pattern: "foo" },
       }).run()
     ).rejects.toThrow();
+  });
+
+  /**
+   * Reproduced pre-fix with a 640 MB newline-free stream: `createInterface`
+   * accumulated the whole thing and threw `RangeError: Invalid string length`
+   * from a stream `'data'` listener. That surfaces as an `uncaughtException`,
+   * not an iterator rejection, so `grepFile`'s try/catch never saw it and the
+   * process died. 1 MB here is enough to exercise the cap without the memory.
+   */
+  test("a file with no line terminator does not crash the process", async () => {
+    const filePath = join(testDir, "oneline.bin");
+    writeFileSync(filePath, "x".repeat(1_000_000), "utf-8");
+
+    const uncaught: unknown[] = [];
+    const spy = (err: unknown): void => {
+      uncaught.push(err);
+    };
+    process.on("uncaughtException", spy);
+
+    try {
+      const result = await new FileGrepTask({
+        defaults: { url: filePath, pattern: "x" },
+      }).run();
+
+      expect(uncaught).toEqual([]);
+      expect(result.matchCount).toBe(1);
+      expect(result.groups[0].lines[0].text).toHaveLength(DEFAULT_LIMITS.grepMaxLineChars);
+    } finally {
+      process.off("uncaughtException", spy);
+    }
+  });
+
+  test("caps an over-long line and reports truncation", async () => {
+    const filePath = join(testDir, "long.txt");
+    const long = "y".repeat(DEFAULT_LIMITS.grepMaxLineChars + 5_000);
+    writeFileSync(filePath, `short\n${long}\ntail foo\n`, "utf-8");
+
+    const result = await new FileGrepTask({
+      defaults: { url: filePath, pattern: "y" },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    const matched = result.groups.flatMap((g) => g.lines.filter((l) => l.match));
+    expect(matched).toHaveLength(1);
+    expect(matched[0].text).toHaveLength(DEFAULT_LIMITS.grepMaxLineChars);
   });
 
   test("refuses a path outside the configured roots", async () => {

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -640,6 +640,30 @@ describe("FileGrepTask", () => {
     expect(Date.now() - started).toBeLessThan(5_000);
   });
 
+  /**
+   * The group de-duplication used to scan `currentGroup.lines` linearly on
+   * every emit, so a run of contiguous matches was quadratic. Measured on the
+   * pre-fix shape: 10 000 lines -> 126 ms, 20 000 -> 286 ms, 40 000 -> 1576 ms,
+   * 80 000 -> 6390 ms — a clean 4x per doubling, which puts 200 000 at roughly
+   * 40 s. The bound below is that curve's cost, not an arbitrary number.
+   */
+  test("greps 200k contiguous matching lines in bounded time", { timeout: 30_000 }, async () => {
+    mockText("foo\n".repeat(200_000));
+
+    const started = Date.now();
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        maxOutputLines: 200_000,
+        maxOutputChars: 10_000_000,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(200_000);
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
   test("empty file has no matches", async () => {
     mockText("");
 

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FileGrepTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
+import { TaskAbortedError } from "@workglow/task-graph";
+import { FileGrepTask, grepLines, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
 import { setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
@@ -574,6 +575,69 @@ describe("FileGrepTask", () => {
         lines: [{ line: 2, text: "two foo", match: true }],
       },
     ]);
+  });
+
+  test("rejects a catastrophic pattern before reading the document", async () => {
+    await expect(
+      new FileGrepTask({
+        defaults: { url: "https://example.com/log.txt", pattern: "(a+)+$" },
+      }).run()
+    ).rejects.toThrow(/nested quantifiers/);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * `((a)*)*$` walks straight past the shape screen — the screen only looks for
+   * a quantifier before the group's first `)`, and here the inner one sits
+   * behind a nested group — and it is exponential all the same: against
+   * `"a".repeat(n) + "!"` V8 takes 8_234 ms at n=26, doubling per added
+   * character. At n=40 that is roughly 2^40 backtracking steps, on the order of
+   * days. Unbounded, this run never returns and no abort can interrupt the one
+   * synchronous `test()` it is stuck inside; the match budget is what turns it
+   * into a rejection. This is exactly why the screen is documented as a
+   * heuristic and the budget as the enforced bound.
+   */
+  test("a guard-bypassing pattern fails on the match budget instead of hanging", async () => {
+    mockText("a".repeat(40) + "!");
+
+    const started = Date.now();
+    await expect(
+      new FileGrepTask({
+        defaults: { url: "https://example.com/log.txt", pattern: "((a)*)*$" },
+      }).run()
+    ).rejects.toThrow(/budget/);
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  /**
+   * Pre-fix the abort check ran between lines, which bought nothing: a single
+   * `regex.test()` is uninterruptible, so a hostile line blocked forever with
+   * the check sitting unreachable above it. It now runs between batches, and
+   * how long one batch may run is what the matcher's budget bounds.
+   *
+   * Driven through `grepLines` rather than the task because an async generator
+   * resolves on the MICROTASK queue: a purely in-memory source starves the
+   * timer phase entirely, so a `setTimeout` abort would not fire until the scan
+   * had already finished. The source below yields to the macrotask queue
+   * periodically, which is what a real file stream does on every read.
+   */
+  test("aborts between batches", async () => {
+    const controller = new AbortController();
+
+    async function* source(): AsyncGenerator<string> {
+      for (let i = 0; i < 200_000; i++) {
+        if (i % 1_000 === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+        yield "foo";
+      }
+    }
+
+    const started = Date.now();
+    const running = grepLines(source(), "foo", { countOnly: true }, controller.signal);
+    setTimeout(() => controller.abort(), 5);
+
+    await expect(running).rejects.toThrow(TaskAbortedError);
+    expect(Date.now() - started).toBeLessThan(5_000);
   });
 
   test("empty file has no matches", async () => {

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -652,23 +652,26 @@ describe("FileGrepTask", () => {
   });
 
   /**
-   * `((a)*)*$` walks straight past the shape screen — the screen only looks for
-   * a quantifier before the group's first `)`, and here the inner one sits
-   * behind a nested group — and it is exponential all the same: against
-   * `"a".repeat(n) + "!"` V8 takes 8_234 ms at n=26, doubling per added
-   * character. At n=40 that is roughly 2^40 backtracking steps, on the order of
-   * days. Unbounded, this run never returns and no abort can interrupt the one
-   * synchronous `test()` it is stuck inside; the match budget is what turns it
-   * into a rejection. This is exactly why the screen is documented as a
+   * `(\w|\d)*$` walks straight past the shape screen and is exponential all the
+   * same: against `"1".repeat(n) + "!"` V8 takes 1 ms at n=16, 14 ms at n=20,
+   * 218 ms at n=24 and 657 ms at n=26 — doubling per added character. At n=40
+   * that is roughly 2^40 backtracking steps, on the order of days. Unbounded,
+   * this run never returns and no abort can interrupt the one synchronous
+   * `test()` it is stuck inside; the match budget is what turns it into a
+   * rejection.
+   *
+   * The bypass is structural rather than an oversight: the two branches overlap
+   * on the digits they both accept, and the screen compares branch TEXT, which
+   * cannot see that. This is exactly why the screen is documented as a
    * heuristic and the budget as the enforced bound.
    */
   test("a guard-bypassing pattern fails on the match budget instead of hanging", async () => {
-    mockText("a".repeat(40) + "!");
+    mockText("1".repeat(40) + "!");
 
     const started = Date.now();
     await expect(
       new FileGrepTask({
-        defaults: { url: "https://example.com/log.txt", pattern: "((a)*)*$" },
+        defaults: { url: "https://example.com/log.txt", pattern: "(\\w|\\d)*$" },
       }).run()
     ).rejects.toThrow(/budget/);
     expect(Date.now() - started).toBeLessThan(5_000);

--- a/packages/test/src/test/task/FileGrepTask.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.test.ts
@@ -6,7 +6,7 @@
 
 import { TaskAbortedError } from "@workglow/task-graph";
 import { FileGrepTask, grepLines, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
-import { setLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -272,6 +272,12 @@ describe("FileGrepTask", () => {
     ]);
   });
 
+  /**
+   * `truncated` is now computed rather than hard-coded: the match is on line 2
+   * of 6, so four lines were never scanned and the scan really did stop early.
+   * `matchCount` stays 1 — `existsOnly` stops at the first match, and 0 would
+   * contradict `exists: true`.
+   */
   test("existsOnly returns whether a match exists without groups", async () => {
     const result = await new FileGrepTask({
       defaults: {
@@ -285,8 +291,66 @@ describe("FileGrepTask", () => {
       groups: [],
       matchCount: 1,
       exists: true,
-      truncated: false,
+      truncated: true,
     });
+  });
+
+  test("existsOnly reports no truncation when the match is the last line", async () => {
+    mockText("alpha\nbravo\ncharlie foo\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        existsOnly: true,
+      },
+    }).run();
+
+    expect(result.truncated).toBe(false);
+  });
+
+  test("truncated is false when the last line is the final match", async () => {
+    mockText("alpha\nfoo one\nbravo\nfoo two\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        maxMatches: 2,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(2);
+    expect(result.truncated).toBe(false);
+  });
+
+  test("maxMatches with afterContext still labels later matching lines as matches", async () => {
+    mockText("foo a\nfoo b\nfoo c\ntail\n");
+
+    const result = await new FileGrepTask({
+      defaults: {
+        url: "https://example.com/log.txt",
+        pattern: "foo",
+        maxMatches: 1,
+        afterContext: 2,
+      },
+    }).run();
+
+    expect(result.matchCount).toBe(1);
+    const byLine = new Map(result.groups.flatMap((g) => g.lines).map((l) => [l.line, l.match]));
+    expect(byLine.get(2)).toBe(true);
+    expect(byLine.get(3)).toBe(true);
+  });
+
+  test("applies default output caps when the caller states none", async () => {
+    mockText("foo\n".repeat(DEFAULT_LIMITS.grepMaxOutputLines + 500));
+
+    const result = await new FileGrepTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo" },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.groups.flatMap((g) => g.lines)).toHaveLength(DEFAULT_LIMITS.grepMaxOutputLines);
   });
 
   test("countOnly returns the match count without groups", async () => {

--- a/packages/test/src/test/task/RegexSafety.test.ts
+++ b/packages/test/src/test/task/RegexSafety.test.ts
@@ -128,6 +128,15 @@ describe("hasUnsafeRegexShape", () => {
     expect(hasUnsafeRegexShape("([a-z]|[a-z])*")).toBe(true);
   });
 
+  /**
+   * The class-stripping regex this scanner replaced matched `\\[` as a class
+   * opener, so it stripped this whole pattern to `\\X` and called the nested
+   * quantifier inside it safe. Reading the escape is what fixes that.
+   */
+  it("does not let an escaped bracket hide a nested quantifier", () => {
+    expect(hasUnsafeRegexShape("\\[(a+)+]")).toBe(true);
+  });
+
   it("still catches a class branch that can match empty", () => {
     expect(hasUnsafeRegexShape("([a-z]*|[A-Z])+")).toBe(true);
   });

--- a/packages/test/src/test/task/RegexSafety.test.ts
+++ b/packages/test/src/test/task/RegexSafety.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { assertSafeRegexPattern } from "@workglow/tasks";
+import { assertSafeRegexPattern, hasUnsafeRegexShape } from "@workglow/tasks";
 import { SECURITY_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { describe, expect, it } from "vitest";
@@ -50,5 +50,85 @@ describe("assertSafeRegexPattern", () => {
     const started = performance.now();
     expect(() => assertSafeRegexPattern(pattern)).toThrow(/too many/);
     expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  it("rejects a repeated alternation with overlapping branches", () => {
+    expect(() => assertSafeRegexPattern("(a|a)*")).toThrow(/overlapping branches/);
+  });
+});
+
+/**
+ * The shape screen behind {@link assertSafeRegexPattern}, exercised directly so
+ * each modelled family is pinned independently of which error text it produces.
+ */
+describe("hasUnsafeRegexShape", () => {
+  it.each(["(a+)+$", "(a*)*$", "(x+x+)+y", "([a-z]+)+$", "((a)*)*$", "((b|c+))+"])(
+    "rejects the nested quantifier %s",
+    (pattern) => {
+      expect(hasUnsafeRegexShape(pattern)).toBe(true);
+    }
+  );
+
+  /**
+   * These were MEASURED as exponential under V8 and are invisible to the
+   * nested-quantifier scan, which pops `(a|a)` with a body carrying no
+   * quantifier of its own: `/(a|a)*$/` against `"a".repeat(n) + "!"` runs 52 ms
+   * at n=18, 118 ms at n=22, 466 ms at n=24 and 1821 ms at n=26 — a clean
+   * doubling per added character — and `(a|a|a)+$` at n=20 ran past a 120 s
+   * timeout. The alternation branches overlap, so the engine has more than one
+   * way to consume the same input.
+   */
+  it.each(["(a|a)*$", "(?:a|a)*$", "(a|a|a)+$"])(
+    "rejects the overlapping alternation %s",
+    (pattern) => {
+      expect(hasUnsafeRegexShape(pattern)).toBe(true);
+    }
+  );
+
+  it("rejects an alternation where one branch prefixes the other", () => {
+    expect(hasUnsafeRegexShape("^(a|ab)+$")).toBe(true);
+  });
+
+  it("rejects an alternation whose branch can match empty", () => {
+    expect(hasUnsafeRegexShape("(a*|b)+$")).toBe(true);
+  });
+
+  it("rejects an unbounded counted quantifier nested under a quantifier", () => {
+    expect(hasUnsafeRegexShape("(a{2,})*$")).toBe(true);
+  });
+
+  it.each(["foo.*bar", "^\\d{3}-\\d{4}$", "[a-z]+", "(a\\+)+", "([*+])+"])(
+    "accepts the ordinary pattern %s",
+    (pattern) => {
+      expect(hasUnsafeRegexShape(pattern)).toBe(false);
+    }
+  );
+
+  /**
+   * The negative control for the alternation rule. `(foo|far)+` shares a first
+   * character but neither branch prefixes the other, and it is verifiably not
+   * exponential. A first-character-overlap rule would reject it — and a large
+   * class of ordinary patterns with it. The screen is shared with RegexTask and
+   * FileSedTask, so over-rejection here breaks callers that work today.
+   */
+  it("accepts an alternation that merely shares a first character", () => {
+    expect(hasUnsafeRegexShape("(foo|far)+")).toBe(false);
+  });
+
+  /**
+   * Two different classes are two different branches. Collapsing every class to
+   * one placeholder would make these compare equal and reject an ordinary
+   * pattern, so overlap is judged on the class text as written.
+   */
+  it("distinguishes two different character classes in an alternation", () => {
+    expect(hasUnsafeRegexShape("([a-z]|[A-Z])*")).toBe(false);
+  });
+
+  it("still catches an alternation of two identical character classes", () => {
+    expect(hasUnsafeRegexShape("([a-z]|[a-z])*")).toBe(true);
+  });
+
+  it("still catches a class branch that can match empty", () => {
+    expect(hasUnsafeRegexShape("([a-z]*|[A-Z])+")).toBe(true);
   });
 });

--- a/packages/util/src/limits.ts
+++ b/packages/util/src/limits.ts
@@ -48,6 +48,10 @@ export const DEFAULT_LIMITS = {
   grepMaxSearchMs: 30_000,
   /** Max characters of one FileGrepTask line; the rest of that physical line is discarded. */
   grepMaxLineChars: 64_000,
+  /** Default max FileGrepTask output lines (including context) when the caller states none. */
+  grepMaxOutputLines: 10_000,
+  /** Default max FileGrepTask output characters when the caller states none. */
+  grepMaxOutputChars: 1_000_000,
 } as const satisfies Record<string, number>;
 
 /**

--- a/packages/util/src/limits.ts
+++ b/packages/util/src/limits.ts
@@ -44,6 +44,8 @@ export const DEFAULT_LIMITS = {
   structuredGenMaxRetries: 2,
   /** Default absolute TTL (ms) for OtpPassphraseCache. */
   otpCacheHardTtlMs: 6 * 60 * 60 * 1000,
+  /** Default wall-clock budget (ms) for a whole FileGrepTask scan. */
+  grepMaxSearchMs: 30_000,
 } as const satisfies Record<string, number>;
 
 /**
@@ -66,4 +68,13 @@ export const SECURITY_LIMITS = {
   safeFetchMaxRedirectHops: 20,
   /** Max accepted length (characters) of an encoded tabular storage pagination cursor. */
   tabularMaxCursorLength: 8 * 1024,
+  /** Lines matched per interruptible regex batch (ReDoS defence, see below). */
+  regexMatchBatchLines: 512,
+  /**
+   * Wall-clock budget (ms) for one interruptible regex batch. A shape screen
+   * cannot decide backtracking, so this is the bound that is actually enforced:
+   * matching runs where it can be interrupted, and a batch that overruns fails
+   * the task instead of blocking forever.
+   */
+  regexMatchBatchTimeoutMs: 1_000,
 } as const satisfies Record<string, number>;

--- a/packages/util/src/limits.ts
+++ b/packages/util/src/limits.ts
@@ -46,6 +46,8 @@ export const DEFAULT_LIMITS = {
   otpCacheHardTtlMs: 6 * 60 * 60 * 1000,
   /** Default wall-clock budget (ms) for a whole FileGrepTask scan. */
   grepMaxSearchMs: 30_000,
+  /** Max characters of one FileGrepTask line; the rest of that physical line is discarded. */
+  grepMaxLineChars: 64_000,
 } as const satisfies Record<string, number>;
 
 /**

--- a/packages/util/src/utilities/__tests__/Limits.test.ts
+++ b/packages/util/src/utilities/__tests__/Limits.test.ts
@@ -24,6 +24,7 @@ describe("DEFAULT_LIMITS", () => {
     expect(DEFAULT_LIMITS.structuredGenMaxRetries).toBe(2);
     expect(DEFAULT_LIMITS.otpCacheHardTtlMs).toBe(6 * 60 * 60 * 1000);
     expect(DEFAULT_LIMITS.grepMaxSearchMs).toBe(30_000);
+    expect(DEFAULT_LIMITS.grepMaxLineChars).toBe(64_000);
   });
 
   it("is a frozen object shape (const assertion) with only number values", () => {

--- a/packages/util/src/utilities/__tests__/Limits.test.ts
+++ b/packages/util/src/utilities/__tests__/Limits.test.ts
@@ -25,6 +25,8 @@ describe("DEFAULT_LIMITS", () => {
     expect(DEFAULT_LIMITS.otpCacheHardTtlMs).toBe(6 * 60 * 60 * 1000);
     expect(DEFAULT_LIMITS.grepMaxSearchMs).toBe(30_000);
     expect(DEFAULT_LIMITS.grepMaxLineChars).toBe(64_000);
+    expect(DEFAULT_LIMITS.grepMaxOutputLines).toBe(10_000);
+    expect(DEFAULT_LIMITS.grepMaxOutputChars).toBe(1_000_000);
   });
 
   it("is a frozen object shape (const assertion) with only number values", () => {

--- a/packages/util/src/utilities/__tests__/Limits.test.ts
+++ b/packages/util/src/utilities/__tests__/Limits.test.ts
@@ -23,6 +23,7 @@ describe("DEFAULT_LIMITS", () => {
     expect(DEFAULT_LIMITS.aiChatMaxIterations).toBe(100);
     expect(DEFAULT_LIMITS.structuredGenMaxRetries).toBe(2);
     expect(DEFAULT_LIMITS.otpCacheHardTtlMs).toBe(6 * 60 * 60 * 1000);
+    expect(DEFAULT_LIMITS.grepMaxSearchMs).toBe(30_000);
   });
 
   it("is a frozen object shape (const assertion) with only number values", () => {
@@ -40,6 +41,8 @@ describe("SECURITY_LIMITS", () => {
     expect(SECURITY_LIMITS.imageMaxInputBytesBrowser).toBe(32 * 1024 * 1024);
     expect(SECURITY_LIMITS.safeFetchMaxRedirectHops).toBe(20);
     expect(SECURITY_LIMITS.tabularMaxCursorLength).toBe(8 * 1024);
+    expect(SECURITY_LIMITS.regexMatchBatchLines).toBe(512);
+    expect(SECURITY_LIMITS.regexMatchBatchTimeoutMs).toBe(1_000);
   });
 
   it("is a frozen object shape (const assertion) with only number values", () => {


### PR DESCRIPTION
Hardening follow-up for #821, targeting `file-grep-task` so it merges into that PR before it reaches `main`. One CRITICAL, four HIGH, five MEDIUM, in eight ordered commits.

Sequencing is load-bearing: commit 2 imports the module commit 1 extracts, and commits 2 → 5 → 6 → 7 all edit `grepLines`' scan loop.

---

## C1 — regex matching was unbounded and uninterruptible

`matcher(text)` was a synchronous `regex.test()`, and `signal?.aborted` was only checked *between* lines. One hostile line blocked the event loop indefinitely with nothing able to interrupt it.

Measured on `/(a|a)*$/` against `"a".repeat(n) + "!"`:

| n | time |
| --- | --- |
| 18 | 52 ms |
| 22 | 118 ms |
| 24 | 466 ms |
| 26 | 1821 ms |

`(a|a|a)+$` at n=20 ran past a 120 s timeout.

**Guard-bypassing patterns.** `(a|a)*$`, `(?:a|a)*$` and `(a|a|a)+$` all passed the existing `hasNestedQuantifiers` screen untouched. Two corrections to the original report, both verified: `(a{2,})*$` and `^(a|ab)+$` bypass the guard but are **not** exponential under V8 — they are guard bypasses, not live ReDoS. The tests use the measured-exponential family instead. The one used for the budget test is `((a)*)*$`, which bypasses even the *widened* screen (the inner quantifier sits behind a nested group, past the first `)`) and takes **8_234 ms at n=26**, doubling per added character — on the order of 2^40 steps at the n=40 the test uses.

### Why `vm`, and not the two alternatives

V8's script-execution timeout **does** reach inside Irregexp backtracking. Verified: `vm.runInContext("/(a|a)*$/.test(s)", ctx, {timeout: 200})` on `"a".repeat(40)+"!"` threw `Script execution timed out after 200ms` at ~210 ms — with the `RegExp` created in the outer realm and passed through the context, and the context reusable afterwards.

Cost, measured over 100 000 lines with `/foo/`:

| approach | time |
| --- | --- |
| plain `regex.test` per line | 6 ms |
| one `vm` call **per line** | 25 051 ms (unusable) |
| one `vm` call **per 512-line batch** | 129 ms |

So the matcher is batched. `SECURITY_LIMITS.regexMatchBatchLines` (512) and `regexMatchBatchTimeoutMs` (1000) are the knobs.

**Worker isolation was rejected.** It needs a new worker entry and build target in `packages/tasks` (which builds exactly browser/node/electron), per-run startup, and structured-cloning every line — to buy what a `vm` timeout buys in-process. The one property workers would add and `vm` does not: **`vm` still blocks the event loop for up to ONE batch budget.** That is bounded and finite; today it is unbounded. Bun honours the timeout more coarsely (a 300 ms budget terminated at ~1025 ms), so treat it as an order of magnitude rather than a deadline.

**A shape heuristic alone was rejected** as the containment. It cannot decide backtracking — `((a)*)*$` is the proof — so the screen is documented as a fast friendly rejection and the budget is what is enforced.

`fixedString` never enters `vm`: `String.includes` cannot backtrack.

**Browser residual**, documented on the base class: there is no `vm` there, so one evil line still blocks that tab. A tab — not the Electron utility process hosting the local API, which runs the server build.

---

## H1 — arbitrary filesystem read

`FileGrepTask.server` did `url = url.slice(7)` and handed the result to `createReadStream`: no root, no allowlist, no `path.resolve` + prefix check, no `realpath`, relative paths against `process.cwd()`. The class declared **no entitlements at all**, so `Task.entitlements()` returned `EMPTY_ENTITLEMENTS` even though `Entitlements.FILESYSTEM_READ` exists. It is registered globally by both the node and electron entries.

**Extra bug found:** the http bypass was case-**sensitive**, so `HTTP://x` and `FILE://x` fell through into the filesystem branch.

`resolveLocalFilePath` now: parses a `file:` URL with `fileURLToPath` (percent-decodes, rejects a non-localhost host, yields `C:\x` not `/c:/x`) → `path.resolve` → `realpathSync` (ENOENT falls back to a realpath'd parent directory, so a missing file still fails with ENOENT at open time) → **containment check, after realpath, so a symlink cannot escape** → `statSync().isFile()`, because `/dev/zero` or a fifo is an unbounded un-deadlined read.

`roots` is opt-in task config defaulting to `undefined` — today's behaviour, nothing breaks. The **enforced** control is the entitlement; `roots` is the embedder's belt-and-braces.

Residual TOCTOU (a component swapped between realpath and open) is documented in one line; closing it needs an openat-with-fd-relative walk Node does not expose.

---

## H2 — an owned child escaped the graph's entitlement snapshot

Entitlements are computed **once, at graph start**, over `graph.getTasks()` (`TaskGraphRunner.ts:895-909` → `computeGraphEntitlements` → `GraphEntitlementUtils.ts:59,77`), before any `execute()`. The runtime re-check (`TaskGraphRunner.ts:547-558`) fires only in `runTask`, and `TaskRunner.ts:1073` states in-source that owned children run via `child.run()`.

So: `FileGrepTask` declared nothing → the snapshot was empty → the enforcer passed → the owned `FetchUrlTask` set `allowPrivate` from `classifyUrl(input.url).kind === "private"` (`FetchUrlTask.ts:526-534`) → its own `assertResolvedDestinationDeclared` passed, because the child's `runInputData.url` **is** the private URL. A browser-profile graph reached `http://169.254.169.254/latest/meta-data/iam/security-credentials/`.

`FetchUrlTask`'s instance `entitlements()` body is lifted into an exported pure `fetchUrlEntitlementsFor(url)` — no behaviour change, the fail-closed unscoped `network:private` for an unknown URL is preserved. The base `FileGrepTask` declares it and sets `hasDynamicEntitlements`; the server build narrows to `filesystem:read` scoped to the resolved path for a local url, the fetch entitlements for http(s), and both unscoped when the url is unknown.

`execute()` additionally asserts the path it opens is the one the instance declared — mirroring `assertResolvedDestinationDeclared`. That is what makes a standalone `fileGrep(...)` (no graph, no enforcer) still honour `roots`, and closes declare-then-swap.

---

## H3 — unterminated lines accumulated without bound

Reproduced: a 640 MB newline-free stream through `createInterface` throws `RangeError: Invalid string length` from a stream `'data'` listener, surfacing as an **`uncaughtException`** — not an iterator rejection, so the `try/catch` around `grepLines` could not see it and the process died.

**Correction to the original report:** a stream-*emitted* error already rejects the `for await` (verified: `s.destroy(new Error("boom"))` → `iterator rejected: boom`), so adding `'error'` handlers was unnecessary. The unbounded accumulation was the bug.

`node:readline` is dropped for a local generator that emits on `\n`, strips a trailing `\r` (preserving the CRLF behaviour the existing test asserts), and caps a pending unterminated segment at `grepMaxLineChars` (64 000), discarding the rest of that physical line. `setEncoding` puts a `StringDecoder` in front so a multi-byte character split across reads survives. The shared side applies the same cap when filling a batch.

`linesFromText` also stops using `split(/\r?\n/)`, which materialized an array of every line in the document before yielding the first.

---

## H4 — group de-duplication was quadratic

`emitLine` scanned `currentGroup.lines` linearly on every emit. Measured on the replicated shape: 10 000 → 126 ms, 20 000 → 286 ms, 40 000 → 1576 ms, 80 000 → 6390 ms — a clean 4× per doubling, putting 200 000 at ≈40 s.

Entries are appended in strictly increasing line order, so `entry.line <= endLine` already means "already emitted" and only the last entry can be it. The scan existed solely to skip replayed `beforeBuffer` entries, and those always carry `match: false`, so no flag is lost. The same 200 000-line scan now runs in **~2.6 s**.

---

## M1 / M2 / M3 — output caps and honest reporting

- **M1** — `maxOutputLines` / `maxOutputChars` were only enforced when the caller stated them, so the default was unbounded. They now default to `grepMaxOutputLines` (10 000) / `grepMaxOutputChars` (1 000 000), still overridable, and the schema descriptions say so.
- **M2** — a line emitted as trailing context after the match budget was reached was labelled `match: false` even when it matched. `maxMatchesReached` governs whether a match *counts* toward the budget, not whether the line *is* a match.
- **M3** — `truncated` was hard-coded at six sites, reporting the shape of the exit rather than the fact. Because the loop now drives the source iterator itself, it is **exact**: truncated only if something was really left. `grepLines(["foo"], "foo", {maxMatches: 1})` now reports `truncated: false`; `existsOnly` over a document with lines after the match reports `true`.

Two existing assertions were intentionally updated: the `existsOnly` test asserted `truncated: false` for a match on line 2 of 6 and now asserts `true`. Its `matchCount: 1` stays — 0 would contradict `exists: true`, and the output schema now says so.

---

## M4 / M5 — shared guard, corrected docs

`FileGrepTask.ts` and `RegexTask.ts` carried byte-identical copies of the ReDoS screen, neither rejection path tested. Extracted to `packages/tasks/src/util/RegexSafety.ts` and exported from the barrel. Two shapes added: `{n,}` / `{n,m}` nested under a quantifier, and an overlapping alternation under a quantifier (identical branches, one a literal prefix of another, or a branch that can match empty).

The base class doc claimed "including file:// URLs … Works in all environments". False — the base routes through `FetchUrlTask` → `safeFetch` → `classifyUrl`, which rejects non-http(s) (`UrlClassifier.ts:254-256`). Corrected, and the `url` schema description now carries the whole truth for the UI and for authoring models.

---

## Verification

```
bun scripts/test.ts task vitest   →  70 files, 1095 passed | 24 skipped, 0 failed
bun scripts/test.ts util vitest   →  53 files,  757 passed | 10 skipped, 0 failed
bun run format                    →  All matched files use Prettier code style!
npx tsgo --noEmit -p tsconfig.typecheck.json  →  exit 0
```

The four pre-existing FileGrep suites are green (with the two intentionally-updated assertions); the H4 test runs in 2.58 s against its 5 s bound; both budget tests **reject** rather than time out (`1071 ms`); `uncaughtException` never fired.

## Risks

- **`vm` matching is ~20× slower than a bare `regex.test`** (129 ms vs 6 ms per 100 k lines). Batch size is the knob and lives in `SECURITY_LIMITS`.
- **Abort latency moves from per-line to per-batch.** Nothing is lost — a per-line check could not interrupt the one call that blocks — but the granularity is now bounded by the batch budget rather than a single line.
- **Default output caps change behaviour** for a caller receiving unlimited output today. Overridable, and `truncated` reports it.
- **`realpathSync` + `statSync` add two synchronous syscalls** per local grep, and change the error a dangling symlink produces.
- **`hasUnsafeRegexShape` is shared with `RegexTask`**, so widening it can reject patterns that task accepts today. Hence the deliberately narrow alternation rule and the `(foo|far)+` negative test — a first-character-overlap rule would reject far too much.
- **The exact `truncated` computation consumes one extra element** from the source iterator on an early stop.

## Follow-up issues filed

- #823 — `FileLoaderTask.server` has the identical `slice(7)` + unsandboxed `readFile`. Deliberately not fixed here: it owns its own format/image/pdf surface and tests, and widening this diff hurts review. The new helper is shaped so its fix is ~6 lines.
- #824 — the framework hole: `context.own()` lets an owned child exceed its parent's entitlement declaration. This PR only stops one task from relying on it.
- #825 — a distinct `path` input port instead of overloading `url`. An input-schema break for every existing workflow plus a UI change, so not done here.

## Deferred

- Adjacent groups are still not merged when trailing context runs out.
- **The URL-path materialization half of H3.** The base build still fetches `response_type: "text"`, so the whole document is materialized before the scan. A real fix means consuming `response_type: "stream"` via the `stream_chunk` / `stream_end` / `status` event contract (`TaskRunner.ts:883-889` is the pattern) — a genuine design, not a tweak. Commit 5's `linesFromText` rewrite already removes the `split()` array on that path.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT)_