### PR TITLE
feat: thinking policy for models

### DIFF
--- a/packages/ai/src/model/ModelEffort.ts
+++ b/packages/ai/src/model/ModelEffort.ts
@@ -54,6 +54,21 @@ export function enabledEffortsForModel(
   return policy?.supported;
 }
 
+/**
+ * Whether `model.effort` should be mapped onto a provider request. Native
+ * `provider_config` knobs always win separately; this only gates the coarse dial.
+ */
+export function isModelEffortEnabled(
+  model: object | undefined,
+  policy: ModelEffortPolicy | undefined
+): boolean {
+  if (model === undefined) return false;
+  const effort = (model as { effort?: unknown }).effort;
+  if (!isModelEffort(effort)) return false;
+  const enabled = enabledEffortsForModel(model, policy);
+  return enabled === undefined || enabled.includes(effort);
+}
+
 export function effortPlaceholder(policy: ModelEffortPolicy | undefined): string {
   return policy?.default !== undefined ? `Default: ${policy.default}` : "Default";
 }

--- a/packages/ai/src/model/ModelSchema.ts
+++ b/packages/ai/src/model/ModelSchema.ts
@@ -11,6 +11,7 @@ export {
   effortPlaceholder,
   enabledEffortsForModel,
   isModelEffort,
+  isModelEffortEnabled,
   MODEL_EFFORTS,
   readEffortOptions,
   sanitizeEffortOptions,

--- a/packages/ai/src/model/__tests__/ModelEffort.test.ts
+++ b/packages/ai/src/model/__tests__/ModelEffort.test.ts
@@ -10,6 +10,7 @@ import {
   effortPlaceholder,
   enabledEffortsForModel,
   isModelEffort,
+  isModelEffortEnabled,
   readEffortOptions,
   sanitizeEffortOptions,
   stampEffortOptions,
@@ -80,6 +81,24 @@ describe("enabledEffortsForModel", () => {
   it("falls back to policy.supported, or undefined when neither exists", () => {
     expect(enabledEffortsForModel({}, policy)).toEqual([...MODEL_EFFORTS]);
     expect(enabledEffortsForModel({}, undefined)).toBeUndefined();
+  });
+});
+
+describe("isModelEffortEnabled", () => {
+  const policy = { supported: ["low", "high"] as const, default: "low" as const };
+
+  it("is false when effort is unset or the enabled list excludes it", () => {
+    expect(isModelEffortEnabled({}, policy)).toBe(false);
+    expect(isModelEffortEnabled({ effort: "medium" }, policy)).toBe(false);
+    expect(isModelEffortEnabled({ effort: "high", effort_options: [] }, policy)).toBe(false);
+    expect(isModelEffortEnabled({ effort: "high" }, { supported: [], default: undefined })).toBe(
+      false
+    );
+  });
+
+  it("is true when effort is in the enabled list, or when nothing restricts it", () => {
+    expect(isModelEffortEnabled({ effort: "high" }, policy)).toBe(true);
+    expect(isModelEffortEnabled({ effort: "ultra" }, undefined)).toBe(true);
   });
 });
 

--- a/packages/test/src/contract/ai-provider/assertions/inferAdvertisesRegistered.ts
+++ b/packages/test/src/contract/ai-provider/assertions/inferAdvertisesRegistered.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from "vitest";
+
+/**
+ * A registered run-fn capability that `inferCapabilities` never returns is
+ * unreachable for any model whose record was populated by inference — the
+ * path the catalog exists to serve.
+ */
+export function assertInferAdvertisesRegistered(
+  name: string,
+  registered: readonly (readonly string[])[],
+  inferred: readonly (readonly string[])[]
+): void {
+  const registeredCaps = new Set(registered.flat());
+  const inferredCaps = new Set(inferred.flat());
+  const missing = [...registeredCaps].filter((cap) => !inferredCaps.has(cap)).sort();
+  expect(
+    missing,
+    `${name} registers capabilities that inferCapabilities never returns: ${missing.join(", ")}`
+  ).toEqual([]);
+}

--- a/packages/test/src/test/ai-provider-api/AnthropicProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/AnthropicProvider.test.ts
@@ -171,6 +171,23 @@ describe("AnthropicQueuedProvider.inferCapabilities", () => {
       "vision-input",
     ]);
   });
+
+  it("infers exact capability set for claude-sonnet-5", () => {
+    const caps = provider.inferCapabilities(model("claude-sonnet-5"));
+    const sorted = [...caps].sort();
+    expect(sorted).toEqual([
+      "cache.checkpoint",
+      "json-mode",
+      "model.count-tokens",
+      "model.info",
+      "model.search",
+      "text.generation",
+      "text.rewriter",
+      "text.summary",
+      "tool-use",
+      "vision-input",
+    ]);
+  });
 });
 
 describe("ANTHROPIC_FALLBACK", () => {

--- a/packages/test/src/test/ai-provider-api/DeepSeekProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/DeepSeekProvider.test.ts
@@ -159,6 +159,23 @@ describe("resolveMaxTokens", () => {
     );
   });
 
+  it("does not map model.effort on models the policy rejects", () => {
+    const nonThinking = {
+      ...thinkingModel,
+      effort: "ultra",
+      provider_config: { model_name: "deepseek-chat" },
+    };
+    expect(resolveMaxTokens(nonThinking as never, 4096)).toBe(
+      4096 + DEEPSEEK_DEFAULT_REASONING_ALLOWANCE
+    );
+  });
+
+  it("honours effort_options even when the class policy would allow the effort", () => {
+    expect(
+      resolveMaxTokens({ ...thinkingModel, effort: "ultra", effort_options: [] } as never, 4096)
+    ).toBe(4096 + DEEPSEEK_DEFAULT_REASONING_ALLOWANCE);
+  });
+
   it("lets reasoning_allowance win over model.effort", () => {
     const configured = {
       ...thinkingModel,

--- a/packages/test/src/test/ai-provider-api/GoogleGeminiProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/GoogleGeminiProvider.test.ts
@@ -129,6 +129,7 @@ describe("GoogleGeminiQueuedProvider.inferCapabilities", () => {
       "model.count-tokens",
       "model.info",
       "model.search",
+      "session.dispose",
       "text.generation",
       "text.rewriter",
       "text.summary",

--- a/packages/test/src/test/ai-provider-api/OpenAiProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenAiProvider.test.ts
@@ -176,6 +176,28 @@ describe("getReasoningConfig", () => {
       })
     ).toEqual({ effort: "low" });
   });
+
+  it("does not map model.effort on models the policy rejects", () => {
+    expect(
+      getReasoningConfig({ ...modelWithConfig({ model_name: "gpt-4o" }), effort: "high" })
+    ).toBeUndefined();
+    expect(
+      getReasoningConfig({
+        ...modelWithConfig({ model_name: "text-embedding-3-small" }),
+        effort: "low",
+      })
+    ).toBeUndefined();
+  });
+
+  it("honours effort_options even when the class policy would allow the effort", () => {
+    expect(
+      getReasoningConfig({
+        ...modelWithConfig({ model_name: "gpt-5.6-luna" }),
+        effort: "high",
+        effort_options: [],
+      })
+    ).toBeUndefined();
+  });
 });
 
 describe("isStrictCompatibleSchema", () => {

--- a/packages/test/src/test/ai-provider-api/OpenRouter_RequestParams.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouter_RequestParams.test.ts
@@ -75,4 +75,12 @@ describe("buildOpenRouterExtras", () => {
       )
     ).toEqual({ reasoning: { effort: "low" } });
   });
+
+  it("does not map model.effort when effort_options is empty", () => {
+    expect(
+      buildOpenRouterExtras(
+        cfg({ model_name: "openai/gpt-5" }, { effort: "high", effort_options: [] })
+      )
+    ).toEqual({});
+  });
 });

--- a/packages/test/src/test/ai-provider-api/XaiEffortPolicy.test.ts
+++ b/packages/test/src/test/ai-provider-api/XaiEffortPolicy.test.ts
@@ -58,4 +58,31 @@ describe("getXaiReasoningEffort", () => {
   it("returns undefined when neither native nor effort is set", () => {
     expect(getXaiReasoningEffort(cfg("grok-4"))).toBeUndefined();
   });
+
+  it("does not map model.effort when the policy supports no levels", () => {
+    expect(
+      getXaiReasoningEffort(cfg("grok-4-fast-non-reasoning", { effort: "high" }))
+    ).toBeUndefined();
+    expect(getXaiReasoningEffort(cfg("grok-2-image-1212", { effort: "ultra" }))).toBeUndefined();
+  });
+
+  it("honours effort_options even when the class policy would allow the effort", () => {
+    expect(
+      getXaiReasoningEffort(cfg("grok-4", { effort: "high", effort_options: [] }))
+    ).toBeUndefined();
+  });
+
+  it("still sends a native reasoning_effort on a non-reasoning id", () => {
+    expect(
+      getXaiReasoningEffort(
+        cfg("grok-4-fast-non-reasoning", {
+          effort: "high",
+          provider_config: {
+            model_name: "grok-4-fast-non-reasoning",
+            reasoning_effort: "low",
+          },
+        })
+      )
+    ).toBe("low");
+  });
 });

--- a/packages/test/src/test/ai-provider/Anthropic_Thinking.test.ts
+++ b/packages/test/src/test/ai-provider/Anthropic_Thinking.test.ts
@@ -17,12 +17,14 @@ const {
 function model(opts: {
   model_name: string;
   effort?: string;
+  effort_options?: readonly string[];
   thinking?: Record<string, unknown>;
   output_config?: Record<string, unknown>;
 }) {
   return {
     provider: "ANTHROPIC",
     effort: opts.effort,
+    effort_options: opts.effort_options,
     provider_config: {
       model_name: opts.model_name,
       ...(opts.thinking ? { thinking: opts.thinking } : {}),
@@ -54,6 +56,21 @@ describe("buildAnthropicThinkingParams", () => {
     });
     expect(
       buildAnthropicThinkingParams(model({ model_name: "claude-sonnet-5", effort: "none" }), 4096)
+    ).toEqual({ max_tokens: 4096 });
+  });
+
+  it("does not map model.effort on ids the policy rejects", () => {
+    expect(
+      buildAnthropicThinkingParams(model({ model_name: "not-a-claude", effort: "high" }), 4096)
+    ).toEqual({ max_tokens: 4096 });
+  });
+
+  it("honours effort_options even when the class policy would allow the effort", () => {
+    expect(
+      buildAnthropicThinkingParams(
+        model({ model_name: "claude-sonnet-5", effort: "high", effort_options: [] }),
+        4096
+      )
     ).toEqual({ max_tokens: 4096 });
   });
 

--- a/packages/test/src/test/ai-provider/Gemini_ThinkingBudget.test.ts
+++ b/packages/test/src/test/ai-provider/Gemini_ThinkingBudget.test.ts
@@ -62,4 +62,32 @@ describe("resolveThinkingConfig", () => {
       expect(result.maxOutputTokens).toBe(budget > 0 ? 100 + budget : 100);
     }
   });
+
+  it("does not map model.effort on embedding or image models", () => {
+    expect(
+      resolveThinkingConfig(
+        model({
+          effort: "high",
+          provider_config: { model_name: "gemini-embedding-001" },
+        }),
+        1000
+      )
+    ).toEqual({ thinkingConfig: undefined, maxOutputTokens: 1000 });
+    expect(
+      resolveThinkingConfig(
+        model({
+          effort: "ultra",
+          provider_config: { model_name: "imagen-4.0-generate-001" },
+        }),
+        1000
+      )
+    ).toEqual({ thinkingConfig: undefined, maxOutputTokens: 1000 });
+  });
+
+  it("honours effort_options even when the class policy would allow the effort", () => {
+    expect(resolveThinkingConfig(model({ effort: "high", effort_options: [] }), 1000)).toEqual({
+      thinkingConfig: undefined,
+      maxOutputTokens: 1000,
+    });
+  });
 });

--- a/packages/test/src/test/ai-provider/inferAdvertisesRegistered.test.ts
+++ b/packages/test/src/test/ai-provider/inferAdvertisesRegistered.test.ts
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Capability, ModelRecord } from "@workglow/ai";
+import { _testOnly as anthropic } from "@workglow/anthropic/ai";
+import { _testOnly as cactus } from "@workglow/cactus/ai";
+import { _testOnly as chromeAi } from "@workglow/chrome-ai/ai";
+import { _testOnly as deepseek } from "@workglow/deepseek/ai";
+import { _testOnly as gemini } from "@workglow/google-gemini/ai";
+import { _testOnly as hfi } from "@workglow/huggingface-inference/ai";
+import { _testOnly as hft } from "@workglow/huggingface-transformers/ai";
+import { _testOnly as llamaServer } from "@workglow/llamacpp-server/ai";
+import { _testOnly as llamaCpp } from "@workglow/node-llama-cpp/ai";
+import { _testOnly as ollama } from "@workglow/ollama/ai";
+import { _testOnly as openai } from "@workglow/openai/ai";
+import { _testOnly as openrouter } from "@workglow/openrouter/ai";
+import { _testOnly as sdCpp } from "@workglow/stable-diffusion-server/ai";
+import { _testOnly as tfmp } from "@workglow/tf-mediapipe/ai";
+import { _testOnly as xai } from "@workglow/xai/ai";
+import { describe, it } from "vitest";
+
+import { assertInferAdvertisesRegistered } from "../../contract/ai-provider/assertions/inferAdvertisesRegistered";
+
+function model(
+  provider: string,
+  model_id: string,
+  extra: { provider_config?: Record<string, unknown>; metadata?: Record<string, unknown> } = {}
+): ModelRecord {
+  return {
+    model_id,
+    title: model_id,
+    description: "",
+    provider,
+    provider_config: { model_name: model_id, model_path: model_id, ...extra.provider_config },
+    capabilities: [],
+    metadata: extra.metadata ?? {},
+  } as ModelRecord;
+}
+
+function servesOf(
+  specs: readonly { readonly serves: readonly Capability[] }[]
+): readonly (readonly string[])[] {
+  return specs.map((spec) => spec.serves);
+}
+
+describe("inferCapabilities advertises every registered capability", () => {
+  it.each([
+    {
+      name: "anthropic",
+      registered: servesOf(anthropic.ANTHROPIC_RUN_FN_SPECS),
+      inferred: ["claude-sonnet-5"].map((id) =>
+        new anthropic.AnthropicQueuedProvider(anthropic.ANTHROPIC_RUN_FNS).inferCapabilities(
+          model("ANTHROPIC", id)
+        )
+      ),
+    },
+    {
+      name: "openai",
+      registered: servesOf(openai.OPENAI_RUN_FN_SPECS),
+      inferred: ["gpt-4o", "text-embedding-3-small", "dall-e-3", "gpt-image-1"].map((id) =>
+        new openai.OpenAiQueuedProvider(openai.OPENAI_RUN_FNS).inferCapabilities(
+          model("OPENAI", id)
+        )
+      ),
+    },
+    {
+      name: "google-gemini",
+      registered: servesOf(gemini.GEMINI_RUN_FN_SPECS),
+      inferred: [
+        "gemini-2.5-pro",
+        "gemini-embedding-001",
+        "imagen-4.0-generate-001",
+        "gemini-3.1-flash-image",
+      ].map((id) =>
+        new gemini.GoogleGeminiQueuedProvider(gemini.GEMINI_RUN_FNS).inferCapabilities(
+          model("GOOGLE_GEMINI", id)
+        )
+      ),
+    },
+    {
+      name: "xai",
+      registered: servesOf(xai.XAI_RUN_FN_SPECS),
+      inferred: ["grok-4", "grok-2-image-1212"].map((id) =>
+        new xai.XaiQueuedProvider(xai.XAI_RUN_FNS).inferCapabilities(model("XAI", id))
+      ),
+    },
+    {
+      name: "deepseek",
+      registered: servesOf(deepseek.DEEPSEEK_RUN_FN_SPECS),
+      inferred: ["deepseek-v4-flash"].map((id) =>
+        new deepseek.DeepSeekQueuedProvider(deepseek.DEEPSEEK_RUN_FNS).inferCapabilities(
+          model("DEEPSEEK", id)
+        )
+      ),
+    },
+    {
+      name: "openrouter",
+      registered: servesOf(openrouter.OPENROUTER_RUN_FN_SPECS),
+      inferred: [
+        new openrouter.OpenRouterQueuedProvider(openrouter.OPENROUTER_RUN_FNS).inferCapabilities(
+          model("OPENROUTER", "openai/gpt-5", {
+            metadata: {
+              architecture: { input_modalities: ["text"] },
+              supported_parameters: ["tools", "response_format"],
+            },
+          })
+        ),
+      ],
+    },
+    {
+      name: "huggingface-transformers",
+      registered: servesOf(hft.HFT_RUN_FN_SPECS),
+      inferred: (
+        [
+          ["onnx-community/Llama-3.2-1B-Instruct-q4f16"],
+          ["Xenova/all-MiniLM-L6-v2", { pipeline_task: "feature-extraction" }],
+          ["Xenova/modnet", { pipeline_task: "background-removal" }],
+          ["Xenova/bge-reranker-base"],
+          ["Xenova/language-detection"],
+          ["Xenova/clip-vit-base-patch32"],
+          ["Xenova/distilbert-base-uncased", { pipeline_task: "text-classification" }],
+          ["Xenova/bert-base-ner", { pipeline_task: "token-classification" }],
+          ["Xenova/bert-base-uncased", { pipeline_task: "fill-mask" }],
+          ["Xenova/t5-small", { pipeline_task: "translation" }],
+          ["Xenova/distilbert-base-cased-distilled-squad", { pipeline_task: "question-answering" }],
+          ["Xenova/segformer", { pipeline_task: "image-segmentation" }],
+          ["Xenova/vit-gpt2", { pipeline_task: "image-to-text" }],
+          ["Xenova/yolos-tiny", { pipeline_task: "object-detection" }],
+        ] as const
+      ).map(([id, pc]) =>
+        new hft.HuggingFaceTransformersQueuedProvider(hft.HFT_RUN_FNS).inferCapabilities(
+          model("HF_TRANSFORMERS_ONNX", id, pc ? { provider_config: pc } : {})
+        )
+      ),
+    },
+    {
+      name: "huggingface-inference",
+      registered: servesOf(hfi.HFI_RUN_FN_SPECS),
+      inferred: [
+        "mistralai/Mistral-7B-Instruct-v0.3",
+        "Xenova/all-MiniLM-L6-v2",
+        "black-forest-labs/FLUX.1-dev",
+      ].map((id) =>
+        new hfi.HfInferenceQueuedProvider(hfi.HFI_RUN_FNS).inferCapabilities(
+          model("HF_INFERENCE", id)
+        )
+      ),
+    },
+    {
+      name: "node-llama-cpp",
+      registered: servesOf(llamaCpp.LLAMACPP_RUN_FN_SPECS),
+      inferred: ["Mistral-7B-Instruct-v0.3.Q4_K_M.gguf", "nomic-embed-text-v1.5.Q4_K_M.gguf"].map(
+        (id) =>
+          new llamaCpp.LlamaCppQueuedProvider(llamaCpp.LLAMACPP_RUN_FNS).inferCapabilities(
+            model("LOCAL_LLAMACPP", id)
+          )
+      ),
+    },
+    {
+      name: "llamacpp-server",
+      registered: servesOf(llamaServer.LLAMACPP_SERVER_RUN_FN_SPECS),
+      inferred: ["llama-3-8b-q4_k_m.gguf", "nomic-embed-text.gguf"].map((id) =>
+        new llamaServer.LlamaCppServerQueuedProvider(
+          llamaServer.buildLlamaCppServerRunFns({})
+        ).inferCapabilities(model("LOCAL_LLAMACPP_SERVER", id))
+      ),
+    },
+    {
+      name: "ollama",
+      registered: servesOf(ollama.OLLAMA_RUN_FN_SPECS),
+      inferred: ["llama3.2", "nomic-embed-text", "llava"].map((id) =>
+        new ollama.OllamaQueuedProvider(ollama.OLLAMA_RUN_FNS).inferCapabilities(
+          model("OLLAMA", id)
+        )
+      ),
+    },
+    {
+      name: "chrome-ai",
+      registered: servesOf(chromeAi.WEB_BROWSER_RUN_FN_SPECS),
+      inferred: [
+        "chrome-prompt",
+        "chrome-summarizer",
+        "chrome-rewriter",
+        "chrome-translator",
+        "chrome-language-detector",
+      ].map((id) => chromeAi.inferWebBrowserCapabilities(model("WEB_BROWSER", id))),
+    },
+    {
+      name: "tf-mediapipe",
+      registered: servesOf(tfmp.TFMP_RUN_FN_SPECS),
+      inferred: [
+        "gemma3-1b-it-int4-web.task",
+        "gesture_recognizer.task",
+        "face_landmarker.task",
+        "blaze_face_short_range.tflite",
+        "pose_landmarker_lite.task",
+        "efficientdet_lite0.tflite",
+        "selfie_segmenter.tflite",
+        "efficientnet_lite0.tflite",
+        "image_embedder.tflite",
+        "universal_sentence_encoder.tflite",
+        "bert_classifier.tflite",
+        "language_detector.tflite",
+      ].map((id) =>
+        new tfmp.TensorFlowMediaPipeQueuedProvider(tfmp.TFMP_RUN_FNS).inferCapabilities(
+          model("TENSORFLOW_MEDIAPIPE", id)
+        )
+      ),
+    },
+    {
+      name: "cactus",
+      registered: cactus.CACTUS_RUN_FNS.map((r) => r.serves),
+      inferred: [
+        new cactus.CactusQueuedProvider().inferCapabilities(model("LOCAL_CACTUS", "needle-26m")),
+      ],
+    },
+    {
+      name: "stable-diffusion-server",
+      registered: servesOf(sdCpp.STABLE_DIFFUSION_CPP_RUN_FN_SPECS),
+      inferred: ["sd-1.5.gguf"].map((id) =>
+        new sdCpp.StableDiffusionCppQueuedProvider(
+          sdCpp.buildStableDiffusionCppRunFns({})
+        ).inferCapabilities(model("LOCAL_STABLE_DIFFUSION_CPP", id))
+      ),
+    },
+  ])("$name", ({ name, registered, inferred }) => {
+    assertInferAdvertisesRegistered(name, registered, inferred);
+  });
+});

--- a/providers/anthropic/src/ai/common/Anthropic_Capabilities.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Capabilities.ts
@@ -52,6 +52,7 @@ export function inferAnthropicCapabilities(model: CapabilityHints): readonly Cap
       "tool-use",
       "json-mode",
       "vision-input",
+      "cache.checkpoint",
       "model.count-tokens",
       "model.info",
       "model.search",

--- a/providers/anthropic/src/ai/common/Anthropic_Thinking.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Thinking.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isModelEffort, type ModelEffort } from "@workglow/ai/worker";
+import { isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
 import { getLogger } from "@workglow/util/worker";
+import { anthropicEffortPolicy } from "./Anthropic_EffortPolicy";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
 import { parseAnthropicModelId } from "./Anthropic_RequestParams";
 
@@ -95,11 +96,15 @@ export function buildAnthropicThinkingParams(
     return result;
   }
 
-  if (!isModelEffort(model?.effort) || model.effort === "none") {
+  if (
+    model === undefined ||
+    !isModelEffortEnabled(model, anthropicEffortPolicy(model)) ||
+    model.effort === "none"
+  ) {
     return { max_tokens: maxTokens };
   }
 
-  const effort = model.effort;
+  const effort = model.effort as ModelEffort;
   const budget = EFFORT_TO_BUDGET[effort];
 
   if (anthropicSupportsAdaptiveThinking(model)) {

--- a/providers/anthropic/src/ai/common/Anthropic_Thinking.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Thinking.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
+import { isModelEffort, isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
 import { getLogger } from "@workglow/util/worker";
 import { anthropicEffortPolicy } from "./Anthropic_EffortPolicy";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
@@ -96,15 +96,16 @@ export function buildAnthropicThinkingParams(
     return result;
   }
 
+  const effort = model?.effort;
   if (
     model === undefined ||
     !isModelEffortEnabled(model, anthropicEffortPolicy(model)) ||
-    model.effort === "none"
+    !isModelEffort(effort) ||
+    effort === "none"
   ) {
     return { max_tokens: maxTokens };
   }
 
-  const effort = model.effort as ModelEffort;
   const budget = EFFORT_TO_BUDGET[effort];
 
   if (anthropicSupportsAdaptiveThinking(model)) {

--- a/providers/chrome-ai/src/ai/index.ts
+++ b/providers/chrome-ai/src/ai/index.ts
@@ -11,7 +11,10 @@ export * from "./common/WebBrowser_Constants";
 export * from "./common/WebBrowser_ModelSchema";
 export * from "./registerWebBrowser";
 
-import { WEB_BROWSER_RUN_FN_SPECS } from "./common/WebBrowser_Capabilities";
+import {
+  inferWebBrowserCapabilities,
+  WEB_BROWSER_RUN_FN_SPECS,
+} from "./common/WebBrowser_Capabilities";
 import { _resetProbeCache, probeWebBrowserCapabilities } from "./common/WebBrowser_CapabilityProbe";
 import { WebBrowser_Chat } from "./common/WebBrowser_Chat";
 import {
@@ -49,6 +52,7 @@ export const _testOnly = {
   WebBrowserProvider,
   WEB_BROWSER_RUN_FN_SPECS,
   WEB_BROWSER_RUN_FNS,
+  inferWebBrowserCapabilities,
   WebBrowser_Chat,
   WebBrowser_TextGeneration_Unified,
   WebBrowser_StructuredGeneration,

--- a/providers/deepseek/src/ai/common/DeepSeek_Client.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_Client.ts
@@ -5,7 +5,8 @@
  */
 
 import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
-import { isModelEffort, type ModelEffort } from "@workglow/ai/worker";
+import { isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
+import { deepseekEffortPolicy } from "./DeepSeek_EffortPolicy";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
 
 /** Maps coarse {@link ModelEffort} to DeepSeek reasoning token allowance. */
@@ -143,8 +144,8 @@ export function resolveMaxTokens(
   let allowance: number;
   if (typeof configured === "number") {
     allowance = configured;
-  } else if (isModelEffort(model?.effort)) {
-    allowance = EFFORT_TO_REASONING_ALLOWANCE[model.effort];
+  } else if (model && isModelEffortEnabled(model, deepseekEffortPolicy(model))) {
+    allowance = EFFORT_TO_REASONING_ALLOWANCE[model.effort as ModelEffort];
   } else {
     allowance = DEEPSEEK_DEFAULT_REASONING_ALLOWANCE;
   }

--- a/providers/google-gemini/src/ai/common/Gemini_Capabilities.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Capabilities.ts
@@ -127,6 +127,7 @@ export function inferGeminiCapabilities(model: CapabilityHints): readonly Capabi
       "json-mode",
       "vision-input",
       "cache.checkpoint",
+      "session.dispose",
       "model.count-tokens",
       "model.info",
       "model.search",

--- a/providers/google-gemini/src/ai/common/Gemini_Client.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Client.ts
@@ -6,7 +6,8 @@
 
 import type { GoogleGenAI } from "@google/genai";
 import { resolveApiKey } from "@workglow/ai/provider-utils";
-import { isModelEffort, type ModelEffort } from "@workglow/ai/worker";
+import { isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
+import { geminiEffortPolicy } from "./Gemini_EffortPolicy";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 
 /** Maps coarse {@link ModelEffort} to Gemini thinkingBudget tokens. */
@@ -124,7 +125,9 @@ export function getModelName(model: GeminiModelConfig | undefined): string {
 export function getThinkingBudget(model: GeminiModelConfig | undefined): number | undefined {
   const configured = model?.provider_config?.thinking_budget;
   if (typeof configured === "number") return configured;
-  if (isModelEffort(model?.effort)) return EFFORT_TO_THINKING_BUDGET[model.effort];
+  if (model && isModelEffortEnabled(model, geminiEffortPolicy(model))) {
+    return EFFORT_TO_THINKING_BUDGET[model.effort as ModelEffort];
+  }
   return undefined;
 }
 

--- a/providers/huggingface-transformers/src/ai/common/HFT_Capabilities.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Capabilities.ts
@@ -15,6 +15,13 @@ export function hftWorkerRunFnSpecs(): readonly { readonly serves: readonly Capa
 
 type CapabilityHints = Pick<ModelRecord, "model_id" | "provider_config" | "capabilities">;
 
+const HFT_META = [
+  "model.download",
+  "model.download-remove",
+  "model.info",
+  "model.search",
+] as const satisfies readonly Capability[];
+
 /**
  * Heuristic capability inference for a HuggingFace Transformers
  * {@link ModelRecord}.
@@ -52,67 +59,65 @@ export function inferHftCapabilities(model: CapabilityHints): readonly Capabilit
         "text.rewriter",
         "text.summary",
         "tool-use",
+        "json-mode",
         "cache.checkpoint",
+        "session.dispose",
         "model.count-tokens",
-        "model.download-remove",
-        "model.info",
-        "model.search",
+        ...HFT_META,
       ];
     case "feature-extraction":
     case "sentence-similarity":
-      return ["text.embedding", "model.download-remove", "model.info", "model.search"];
+      return ["text.embedding", ...HFT_META];
     case "text-classification":
-      return ["text.classification", "model.download-remove", "model.info", "model.search"];
+      return ["text.classification", ...HFT_META];
     case "token-classification":
-      return ["text.ner", "model.download-remove", "model.info", "model.search"];
+      return ["text.ner", ...HFT_META];
     case "fill-mask":
-      return ["text.fill-mask", "model.download-remove", "model.info", "model.search"];
+      return ["text.fill-mask", ...HFT_META];
     case "translation":
-      return ["text.translation", "model.download-remove", "model.info", "model.search"];
+      return ["text.translation", ...HFT_META];
     case "summarization":
-      return ["text.summary", "model.download-remove", "model.info", "model.search"];
+      return ["text.summary", ...HFT_META];
     case "question-answering":
-      return ["text.question-answering", "model.download-remove", "model.info", "model.search"];
+      return ["text.question-answering", ...HFT_META];
     case "image-classification":
-      return ["image.classification", "model.download-remove", "model.info", "model.search"];
+      return ["image.classification", ...HFT_META];
     case "image-segmentation":
-      return ["image.segmentation", "model.download-remove", "model.info", "model.search"];
+      return ["image.segmentation", ...HFT_META];
     case "image-to-text":
-      return ["image.to-text", "model.download-remove", "model.info", "model.search"];
+      return ["image.to-text", ...HFT_META];
     case "object-detection":
-      return ["image.object-detection", "model.download-remove", "model.info", "model.search"];
+      return ["image.object-detection", ...HFT_META];
+    case "background-removal":
+      return ["image.background-removal", ...HFT_META];
     case "zero-shot-image-classification":
-      return [
-        "image.classification",
-        "image.embedding",
-        "model.download-remove",
-        "model.info",
-        "model.search",
-      ];
+      return ["image.classification", "image.embedding", ...HFT_META];
   }
 
   // Fallback name-based pattern matching for repos without pipeline_task.
   const baseName = id.split("/").pop() ?? id;
+  // Rerankers share `bge-` with embedders; match them first so they don't
+  // collapse into text.embedding.
+  if (/rerank/i.test(baseName)) {
+    return ["text.reranking", ...HFT_META];
+  }
+  if (/language.?detect|langid/i.test(baseName)) {
+    return ["text.language-detection", ...HFT_META];
+  }
   if (/embed|minilm|bge-|gte-|e5-/i.test(baseName)) {
-    return ["text.embedding", "model.download-remove", "model.info", "model.search"];
+    return ["text.embedding", ...HFT_META];
   }
   if (/clip|siglip/i.test(baseName)) {
-    return [
-      "image.classification",
-      "image.embedding",
-      "model.download-remove",
-      "model.info",
-      "model.search",
-    ];
+    return ["image.classification", "image.embedding", ...HFT_META];
   }
   if (/yolo|detr|owl/i.test(baseName)) {
-    return ["image.object-detection", "model.download-remove", "model.info", "model.search"];
+    return ["image.object-detection", ...HFT_META];
   }
   if (/sam|segformer|mask/i.test(baseName)) {
-    return ["image.segmentation", "model.download-remove", "model.info", "model.search"];
+    return ["image.segmentation", ...HFT_META];
   }
   if (/blip|llava|vision/i.test(baseName)) {
-    return ["image.to-text", "model.download-remove", "model.info", "model.search"];
+    return ["image.to-text", ...HFT_META];
   }
   if (/llama|mistral|gemma|phi|qwen|tinyllama|smollm/i.test(baseName)) {
     return [
@@ -120,11 +125,11 @@ export function inferHftCapabilities(model: CapabilityHints): readonly Capabilit
       "text.rewriter",
       "text.summary",
       "tool-use",
+      "json-mode",
       "cache.checkpoint",
+      "session.dispose",
       "model.count-tokens",
-      "model.download-remove",
-      "model.info",
-      "model.search",
+      ...HFT_META,
     ];
   }
 

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Capabilities.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Capabilities.ts
@@ -41,10 +41,13 @@ export function inferLlamaCppCapabilities(model: CapabilityHints): readonly Capa
   if (/embed|minilm|bge-|gte-|e5-/i.test(baseName)) {
     return [
       "text.embedding",
+      "cache.checkpoint",
       "model.count-tokens",
+      "model.download",
       "model.download-remove",
       "model.info",
       "model.search",
+      "session.dispose",
     ];
   }
 
@@ -56,10 +59,13 @@ export function inferLlamaCppCapabilities(model: CapabilityHints): readonly Capa
       "text.summary",
       "tool-use",
       "json-mode",
+      "cache.checkpoint",
       "model.count-tokens",
+      "model.download",
       "model.download-remove",
       "model.info",
       "model.search",
+      "session.dispose",
     ];
   }
 

--- a/providers/openai/src/ai/common/OpenAI_Client.ts
+++ b/providers/openai/src/ai/common/OpenAI_Client.ts
@@ -5,7 +5,8 @@
  */
 
 import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
-import { isModelEffort, type ModelEffort } from "@workglow/ai/worker";
+import { isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
+import { openaiEffortPolicy } from "./OpenAI_EffortPolicy";
 import type { OpenAiModelConfig } from "./OpenAI_ModelSchema";
 
 /** Maps coarse {@link ModelEffort} to OpenAI Responses `reasoning.effort`. */
@@ -131,8 +132,8 @@ export function getReasoningConfig(
   if (reasoning && (reasoning.effort !== undefined || reasoning.mode !== undefined)) {
     return reasoning;
   }
-  if (isModelEffort(model?.effort)) {
-    return { effort: EFFORT_TO_OPENAI[model.effort] };
+  if (model && isModelEffortEnabled(model, openaiEffortPolicy(model))) {
+    return { effort: EFFORT_TO_OPENAI[model.effort as ModelEffort] };
   }
   return undefined;
 }

--- a/providers/openrouter/src/ai/common/OpenRouter_RequestParams.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_RequestParams.ts
@@ -5,9 +5,10 @@
  */
 
 import type { TextGenerationTaskInput } from "@workglow/ai";
-import { isModelEffort, toOpenAIMessages, type ModelEffort } from "@workglow/ai/worker";
+import { isModelEffortEnabled, toOpenAIMessages, type ModelEffort } from "@workglow/ai/worker";
 import type { OpenRouterProviderConfig } from "./OpenRouter_Client";
 import { getModelName } from "./OpenRouter_Client";
+import { openrouterEffortPolicy } from "./OpenRouter_EffortPolicy";
 import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
 
 /** Maps coarse {@link ModelEffort} onto OpenRouter's `reasoning` extras. */
@@ -68,8 +69,8 @@ export function buildOpenRouterExtras(
   const extras: Record<string, unknown> = {};
   if (pc?.provider_routing) extras.provider = pc.provider_routing;
   if (pc?.reasoning) extras.reasoning = pc.reasoning;
-  else if (isModelEffort(model?.effort)) {
-    extras.reasoning = mapEffortToOpenRouterReasoning(model.effort);
+  else if (model && isModelEffortEnabled(model, openrouterEffortPolicy(model))) {
+    extras.reasoning = mapEffortToOpenRouterReasoning(model.effort as ModelEffort);
   }
   if (pc?.web_search) {
     extras.plugins = [pc.web_search === true ? { id: "web" } : { id: "web", ...pc.web_search }];

--- a/providers/tf-mediapipe/src/ai/common/TFMP_Capabilities.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_Capabilities.ts
@@ -15,6 +15,13 @@ export function tfmpWorkerRunFnSpecs(): readonly { readonly serves: readonly Cap
 
 type CapabilityHints = Pick<ModelRecord, "model_id" | "provider_config" | "capabilities">;
 
+const TFMP_META = [
+  "model.download",
+  "model.download-remove",
+  "model.info",
+  "model.search",
+] as const satisfies readonly Capability[];
+
 /**
  * Heuristic capability inference for TensorFlow MediaPipe {@link ModelRecord}.
  *
@@ -38,58 +45,45 @@ export function inferTfmpCapabilities(model: CapabilityHints): readonly Capabili
 
   // LLM bundles for the genai engine (e.g. Gemma/Qwen .task / .litertlm files).
   if (/gemma|qwen|\.litertlm$|(?:^|[-_])llm(?:[-_.]|$)/.test(baseName)) {
-    return [
-      "text.generation",
-      "json-mode",
-      "model.count-tokens",
-      "model.download-remove",
-      "model.info",
-      "model.search",
-    ];
+    return ["text.generation", "json-mode", "model.count-tokens", ...TFMP_META];
   }
 
   // Hand landmarker / gesture recognizer share `hand_*` filenames.
   if (/gesture_recognizer/.test(baseName)) {
-    return [
-      "vision.gesture",
-      "vision.hand-landmarks",
-      "model.download-remove",
-      "model.info",
-      "model.search",
-    ];
+    return ["vision.gesture", "vision.hand-landmarks", ...TFMP_META];
   }
   if (/hand_landmarker/.test(baseName)) {
-    return ["vision.hand-landmarks", "model.download-remove", "model.info", "model.search"];
+    return ["vision.hand-landmarks", ...TFMP_META];
   }
   if (/face_landmarker/.test(baseName)) {
-    return ["vision.face-landmarks", "model.download-remove", "model.info", "model.search"];
+    return ["vision.face-landmarks", ...TFMP_META];
   }
   if (/face_detector|blaze_face/.test(baseName)) {
-    return ["vision.face-detection", "model.download-remove", "model.info", "model.search"];
+    return ["vision.face-detection", ...TFMP_META];
   }
   if (/pose_landmarker/.test(baseName)) {
-    return ["vision.pose-landmarks", "model.download-remove", "model.info", "model.search"];
+    return ["vision.pose-landmarks", ...TFMP_META];
   }
   if (/object_detector|efficientdet|ssd_mobilenet|yolo/.test(baseName)) {
-    return ["image.object-detection", "model.download-remove", "model.info", "model.search"];
+    return ["image.object-detection", ...TFMP_META];
   }
   if (/segmenter|deeplab|selfie/.test(baseName)) {
-    return ["image.segmentation", "model.download-remove", "model.info", "model.search"];
+    return ["image.segmentation", ...TFMP_META];
   }
   if (/image_classifier|efficientnet|mobilenet/.test(baseName)) {
-    return ["image.classification", "model.download-remove", "model.info", "model.search"];
+    return ["image.classification", ...TFMP_META];
   }
   if (/image_embed/.test(baseName)) {
-    return ["image.embedding", "model.download-remove", "model.info", "model.search"];
+    return ["image.embedding", ...TFMP_META];
   }
   if (/text_embed|universal_sentence_encoder|use_/.test(baseName)) {
-    return ["text.embedding", "model.download-remove", "model.info", "model.search"];
+    return ["text.embedding", ...TFMP_META];
   }
   if (/text_classifier|bert_classifier/.test(baseName)) {
-    return ["text.classification", "model.download-remove", "model.info", "model.search"];
+    return ["text.classification", ...TFMP_META];
   }
   if (/language_detector/.test(baseName)) {
-    return ["text.language-detection", "model.download-remove", "model.info", "model.search"];
+    return ["text.language-detection", ...TFMP_META];
   }
 
   return ["model.search", "model.info"];

--- a/providers/xai/src/ai/common/Xai_Client.ts
+++ b/providers/xai/src/ai/common/Xai_Client.ts
@@ -5,7 +5,8 @@
  */
 
 import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
-import { isModelEffort, type ModelEffort } from "@workglow/ai/worker";
+import { isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
+import { xaiEffortPolicy } from "./Xai_EffortPolicy";
 import type { XaiModelConfig } from "./Xai_ModelSchema";
 
 /** Default base URL for the xAI (Grok) OpenAI-compatible API. */
@@ -128,6 +129,8 @@ export function getXaiReasoningEffort(model: XaiModelConfig | undefined): string
     const trimmed = native.trim();
     if (XAI_REASONING_EFFORTS.has(trimmed)) return trimmed;
   }
-  if (model && isModelEffort(model.effort)) return EFFORT_TO_XAI[model.effort];
+  if (model && isModelEffortEnabled(model, xaiEffortPolicy(model))) {
+    return EFFORT_TO_XAI[model.effort as ModelEffort];
+  }
   return undefined;
 }


### PR DESCRIPTION
Implement `isModelEffortEnabled` function to determine if a model's effort is valid based on its policy. Update related tests and integrate the new function into existing provider logic for effort handling. This enhances the model's capability management by ensuring that only supported efforts are processed.