### PR TITLE
fix(bootstrap): review fixes for #672 — dead lint guard, version skew, cross-bundle resolver

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -181,7 +181,7 @@
     },
     "packages/bootstrap": {
       "name": "@workglow/bootstrap",
-      "version": "0.3.39",
+      "version": "0.3.45",
       "devDependencies": {
         "@workglow/ai": "workspace:*",
         "@workglow/knowledge-base": "workspace:*",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,15 @@ import regexpPlugin from "eslint-plugin-regexp";
 import { defineConfig } from "eslint/config";
 import globals from "globals";
 
+const WORKER_STATE_MESSAGE =
+  "Main-thread-only state is unavailable in workers. Resolve it in the task class " +
+  "(e.g. AiTask.getJobInput()) and pass it through the serialized job input.";
+
+const BOOTSTRAP_MESSAGE =
+  "A run-fn executes in a worker with its own globalServiceRegistry, so bootstrapWorkglow " +
+  "mutates a registry the main thread never sees. Resolve the services in the task class " +
+  "(e.g. AiTask.getJobInput()) and pass them through the serialized job input.";
+
 export default defineConfig(
   {
     ignores: ["**/dist", "**/storybook-static", "**/node_modules"],
@@ -65,53 +74,6 @@ export default defineConfig(
     },
   },
   {
-    // `*_JobRunFns.ts` files execute inside workers, which have an isolated
-    // runtime with their own `globalServiceRegistry`. Importing main-thread-only
-    // state (the global service registry or credential stores) resolves against a
-    // different, empty registry at runtime. Resolve such state in the task class on
-    // the main thread and pass it through the serialized job input instead.
-    files: ["**/*_JobRunFns.ts"],
-    rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          paths: [
-            {
-              name: "@workglow/util",
-              importNames: [
-                "globalServiceRegistry",
-                "getGlobalCredentialStore",
-                "setGlobalCredentialStore",
-              ],
-              message:
-                "Main-thread-only state is unavailable in workers. Resolve it in the task class (e.g. AiTask.getJobInput()) and pass it through the serialized job input.",
-            },
-            {
-              name: "@workglow/util/worker",
-              importNames: ["globalServiceRegistry"],
-              message:
-                "Main-thread-only state is unavailable in workers. Resolve it in the task class (e.g. AiTask.getJobInput()) and pass it through the serialized job input.",
-            },
-            // Blocked WHOLESALE rather than by importNames: every export of
-            // this package registers services into the global registry, so a
-            // name list would be the whole surface and would drift the moment
-            // one was added.
-            {
-              name: "@workglow/bootstrap",
-              message:
-                "A run-fn executes in a worker with its own globalServiceRegistry, so bootstrapWorkglow mutates a registry the main thread never sees. Resolve the services in the task class (e.g. AiTask.getJobInput()) and pass them through the serialized job input.",
-            },
-            {
-              name: "workglow/bootstrap",
-              message:
-                "A run-fn executes in a worker with its own globalServiceRegistry, so bootstrapWorkglow mutates a registry the main thread never sees. Resolve the services in the task class (e.g. AiTask.getJobInput()) and pass them through the serialized job input.",
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
     // Provider `src/ai/common/**` files are re-exported from each provider's
     // `runtime.ts`, so they are evaluated inside worker bundles.
     // `@workglow/ai/worker` exists to keep the 50+ task classes out of those
@@ -146,6 +108,73 @@ export default defineConfig(
                 "Import effort helpers from @workglow/ai/worker. The root barrel " +
                 "pulls all task classes and a second copy of AiProviderRegistry / " +
                 "CheckpointRegistry into the worker bundle.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // `*_JobRunFns.ts` files execute inside workers, which have an isolated
+    // runtime with their own `globalServiceRegistry`. Importing main-thread-only
+    // state (the global service registry or credential stores) resolves against a
+    // different, empty registry at runtime. Resolve such state in the task class on
+    // the main thread and pass it through the serialized job input instead.
+    //
+    // This block MUST stay LAST. Every run-fn in the repo lives under
+    // `providers/*/src/ai/common/`, and that block sets `"no-restricted-imports":
+    // "off"` — correctly, because its typescript-eslint extension replaces the base
+    // rule and running both double-reports. In flat config a later object's entry
+    // for a rule replaces the earlier one wholesale, so with this block placed
+    // first the guard below matched zero real files. Re-enabling it here is safe:
+    // the two rules restrict disjoint specifiers, so nothing double-reports, and
+    // `scripts/eslintRestrictedImports.test.ts` pins both directions.
+    files: ["**/*_JobRunFns.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@workglow/util",
+              importNames: [
+                "globalServiceRegistry",
+                "getGlobalCredentialStore",
+                "setGlobalCredentialStore",
+              ],
+              message: WORKER_STATE_MESSAGE,
+            },
+            {
+              name: "@workglow/util/worker",
+              importNames: ["globalServiceRegistry"],
+              message: WORKER_STATE_MESSAGE,
+            },
+            // Only `bootstrapWorkglow` touches the global registry.
+            // `createOrchestrationContext` builds a fresh `Container`, and
+            // `registerAllDefaults(registry)` mutates only what it is handed —
+            // both legitimate against a registry the run-fn owns.
+            {
+              name: "@workglow/bootstrap",
+              importNames: ["bootstrapWorkglow"],
+              message: BOOTSTRAP_MESSAGE,
+            },
+            {
+              name: "workglow/bootstrap",
+              importNames: ["bootstrapWorkglow"],
+              message: BOOTSTRAP_MESSAGE,
+            },
+            // `packages/workglow/src/common.ts:30` does `export * from
+            // "./bootstrap"` and also re-exports `@workglow/util`, so every name
+            // restricted above is one specifier away through the root barrel.
+            {
+              name: "workglow",
+              importNames: [
+                "bootstrapWorkglow",
+                "globalServiceRegistry",
+                "getGlobalCredentialStore",
+                "setGlobalCredentialStore",
+              ],
+              message: `The workglow root barrel re-exports both @workglow/bootstrap and @workglow/util. ${WORKER_STATE_MESSAGE}`,
             },
           ],
         },

--- a/packages/bootstrap/CHANGELOG.md
+++ b/packages/bootstrap/CHANGELOG.md
@@ -13,3 +13,11 @@
 - `registerAllDefaults(registry)` takes a **required** registry. It mutates
   whichever container it is handed, so the target is always stated at the call
   site rather than defaulting to the global one.
+- The vitest harness now installs the `image` input resolver on the MAIN
+  global registry. The removed `bootstrapTestRegistry` called each registrar
+  with no argument, so `registerImageDefaults()` defaulted to the
+  `@workglow/util/media` bundle's own `globalServiceRegistry` — a separate
+  module instance under dist resolution — and the map `resolveSchemaInputs`
+  reads never received it. Consequence: a `format: "image"` port fed a plain
+  string id now throws `resolver received an unsupported string` instead of
+  passing the string through. Object-valued image ports are unaffected.

--- a/packages/bootstrap/CHANGELOG.md
+++ b/packages/bootstrap/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Changelog
+# @workglow/bootstrap
 
-## 0.3.39
+## 0.3.45
 
 ### Features
 

--- a/packages/bootstrap/README.md
+++ b/packages/bootstrap/README.md
@@ -59,11 +59,13 @@ backend, say — survives, so those may be installed **before**
 
 The **input resolvers and compactors** do not. `registerInputResolver` /
 `registerInputCompactor` are an unconditional `resolvers.set(formatPrefix, fn)`:
-last writer wins. Nine of the fourteen registrars call them, covering the
-`credential`, `image`, `knowledge-base`, `mcp-server`, `model`,
-`storage:tabular` and `tasks` prefixes. A custom resolver installed **before**
-`bootstrapWorkglow()` is silently replaced by the built-in one, with no warning
-and nothing in the registry to inspect:
+last writer wins. Seven of the fourteen registrars install a resolver, covering
+the `credential`, `image`, `knowledge-base`, `mcp-server`, `model`,
+`storage:tabular` and `tasks` prefixes; six of those install a compactor too.
+`image` is the exception — it hydrates a data URI it cannot compact back to an
+id. A custom resolver installed **before** `bootstrapWorkglow()` is silently
+replaced by the built-in one, with no warning and nothing in the registry to
+inspect:
 
 ```typescript
 // WRONG — bootstrapWorkglow() overwrites this during startup, and every

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workglow/bootstrap",
   "type": "module",
-  "version": "0.3.39",
+  "version": "0.3.45",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bootstrap/src/bootstrap/registerAllDefaults.ts
+++ b/packages/bootstrap/src/bootstrap/registerAllDefaults.ts
@@ -32,10 +32,10 @@ import { registerWorkerManagerDefaults } from "@workglow/util/worker";
  *   explicit registration (a custom storage backend, say) is not overwritten.
  * - **Input resolvers and compactors** do not. `registerInputResolver` /
  *   `registerInputCompactor` are an unconditional `Map.set` — last writer
- *   wins — and nine of the fourteen calls below register one of each. A custom
- *   resolver installed BEFORE this function is silently replaced by the
- *   built-in one, so install custom resolvers AFTER `bootstrapWorkglow()` /
- *   `registerAllDefaults()`.
+ *   wins — and seven of the fourteen calls below install a resolver, six of
+ *   those a compactor too. A custom resolver installed BEFORE this function is
+ *   silently replaced by the built-in one, so install custom resolvers AFTER
+ *   `bootstrapWorkglow()` / `registerAllDefaults()`.
  *
  * The registry is required, never defaulted: this mutates whichever container
  * it is handed, so the target is always stated at the call site. Pass

--- a/packages/test/src/test/util/RegisterAllDefaults.test.ts
+++ b/packages/test/src/test/util/RegisterAllDefaults.test.ts
@@ -212,7 +212,7 @@ describe("registerAllDefaults", () => {
    * Ordering is invisible at runtime and cannot be asserted by calling the
    * function. `getInputResolvers` SELF-HEALS: handed a registry with no
    * `INPUT_RESOLVERS` map it calls `registerInputResolverDefaults` and carries
-   * on, so moving `registerInputResolverDefaults` after its nine consumers
+   * on, so moving `registerInputResolverDefaults` after its seven consumers
    * produces an identical registry and a green suite — until a resolver map is
    * pre-registered by a caller and the healed one silently replaces it. The
    * source text is the only place the ordering is stated, so it is the only

--- a/packages/test/src/test/util/RegisterAllDefaults.test.ts
+++ b/packages/test/src/test/util/RegisterAllDefaults.test.ts
@@ -48,6 +48,7 @@ import {
   TELEMETRY_PROVIDER,
   WORKER_MANAGER,
 } from "@workglow/util";
+import { registerImageDefaults } from "@workglow/util/media";
 import { describe, expect, it } from "vitest";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../../..");
@@ -251,5 +252,59 @@ describe("registerAllDefaults", () => {
     for (const consumer of consumers) {
       expect(callOrder.indexOf(consumer), consumer).toBeGreaterThan(lastPrimitive);
     }
+  });
+
+  /**
+   * `registerImageDefaults` does not live in the same JS bundle as the registry
+   * it is handed. `@workglow/util/media` is built separately
+   * (`bun build --target=node --packages=external ./src/media-node.ts`), and
+   * `--packages=external` externalizes bare specifiers only — `media-node.ts`
+   * reaches `di/ServiceRegistry` through a RELATIVE import, so
+   * `dist/media-node.js` carries its own inlined `globalContainer` and its own
+   * `INPUT_RESOLVERS` token object.
+   *
+   * The call lands in the caller's map only because `ServiceRegistry` keys the
+   * container by `token.id`, a plain string. Rename that id in one bundle and
+   * the two silently become two maps: the `image` resolver registers into a
+   * registry nothing reads, and a `format: "image"` port gets the raw id string
+   * back with no error anywhere.
+   *
+   * Under `bun run use-source` both entries resolve to the same module and the
+   * property is vacuously true — which is exactly why it is pinned by ID rather
+   * than by comparing module instances. A green source-mode run is not proof;
+   * the dist-mode run is.
+   */
+  describe("the cross-bundle registrar contract", () => {
+    it("the resolver-map token is keyed by a stable string id", () => {
+      expect(INPUT_RESOLVERS.id).toBe("task.input.resolvers");
+      expect(INPUT_COMPACTORS.id).toBe("task.input.compactors");
+    });
+
+    it("registerImageDefaults from @workglow/util/media reaches a registry built from @workglow/util", () => {
+      const registry = bareRegistry();
+      registerImageDefaults(registry);
+      expect(typeof getInputResolvers(registry).get("image")).toBe("function");
+    });
+
+    it("registerAllDefaults installs that same image resolver", () => {
+      const direct = bareRegistry();
+      registerImageDefaults(direct);
+
+      const viaDefaults = bareRegistry();
+      registerAllDefaults(viaDefaults);
+
+      expect(getInputResolvers(viaDefaults).get("image")).toBe(
+        getInputResolvers(direct).get("image")
+      );
+    });
+
+    it("the harness populated the image resolver on the process-wide map", () => {
+      // The harness-level property: the no-argument `getInputResolvers()` is
+      // what `InputResolver` consults, and this was FALSE before this PR under
+      // dist resolution — the old `bootstrapTestRegistry` called
+      // `registerImageDefaults()` with no argument, landing it on the media
+      // bundle's private registry instead. Vacuous under `use-source`.
+      expect(getInputResolvers().has("image")).toBe(true);
+    });
   });
 });

--- a/scripts/eslintRestrictedImports.test.ts
+++ b/scripts/eslintRestrictedImports.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { ESLint } from "eslint";
+import { readdirSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { ROOT } from "./lib/testDiscovery";
 
@@ -24,12 +25,41 @@ const RUN_FN_PATH = "providers/openai/src/ai/common/Fixture_JobRunFns.ts";
 /** The same directory, so only the `_JobRunFns` suffix differs. */
 const ORDINARY_PATH = "providers/openai/src/ai/common/Fixture.ts";
 
-async function restrictedImportMessages(code: string, filePath: string): Promise<string[]> {
+/**
+ * A run-fn that actually exists, DISCOVERED from disk rather than written down.
+ *
+ * The synthetic path above only has to MATCH the config globs, which is exactly
+ * how this guard came to be dead: it matched a glob whose rule a later config
+ * object had turned off. Linting a real file makes the fixture follow the
+ * repo's layout instead of restating a belief about it.
+ */
+const REAL_RUN_FN = findRealRunFn();
+
+function findRealRunFn(): string | undefined {
+  for (const provider of readdirSync(`${ROOT}/providers`).sort()) {
+    const dir = `providers/${provider}/src/ai/common`;
+    let entries: string[];
+    try {
+      entries = readdirSync(`${ROOT}/${dir}`).sort();
+    } catch {
+      continue;
+    }
+    const runFn = entries.find((name) => name.endsWith("_JobRunFns.ts"));
+    if (runFn) return `${dir}/${runFn}`;
+  }
+  return undefined;
+}
+
+async function messagesForRule(code: string, filePath: string, ruleId: string): Promise<string[]> {
   const eslint = new ESLint({ cwd: ROOT });
   const [result] = await eslint.lintText(code, { filePath: `${ROOT}/${filePath}` });
   return (result?.messages ?? [])
-    .filter((message) => message.ruleId === "no-restricted-imports")
+    .filter((message) => message.ruleId === ruleId)
     .map((message) => message.message);
+}
+
+async function restrictedImportMessages(code: string, filePath: string): Promise<string[]> {
+  return messagesForRule(code, filePath, "no-restricted-imports");
 }
 
 describe("run-fn restricted imports", () => {
@@ -80,5 +110,88 @@ describe("run-fn restricted imports", () => {
       RUN_FN_PATH
     );
     expect(messages).toEqual([]);
+  });
+
+  it("still allows registerAllDefaults from @workglow/bootstrap", async () => {
+    // The bootstrap entries are name-scoped, not wholesale: only
+    // `bootstrapWorkglow` reaches the global registry. Re-broadening them fails
+    // here rather than silently banning the legitimate calls.
+    const messages = await restrictedImportMessages(
+      `import { registerAllDefaults } from "@workglow/bootstrap";\nvoid registerAllDefaults;\n`,
+      RUN_FN_PATH
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("blocks bootstrapWorkglow from the workglow root barrel", async () => {
+    // `packages/workglow/src/common.ts` re-exports `./bootstrap`, so the banned
+    // import is one specifier away through the meta-package's root entry.
+    const messages = await restrictedImportMessages(
+      `import { bootstrapWorkglow } from "workglow";\nbootstrapWorkglow();\n`,
+      RUN_FN_PATH
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it("blocks globalServiceRegistry from the workglow root barrel", async () => {
+    // The same barrel re-exports `@workglow/util`, so the pre-existing
+    // main-thread-state surface is reachable there too.
+    const messages = await restrictedImportMessages(
+      `import { globalServiceRegistry } from "workglow";\nvoid globalServiceRegistry;\n`,
+      RUN_FN_PATH
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("Main-thread-only state");
+  });
+
+  it("leaves an unrelated workglow import alone", async () => {
+    const messages = await restrictedImportMessages(
+      `import { Workflow } from "workglow";\nvoid Workflow;\n`,
+      RUN_FN_PATH
+    );
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("run-fn and provider restrictions coexist", () => {
+  it("finds at least one real run-fn to lint", () => {
+    expect(REAL_RUN_FN).toBeDefined();
+  });
+
+  it("blocks @workglow/bootstrap from a REAL run-fn file", async () => {
+    // The case the synthetic path could not catch. Every run-fn on disk lives
+    // under `providers/*/src/ai/common/`, whose config object turns the base
+    // rule off — so this only passes while the run-fn block stays last.
+    const messages = await restrictedImportMessages(
+      `import { bootstrapWorkglow } from "@workglow/bootstrap";\nbootstrapWorkglow();\n`,
+      REAL_RUN_FN!
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it("the effort-helper restriction still fires in the same file", async () => {
+    // The ordering guard. It proves the reorder did not clobber the provider
+    // block, AND that the run-fn path genuinely sits inside that block's zone —
+    // so the case above cannot be passing because the globs stopped overlapping.
+    const messages = await messagesForRule(
+      `import { MODEL_EFFORTS } from "@workglow/ai";\nvoid MODEL_EFFORTS;\n`,
+      RUN_FN_PATH,
+      "@typescript-eslint/no-restricted-imports"
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it("neither rule reports the same import twice", async () => {
+    // The two rules restrict disjoint specifiers, which is what makes it safe
+    // to have both active on the same file.
+    const code = `import { bootstrapWorkglow } from "@workglow/bootstrap";\nbootstrapWorkglow();\n`;
+    const extensionMessages = await messagesForRule(
+      code,
+      RUN_FN_PATH,
+      "@typescript-eslint/no-restricted-imports"
+    );
+    const baseMessages = await restrictedImportMessages(code, RUN_FN_PATH);
+    expect(extensionMessages).toEqual([]);
+    expect(baseMessages).toHaveLength(1);
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,10 +7,12 @@
 import "./scripts/configure-hft-test-cache";
 import "./scripts/lib/preload-credentials";
 
-// Workglow no longer self-registers defaults at import time. Tests rely on
-// the global registry being populated, so bootstrap once here. Imported by
-// source path rather than as `@workglow/bootstrap`: the isolated linker keeps
-// workspace packages out of the repo root's node_modules.
+// Each registrar self-registers on ITS OWN bundle's global registry at import
+// time, so what ends up populated depends on which modules the import graph
+// pulled in. Tests rely on the full set being present on the main registry, so
+// bootstrap once here. Imported by source path rather than as
+// `@workglow/bootstrap`: the isolated linker keeps workspace packages out of
+// the repo root's node_modules.
 //
 // `bootstrapWorkglow()` rather than `registerAllDefaults(globalServiceRegistry)`
 // because `globalServiceRegistry` is likewise unresolvable from this file: a


### PR DESCRIPTION
Stacked on #672 (`claude/libs-issues-triage-prs-mh6x2o-574`) so the diff here is just the review fixes. Merge into that branch.

## What this fixes

### 1. The run-fn import guard governed zero real files

`eslint.config.js` gained a `**/*_JobRunFns.ts` block banning `@workglow/bootstrap` from worker code — but every run-fn in the repo lives under `providers/*/src/ai/common/`, and that block sets `"no-restricted-imports": "off"` (correctly: its typescript-eslint extension replaces the base rule, and running both double-reports). In flat config a later object's entry for a rule replaces the earlier one wholesale, so with the run-fn block placed first the guard matched nothing. `eslint providers/openai/src/ai/common/OpenAI_JobRunFns.ts` reported nothing, and three of the five cases in `scripts/eslintRestrictedImports.test.ts` asserted a rule that was never running.

Fix is a reorder, not a deletion of the `off`: the run-fn block moves **last**, so the provider block keeps its `off` for the 313 non-run-fn files it governs and the base rule is re-enabled only on the 15 files the guard is about. The two rules restrict disjoint specifiers, so nothing double-reports.

While the entries were being touched:

- the two duplicated messages hoist to module scope;
- the two bootstrap entries narrow from wholesale to `importNames: ["bootstrapWorkglow"]` — `createOrchestrationContext` builds a fresh container and `registerAllDefaults(registry)` mutates only what it is handed, so banning them was wrong;
- a `workglow` root-barrel entry is added, since `packages/workglow/src/common.ts` re-exports both `./bootstrap` and `@workglow/util`, leaving every restricted name one specifier away.

The test now also lints a **real** run-fn discovered from disk. The synthetic path only had to match the config globs, which is exactly how the guard came to be dead. A coexistence case pins that the provider block's effort-helper restriction still fires in the same file, so the bootstrap case cannot pass by the globs having stopped overlapping.

### 2. Version skew: the new package was at 0.3.39, the family at 0.3.45

`WorkspaceVersions.test.ts` requires one version across the workspace and saw two. The practical cost is the release flow — `bunset --patch --all` bumps every manifest from its own current value, so the family would have published 0.3.46 alongside a bootstrap 0.3.40 and stayed permanently skewed. The changelog is also retitled `# Changelog` → `# @workglow/bootstrap` to match every sibling, with the initial-release entry moved under `## 0.3.45`, body unchanged. `bun.lock` regenerated by `bun install`; the delta is the one recorded version.

### 3. Replacing `bootstrapTestRegistry` changed harness behavior, and nothing recorded it

The removed helper called each registrar with **no argument**, so `registerImageDefaults()` defaulted to the `@workglow/util/media` bundle's own `globalServiceRegistry` — a genuinely different module instance under dist resolution, since `./media` builds as its own bundle with `--packages=external` and reaches `di/ServiceRegistry.ts` through a *relative* import. The `image` resolver landed in a map nothing read. `bootstrapWorkglow()` passes `@workglow/util`'s registry explicitly and `ServiceRegistry` keys the container by `token.id`, so the cross-bundle call now lands in the shared map.

The behavior is kept — it is the correct one — but it is now documented and pinned. The changelog records the visible consequence (a `format: "image"` port fed a plain string id now throws instead of passing the string through; object-valued image ports are unaffected, since `InputResolver` invokes a resolver only for a string value or string array elements). A new describe block asserts the property that makes the cross-bundle call work at all: the token is keyed by a stable string id, `registerImageDefaults` from `@workglow/util/media` reaches a registry built from `@workglow/util`, `registerAllDefaults` installs that same function, and the process-wide map the task input resolver actually consults has the entry. Rename that token id in one bundle and the two silently become two maps with no error anywhere.

Under `bun run use-source` both entries resolve to the same module and the property is vacuously true, which is why it is pinned by **id** rather than by comparing module instances — the dist-mode run is the one that exercises the split bundle.

### 4. Doc claims that did not match the code

- `registerAllDefaults`'s doc comment and the README both said "nine of the fourteen" registrars install an input resolver and compactor. **Seven** do (`credential`, `image`, `knowledge-base`, `mcp-server`, `model`, `storage:tabular`, `tasks`), and only **six** of those install a compactor too — `image` hydrates a data URI it cannot compact back to an id. `RegisterAllDefaults.test.ts` already pins both prefix sets exactly, so the prose was contradicting a green test. Its own ordering doc carried the same "nine consumers"; corrected there too.
- `vitest.setup.ts` said "Workglow no longer self-registers defaults at import time". It does — all fourteen `register*Defaults` modules end in a no-argument self-registering call. What changed is *which registry* those calls land on. That is the actual reason the harness bootstraps explicitly, and the same property the new cross-bundle test pins.

## Verification

Run from the worktree root, dist-mode (not `use-source`), real results.

| Command | Result |
| --- | --- |
| `bun run build:types` | ✅ **42 successful, 42 total**, 0 cached |
| `bun scripts/test.ts util vitest` | ✅ 57 files, **782 passed / 10 skipped** |
| `bun scripts/test.ts scripts vitest` | ✅ 3 files, **23 passed** (13 of them `eslintRestrictedImports.test.ts`) |
| `bun scripts/test.ts task graph mcp vitest` | ✅ 125 files, **1643 passed / 24 skipped** |
| `bun scripts/test.ts task-graph ai vitest` | ✅ 153 files, **1379 passed** |
| `bunx eslint "providers/*/src/ai/common/*_JobRunFns.ts" --max-warnings 0` | ✅ exit 0 — no real run-fn violates the newly-live guard |
| `bunx eslint providers packages/bootstrap --max-warnings 0` | ✅ exit 0 |
| `bunx prettier --check` on all 9 touched files | ✅ "All matched files use Prettier code style!" |

`task-graph` and `ai` were run specifically because they hold the other `format: "image"` tests (`CacheSerialization`, `TaskGraphRunner.previewSource`, `AiVisionTask`); `util` covers `GpuImage.test.ts`. Every suite passed, so no pristine-baseline comparison was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT)_