### PR TITLE
fix(tasks): harden FileSedTask — bounded substitution, path containment, entitlements, output caps

### DIFF
--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -21,6 +21,7 @@ import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexMatcher } from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
 import { compileSafeRegex } from "../util/regexSafety";
+import { linesFromStream } from "../util/StreamLines.server";
 import type {
   FileGrepTaskConfig,
   FileGrepTaskInput,
@@ -195,60 +196,6 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
     await context.updateProgress(100, "Search complete");
 
     return result;
-  }
-}
-
-/**
- * Splits a byte stream into lines with a hard per-line cap.
- *
- * `readline.createInterface` accumulates an unterminated line without bound: a
- * 640 MB newline-free stream threw `RangeError: Invalid string length` from a
- * stream `'data'` listener, which surfaces as an `uncaughtException` rather
- * than an iterator rejection — so the caller's try/catch could not see it and
- * the process died.
- *
- * A line reaching `maxLineChars` with no terminator yields its first
- * `maxLineChars` characters, and the rest of that physical line is discarded up
- * to the next `\n`. `setEncoding` puts a `StringDecoder` in front, so a
- * multi-byte character split across two reads is not corrupted.
- */
-async function* linesFromStream(
-  stream: NodeJS.ReadableStream,
-  maxLineChars: number
-): AsyncGenerator<string> {
-  stream.setEncoding("utf8");
-
-  let pending = "";
-  let skipping = false;
-
-  const stripCr = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line);
-
-  for await (const chunk of stream as AsyncIterable<string>) {
-    pending += chunk;
-
-    let newline = pending.indexOf("\n");
-    while (newline !== -1) {
-      const line = pending.slice(0, newline);
-      pending = pending.slice(newline + 1);
-      if (skipping) {
-        skipping = false;
-      } else {
-        yield stripCr(line);
-      }
-      newline = pending.indexOf("\n");
-    }
-
-    if (!skipping && pending.length >= maxLineChars) {
-      yield pending.slice(0, maxLineChars);
-      pending = "";
-      skipping = true;
-    } else if (skipping) {
-      pending = "";
-    }
-  }
-
-  if (!skipping && pending.length > 0) {
-    yield stripCr(pending);
   }
 }
 

--- a/packages/tasks/src/task/FileSedTask.server.ts
+++ b/packages/tasks/src/task/FileSedTask.server.ts
@@ -4,14 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph";
+import type { IExecuteContext, TaskEntitlements } from "@workglow/task-graph";
+import {
+  CreateWorkflow,
+  Entitlements,
+  mergeEntitlements,
+  TaskAbortedError,
+  TaskConfigSchema,
+  Workflow,
+} from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 
 import { SECURITY_LIMITS } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexReplacer } from "../util/BoundedRegex.server";
+import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
 import type {
+  FileSedTaskConfig,
   FileSedTaskInput,
   FileSedTaskOutput,
   SedLineSubstituter,
@@ -24,18 +34,53 @@ import {
   sedLines,
 } from "./FileSedTask";
 
-export type { FileSedTaskInput, FileSedTaskOutput };
+export type { FileSedTaskConfig, FileSedTaskInput, FileSedTaskOutput };
+
+const fileSedTaskConfigSchema = {
+  type: "object",
+  properties: {
+    ...TaskConfigSchema["properties"],
+    roots: {
+      type: "array",
+      items: { type: "string" },
+      title: "Roots",
+      description: "Directories a local path must resolve inside (after symlink resolution)",
+      "x-ui-hidden": true,
+    },
+  },
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
 
 /**
- * Server-only task for substituting text in files on the filesystem.
- * Streams the file line-by-line rather than loading it into memory.
- * Only available in Node.js and Bun environments.
+ * Server-only task for substituting text in files on the filesystem, on top of
+ * the base task's http(s) handling.
  *
- * The file on disk is never modified — there is no in-place (`sed -i`) mode.
+ * The file is streamed line-by-line rather than loaded into memory, and the
+ * file on disk is never modified — there is no in-place (`sed -i`) mode.
  *
- * For cross-platform substitution (including browser), use FileSedTask with URLs.
+ * A local path is resolved and realpath'd before it is opened, and constrained
+ * to `config.roots` when the embedder sets them. Reading requires the
+ * `filesystem:read` entitlement.
+ *
+ * Only available in Node.js and Bun environments. For cross-platform
+ * substitution (including browser), use FileSedTask with an http(s) URL.
  */
-export class FileSedTask extends BaseFileSedTask {
+export class FileSedTask extends BaseFileSedTask<FileSedTaskConfig> {
+  public static override configSchema(): DataPortSchema {
+    return fileSedTaskConfigSchema as DataPortSchema;
+  }
+
+  public static override entitlements(): TaskEntitlements {
+    return mergeEntitlements(super.entitlements(), {
+      entitlements: [
+        {
+          id: Entitlements.FILESYSTEM_READ,
+          reason: "Reads a local file or file:// URL from disk",
+        },
+      ],
+    });
+  }
+
   /**
    * Runs the substitution inside a `vm` context under a wall-clock budget, so
    * a catastrophically backtracking pattern fails instead of wedging the event
@@ -67,9 +112,9 @@ export class FileSedTask extends BaseFileSedTask {
     input: FileSedTaskInput,
     context: IExecuteContext
   ): Promise<FileSedTaskOutput> {
-    let { url, pattern, replacement, ...options } = input;
+    const { url, pattern, replacement, ...options } = input;
 
-    if (url.startsWith("http://") || url.startsWith("https://")) {
+    if (isHttpUrl(url)) {
       return super.execute(input, context);
     }
 
@@ -78,9 +123,7 @@ export class FileSedTask extends BaseFileSedTask {
     }
     await context.updateProgress(0, "Opening file");
 
-    if (url.startsWith("file://")) {
-      url = url.slice(7);
-    }
+    const file = resolveLocalFilePath(url, { roots: this.config.roots });
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
@@ -88,7 +131,7 @@ export class FileSedTask extends BaseFileSedTask {
     await context.updateProgress(10, "Substituting text");
 
     const result = await sedFile(
-      url,
+      file,
       pattern,
       replacement,
       options,
@@ -132,13 +175,13 @@ async function sedFile(
   }
 }
 
-export const fileSed = (input: FileSedTaskInput, config?: TaskConfig) => {
+export const fileSed = (input: FileSedTaskInput, config?: FileSedTaskConfig) => {
   return new FileSedTask(config).run(input);
 };
 
 declare module "@workglow/task-graph" {
   interface Workflow {
-    fileSed: CreateWorkflow<FileSedTaskInput, FileSedTaskOutput, TaskConfig>;
+    fileSed: CreateWorkflow<FileSedTaskInput, FileSedTaskOutput, FileSedTaskConfig>;
   }
 }
 

--- a/packages/tasks/src/task/FileSedTask.server.ts
+++ b/packages/tasks/src/task/FileSedTask.server.ts
@@ -11,6 +11,7 @@ import {
   mergeEntitlements,
   TaskAbortedError,
   TaskConfigSchema,
+  TaskEntitlementError,
   Workflow,
 } from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
@@ -82,6 +83,66 @@ export class FileSedTask extends BaseFileSedTask<FileSedTaskConfig> {
   }
 
   /**
+   * Declares whichever half of the surface this url actually uses: the fetch
+   * entitlements for http(s), otherwise `filesystem:read` scoped to the
+   * resolved real path. An unknown url fails closed to both, unscoped.
+   *
+   * Never throws — entitlement evaluation runs before `execute()` and must
+   * produce a declaration for any input, so an unresolvable path degrades to
+   * the unscoped declaration and is refused later, at open time.
+   */
+  public override entitlements(): TaskEntitlements {
+    const url = this.runInputData?.url;
+    const unscopedRead: TaskEntitlements = {
+      entitlements: [{ id: Entitlements.FILESYSTEM_READ, reason: "Reads a local file from disk" }],
+    };
+
+    if (typeof url !== "string" || url.length === 0) {
+      return mergeEntitlements(super.entitlements(), unscopedRead);
+    }
+
+    if (isHttpUrl(url)) {
+      return super.entitlements();
+    }
+
+    try {
+      return {
+        entitlements: [
+          {
+            id: Entitlements.FILESYSTEM_READ,
+            reason: "Reads a local file from disk",
+            resources: [resolveLocalFilePath(url, { roots: this.config.roots })],
+          },
+        ],
+      };
+    } catch {
+      return unscopedRead;
+    }
+  }
+
+  /**
+   * Refuses a path the instance did not declare. Entitlements are evaluated
+   * on the unresolved input, so without this a declare-then-swap would let the
+   * open authorize itself — and a standalone `fileSed(...)` with no graph and
+   * no enforcer would honour no `roots` at all.
+   */
+  private assertResolvedPathDeclared(file: string): void {
+    const declared = this.entitlements().entitlements.find(
+      (entitlement) => entitlement.id === Entitlements.FILESYSTEM_READ
+    );
+    if (declared?.resources === undefined) {
+      throw new TaskEntitlementError(
+        `Refusing to read ${file}: the path could not be resolved when entitlements were declared`
+      );
+    }
+    if (!declared.resources.includes(file)) {
+      throw new TaskEntitlementError(
+        `Refusing to read ${file}: it differs from the declared path ${declared.resources.join(", ")}`
+      );
+    }
+  }
+
+  /**
    * Runs the substitution inside a `vm` context under a wall-clock budget, so
    * a catastrophically backtracking pattern fails instead of wedging the event
    * loop. Overriding here covers both branches: the http branch reaches
@@ -124,6 +185,7 @@ export class FileSedTask extends BaseFileSedTask<FileSedTaskConfig> {
     await context.updateProgress(0, "Opening file");
 
     const file = resolveLocalFilePath(url, { roots: this.config.roots });
+    this.assertResolvedPathDeclared(file);
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");

--- a/packages/tasks/src/task/FileSedTask.server.ts
+++ b/packages/tasks/src/task/FileSedTask.server.ts
@@ -9,8 +9,20 @@ import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 
-import type { FileSedTaskInput, FileSedTaskOutput } from "./FileSedTask";
-import { FileSedTask as BaseFileSedTask, sedLines } from "./FileSedTask";
+import { SECURITY_LIMITS } from "@workglow/util";
+import { createBoundedRegexReplacer } from "../util/BoundedRegex.server";
+import type {
+  FileSedTaskInput,
+  FileSedTaskOutput,
+  SedLineSubstituter,
+  SedOptions,
+} from "./FileSedTask";
+import {
+  FileSedTask as BaseFileSedTask,
+  createSedExpander,
+  createSedRegex,
+  sedLines,
+} from "./FileSedTask";
 
 export type { FileSedTaskInput, FileSedTaskOutput };
 
@@ -24,6 +36,33 @@ export type { FileSedTaskInput, FileSedTaskOutput };
  * For cross-platform substitution (including browser), use FileSedTask with URLs.
  */
 export class FileSedTask extends BaseFileSedTask {
+  /**
+   * Runs the substitution inside a `vm` context under a wall-clock budget, so
+   * a catastrophically backtracking pattern fails instead of wedging the event
+   * loop. Overriding here covers both branches: the http branch reaches
+   * `super.execute`, which uses the substituter this returns.
+   *
+   * `fixedString` never enters `vm` — an escaped literal cannot backtrack, and
+   * the `vm` hop would cost ~4x for nothing.
+   */
+  protected override createSubstituter(
+    pattern: string,
+    replacement: string,
+    options: SedOptions
+  ): SedLineSubstituter {
+    if (options.fixedString) {
+      return super.createSubstituter(pattern, replacement, options);
+    }
+
+    const regex = createSedRegex(pattern, options);
+    const substituteBatch = createBoundedRegexReplacer(
+      regex,
+      createSedExpander(replacement, options),
+      SECURITY_LIMITS.regexMatchBatchTimeoutMs
+    );
+    return { substituteBatch };
+  }
+
   override async execute(
     input: FileSedTaskInput,
     context: IExecuteContext
@@ -48,7 +87,14 @@ export class FileSedTask extends BaseFileSedTask {
     }
     await context.updateProgress(10, "Substituting text");
 
-    const result = await sedFile(url, pattern, replacement, options, context.signal);
+    const result = await sedFile(
+      url,
+      pattern,
+      replacement,
+      options,
+      context.signal,
+      this.createSubstituter(pattern, replacement, options)
+    );
 
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
@@ -63,8 +109,9 @@ async function sedFile(
   file: string,
   pattern: string,
   replacement: string,
-  options: Omit<FileSedTaskInput, "url" | "pattern" | "replacement">,
-  signal: AbortSignal
+  options: SedOptions,
+  signal: AbortSignal,
+  substituter: SedLineSubstituter
 ): Promise<FileSedTaskOutput> {
   const input = createReadStream(file, { signal });
   const rl = createInterface({
@@ -73,7 +120,7 @@ async function sedFile(
   });
 
   try {
-    return await sedLines(rl, pattern, replacement, options, signal);
+    return await sedLines(rl, pattern, replacement, options, signal, substituter);
   } catch (err) {
     if (signal.aborted) {
       throw new TaskAbortedError("Task aborted");

--- a/packages/tasks/src/task/FileSedTask.server.ts
+++ b/packages/tasks/src/task/FileSedTask.server.ts
@@ -15,12 +15,12 @@ import {
   Workflow,
 } from "@workglow/task-graph";
 import { createReadStream } from "node:fs";
-import { createInterface } from "node:readline";
 
-import { SECURITY_LIMITS } from "@workglow/util";
+import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { createBoundedRegexReplacer } from "../util/BoundedRegex.server";
 import { isHttpUrl, resolveLocalFilePath } from "../util/LocalFilePath.server";
+import { linesFromStream } from "../util/StreamLines.server";
 import type {
   FileSedTaskConfig,
   FileSedTaskInput,
@@ -56,8 +56,11 @@ const fileSedTaskConfigSchema = {
  * Server-only task for substituting text in files on the filesystem, on top of
  * the base task's http(s) handling.
  *
- * The file is streamed line-by-line rather than loaded into memory, and the
- * file on disk is never modified — there is no in-place (`sed -i`) mode.
+ * The file is streamed line-by-line rather than loaded into memory, and split
+ * into lines with a hard per-line cap ({@link DEFAULT_LIMITS.grepMaxLineChars})
+ * — a longer physical line is truncated to that length and the remainder
+ * discarded, so a file with no line terminator cannot exhaust memory. The file
+ * on disk is never modified — there is no in-place (`sed -i`) mode.
  *
  * A local path is resolved and realpath'd before it is opened, and constrained
  * to `config.roots` when the embedder sets them. Reading requires the
@@ -219,20 +222,22 @@ async function sedFile(
   substituter: SedLineSubstituter
 ): Promise<FileSedTaskOutput> {
   const input = createReadStream(file, { signal });
-  const rl = createInterface({
-    input,
-    crlfDelay: Infinity,
-  });
 
   try {
-    return await sedLines(rl, pattern, replacement, options, signal, substituter);
+    return await sedLines(
+      linesFromStream(input, DEFAULT_LIMITS.grepMaxLineChars),
+      pattern,
+      replacement,
+      options,
+      signal,
+      substituter
+    );
   } catch (err) {
     if (signal.aborted) {
       throw new TaskAbortedError("Task aborted");
     }
     throw err;
   } finally {
-    rl.close();
     input.destroy();
   }
 }

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -104,7 +104,8 @@ const outputSchema = {
     truncated: {
       type: "boolean",
       title: "Truncated",
-      description: "Output stopped before EOF because of an output limit",
+      description:
+        "Output stopped before EOF because an output cap was reached or an input line was capped",
     },
   },
   required: ["text", "replacementCount", "linesChanged", "truncated"],
@@ -431,9 +432,10 @@ export async function sedLines(
 }
 
 /**
- * Task for substituting text in documents from URLs (including file:// URLs).
+ * Task for substituting text in documents fetched from URLs.
  * Works in all environments (browser, Node.js, Bun) by using fetch API.
- * For server-only filesystem path access, see FileSedTask.server.
+ * `file://` filesystem access is implemented in the server build only; see
+ * FileSedTask.server.
  *
  * The source is never modified: the transformed document is returned as output.
  */

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -12,7 +12,7 @@ import {
   TaskInvalidInputError,
   Workflow,
 } from "@workglow/task-graph";
-import { SECURITY_LIMITS } from "@workglow/util";
+import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
@@ -341,8 +341,10 @@ export async function sedLines(
   let outputChars = 0;
 
   const iterator = lines[Symbol.asyncIterator]();
+  const maxLineChars = DEFAULT_LIMITS.grepMaxLineChars;
   const batch: string[] = [];
   let exhausted = false;
+  let lineCapped = false;
 
   try {
     outer: while (!exhausted) {
@@ -353,7 +355,15 @@ export async function sedLines(
           exhausted = true;
           break;
         }
-        batch.push(next.value);
+        // `>=` rather than `>`: conservative by one character, and it lets the
+        // server's line splitter signal truncation without a side channel.
+        const text = next.value;
+        if (text.length >= maxLineChars) {
+          lineCapped = true;
+          batch.push(text.slice(0, maxLineChars));
+        } else {
+          batch.push(text);
+        }
       }
 
       if (batch.length === 0) break;
@@ -407,7 +417,10 @@ export async function sedLines(
     text: out.length === 0 ? "" : `${out.join("\n")}\n`,
     replacementCount,
     linesChanged,
-    truncated,
+    // A capped line means the emitted document is missing part of the source,
+    // which is what `truncated` is for — an output cap is not the only way to
+    // stop short of the whole document.
+    truncated: truncated || lineCapped,
   };
 }
 

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
+import type { IExecuteContext, TaskConfig, TaskEntitlements } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   Task,
@@ -16,7 +16,7 @@ import { SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
-import { FetchUrlTask } from "./FetchUrlTask";
+import { fetchUrlEntitlementsFor, FetchUrlTask } from "./FetchUrlTask";
 
 const inputSchema = {
   type: "object",
@@ -428,6 +428,21 @@ export class FileSedTask<Config extends TaskConfig = TaskConfig> extends Task<
   public static override title = "File Sed";
   public static override description = "Substitute matching text in a file (sed)";
   public static override cacheable = true;
+  public static override hasDynamicEntitlements: boolean = true;
+
+  /**
+   * The owned `FetchUrlTask` does the network access, but an owned child is
+   * created inside `execute()` and so is absent from the graph-start snapshot
+   * `computeGraphEntitlements` takes over `graph.getTasks()`. Declaring the
+   * fetch's entitlements here is what puts them in front of the enforcer.
+   */
+  public static override entitlements(): TaskEntitlements {
+    return FetchUrlTask.entitlements();
+  }
+
+  public override entitlements(): TaskEntitlements {
+    return fetchUrlEntitlementsFor(this.runInputData?.url);
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -12,8 +12,9 @@ import {
   TaskInvalidInputError,
   Workflow,
 } from "@workglow/task-graph";
+import { SECURITY_LIMITS } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-import { assertSafeRegexPattern, escapeRegExp } from "../util/regexSafety";
+import { compileSafeRegex, escapeRegExp } from "../util/regexSafety";
 import { linesFromText } from "../util/textLines";
 import { FetchUrlTask } from "./FetchUrlTask";
 
@@ -111,11 +112,24 @@ const outputSchema = {
 export type FileSedTaskInput = FromSchema<typeof inputSchema>;
 export type FileSedTaskOutput = FromSchema<typeof outputSchema>;
 
-type SedOptions = Omit<FileSedTaskInput, "url" | "pattern" | "replacement">;
+export type SedOptions = Omit<FileSedTaskInput, "url" | "pattern" | "replacement">;
 
-interface LineSubstitution {
-  readonly text: string;
-  readonly replacements: number;
+/** One batch of substituted lines, positionally aligned with the input. */
+export interface SedBatchResult {
+  readonly texts: readonly string[];
+  readonly counts: readonly number[];
+}
+
+/**
+ * Substitutes over a batch of lines at once. Batching is what makes an
+ * interruptible substituter affordable — see `createBoundedRegexReplacer` on
+ * the server build, whose per-call cost only amortizes over a batch.
+ *
+ * `budget` is how many replacements the whole run may still make, so a global
+ * substitution can be cut mid-line and the rest of the document copied verbatim.
+ */
+export interface SedLineSubstituter {
+  readonly substituteBatch: (texts: readonly string[], budget: number) => SedBatchResult;
 }
 
 function validateOptions(options: SedOptions): void {
@@ -136,40 +150,41 @@ function validateOptions(options: SedOptions): void {
   }
 }
 
-/**
- * Builds the per-line substitution. `budget` caps how many replacements the
- * whole run may still make, so a global substitution can be cut mid-line and
- * the rest of the document copied verbatim.
- */
-function createSubstituter(
-  pattern: string,
-  replacement: string,
-  options: SedOptions
-): (text: string, budget: number) => LineSubstitution {
+/** Compiles the substitution pattern, screening it for ReDoS shapes first. */
+export function createSedRegex(pattern: string, options: SedOptions): RegExp {
   const flags = `${options.global ? "g" : ""}${options.ignoreCase ? "i" : ""}`;
-
-  let regex: RegExp;
 
   if (options.fixedString) {
     if (pattern.length === 0) {
       throw new TaskInvalidInputError("pattern must not be empty when fixedString is set");
     }
-    regex = new RegExp(escapeRegExp(pattern), flags);
-  } else {
-    assertSafeRegexPattern(pattern);
-    try {
-      regex = new RegExp(pattern, flags);
-    } catch {
-      throw new TaskInvalidInputError(`Invalid regular expression: ${pattern}`);
-    }
+    return new RegExp(escapeRegExp(pattern), flags);
   }
 
-  // A literal replacement must not be re-read for `$1` / `$&` expansion.
-  const substitute: (args: unknown[]) => string = options.fixedString
-    ? () => replacement
-    : (args) => expandReplacement(replacement, args);
+  return compileSafeRegex(pattern, flags);
+}
 
-  return (text, budget) => {
+/**
+ * The expansion `String.replace` would do itself if it were handed a string.
+ * A literal replacement must not be re-read for `$1` / `$&` expansion.
+ */
+export function createSedExpander(
+  replacement: string,
+  options: SedOptions
+): (args: unknown[]) => string {
+  return options.fixedString ? () => replacement : (args) => expandReplacement(replacement, args);
+}
+
+/** Unbounded substituter; the server build overrides it with a bounded one. */
+export function createSubstituter(
+  pattern: string,
+  replacement: string,
+  options: SedOptions
+): SedLineSubstituter {
+  const regex = createSedRegex(pattern, options);
+  const substitute = createSedExpander(replacement, options);
+
+  const substituteLine = (text: string, budget: number): [string, number] => {
     let replacements = 0;
 
     const result = text.replace(regex, (...args: unknown[]): string => {
@@ -180,7 +195,30 @@ function createSubstituter(
       return substitute(args);
     });
 
-    return { text: result, replacements };
+    return [result, replacements];
+  };
+
+  return {
+    substituteBatch: (lines, budget) => {
+      const texts: string[] = [];
+      const counts: number[] = [];
+
+      let remaining = budget;
+
+      for (const line of lines) {
+        if (remaining <= 0) {
+          texts.push(line);
+          counts.push(0);
+          continue;
+        }
+        const [text, replacements] = substituteLine(line, remaining);
+        texts.push(text);
+        counts.push(replacements);
+        remaining -= replacements;
+      }
+
+      return { texts, counts };
+    },
   };
 }
 
@@ -188,7 +226,7 @@ function createSubstituter(
  * `String.replace` only expands `$n` when handed a string, and a callback is
  * what bounds the substitution count — so the expansion is done here instead.
  */
-function expandReplacement(replacement: string, args: unknown[]): string {
+export function expandReplacement(replacement: string, args: unknown[]): string {
   if (!replacement.includes("$")) {
     return replacement;
   }
@@ -272,16 +310,25 @@ function expandReplacement(replacement: string, args: unknown[]): string {
   return out;
 }
 
+/**
+ * Substitutes over `lines` in batches of {@link SECURITY_LIMITS.regexMatchBatchLines}.
+ *
+ * Abort is checked once per BATCH, not per line: a single `String.replace` is
+ * uninterruptible, so a per-line check bought nothing a hostile pattern could
+ * not ignore. The granularity that matters is therefore the batch, and the
+ * substituter itself bounds how long one batch may run.
+ */
 export async function sedLines(
   lines: AsyncIterable<string>,
   pattern: string,
   replacement: string,
   options: SedOptions = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  substituter?: SedLineSubstituter | undefined
 ): Promise<FileSedTaskOutput> {
   validateOptions(options);
 
-  const substituter = createSubstituter(pattern, replacement, options);
+  const lineSubstituter = substituter ?? createSubstituter(pattern, replacement, options);
 
   const out: string[] = [];
 
@@ -292,43 +339,67 @@ export async function sedLines(
   let outputLines = 0;
   let outputChars = 0;
 
-  for await (const text of lines) {
-    if (signal?.aborted) {
-      throw new TaskAbortedError("Task aborted");
+  const iterator = lines[Symbol.asyncIterator]();
+  const batch: string[] = [];
+  let exhausted = false;
+
+  try {
+    outer: while (!exhausted) {
+      batch.length = 0;
+      while (batch.length < SECURITY_LIMITS.regexMatchBatchLines) {
+        const next = await iterator.next();
+        if (next.done === true) {
+          exhausted = true;
+          break;
+        }
+        batch.push(next.value);
+      }
+
+      if (batch.length === 0) break;
+
+      if (signal?.aborted) {
+        throw new TaskAbortedError("Task aborted");
+      }
+
+      const budget =
+        options.maxReplacements === undefined
+          ? Number.POSITIVE_INFINITY
+          : options.maxReplacements - replacementCount;
+
+      const { texts, counts } = lineSubstituter.substituteBatch(batch, budget);
+
+      for (let i = 0; i < batch.length; i++) {
+        const replaced = texts[i]!;
+        const replacements = counts[i]!;
+
+        replacementCount += replacements;
+        if (replacements > 0) {
+          linesChanged++;
+        }
+
+        if (options.onlyChangedLines && replacements === 0) {
+          continue;
+        }
+
+        if (options.maxOutputLines !== undefined && outputLines >= options.maxOutputLines) {
+          truncated = true;
+          break outer;
+        }
+
+        const chars = replaced.length + 1;
+
+        if (options.maxOutputChars !== undefined && outputChars + chars > options.maxOutputChars) {
+          truncated = true;
+          break outer;
+        }
+
+        out.push(replaced);
+        outputLines++;
+        outputChars += chars;
+      }
     }
-
-    const budget =
-      options.maxReplacements === undefined
-        ? Number.POSITIVE_INFINITY
-        : options.maxReplacements - replacementCount;
-
-    const { text: replaced, replacements } =
-      budget > 0 ? substituter(text, budget) : { text, replacements: 0 };
-
-    replacementCount += replacements;
-    if (replacements > 0) {
-      linesChanged++;
-    }
-
-    if (options.onlyChangedLines && replacements === 0) {
-      continue;
-    }
-
-    if (options.maxOutputLines !== undefined && outputLines >= options.maxOutputLines) {
-      truncated = true;
-      break;
-    }
-
-    const chars = replaced.length + 1;
-
-    if (options.maxOutputChars !== undefined && outputChars + chars > options.maxOutputChars) {
-      truncated = true;
-      break;
-    }
-
-    out.push(replaced);
-    outputLines++;
-    outputChars += chars;
+  } finally {
+    await iterator.return?.();
   }
 
   return {
@@ -361,6 +432,20 @@ export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskC
     return outputSchema as DataPortSchema;
   }
 
+  /**
+   * Seam for the substituter the scan runs. The server build overrides it to
+   * bound matching with an interruptible time budget; there is no `vm` in a
+   * browser, so a hostile pattern there still blocks that tab (a tab — not the
+   * process hosting a local API).
+   */
+  protected createSubstituter(
+    pattern: string,
+    replacement: string,
+    options: SedOptions
+  ): SedLineSubstituter {
+    return createSubstituter(pattern, replacement, options);
+  }
+
   override async execute(
     input: FileSedTaskInput,
     context: IExecuteContext
@@ -370,6 +455,10 @@ export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskC
     if (context.signal.aborted) {
       throw new TaskAbortedError("Task aborted");
     }
+
+    // Compiled before the fetch so a rejected pattern costs no network call.
+    const substituter = this.createSubstituter(pattern, replacement, options);
+
     await context.updateProgress(0, "Fetching file");
 
     const fetchTask = context.own(new FetchUrlTask({ queue: false }));
@@ -388,7 +477,8 @@ export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskC
       pattern,
       replacement,
       options,
-      context.signal
+      context.signal,
+      substituter
     );
 
     if (context.signal.aborted) {

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -24,7 +24,8 @@ const inputSchema = {
     url: {
       type: "string",
       title: "URL",
-      description: "URL to transform (http://, https://)",
+      description:
+        "URL to transform (http://, https://). The Node/Electron build additionally accepts a `file://` URL or an absolute filesystem path, subject to the `filesystem:read` entitlement and any configured `roots`.",
       format: "uri",
     },
     pattern: {
@@ -417,7 +418,11 @@ export async function sedLines(
  *
  * The source is never modified: the transformed document is returned as output.
  */
-export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskConfig> {
+export class FileSedTask<Config extends TaskConfig = TaskConfig> extends Task<
+  FileSedTaskInput,
+  FileSedTaskOutput,
+  Config
+> {
   public static override type = "FileSedTask";
   public static override category = "Document";
   public static override title = "File Sed";
@@ -490,13 +495,31 @@ export class FileSedTask extends Task<FileSedTaskInput, FileSedTaskOutput, TaskC
   }
 }
 
-export const fileSed = (input: FileSedTaskInput, config?: TaskConfig) => {
+/**
+ * Config for both builds. `roots` is declared here rather than beside the
+ * server subclass because a `declare module` augmentation must state one type
+ * across every file that contributes it, and both files augment `Workflow`
+ * with `fileSed`.
+ */
+export interface FileSedTaskConfig extends TaskConfig {
+  /**
+   * Directories a local path must resolve inside, checked after symlinks are
+   * resolved. Omitted means unrestricted: the enforced control is the
+   * `filesystem:read` entitlement, and this is the embedder's extra fence.
+   *
+   * Honored only by the server build — the cross-platform class reaches
+   * http(s) through `FetchUrlTask` and touches no filesystem.
+   */
+  readonly roots?: readonly string[] | undefined;
+}
+
+export const fileSed = (input: FileSedTaskInput, config?: FileSedTaskConfig) => {
   return new FileSedTask(config).run(input);
 };
 
 declare module "@workglow/task-graph" {
   interface Workflow {
-    fileSed: CreateWorkflow<FileSedTaskInput, FileSedTaskOutput, TaskConfig>;
+    fileSed: CreateWorkflow<FileSedTaskInput, FileSedTaskOutput, FileSedTaskConfig>;
   }
 }
 

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -68,13 +68,14 @@ const inputSchema = {
     maxOutputLines: {
       type: "integer",
       title: "Max Output Lines",
-      description: "Maximum number of output lines",
+      description: "Maximum number of output lines. Defaults to 10000; set this to override.",
       minimum: 0,
     },
     maxOutputChars: {
       type: "integer",
       title: "Max Output Characters",
-      description: "Maximum number of output characters, including newlines",
+      description:
+        "Maximum number of output characters, including newlines. Defaults to 1000000; set this to override.",
       minimum: 0,
     },
   },
@@ -340,6 +341,11 @@ export async function sedLines(
   let outputLines = 0;
   let outputChars = 0;
 
+  // Caps apply whether or not the caller stated them: an unbounded default
+  // returned the whole document to whoever asked for one substitution.
+  const maxOutputLines = options.maxOutputLines ?? DEFAULT_LIMITS.grepMaxOutputLines;
+  const maxOutputChars = options.maxOutputChars ?? DEFAULT_LIMITS.grepMaxOutputChars;
+
   const iterator = lines[Symbol.asyncIterator]();
   const maxLineChars = DEFAULT_LIMITS.grepMaxLineChars;
   const batch: string[] = [];
@@ -392,14 +398,14 @@ export async function sedLines(
           continue;
         }
 
-        if (options.maxOutputLines !== undefined && outputLines >= options.maxOutputLines) {
+        if (outputLines >= maxOutputLines) {
           truncated = true;
           break outer;
         }
 
         const chars = replaced.length + 1;
 
-        if (options.maxOutputChars !== undefined && outputChars + chars > options.maxOutputChars) {
+        if (outputChars + chars > maxOutputChars) {
           truncated = true;
           break outer;
         }

--- a/packages/tasks/src/util/BoundedRegex.server.ts
+++ b/packages/tasks/src/util/BoundedRegex.server.ts
@@ -59,3 +59,110 @@ export function createBoundedRegexMatcher(
     return [...scope.out];
   };
 }
+
+/** One batch of substituted lines, positionally aligned with the input. */
+export interface BoundedReplaceResult {
+  readonly texts: readonly string[];
+  readonly counts: readonly number[];
+}
+
+/**
+ * Substitutes over a batch of lines under the same interruptible budget as
+ * {@link createBoundedRegexMatcher}, and for the same reason: `String.replace`
+ * backtracks exactly like `test` does. Measured on `/(\w|\d)*$/` against
+ * `"1".repeat(n) + "!"`: 25 ms at n=20, 392 ms at n=24, 1538 ms at n=26.
+ *
+ * Batched for the same cost reason as well. Over 100 000 lines with `/foo/g`:
+ * a bare `replace` per line runs 39 ms, one `vm` call per line ~13 650 ms, one
+ * `vm` call per 512-line batch 147 ms.
+ *
+ * `expand` is called from inside the context, once per replaced match, and its
+ * return value is what `String.replace` splices in. Keeping the substitution
+ * itself in the engine is what lets `budget` cap replacements — which needs a
+ * callback, so `$1` / `$&` expansion cannot be left to `replace` — without this
+ * helper reimplementing where a match starts and ends. It also means no
+ * per-match record outlives the call: peak memory is the output, not a
+ * description of every match in the batch.
+ *
+ * `budget` is the number of replacements the whole run may still make; it is
+ * threaded across the batch, so a line that exhausts it leaves the rest of the
+ * batch copied verbatim.
+ */
+export function createBoundedRegexReplacer(
+  regex: RegExp,
+  expand: (args: unknown[]) => string,
+  timeoutMs: number
+): (texts: readonly string[], budget: number) => BoundedReplaceResult {
+  // An `expand` that throws would otherwise surface as a timeout, since a
+  // terminated script and a rejected one are the same rejection out here.
+  let expandError: unknown;
+
+  const context = createContext({
+    re: regex,
+    expand: (args: unknown[]): string => {
+      try {
+        return expand(args);
+      } catch (err) {
+        expandError = err;
+        throw err;
+      }
+    },
+    lines: [] as readonly string[],
+    budget: 0,
+    out: [] as string[],
+    counts: [] as number[],
+  });
+
+  // Wrapped in a function so `remaining` is not redeclared in the context's
+  // global scope on the second call.
+  const script = new Script(`(function () {
+  out.length = 0;
+  counts.length = 0;
+  let remaining = budget;
+  for (let i = 0; i < lines.length; i++) {
+    const text = lines[i];
+    if (remaining <= 0) {
+      out.push(text);
+      counts.push(0);
+      continue;
+    }
+    let n = 0;
+    const replaced = text.replace(re, function () {
+      if (n >= remaining) return arguments[0];
+      n++;
+      return expand(Array.prototype.slice.call(arguments));
+    });
+    out.push(replaced);
+    counts.push(n);
+    remaining -= n;
+  }
+})();`);
+
+  return (texts, budget) => {
+    const scope = context as {
+      lines: readonly string[];
+      budget: number;
+      out: string[];
+      counts: number[];
+    };
+    scope.lines = texts;
+    scope.budget = budget;
+    expandError = undefined;
+
+    try {
+      script.runInContext(context, { timeout: timeoutMs });
+    } catch {
+      if (expandError !== undefined) {
+        throw expandError;
+      }
+      // Deliberately not a TaskTimeoutError: that extends TaskAbortedError and
+      // would report the run as aborted rather than failed by bad input.
+      throw new TaskInvalidInputError(
+        `Regex substitution exceeded its ${timeoutMs}ms budget for pattern /${regex.source}/ — ` +
+          `the pattern backtracks catastrophically on this input. Simplify the pattern.`
+      );
+    }
+
+    return { texts: [...scope.out], counts: [...scope.counts] };
+  };
+}

--- a/packages/tasks/src/util/LocalFilePath.server.ts
+++ b/packages/tasks/src/util/LocalFilePath.server.ts
@@ -70,7 +70,20 @@ export function resolveLocalFilePath(url: string, options: LocalFilePathOptions 
   const { roots } = options;
   if (roots !== undefined) {
     const allowed = roots.some((root) => {
-      const realRoot = realpathSync(root);
+      // A root that cannot be resolved is a misconfiguration, and saying which
+      // one beats an `ENOENT ... lstat` raised from inside the containment
+      // check. It is deliberately NOT treated as "does not contain the path":
+      // that reads as a containment verdict on evidence nobody has.
+      let realRoot: string;
+      try {
+        realRoot = realpathSync(root);
+      } catch (err) {
+        throw new TaskInvalidInputError(
+          `Configured root ${root} could not be resolved: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
       return real === realRoot || real.startsWith(realRoot + sep);
     });
     if (!allowed) {

--- a/packages/tasks/src/util/StreamLines.server.ts
+++ b/packages/tasks/src/util/StreamLines.server.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Splits a byte stream into lines with a hard per-line cap.
+ *
+ * `readline.createInterface` accumulates an unterminated line without bound: a
+ * 640 MB newline-free stream threw `RangeError: Invalid string length` from a
+ * stream `'data'` listener, which surfaces as an `uncaughtException` rather
+ * than an iterator rejection — so the caller's try/catch could not see it and
+ * the process died.
+ *
+ * A line reaching `maxLineChars` with no terminator yields its first
+ * `maxLineChars` characters, and the rest of that physical line is discarded up
+ * to the next `\n`. `setEncoding` puts a `StringDecoder` in front, so a
+ * multi-byte character split across two reads is not corrupted.
+ */
+export async function* linesFromStream(
+  stream: NodeJS.ReadableStream,
+  maxLineChars: number
+): AsyncGenerator<string> {
+  stream.setEncoding("utf8");
+
+  let pending = "";
+  let skipping = false;
+
+  const stripCr = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line);
+
+  for await (const chunk of stream as AsyncIterable<string>) {
+    pending += chunk;
+
+    let newline = pending.indexOf("\n");
+    while (newline !== -1) {
+      const line = pending.slice(0, newline);
+      pending = pending.slice(newline + 1);
+      if (skipping) {
+        skipping = false;
+      } else {
+        yield stripCr(line);
+      }
+      newline = pending.indexOf("\n");
+    }
+
+    if (!skipping && pending.length >= maxLineChars) {
+      yield pending.slice(0, maxLineChars);
+      pending = "";
+      skipping = true;
+    } else if (skipping) {
+      pending = "";
+    }
+  }
+
+  if (!skipping && pending.length > 0) {
+    yield stripCr(pending);
+  }
+}

--- a/packages/test/src/test/task/FileSedEntitlements.test.ts
+++ b/packages/test/src/test/task/FileSedEntitlements.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createPolicyEnforcer,
+  createProfilePolicy,
+  ENTITLEMENT_ENFORCER,
+  Entitlements,
+  TaskEntitlementError,
+  TaskGraph,
+  TaskGraphRunner,
+  TaskRegistry,
+  type IEntitlementEnforcer,
+} from "@workglow/task-graph";
+import { FileSedTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
+import { Container, ServiceRegistry, setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+const METADATA_URL = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
+
+describe("FileSedTask entitlement enforcement", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+
+  let prevSafeFetch: SafeFetchFn;
+  let testDir: string;
+
+  beforeAll(() => {
+    // The enforcer is what is under test, not the network layer.
+    prevSafeFetch = registerSafeFetch(() =>
+      Promise.resolve(
+        new Response("alpha\nbravo foo\n", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        })
+      )
+    );
+    TaskRegistry.registerTask(FileSedTask);
+  });
+
+  afterAll(() => {
+    registerSafeFetch(prevSafeFetch);
+  });
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `filesed-ent-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function makeRegistry(enforcer: IEntitlementEnforcer): ServiceRegistry {
+    const registry = new ServiceRegistry(new Container());
+    registry.register(ENTITLEMENT_ENFORCER, () => enforcer);
+    return registry;
+  }
+
+  function makeGraph(url: string, roots?: readonly string[]): TaskGraph {
+    const graph = new TaskGraph();
+    graph.addTask(
+      new FileSedTask({
+        id: "sed-node",
+        roots,
+        defaults: { url, pattern: "foo", replacement: "bar" },
+      })
+    );
+    return graph;
+  }
+
+  /**
+   * The scenario that motivated the declaration. Pre-fix the task declared
+   * nothing at all: `computeGraphEntitlements` runs over `graph.getTasks()` at
+   * graph start and saw an empty set, and the `FetchUrlTask` the task owns
+   * inside `execute()` is not in that snapshot — so it reached the metadata
+   * endpoint with `allowPrivate: true`, its own resolved-destination check
+   * satisfied because the child's input url IS the private one.
+   */
+  test("a profile without network:private denies a metadata-endpoint substitution", async () => {
+    const enforcer = createPolicyEnforcer(createProfilePolicy("browser"));
+    const runner = new TaskGraphRunner(makeGraph(METADATA_URL));
+
+    await expect(
+      runner.runGraph({}, { registry: makeRegistry(enforcer), enforceEntitlements: true })
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("the same profile allows a public substitution", async () => {
+    const enforcer = createPolicyEnforcer(createProfilePolicy("browser"));
+    const runner = new TaskGraphRunner(makeGraph("https://example.com/log.txt"));
+
+    await expect(
+      runner.runGraph({}, { registry: makeRegistry(enforcer), enforceEntitlements: true })
+    ).resolves.toBeDefined();
+  });
+
+  test("a profile granting filesystem:read only under /tmp denies /etc", async () => {
+    const browserPolicy = createProfilePolicy("browser");
+    const scopedPolicy = {
+      deny: browserPolicy.deny,
+      grant: [
+        ...browserPolicy.grant,
+        { id: Entitlements.FILESYSTEM_READ, resources: [`${testDir}/*`] },
+      ],
+      ask: browserPolicy.ask,
+    };
+
+    const allowed = join(testDir, "notes.txt");
+    writeFileSync(allowed, "alpha\nbravo foo\n", "utf-8");
+
+    const permitted = new TaskGraphRunner(makeGraph(allowed));
+    await expect(
+      permitted.runGraph(
+        {},
+        { registry: makeRegistry(createPolicyEnforcer(scopedPolicy)), enforceEntitlements: true }
+      )
+    ).resolves.toBeDefined();
+
+    const denied = new TaskGraphRunner(makeGraph("/etc/passwd"));
+    await expect(
+      denied.runGraph(
+        {},
+        { registry: makeRegistry(createPolicyEnforcer(scopedPolicy)), enforceEntitlements: true }
+      )
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("declares filesystem:read scoped to the resolved path, and no network", () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "bravo foo\n", "utf-8");
+
+    const declared = new FileSedTask({
+      defaults: { url: filePath, pattern: "foo", replacement: "bar" },
+    }).entitlements().entitlements;
+
+    expect(declared.map((e) => e.id)).toEqual([Entitlements.FILESYSTEM_READ]);
+    expect(declared[0].resources).toEqual([filePath]);
+  });
+
+  test("declares the fetch entitlements for an http url, and no filesystem:read", () => {
+    const declared = new FileSedTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo", replacement: "bar" },
+    }).entitlements().entitlements;
+
+    expect(declared.map((e) => e.id)).toContain(Entitlements.NETWORK_HTTP);
+    expect(declared.map((e) => e.id)).not.toContain(Entitlements.FILESYSTEM_READ);
+  });
+
+  test("declares fail-closed entitlements when the url is unknown", () => {
+    const declared = new FileSedTask({
+      defaults: { pattern: "foo", replacement: "bar" } as never,
+    }).entitlements().entitlements;
+    const ids = declared.map((e) => e.id);
+
+    expect(ids).toContain(Entitlements.FILESYSTEM_READ);
+    expect(ids).toContain(Entitlements.NETWORK_PRIVATE);
+    // Unscoped: nothing is known about the destination yet.
+    expect(declared.find((e) => e.id === Entitlements.NETWORK_PRIVATE)?.resources).toBeUndefined();
+    expect(declared.find((e) => e.id === Entitlements.FILESYSTEM_READ)?.resources).toBeUndefined();
+  });
+
+  /**
+   * The declaration must name the path that will actually be OPENED, not the
+   * url as written: a policy scoped to a directory is worthless if a symlink
+   * inside it can be declared under its own name and then followed elsewhere.
+   */
+  test("declares the resolved real path, not the url as given", () => {
+    const target = join(testDir, "target.txt");
+    const link = join(testDir, "link.txt");
+    writeFileSync(target, "bravo foo\n", "utf-8");
+    symlinkSync(target, link);
+
+    const declared = new FileSedTask({
+      defaults: { url: `file://${link}`, pattern: "foo", replacement: "bar" },
+    }).entitlements().entitlements;
+
+    expect(declared[0].resources).toEqual([target]);
+  });
+});

--- a/packages/test/src/test/task/FileSedEntitlements.test.ts
+++ b/packages/test/src/test/task/FileSedEntitlements.test.ts
@@ -12,6 +12,7 @@ import {
   TaskEntitlementError,
   TaskGraph,
   TaskGraphRunner,
+  TaskInvalidInputError,
   TaskRegistry,
   type IEntitlementEnforcer,
 } from "@workglow/task-graph";
@@ -183,5 +184,29 @@ describe("FileSedTask entitlement enforcement", () => {
     }).entitlements().entitlements;
 
     expect(declared[0].resources).toEqual([target]);
+  });
+
+  /**
+   * A misconfigured root (or one cleaned up mid-run) must not escape as a raw
+   * `ENOENT ... lstat` from deep inside the resolver. It names the root, and
+   * the read is refused either way — the declaration degrades to an UNSCOPED
+   * `filesystem:read`, which `execute()` never reaches because resolution
+   * throws there too.
+   */
+  test("names a configured root that does not exist, and still fails closed", async () => {
+    const missingRoot = join(testDir, "nope");
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "bravo foo\n", "utf-8");
+
+    const task = new FileSedTask({
+      roots: [missingRoot],
+      defaults: { url: filePath, pattern: "foo", replacement: "bar" },
+    });
+
+    const declared = task.entitlements().entitlements;
+    expect(declared.find((e) => e.id === Entitlements.FILESYSTEM_READ)?.resources).toBeUndefined();
+
+    await expect(task.run()).rejects.toThrow(TaskInvalidInputError);
+    await expect(task.run()).rejects.toThrow(missingRoot);
   });
 });

--- a/packages/test/src/test/task/FileSedTask.server.test.ts
+++ b/packages/test/src/test/task/FileSedTask.server.test.ts
@@ -84,4 +84,46 @@ describe("FileSedTask (server - local files)", () => {
       }).run()
     ).rejects.toThrow();
   });
+
+  /**
+   * `String.replace` backtracks exactly like `test` does, and the shape screen
+   * is a heuristic rather than a decision procedure — so the enforced bound is
+   * the wall-clock budget the substitution runs under.
+   *
+   * `(\w|\d)*$` bypasses the screen: its branches overlap on the digits both
+   * accept, which comparing branch text cannot see. Measured here: 1 ms at
+   * n=16, 25 ms at n=20, 392 ms at n=24, 1538 ms at n=26 — doubling per added
+   * character, so the n=40 below is on the order of 2^40 steps. Unbounded it
+   * blocks the event loop with no abort able to reach it; the run must instead
+   * be REJECTED, and quickly.
+   */
+  test("a catastrophic pattern over a local file fails on the budget", async () => {
+    const filePath = join(testDir, "evil.txt");
+    writeFileSync(filePath, "1".repeat(40) + "!\n", "utf-8");
+
+    const started = Date.now();
+    await expect(
+      new FileSedTask({
+        defaults: { url: filePath, pattern: "(\\w|\\d)*$", replacement: "X" },
+      }).run()
+    ).rejects.toThrow(/budget/);
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  test("the budget does not disturb an ordinary substitution", async () => {
+    const filePath = join(testDir, "groups.txt");
+    writeFileSync(filePath, "2026-08-17\nname: ada\n", "utf-8");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: filePath,
+        pattern: "(\\d{4})-(\\d{2})-(\\d{2})|name: (?<who>\\w+)",
+        replacement: "[$3/$2/$1 $<who> $&]",
+        global: true,
+      },
+    }).run();
+
+    expect(result.replacementCount).toBe(2);
+    expect(result.text).toBe("[17/08/2026  2026-08-17]\n[// ada name: ada]\n");
+  });
 });

--- a/packages/test/src/test/task/FileSedTask.server.test.ts
+++ b/packages/test/src/test/task/FileSedTask.server.test.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FileSedTask } from "@workglow/tasks";
+import { TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
+import { FileSedTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
 import { setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -83,6 +84,140 @@ describe("FileSedTask (server - local files)", () => {
         defaults: { url: filePath, pattern: "foo", replacement: "bar" },
       }).run()
     ).rejects.toThrow();
+  });
+
+  test("refuses a path outside the configured roots", async () => {
+    const outside = join(tmpdir(), `filesed-outside-${Date.now()}.txt`);
+    writeFileSync(outside, "bravo foo\n", "utf-8");
+
+    try {
+      await expect(
+        new FileSedTask({
+          roots: [testDir],
+          defaults: { url: outside, pattern: "foo", replacement: "bar" },
+        }).run()
+      ).rejects.toThrow(TaskEntitlementError);
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
+  /**
+   * The containment check runs AFTER `realpathSync`. A pre-realpath check
+   * passes here — the link itself sits inside the root — and then opens the
+   * target, which is the whole escape.
+   */
+  test("refuses a symlink that escapes the configured roots", async () => {
+    const link = join(testDir, "escape.txt");
+    symlinkSync("/etc/passwd", link);
+
+    await expect(
+      new FileSedTask({
+        roots: [testDir],
+        defaults: { url: link, pattern: "root", replacement: "x" },
+      }).run()
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("allows a symlink that stays inside the roots", async () => {
+    const target = join(testDir, "target.txt");
+    const link = join(testDir, "link.txt");
+    writeFileSync(target, "alpha\nbravo foo\n", "utf-8");
+    symlinkSync(target, link);
+
+    const result = await new FileSedTask({
+      roots: [testDir],
+      defaults: { url: link, pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.text).toBe("alpha\nbravo bar\n");
+  });
+
+  /**
+   * `slice(7)` left the path percent-encoded, so a filer-authored name with a
+   * space or a `%` addressed a file that does not exist.
+   */
+  test("parses file:// URLs rather than slicing the scheme", async () => {
+    const filePath = join(testDir, "a b%c.txt");
+    writeFileSync(filePath, "alpha\nbravo foo\n", "utf-8");
+
+    const result = await new FileSedTask({
+      defaults: {
+        url: `file://${testDir}/a%20b%25c.txt`,
+        pattern: "foo",
+        replacement: "bar",
+      },
+    }).run();
+
+    expect(result.text).toBe("alpha\nbravo bar\n");
+  });
+
+  test("rejects a file:// URL carrying a remote host", async () => {
+    await expect(
+      new FileSedTask({
+        defaults: { url: "file://evil.example/etc/passwd", pattern: "root", replacement: "x" },
+      }).run()
+    ).rejects.toThrow(TaskInvalidInputError);
+  });
+
+  /**
+   * `url.slice(7)` on a relative path opened it against the process cwd, so a
+   * bare `package.json` was readable with no root, no containment and no
+   * declaration.
+   */
+  test("resolves a relative path rather than reading it from the process cwd", async () => {
+    await expect(
+      new FileSedTask({
+        roots: [testDir],
+        defaults: { url: "package.json", pattern: "name", replacement: "x" },
+      }).run()
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  /**
+   * The scheme test was case-sensitive, so `HTTP://x` fell through to the
+   * filesystem branch and was opened as a relative path against the process
+   * cwd. It must route to the fetch branch instead.
+   */
+  describe("uppercase schemes", () => {
+    let prevSafeFetch: SafeFetchFn;
+
+    beforeEach(() => {
+      prevSafeFetch = registerSafeFetch(() =>
+        Promise.resolve(
+          new Response("alpha\nbravo foo\n", {
+            status: 200,
+            headers: { "Content-Type": "text/plain" },
+          })
+        )
+      );
+    });
+
+    afterEach(() => {
+      registerSafeFetch(prevSafeFetch);
+    });
+
+    test("treats HTTP:// case-insensitively", async () => {
+      const result = await new FileSedTask({
+        defaults: {
+          url: "HTTP://example.com/log.txt",
+          pattern: "foo",
+          replacement: "bar",
+        },
+      }).run();
+
+      expect(result.text).toBe("alpha\nbravo bar\n");
+    });
+  });
+
+  describe.skipIf(!existsSync("/dev/zero"))("non-regular files", () => {
+    test("refuses a character device", async () => {
+      await expect(
+        new FileSedTask({
+          defaults: { url: "/dev/zero", pattern: "foo", replacement: "bar" },
+        }).run()
+      ).rejects.toThrow(TaskInvalidInputError);
+    });
   });
 
   /**

--- a/packages/test/src/test/task/FileSedTask.server.test.ts
+++ b/packages/test/src/test/task/FileSedTask.server.test.ts
@@ -6,7 +6,7 @@
 
 import { TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
 import { FileSedTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
-import { setLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
@@ -84,6 +84,52 @@ describe("FileSedTask (server - local files)", () => {
         defaults: { url: filePath, pattern: "foo", replacement: "bar" },
       }).run()
     ).rejects.toThrow();
+  });
+
+  /**
+   * Reproduced pre-fix with a 640 MB newline-free stream: `createInterface`
+   * accumulated the whole thing and threw `RangeError: Invalid string length`
+   * from a stream `'data'` listener. That surfaces as an `uncaughtException`,
+   * not an iterator rejection, so `sedFile`'s try/catch never saw it and the
+   * process died. 1 MB here is enough to exercise the cap without the memory.
+   */
+  test("a file with no line terminator does not crash the process", async () => {
+    const filePath = join(testDir, "oneline.bin");
+    writeFileSync(filePath, "x".repeat(1_000_000), "utf-8");
+
+    const uncaught: unknown[] = [];
+    const spy = (err: unknown): void => {
+      uncaught.push(err);
+    };
+    process.on("uncaughtException", spy);
+
+    try {
+      const result = await new FileSedTask({
+        defaults: { url: filePath, pattern: "x", replacement: "y", global: true },
+      }).run();
+
+      expect(uncaught).toEqual([]);
+      expect(result.replacementCount).toBe(DEFAULT_LIMITS.grepMaxLineChars);
+      expect(result.text).toHaveLength(DEFAULT_LIMITS.grepMaxLineChars + 1);
+    } finally {
+      process.off("uncaughtException", spy);
+    }
+  });
+
+  test("caps an over-long line and reports truncation", async () => {
+    const filePath = join(testDir, "long.txt");
+    const long = "y".repeat(DEFAULT_LIMITS.grepMaxLineChars + 5_000);
+    writeFileSync(filePath, `short\n${long}\ntail foo\n`, "utf-8");
+
+    const result = await new FileSedTask({
+      defaults: { url: filePath, pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    const lines = result.text.split("\n");
+    expect(lines[1]).toHaveLength(DEFAULT_LIMITS.grepMaxLineChars);
+    // The rest of the physical line is discarded, not folded into a new one.
+    expect(lines[2]).toBe("tail bar");
   });
 
   test("refuses a path outside the configured roots", async () => {

--- a/packages/test/src/test/task/FileSedTask.test.ts
+++ b/packages/test/src/test/task/FileSedTask.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { FileSedTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
-import { setLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -288,6 +288,41 @@ describe("FileSedTask", () => {
 
     expect(result.truncated).toBe(true);
     expect(result.text).toBe("ab\ncd\n");
+  });
+
+  /**
+   * The caps were enforced only when the caller STATED them, so omitting them
+   * meant no cap at all: a workflow substituting one word in a large document
+   * got the whole document back, and `truncated: false` said that was the
+   * complete answer.
+   */
+  test("caps output lines even when the caller states no limit", async () => {
+    const lines = DEFAULT_LIMITS.grepMaxOutputLines + 500;
+    mockText(`${Array.from({ length: lines }, (_, i) => `line ${i} foo`).join("\n")}\n`);
+
+    const result = await new FileSedTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.text.split("\n").filter((l) => l.length > 0)).toHaveLength(
+      DEFAULT_LIMITS.grepMaxOutputLines
+    );
+  });
+
+  test("caps output characters even when the caller states no limit", async () => {
+    // Few enough lines to stay under the line cap, wide enough to pass the
+    // character one — so this can only be the character cap firing.
+    const wide = "z".repeat(20_000);
+    mockText(`${Array.from({ length: 100 }, () => `${wide} foo`).join("\n")}\n`);
+
+    const result = await new FileSedTask({
+      defaults: { url: "https://example.com/log.txt", pattern: "foo", replacement: "bar" },
+    }).run();
+
+    expect(result.truncated).toBe(true);
+    expect(result.text.length).toBeLessThanOrEqual(DEFAULT_LIMITS.grepMaxOutputChars);
+    expect(result.text.split("\n").filter((l) => l.length > 0).length).toBeLessThan(100);
   });
 
   test("rejects maxReplacements of zero", async () => {


### PR DESCRIPTION
`FileSedTask` was added to `file-grep-task` after #833 opened, and it repeats
that PR's findings verbatim on the substitution side. Same diagnoses, same
helpers, seven ordered commits. #833 is the sibling change the findings were
carried over from; each one was re-verified against this code rather than
assumed, and every security test here was confirmed to FAIL against the unfixed
source.

Sequencing is load-bearing: commit 1 extracts the module commit 5 imports, and
commits 2 → 5 → 7 all edit `sedLines`' scan loop.

---

## 1 — substitution was unbounded and uninterruptible

`sedLines` ran `regex.replace(...)` per line synchronously and checked
`signal?.aborted` only *between* lines. One hostile line blocked the event loop
with nothing able to interrupt it.

`assertSafeRegexPattern` does not close this — it is a shape heuristic, not a
decision procedure. Measured here on `(\w|\d)*$` (which walks past the screen:
its branches overlap on the digits both accept, and the screen compares branch
*text*) against `"1".repeat(n) + "!"`:

| n | `String.replace` |
| --- | --- |
| 16 | 1 ms |
| 20 | 25 ms |
| 24 | 392 ms |
| 26 | 1538 ms |

Doubling per added character, so the n=40 the test uses is on the order of 2^40
steps.

### The design question, and the alternative rejected

`createBoundedRegexMatcher` could not be reused: it bounds `test()` and returns
booleans, and sed needs replaced **text**. `createBoundedRegexReplacer` is the
substitution equivalent, in the same module, under the same budget.

Bounding the replacement **count** requires a callback, which is why
`FileSedTask` expands `$1` / `$&` / `$<name>` by hand rather than letting
`String.replace` do it. So the question is which side of the `vm` boundary that
expander runs on. Two designs:

- **chosen** — the expander is passed *into* the context and called back per
  match; what crosses the boundary is one match's arguments and the string to
  splice. `String.replace` stays authoritative about where a match starts and
  ends, and nothing is retained beyond the output string it is already building.
- **rejected** — collect match records (index, groups, named) inside the context
  and splice them outside, keeping the script pure like the matcher's. Rejected
  on memory: a global substitution over a 512-line batch retains a record per
  match for the whole batch, where the callback retains none. It also
  reimplements match boundaries that `replace` already knows.

The cost of the chosen design is that our own expander runs under the timeout,
so a throw from it would read as a budget overrun. It is captured and rethrown
verbatim instead.

### The `vm` hop is per BATCH, not per line

Same reason as #833, re-measured for `replace` over 100 000 lines with `/foo/g`:

| approach | time |
| --- | --- |
| plain `replace` per line | 39 ms |
| one `vm` call **per line** | ~13 650 ms |
| one `vm` call **per 512-line batch** | 147 ms |

`sedLines` therefore scans in batches of `SECURITY_LIMITS.regexMatchBatchLines`
and checks abort once per batch — a per-line check bought nothing a hostile
pattern could ignore. `fixedString` never enters `vm`: the pattern is escaped to
a literal and cannot backtrack.

Residual, inherited: the loop is still blocked for up to one batch budget. That
is bounded and finite where it was neither.

---

## 2 — arbitrary filesystem read, and a case-sensitive scheme check

`FileSedTask.server` did `url = url.slice(7)` and handed the result straight to
`createReadStream`: no `path.resolve`, no `realpath`, no containment, no
regular-file check, and a relative path opened against `process.cwd()`. The
class declared **no entitlements at all**, so `filesystem:read` was never
required for a read it performs by design. It is registered globally by both the
node and electron entries.

The scheme test was also case-**sensitive**, so `HTTP://x` and `FILE://x` fell
past it into the filesystem branch.

Both fixed with the helpers the sibling grep task already uses —
`resolveLocalFilePath` (percent-decoding `fileURLToPath`, resolve, realpath,
containment *after* realpath so a symlink cannot escape, `isFile()` so a fifo or
`/dev/zero` is not an unbounded read) and `isHttpUrl`. `roots` is opt-in config
defaulting to `undefined`; the enforced control is the entitlement.

---

## 3 — an owned child escaped the graph's entitlement snapshot

Entitlements are computed once at graph start over `graph.getTasks()`, before
any `execute()`. The `FetchUrlTask` this task owns is created *inside*
`execute()`, so it is absent from that snapshot: the task declared nothing, the
enforcer had nothing to refuse, and the child then set `allowPrivate` from its
own input url — whose destination check passes, because the child's url *is* the
private one. A browser-profile graph substituting over
`http://169.254.169.254/latest/meta-data/...` ran to completion.

The base class now declares `FetchUrlTask.entitlements()` and sets
`hasDynamicEntitlements`; the server build narrows to `filesystem:read` scoped to
the **resolved real path**, plus the `assertResolvedPathDeclared` check in
`execute()`. Scoping to the realpath is what makes a policy granting
`filesystem:read` under one directory meaningful — a symlink inside it is
declared as its target, not under its own name.

---

## 4 — an unresolvable configured root escaped as a raw ENOENT

Not a FileSedTask bug, found while testing one: `resolveLocalFilePath` guards the
ENOENT on the path it resolves, but the `realpathSync(root)` inside the
containment check had no guard. A misconfigured root — or one cleaned up
mid-run — surfaced as `ENOENT: no such file or directory, lstat '/...'` from
inside a security check, naming a path the caller never passed and not saying it
was a root.

It now throws `TaskInvalidInputError` naming the root. Deliberately **not**
folded into the containment verdict: treating an unresolvable root as "does not
contain this path" would report a `TaskEntitlementError` about the *file* on
evidence nobody has about the *root*. A root that exists and simply does not
contain the path is unchanged.

Verified: it already failed **closed** and still does — the declaration degrades
to an unscoped `filesystem:read` and `execute()` opens nothing, because
resolution throws there too. This is the message, not the containment.

---

## 5 — unterminated lines accumulated without bound

`createInterface` accumulates an unterminated line without bound; a large enough
newline-free stream throws `RangeError: Invalid string length` from a stream
`'data'` listener, which surfaces as an **uncaughtException** rather than an
iterator rejection — so `sedFile`'s try/catch could not see it and the process
died.

`linesFromStream` is **extracted** from `FileGrepTask.server` to
`util/StreamLines.server` rather than copied (commit 1, no behavior change), and
both tasks import it. `sedLines` applies the same cap while filling a batch, so
the http path is bounded too, and reports `truncated` — a capped line means the
emitted document is missing part of the source, which is what that flag is for.

---

## 6 — output caps were unbounded by default

`maxOutputLines` / `maxOutputChars` were enforced only when the caller *stated*
them, so omitting them meant no cap: a workflow substituting one word in a large
document got the whole document back, with `truncated: false` reporting that as
the complete answer. They now default to `grepMaxOutputLines` (10 000) /
`grepMaxOutputChars` (1 000 000), still overridable, and the schema descriptions
say so.

---

## Verification

```
bun run build:types --force              →  41 successful, 41 total (0 cached)
bun scripts/test.ts task vitest          →  73 files, 1170 passed | 24 skipped, 0 failed
bunx prettier --check <touched files>    →  All matched files use Prettier code style!
```

Baseline before this branch was 72 files / 1148 passed; the additions are one new
suite and 22 tests.

### Negative controls

No security test here passes vacuously — each was run against the unfixed source:

| finding | control | observed without the fix |
| --- | --- | --- |
| 1 substitution budget | keep test, revert the three source files | suite **never completed**; killed at 120 s (it completes in ~6 s with the fix) |
| 2 path / scheme | revert to `slice(7)` + `startsWith("http://")` | **7 of 15** fail — roots, symlink escape, percent-decoding, remote host, relative-path-vs-cwd, `HTTP://`, `/dev/zero` (which hung 30 s) |
| 3 entitlements | revert `FileSedTask.{ts,server.ts}` to their pre-branch state | **7 of 8** fail, including the metadata-endpoint SSRF graph reaching the endpoint and resolving |
| 4 root ENOENT | revert `LocalFilePath.server.ts` only | fails with the raw `ENOENT ... lstat '/tmp/.../nope'` |
| 5 line cap | restore `createInterface`, drop the batch cap | 2 fail: `expected 1000000 to be 64000`, and `truncated` stayed `false` |
| 6 output caps | restore the `!== undefined` guards | 2 fail: `truncated` stayed `false` in both |

The one test that passes both ways is the positive control by design ("the same
profile allows a public substitution").

## Risks

- **`vm` substitution is slower than a bare `replace`** (147 ms vs 39 ms per
  100 k lines). Batch size is the knob and lives in `SECURITY_LIMITS`.
- **Abort latency moves from per-line to per-batch.** Nothing is lost — a
  per-line check could not interrupt the one call that blocks.
- **Default output caps change behavior** for a caller receiving unlimited output
  today. Overridable, and `truncated` reports it.
- **Batching does extra work past an output cap**: lines already in the batch are
  substituted before the cap is noticed. Same trade the grep scan makes.
- **`realpathSync` + `statSync` add two synchronous syscalls** per local run.
- The **browser** build has no `vm`, so a hostile pattern still blocks that tab.
  Documented on the base class, same as the grep task.

## Not done

- `FileLoaderTask.server` still has the identical `slice(7)` + unsandboxed
  `readFile` (tracked in #823) — out of scope here for the same reason it was
  out of scope in #833.
- The URL-path materialization half of finding 5: the base build still fetches
  `response_type: "text"`, so the document is materialized before the scan.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRf3YFa8DjmjsZvXz8xDT)_