### PR TITLE
fix(tasks)!: contain the server filesystem tasks by default

### DIFF
--- a/packages/tasks/README.md
+++ b/packages/tasks/README.md
@@ -15,6 +15,7 @@ A package of task types for common operations, workflow management, and data pro
   - [LambdaTask](#lambdatask)
   - [JsonTask](#jsontask)
   - [ArrayTask](#arraytask)
+- [Filesystem Tasks (server builds)](#filesystem-tasks-server-builds)
 - [Workflow Integration](#workflow-integration)
 - [Error Handling](#error-handling)
 - [Configuration](#configuration)
@@ -562,6 +563,58 @@ const result = await task.run();
 - Automatic task instance creation per array element
 - Combination generation for multiple array inputs
 - Seamless single-value and array handling
+
+## Filesystem Tasks (server builds)
+
+The Node and Electron builds ship three tasks that read the local filesystem —
+`FileGrepTask`, `FileLoaderTask` and `FileSedTask`.
+
+**They are not registered by default.** `registerCommonTasks()` deliberately
+leaves them out of `TaskRegistry`, because the registry is what a _deserialized_
+graph resolves a task type through, and a serialized node supplies its own
+`config` — so a graph naming `FileGrepTask` also names its own `roots`, and no
+default this package picks can constrain it. The only control that survives
+untrusted graph JSON is the task not being resolvable at all.
+
+A host that intends to expose them opts in:
+
+```typescript
+import { registerCommonTasks, registerFileSystemTasks } from "@workglow/tasks";
+
+registerCommonTasks();
+// Only where every graph reaching the registry is trusted:
+registerFileSystemTasks();
+```
+
+The classes are exported either way, so constructing one directly needs no
+registration:
+
+```typescript
+import { FileGrepTask } from "@workglow/tasks";
+
+const result = await new FileGrepTask({
+  roots: ["/srv/data"], // defaults to [process.cwd()]
+  defaults: { url: "/srv/data/app.log", pattern: "ERROR" },
+}).run();
+```
+
+### Root containment
+
+Each task resolves and `realpath`s a local path before opening it, then
+requires the result to sit inside one of `config.roots`. Omitting `roots` means
+`[process.cwd()]` — **not** "anywhere on the host". The `filesystem:read`
+entitlement is not a substitute: it is only consulted when the embedder both
+runs the graph with `enforceEntitlements` and registers an
+`ENTITLEMENT_ENFORCER`, and neither is the default.
+
+Set `allowAnyRoot: true` to read any path the process can open. It has to be
+said explicitly; leaving `roots` unset never implies it.
+
+```typescript
+new FileGrepTask({ allowAnyRoot: true, defaults: { url, pattern } });
+```
+
+An unresolvable entry in `roots` fails the call wherever it sits in the array.
 
 ## Workflow Integration
 

--- a/packages/tasks/src/electron.ts
+++ b/packages/tasks/src/electron.ts
@@ -22,10 +22,37 @@ import { FileGrepTask } from "./task/FileGrepTask.server";
 import { FileLoaderTask } from "./task/FileLoaderTask.server";
 import { FileSedTask } from "./task/FileSedTask.server";
 
+/**
+ * Registers the tasks that are safe to have in the ambient registry on a
+ * server.
+ *
+ * The three filesystem tasks are NOT among them, and their absence is the
+ * point. `TaskRegistry` is what a deserialized graph resolves a task type
+ * through, and a serialized node carries its own `config` — so a graph that
+ * names `FileGrepTask` also states its own `roots`, and no default this
+ * package picks can constrain it. The only control that survives untrusted
+ * JSON is the task not being resolvable at all.
+ *
+ * A host that intends to expose them opts in with
+ * {@link registerFileSystemTasks}. The classes are exported either way, so
+ * constructing one directly is unchanged.
+ */
 export const registerCommonTasks = () => {
-  const tasks = registerCommonTasksFn();
+  return registerCommonTasksFn();
+};
+
+/**
+ * Adds the filesystem tasks to the ambient registry, making them resolvable by
+ * type name — including from graph JSON the host did not author.
+ *
+ * Call it only where every graph that can reach the registry is trusted. Each
+ * task still contains reads to its `config.roots`, which defaults to
+ * `process.cwd()`, but a serialized node supplies its own config: registration
+ * is the boundary, containment is the backstop behind it.
+ */
+export const registerFileSystemTasks = () => {
   TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
   TaskRegistry.registerTask(FileSedTask);
-  return [...tasks, FileGrepTask, FileLoaderTask, FileSedTask];
+  return [FileGrepTask, FileLoaderTask, FileSedTask];
 };

--- a/packages/tasks/src/node.ts
+++ b/packages/tasks/src/node.ts
@@ -24,10 +24,37 @@ import { FileGrepTask } from "./task/FileGrepTask.server";
 import { FileLoaderTask } from "./task/FileLoaderTask.server";
 import { FileSedTask } from "./task/FileSedTask.server";
 
+/**
+ * Registers the tasks that are safe to have in the ambient registry on a
+ * server.
+ *
+ * The three filesystem tasks are NOT among them, and their absence is the
+ * point. `TaskRegistry` is what a deserialized graph resolves a task type
+ * through, and a serialized node carries its own `config` — so a graph that
+ * names `FileGrepTask` also states its own `roots`, and no default this
+ * package picks can constrain it. The only control that survives untrusted
+ * JSON is the task not being resolvable at all.
+ *
+ * A host that intends to expose them opts in with
+ * {@link registerFileSystemTasks}. The classes are exported either way, so
+ * constructing one directly is unchanged.
+ */
 export const registerCommonTasks = () => {
-  const tasks = registerCommonTasksFn();
+  return registerCommonTasksFn();
+};
+
+/**
+ * Adds the filesystem tasks to the ambient registry, making them resolvable by
+ * type name — including from graph JSON the host did not author.
+ *
+ * Call it only where every graph that can reach the registry is trusted. Each
+ * task still contains reads to its `config.roots`, which defaults to
+ * `process.cwd()`, but a serialized node supplies its own config: registration
+ * is the boundary, containment is the backstop behind it.
+ */
+export const registerFileSystemTasks = () => {
   TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
   TaskRegistry.registerTask(FileSedTask);
-  return [...tasks, FileGrepTask, FileLoaderTask, FileSedTask];
+  return [FileGrepTask, FileLoaderTask, FileSedTask];
 };

--- a/packages/tasks/src/task/FileGrepTask.server.ts
+++ b/packages/tasks/src/task/FileGrepTask.server.ts
@@ -44,7 +44,14 @@ const fileGrepTaskConfigSchema = {
       type: "array",
       items: { type: "string" },
       title: "Roots",
-      description: "Directories a local path must resolve inside (after symlink resolution)",
+      description:
+        "Directories a local path must resolve inside (after symlink resolution). Defaults to the process working directory",
+      "x-ui-hidden": true,
+    },
+    allowAnyRoot: {
+      type: "boolean",
+      title: "Allow Any Root",
+      description: "Skip root containment entirely and read any path the process can open",
       "x-ui-hidden": true,
     },
   },
@@ -61,8 +68,10 @@ const fileGrepTaskConfigSchema = {
  * so a file with no line terminator cannot exhaust memory.
  *
  * A local path is resolved and realpath'd before it is opened, and constrained
- * to `config.roots` when the embedder sets them. Reading requires the
- * `filesystem:read` entitlement, declared scoped to the resolved path.
+ * to `config.roots` — which defaults to the process working directory, so a
+ * task with no stated root reads from there and nowhere else. Set
+ * `config.allowAnyRoot` to opt out. Reading requires the `filesystem:read`
+ * entitlement, declared scoped to the resolved path.
  *
  * Only available in Node.js and Bun environments. For cross-platform grep
  * (including browser), use FileGrepTask with an http(s) URL.
@@ -112,7 +121,12 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
           {
             id: Entitlements.FILESYSTEM_READ,
             reason: "Reads a local file from disk",
-            resources: [resolveLocalFilePath(url, { roots: this.config.roots })],
+            resources: [
+              resolveLocalFilePath(url, {
+                roots: this.config.roots,
+                allowAnyRoot: this.config.allowAnyRoot,
+              }),
+            ],
           },
         ],
       };
@@ -189,7 +203,10 @@ export class FileGrepTask extends BaseFileGrepTask<FileGrepTaskConfig> {
     }
     await context.updateProgress(0, "Opening file");
 
-    const file = resolveLocalFilePath(url, { roots: this.config.roots });
+    const file = resolveLocalFilePath(url, {
+      roots: this.config.roots,
+      allowAnyRoot: this.config.allowAnyRoot,
+    });
     this.assertResolvedPathDeclared(file);
 
     if (context.signal.aborted) {

--- a/packages/tasks/src/task/FileGrepTask.ts
+++ b/packages/tasks/src/task/FileGrepTask.ts
@@ -694,13 +694,21 @@ export class FileGrepTask<Config extends TaskConfig = TaskConfig> extends Task<
 export interface FileGrepTaskConfig extends TaskConfig {
   /**
    * Directories a local path must resolve inside, checked after symlinks are
-   * resolved. Omitted means unrestricted: the enforced control is the
-   * `filesystem:read` entitlement, and this is the embedder's extra fence.
+   * resolved. Omitted means `[process.cwd()]`, NOT unrestricted — the
+   * `filesystem:read` entitlement is only consulted when the embedder runs
+   * with `enforceEntitlements` and a registered enforcer, so it cannot stand
+   * in as the default fence. State {@link allowAnyRoot} to opt out.
    *
    * Honored only by the server build — the cross-platform class reaches
    * http(s) through `FetchUrlTask` and touches no filesystem.
    */
   readonly roots?: readonly string[] | undefined;
+  /**
+   * Read any path the process can open, skipping containment entirely. Only
+   * the literal `true` does so, and it is never implied by leaving `roots`
+   * unset.
+   */
+  readonly allowAnyRoot?: boolean | undefined;
 }
 
 export const fileGrep = (input: FileGrepTaskInput, config?: FileGrepTaskConfig) => {

--- a/packages/tasks/src/task/FileLoaderTask.server.ts
+++ b/packages/tasks/src/task/FileLoaderTask.server.ts
@@ -4,30 +4,166 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, TaskAbortedError, Workflow } from "@workglow/task-graph";
+import type { IExecuteContext, TaskEntitlements } from "@workglow/task-graph";
+import {
+  CreateWorkflow,
+  Entitlements,
+  mergeEntitlements,
+  TaskAbortedError,
+  TaskConfigSchema,
+  TaskEntitlementError,
+  Workflow,
+} from "@workglow/task-graph";
+import type { DataPortSchema } from "@workglow/util/schema";
 import { readFile } from "node:fs/promises";
 
-import type { FileLoaderTaskInput, FileLoaderTaskOutput } from "./FileLoaderTask";
+import {
+  isHttpUrl,
+  localFilePathFromUrl,
+  resolveLocalFilePath,
+} from "../util/LocalFilePath.server";
+import { fetchUrlEntitlementsFor, FetchUrlTask } from "./FetchUrlTask";
+import type {
+  FileLoaderTaskConfig,
+  FileLoaderTaskInput,
+  FileLoaderTaskOutput,
+} from "./FileLoaderTask";
 import { FileLoaderTask as BaseFileLoaderTask } from "./FileLoaderTask";
 
-export type { FileLoaderTaskInput, FileLoaderTaskOutput };
+export type { FileLoaderTaskConfig, FileLoaderTaskInput, FileLoaderTaskOutput };
+
+const fileLoaderTaskConfigSchema = {
+  type: "object",
+  properties: {
+    ...TaskConfigSchema["properties"],
+    roots: {
+      type: "array",
+      items: { type: "string" },
+      title: "Roots",
+      description:
+        "Directories a local path must resolve inside (after symlink resolution). Defaults to the process working directory",
+      "x-ui-hidden": true,
+    },
+    allowAnyRoot: {
+      type: "boolean",
+      title: "Allow Any Root",
+      description: "Skip root containment entirely and read any path the process can open",
+      "x-ui-hidden": true,
+    },
+  },
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
 
 /**
  * Server-only task for loading documents from the filesystem.
  * Uses Node.js/Bun file APIs directly for better performance.
  * Only available in Node.js and Bun environments.
  *
+ * A local path is resolved and realpath'd before it is opened, and constrained
+ * to `config.roots` — which defaults to the process working directory, so a
+ * task with no stated root reads from there and nowhere else. Set
+ * `config.allowAnyRoot` to opt out. Reading requires the `filesystem:read`
+ * entitlement, declared scoped to the resolved path.
+ *
  * For cross-platform document loading (including browser), use FileLoaderTask with URLs.
  */
-export class FileLoaderTask extends BaseFileLoaderTask {
+export class FileLoaderTask extends BaseFileLoaderTask<FileLoaderTaskConfig> {
+  public static override hasDynamicEntitlements: boolean = true;
+
+  public static override configSchema(): DataPortSchema {
+    return fileLoaderTaskConfigSchema as DataPortSchema;
+  }
+
+  /**
+   * The owned `FetchUrlTask` does the network access for the http(s) branch,
+   * but an owned child is created inside `execute()` and so is absent from the
+   * graph-start snapshot `computeGraphEntitlements` takes. Declaring the
+   * fetch's entitlements here is what puts them in front of the enforcer,
+   * alongside the read this build adds.
+   */
+  public static override entitlements(): TaskEntitlements {
+    return mergeEntitlements(FetchUrlTask.entitlements(), {
+      entitlements: [
+        {
+          id: Entitlements.FILESYSTEM_READ,
+          reason: "Reads a local file or file:// URL from disk",
+        },
+      ],
+    });
+  }
+
+  /**
+   * Declares whichever half of the surface this url actually uses: the fetch
+   * entitlements for http(s), otherwise `filesystem:read` scoped to the
+   * resolved real path. An unknown url fails closed to both, unscoped.
+   *
+   * Never throws — entitlement evaluation runs before `execute()` and must
+   * produce a declaration for any input, so an unresolvable path degrades to
+   * the unscoped declaration and is refused later, at open time.
+   */
+  public override entitlements(): TaskEntitlements {
+    const url = this.runInputData?.url;
+    const unscopedRead: TaskEntitlements = {
+      entitlements: [{ id: Entitlements.FILESYSTEM_READ, reason: "Reads a local file from disk" }],
+    };
+
+    if (typeof url !== "string" || url.length === 0) {
+      return mergeEntitlements(fetchUrlEntitlementsFor(undefined), unscopedRead);
+    }
+
+    if (isHttpUrl(url)) {
+      return fetchUrlEntitlementsFor(url);
+    }
+
+    try {
+      return {
+        entitlements: [
+          {
+            id: Entitlements.FILESYSTEM_READ,
+            reason: "Reads a local file from disk",
+            resources: [
+              resolveLocalFilePath(url, {
+                roots: this.config.roots,
+                allowAnyRoot: this.config.allowAnyRoot,
+              }),
+            ],
+          },
+        ],
+      };
+    } catch {
+      return unscopedRead;
+    }
+  }
+
+  /**
+   * Refuses a path the instance did not declare. Entitlements are evaluated
+   * on the unresolved input, so without this a declare-then-swap would let the
+   * open authorize itself — and a standalone `fileLoader(...)` with no graph
+   * and no enforcer would honour no `roots` at all.
+   */
+  private assertResolvedPathDeclared(file: string): void {
+    const declared = this.entitlements().entitlements.find(
+      (entitlement) => entitlement.id === Entitlements.FILESYSTEM_READ
+    );
+    if (declared?.resources === undefined) {
+      throw new TaskEntitlementError(
+        `Refusing to read ${file}: the path could not be resolved when entitlements were declared`
+      );
+    }
+    if (!declared.resources.includes(file)) {
+      throw new TaskEntitlementError(
+        `Refusing to read ${file}: it differs from the declared path ${declared.resources.join(", ")}`
+      );
+    }
+  }
+
   override async execute(
     input: FileLoaderTaskInput,
     context: IExecuteContext
   ): Promise<FileLoaderTaskOutput> {
-    let { url, format = "auto" } = input;
+    const { url: inputUrl, format = "auto" } = input;
 
-    if (url.startsWith("http://") || url.startsWith("https://")) {
+    if (isHttpUrl(inputUrl)) {
       return super.execute(input, context);
     }
 
@@ -36,9 +172,15 @@ export class FileLoaderTask extends BaseFileLoaderTask {
     }
     await context.updateProgress(0, "Detecting file format");
 
-    if (url.startsWith("file://")) {
-      url = url.slice(7);
-    }
+    // The path as the caller named it, with a `file:` scheme decoded away: it
+    // is what the output reports and what the extension sniffing reads. `file`
+    // is the real, contained path, and is the only one opened.
+    const url = localFilePathFromUrl(inputUrl);
+    const file = resolveLocalFilePath(inputUrl, {
+      roots: this.config.roots,
+      allowAnyRoot: this.config.allowAnyRoot,
+    });
+    this.assertResolvedPathDeclared(file);
 
     const detectedFormat = this.detectFormat(url, format);
     const title = url.split("/").pop() || url;
@@ -49,7 +191,7 @@ export class FileLoaderTask extends BaseFileLoaderTask {
     await context.updateProgress(10, `Reading ${detectedFormat} file from filesystem`);
 
     if (detectedFormat === "json") {
-      const fileContent = await readFile(url, { encoding: "utf-8" });
+      const fileContent = await readFile(file, { encoding: "utf-8" });
       if (context.signal.aborted) {
         throw new TaskAbortedError("Task aborted");
       }
@@ -78,7 +220,7 @@ export class FileLoaderTask extends BaseFileLoaderTask {
     }
 
     if (detectedFormat === "csv") {
-      const fileContent = await readFile(url, { encoding: "utf-8" });
+      const fileContent = await readFile(file, { encoding: "utf-8" });
       if (!fileContent) {
         throw new Error(`Failed to load CSV from ${url}`);
       }
@@ -109,7 +251,7 @@ export class FileLoaderTask extends BaseFileLoaderTask {
     }
 
     if (detectedFormat === "image") {
-      const fileBuffer = await readFile(url);
+      const fileBuffer = await readFile(file);
       if (context.signal.aborted) {
         throw new TaskAbortedError("Task aborted");
       }
@@ -139,7 +281,7 @@ export class FileLoaderTask extends BaseFileLoaderTask {
     }
 
     if (detectedFormat === "pdf") {
-      const fileBuffer = await readFile(url);
+      const fileBuffer = await readFile(file);
       if (context.signal.aborted) {
         throw new TaskAbortedError("Task aborted");
       }
@@ -169,7 +311,7 @@ export class FileLoaderTask extends BaseFileLoaderTask {
     }
 
     // text, markdown, or html
-    const fileContent = await readFile(url, { encoding: "utf-8" });
+    const fileContent = await readFile(file, { encoding: "utf-8" });
     if (!fileContent) {
       throw new Error(`Failed to load content from ${url}`);
     }
@@ -225,13 +367,13 @@ export class FileLoaderTask extends BaseFileLoaderTask {
   }
 }
 
-export const fileLoader = (input: FileLoaderTaskInput, config?: TaskConfig) => {
+export const fileLoader = (input: FileLoaderTaskInput, config?: FileLoaderTaskConfig) => {
   return new FileLoaderTask(config).run(input);
 };
 
 declare module "@workglow/task-graph" {
   interface Workflow {
-    fileLoader: CreateWorkflow<FileLoaderTaskInput, FileLoaderTaskOutput, TaskConfig>;
+    fileLoader: CreateWorkflow<FileLoaderTaskInput, FileLoaderTaskOutput, FileLoaderTaskConfig>;
   }
 }
 

--- a/packages/tasks/src/task/FileLoaderTask.ts
+++ b/packages/tasks/src/task/FileLoaderTask.ts
@@ -107,7 +107,11 @@ export type FileLoaderTaskOutput = FromSchema<typeof outputSchema>;
  * Works in all environments (browser, Node.js, Bun) by using fetch API.
  * For server-only filesystem path access, see FileLoaderServerTask.
  */
-export class FileLoaderTask extends Task<FileLoaderTaskInput, FileLoaderTaskOutput, TaskConfig> {
+export class FileLoaderTask<Config extends TaskConfig = TaskConfig> extends Task<
+  FileLoaderTaskInput,
+  FileLoaderTaskOutput,
+  Config
+> {
   public static override type = "FileLoaderTask";
   public static override category = "Document";
   public static override title = "File Loader";
@@ -544,13 +548,39 @@ export class FileLoaderTask extends Task<FileLoaderTaskInput, FileLoaderTaskOutp
   }
 }
 
-export const fileLoader = (input: FileLoaderTaskInput, config?: TaskConfig) => {
+/**
+ * Config for both builds. `roots` is declared here rather than beside the
+ * server subclass because a `declare module` augmentation must state one type
+ * across every file that contributes it, and both files augment `Workflow`
+ * with `fileLoader`.
+ */
+export interface FileLoaderTaskConfig extends TaskConfig {
+  /**
+   * Directories a local path must resolve inside, checked after symlinks are
+   * resolved. Omitted means `[process.cwd()]`, NOT unrestricted — the
+   * `filesystem:read` entitlement is only consulted when the embedder runs
+   * with `enforceEntitlements` and a registered enforcer, so it cannot stand
+   * in as the default fence. State {@link allowAnyRoot} to opt out.
+   *
+   * Honored only by the server build — the cross-platform class reaches
+   * http(s) through `FetchUrlTask` and touches no filesystem.
+   */
+  readonly roots?: readonly string[] | undefined;
+  /**
+   * Read any path the process can open, skipping containment entirely. Only
+   * the literal `true` does so, and it is never implied by leaving `roots`
+   * unset.
+   */
+  readonly allowAnyRoot?: boolean | undefined;
+}
+
+export const fileLoader = (input: FileLoaderTaskInput, config?: FileLoaderTaskConfig) => {
   return new FileLoaderTask(config).run(input);
 };
 
 declare module "@workglow/task-graph" {
   interface Workflow {
-    fileLoader: CreateWorkflow<FileLoaderTaskInput, FileLoaderTaskOutput, TaskConfig>;
+    fileLoader: CreateWorkflow<FileLoaderTaskInput, FileLoaderTaskOutput, FileLoaderTaskConfig>;
   }
 }
 

--- a/packages/tasks/src/task/FileSedTask.server.ts
+++ b/packages/tasks/src/task/FileSedTask.server.ts
@@ -45,7 +45,14 @@ const fileSedTaskConfigSchema = {
       type: "array",
       items: { type: "string" },
       title: "Roots",
-      description: "Directories a local path must resolve inside (after symlink resolution)",
+      description:
+        "Directories a local path must resolve inside (after symlink resolution). Defaults to the process working directory",
+      "x-ui-hidden": true,
+    },
+    allowAnyRoot: {
+      type: "boolean",
+      title: "Allow Any Root",
+      description: "Skip root containment entirely and read any path the process can open",
       "x-ui-hidden": true,
     },
   },
@@ -63,8 +70,10 @@ const fileSedTaskConfigSchema = {
  * on disk is never modified — there is no in-place (`sed -i`) mode.
  *
  * A local path is resolved and realpath'd before it is opened, and constrained
- * to `config.roots` when the embedder sets them. Reading requires the
- * `filesystem:read` entitlement.
+ * to `config.roots` — which defaults to the process working directory, so a
+ * task with no stated root reads from there and nowhere else. Set
+ * `config.allowAnyRoot` to opt out. Reading requires the `filesystem:read`
+ * entitlement.
  *
  * Only available in Node.js and Bun environments. For cross-platform
  * substitution (including browser), use FileSedTask with an http(s) URL.
@@ -114,7 +123,12 @@ export class FileSedTask extends BaseFileSedTask<FileSedTaskConfig> {
           {
             id: Entitlements.FILESYSTEM_READ,
             reason: "Reads a local file from disk",
-            resources: [resolveLocalFilePath(url, { roots: this.config.roots })],
+            resources: [
+              resolveLocalFilePath(url, {
+                roots: this.config.roots,
+                allowAnyRoot: this.config.allowAnyRoot,
+              }),
+            ],
           },
         ],
       };
@@ -187,7 +201,10 @@ export class FileSedTask extends BaseFileSedTask<FileSedTaskConfig> {
     }
     await context.updateProgress(0, "Opening file");
 
-    const file = resolveLocalFilePath(url, { roots: this.config.roots });
+    const file = resolveLocalFilePath(url, {
+      roots: this.config.roots,
+      allowAnyRoot: this.config.allowAnyRoot,
+    });
     this.assertResolvedPathDeclared(file);
 
     if (context.signal.aborted) {

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -540,13 +540,21 @@ export class FileSedTask<Config extends TaskConfig = TaskConfig> extends Task<
 export interface FileSedTaskConfig extends TaskConfig {
   /**
    * Directories a local path must resolve inside, checked after symlinks are
-   * resolved. Omitted means unrestricted: the enforced control is the
-   * `filesystem:read` entitlement, and this is the embedder's extra fence.
+   * resolved. Omitted means `[process.cwd()]`, NOT unrestricted — the
+   * `filesystem:read` entitlement is only consulted when the embedder runs
+   * with `enforceEntitlements` and a registered enforcer, so it cannot stand
+   * in as the default fence. State {@link allowAnyRoot} to opt out.
    *
    * Honored only by the server build — the cross-platform class reaches
    * http(s) through `FetchUrlTask` and touches no filesystem.
    */
   readonly roots?: readonly string[] | undefined;
+  /**
+   * Read any path the process can open, skipping containment entirely. Only
+   * the literal `true` does so, and it is never implied by leaving `roots`
+   * unset.
+   */
+  readonly allowAnyRoot?: boolean | undefined;
 }
 
 export const fileSed = (input: FileSedTaskInput, config?: FileSedTaskConfig) => {

--- a/packages/tasks/src/util/LocalFilePath.server.ts
+++ b/packages/tasks/src/util/LocalFilePath.server.ts
@@ -11,11 +11,28 @@ import { fileURLToPath } from "node:url";
 
 export interface LocalFilePathOptions {
   /**
-   * Directories the path must resolve inside. `undefined` means unrestricted —
-   * the enforced control is the `filesystem:read` entitlement, and this is the
-   * embedder's belt-and-braces on top of it.
+   * Directories the path must resolve inside, checked after symlinks are
+   * resolved. Omitting it means `[process.cwd()]` — NOT "anywhere on the
+   * host".
+   *
+   * The entitlement is not a substitute for this. `filesystem:read` is only
+   * consulted when the embedder BOTH runs the graph with
+   * `enforceEntitlements` AND registers an `ENTITLEMENT_ENFORCER` (the token
+   * has no default factory, so setting the flag without one throws). Neither
+   * is the default, so an unconfigured host that treated an absent `roots` as
+   * unrestricted was readable end to end by any graph naming these tasks.
+   *
+   * An empty array is a deliberate "no path is readable" and is honored as
+   * written.
    */
   readonly roots?: readonly string[] | undefined;
+  /**
+   * Skip containment altogether. Only the literal `true` does so: it is the
+   * explicit "this process may read any path it can open" statement an
+   * embedder makes for itself, and it is never implied by leaving `roots`
+   * unset.
+   */
+  readonly allowAnyRoot?: boolean | undefined;
 }
 
 /** True for an http(s) URL, case-insensitively — `HTTP://x` is an http URL. */
@@ -42,18 +59,35 @@ function fileUrlToPath(url: string): string {
 }
 
 /**
+ * The filesystem path a local-file input names, with a `file:` scheme decoded
+ * away and nothing else done to it — no `resolve`, no `realpath`, no
+ * containment. It is the path as the CALLER wrote it, for reporting and for
+ * extension sniffing; {@link resolveLocalFilePath} is what an open must use.
+ */
+export function localFilePathFromUrl(url: string): string {
+  return /^file:/i.test(url) ? fileUrlToPath(url) : url;
+}
+
+/**
  * Real, absolute path for a local-file input, contained within `roots`.
  *
  * Order matters: the containment check runs AFTER `realpathSync`, so a symlink
  * pointing out of a root is caught rather than followed. Callers must open the
  * returned path, not the one they passed in.
  *
+ * Every configured root is resolved BEFORE any containment verdict is taken,
+ * so an unresolvable root fails the call wherever it sits in the array. Doing
+ * it inside the `some()` predicate made the outcome depend on array order —
+ * `["good", "missing"]` succeeded because `some` short-circuited before
+ * reaching the broken root, while `["missing", "good"]` threw on identical
+ * input.
+ *
  * Residual TOCTOU: a component of the path can be swapped between this
  * resolution and the open that follows it. Closing that needs an
  * openat-with-fd-relative walk, which Node does not expose.
  */
 export function resolveLocalFilePath(url: string, options: LocalFilePathOptions = {}): string {
-  const raw = /^file:/i.test(url) ? fileUrlToPath(url) : url;
+  const raw = localFilePathFromUrl(url);
   const resolved = resolve(raw);
 
   let real: string;
@@ -67,16 +101,16 @@ export function resolveLocalFilePath(url: string, options: LocalFilePathOptions 
     real = join(realpathSync(dirname(resolved)), basename(resolved));
   }
 
-  const { roots } = options;
-  if (roots !== undefined) {
-    const allowed = roots.some((root) => {
-      // A root that cannot be resolved is a misconfiguration, and saying which
-      // one beats an `ENOENT ... lstat` raised from inside the containment
-      // check. It is deliberately NOT treated as "does not contain the path":
-      // that reads as a containment verdict on evidence nobody has.
-      let realRoot: string;
+  const { roots, allowAnyRoot } = options;
+  if (allowAnyRoot !== true) {
+    const configured = roots ?? [process.cwd()];
+    // A root that cannot be resolved is a misconfiguration, and saying which
+    // one beats an `ENOENT ... lstat` raised from inside the containment
+    // check. It is deliberately NOT treated as "does not contain the path":
+    // that reads as a containment verdict on evidence nobody has.
+    const realRoots = configured.map((root) => {
       try {
-        realRoot = realpathSync(root);
+        return realpathSync(root);
       } catch (err) {
         throw new TaskInvalidInputError(
           `Configured root ${root} could not be resolved: ${
@@ -84,11 +118,13 @@ export function resolveLocalFilePath(url: string, options: LocalFilePathOptions 
           }`
         );
       }
-      return real === realRoot || real.startsWith(realRoot + sep);
     });
+    const allowed = realRoots.some(
+      (realRoot) => real === realRoot || real.startsWith(realRoot + sep)
+    );
     if (!allowed) {
       throw new TaskEntitlementError(
-        `Path ${real} is outside the configured roots: ${roots.join(", ")}`
+        `Path ${real} is outside the configured roots: ${configured.join(", ")}`
       );
     }
   }

--- a/packages/test/src/test/task/FileGrepEntitlements.test.ts
+++ b/packages/test/src/test/task/FileGrepEntitlements.test.ts
@@ -110,7 +110,7 @@ describe("FileGrepTask entitlement enforcement", () => {
     const allowed = join(testDir, "notes.txt");
     writeFileSync(allowed, "alpha\nbravo foo\n", "utf-8");
 
-    const permitted = new TaskGraphRunner(makeGraph(allowed));
+    const permitted = new TaskGraphRunner(makeGraph(allowed, [testDir]));
     await expect(
       permitted.runGraph(
         {},
@@ -118,7 +118,9 @@ describe("FileGrepTask entitlement enforcement", () => {
       )
     ).resolves.toBeDefined();
 
-    const denied = new TaskGraphRunner(makeGraph("/etc/passwd"));
+    // Rooted at /etc so containment admits the path and the ENFORCER is what
+    // refuses it — the policy is what this test is about.
+    const denied = new TaskGraphRunner(makeGraph("/etc/passwd", ["/etc"]));
     await expect(
       denied.runGraph(
         {},
@@ -132,6 +134,7 @@ describe("FileGrepTask entitlement enforcement", () => {
     writeFileSync(filePath, "bravo foo\n", "utf-8");
 
     const declared = new FileGrepTask({
+      roots: [testDir],
       defaults: { url: filePath, pattern: "foo" },
     }).entitlements().entitlements;
 

--- a/packages/test/src/test/task/FileGrepTask.server.test.ts
+++ b/packages/test/src/test/task/FileGrepTask.server.test.ts
@@ -36,6 +36,7 @@ describe("FileGrepTask (server - local files)", () => {
     writeFileSync(filePath, "alpha\nbravo foo\ncharlie\n", "utf-8");
 
     const result = await new FileGrepTask({
+      roots: [testDir],
       defaults: { url: filePath, pattern: "foo" },
     }).run();
 
@@ -54,6 +55,7 @@ describe("FileGrepTask (server - local files)", () => {
     writeFileSync(filePath, "keep\nskip foo\nkeep too\n", "utf-8");
 
     const result = await new FileGrepTask({
+      roots: [testDir],
       defaults: { url: `file://${filePath}`, pattern: "foo" },
     }).run();
 
@@ -66,6 +68,7 @@ describe("FileGrepTask (server - local files)", () => {
     writeFileSync(filePath, "one\r\ntwo foo\r\nthree\r\n", "utf-8");
 
     const result = await new FileGrepTask({
+      roots: [testDir],
       defaults: { url: filePath, pattern: "foo" },
     }).run();
 
@@ -83,6 +86,7 @@ describe("FileGrepTask (server - local files)", () => {
 
     await expect(
       new FileGrepTask({
+        roots: [testDir],
         defaults: { url: filePath, pattern: "foo" },
       }).run()
     ).rejects.toThrow();
@@ -107,6 +111,7 @@ describe("FileGrepTask (server - local files)", () => {
 
     try {
       const result = await new FileGrepTask({
+        roots: [testDir],
         defaults: { url: filePath, pattern: "x" },
       }).run();
 
@@ -124,6 +129,7 @@ describe("FileGrepTask (server - local files)", () => {
     writeFileSync(filePath, `short\n${long}\ntail foo\n`, "utf-8");
 
     const result = await new FileGrepTask({
+      roots: [testDir],
       defaults: { url: filePath, pattern: "y" },
     }).run();
 
@@ -131,6 +137,96 @@ describe("FileGrepTask (server - local files)", () => {
     const matched = result.groups.flatMap((g) => g.lines.filter((l) => l.match));
     expect(matched).toHaveLength(1);
     expect(matched[0].text).toHaveLength(DEFAULT_LIMITS.grepMaxLineChars);
+  });
+
+  /**
+   * With no `roots` the resolver used to skip containment entirely, and the
+   * `filesystem:read` entitlement is not a backstop for that: it is consulted
+   * only when the embedder runs with `enforceEntitlements` AND registers an
+   * enforcer, neither of which is the default. So an unconfigured host was
+   * readable end to end by anything that could name this task. The default is
+   * now the process working directory.
+   */
+  describe("root containment defaults to the process working directory", () => {
+    test("refuses a path outside the cwd when no roots are configured", async () => {
+      const outside = join(testDir, "notes.txt");
+      writeFileSync(outside, "bravo foo\n", "utf-8");
+
+      const run = new FileGrepTask({ defaults: { url: outside, pattern: "foo" } }).run();
+
+      await expect(run).rejects.toThrow(TaskEntitlementError);
+      // Naming the cwd is what tells an operator which root they actually got.
+      await expect(run).rejects.toThrow(process.cwd());
+    });
+
+    test("reads a path inside the cwd when no roots are configured", async () => {
+      const inside = join(process.cwd(), `filegrep-cwd-${Date.now()}`);
+      mkdirSync(inside, { recursive: true });
+      const filePath = join(inside, "notes.txt");
+      writeFileSync(filePath, "alpha\nbravo foo\n", "utf-8");
+
+      try {
+        const result = await new FileGrepTask({
+          defaults: { url: filePath, pattern: "foo" },
+        }).run();
+
+        expect(result.matchCount).toBe(1);
+      } finally {
+        rmSync(inside, { recursive: true, force: true });
+      }
+    });
+
+    /**
+     * The escape hatch is deliberately a separate, explicit statement rather
+     * than something an omitted `roots` implies — an embedder that means "any
+     * path this process can open" has to say so.
+     */
+    test("allowAnyRoot restores the unrestricted read", async () => {
+      const outside = join(testDir, "notes.txt");
+      writeFileSync(outside, "alpha\nbravo foo\n", "utf-8");
+
+      const result = await new FileGrepTask({
+        allowAnyRoot: true,
+        defaults: { url: outside, pattern: "foo" },
+      }).run();
+
+      expect(result.matchCount).toBe(1);
+    });
+
+    test("allowAnyRoot must be the literal true, not merely truthy config", async () => {
+      const outside = join(testDir, "notes.txt");
+      writeFileSync(outside, "bravo foo\n", "utf-8");
+
+      await expect(
+        new FileGrepTask({
+          allowAnyRoot: undefined,
+          defaults: { url: outside, pattern: "foo" },
+        }).run()
+      ).rejects.toThrow(TaskEntitlementError);
+    });
+  });
+
+  /**
+   * `realpathSync` on a root used to run inside the `some()` predicate, which
+   * short-circuits: `[good, missing]` never reached the broken root and
+   * succeeded, while `[missing, good]` threw. Same config, same input,
+   * opposite outcome by array order. Every root is resolved before any
+   * containment verdict now, so a broken one fails always rather than
+   * sometimes.
+   */
+  test("an unresolvable root is rejected regardless of its position", async () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "alpha\nbravo foo\n", "utf-8");
+    const missing = join(testDir, "does-not-exist");
+
+    for (const roots of [
+      [testDir, missing],
+      [missing, testDir],
+    ]) {
+      await expect(
+        new FileGrepTask({ roots, defaults: { url: filePath, pattern: "foo" } }).run()
+      ).rejects.toThrow(/Configured root .* could not be resolved/);
+    }
   });
 
   test("refuses a path outside the configured roots", async () => {
@@ -189,6 +285,7 @@ describe("FileGrepTask (server - local files)", () => {
     writeFileSync(filePath, "alpha\nbravo foo\n", "utf-8");
 
     const result = await new FileGrepTask({
+      roots: [testDir],
       defaults: { url: `file://${testDir}/a%20b%25c.txt`, pattern: "foo" },
     }).run();
 
@@ -240,6 +337,7 @@ describe("FileGrepTask (server - local files)", () => {
     test("refuses a character device", async () => {
       await expect(
         new FileGrepTask({
+          roots: ["/dev"],
           defaults: { url: "/dev/zero", pattern: "foo" },
         }).run()
       ).rejects.toThrow(TaskInvalidInputError);
@@ -259,6 +357,7 @@ describe("FileGrepTask (server - local files)", () => {
     const started = Date.now();
     await expect(
       new FileGrepTask({
+        roots: [testDir],
         defaults: { url: filePath, pattern: "(\\w|\\d)*$" },
       }).run()
     ).rejects.toThrow(/budget/);

--- a/packages/test/src/test/task/FileLoaderTask.server.test.ts
+++ b/packages/test/src/test/task/FileLoaderTask.server.test.ts
@@ -5,10 +5,11 @@
  */
 
 // Import directly from source to avoid ambiguous export issue
+import { Entitlements, TaskEntitlementError, TaskInvalidInputError } from "@workglow/task-graph";
 import { FileLoaderTask } from "@workglow/tasks";
 import { setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -38,7 +39,10 @@ describe("FileLoaderTask (server - local files)", () => {
     const filePath = join(testDir, "test.txt");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "text" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "text" },
+    });
     const result = await task.run();
 
     expect(result.text).toBe(content);
@@ -55,7 +59,10 @@ describe("FileLoaderTask (server - local files)", () => {
     const filePath = join(testDir, "test.txt");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "text" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "text" },
+    });
     const result = await task.run();
 
     expect(result.text).toBe(content);
@@ -67,7 +74,10 @@ describe("FileLoaderTask (server - local files)", () => {
     const filePath = join(testDir, "test.md");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.text).toBe(content);
@@ -80,7 +90,10 @@ describe("FileLoaderTask (server - local files)", () => {
     const filePath = join(testDir, "test.json");
     writeFileSync(filePath, JSON.stringify(jsonData), "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.json).toEqual(jsonData);
@@ -93,7 +106,10 @@ describe("FileLoaderTask (server - local files)", () => {
     const filePath = join(testDir, "invalid.json");
     writeFileSync(filePath, invalidJson, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "json" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "json" },
+    });
 
     await expect(task.run()).rejects.toThrow(
       /Failed to parse JSON|JSON Parse error|Expected property name or '\}' in JSON/
@@ -108,7 +124,10 @@ Bob,35,Paris`;
     const filePath = join(testDir, "test.csv");
     writeFileSync(filePath, csvContent, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.metadata.format).toBe("csv");
@@ -127,7 +146,7 @@ Bob,35,Paris`;
     const filePath = join(testDir, "products.csv");
     writeFileSync(filePath, csvContent, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}` } });
+    const task = new FileLoaderTask({ roots: [testDir], defaults: { url: `file://${filePath}` } });
     const result = await task.run();
 
     expect(result.csv).toHaveLength(2);
@@ -148,7 +167,10 @@ Bob,35,Paris`;
     const filePath = join(testDir, "test.html");
     writeFileSync(filePath, htmlContent, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.text).toBe(htmlContent);
@@ -161,7 +183,10 @@ Bob,35,Paris`;
     const filePath = join(testDir, "test.htm");
     writeFileSync(filePath, htmlContent, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.metadata.format).toBe("html");
@@ -174,7 +199,10 @@ Bob,35,Paris`;
     const filePath = join(testDir, "test.png");
     writeFileSync(filePath, imageData);
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.image).toContain("data:image/png;base64,");
@@ -200,7 +228,10 @@ Bob,35,Paris`;
       const filePath = join(testDir, `test.${ext}`);
       writeFileSync(filePath, imageData);
 
-      const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+      const task = new FileLoaderTask({
+        roots: [testDir],
+        defaults: { url: `file://${filePath}`, format: "auto" },
+      });
       const result = await task.run();
 
       expect(result.metadata.format).toBe("image");
@@ -216,7 +247,10 @@ Bob,35,Paris`;
     const filePath = join(testDir, "test.pdf");
     writeFileSync(filePath, pdfData);
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.pdf).toContain("data:application/pdf;base64,");
@@ -231,7 +265,10 @@ Bob,35,Paris`;
     writeFileSync(filePath, textContent, "utf-8");
 
     // Even though file extension is .json, force it as text
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "text" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "text" },
+    });
     const result = await task.run();
 
     expect(result.metadata.format).toBe("text");
@@ -243,7 +280,7 @@ Bob,35,Paris`;
     const filePath = join(testDir, "empty.csv");
     writeFileSync(filePath, csvContent, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}` } });
+    const task = new FileLoaderTask({ roots: [testDir], defaults: { url: `file://${filePath}` } });
     const result = await task.run();
 
     expect(result.csv).toEqual([]);
@@ -254,7 +291,10 @@ Bob,35,Paris`;
     const filePath = join(testDir, "TEST.JSON");
     writeFileSync(filePath, JSON.stringify(jsonData), "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.metadata.format).toBe("json");
@@ -266,7 +306,10 @@ Bob,35,Paris`;
     const filePath = join(testDir, "file.xyz");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.metadata.format).toBe("text");
@@ -281,7 +324,7 @@ Bob,35,`;
     const filePath = join(testDir, "sparse.csv");
     writeFileSync(filePath, csvContent, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}` } });
+    const task = new FileLoaderTask({ roots: [testDir], defaults: { url: `file://${filePath}` } });
     const result = await task.run();
 
     expect(result.csv).toHaveLength(3);
@@ -295,7 +338,10 @@ Bob,35,`;
     const filePath = join(testDir, "file.txt");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "text" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "text" },
+    });
     const result = await task.run();
 
     expect(result.metadata).toHaveProperty("url", filePath);
@@ -319,7 +365,7 @@ Bob,35,`;
     const filePath = join(testDir, "complex.json");
     writeFileSync(filePath, JSON.stringify(jsonData), "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}` } });
+    const task = new FileLoaderTask({ roots: [testDir], defaults: { url: `file://${filePath}` } });
     const result = await task.run();
 
     expect(result.json).toEqual(jsonData);
@@ -337,7 +383,7 @@ Bob,35,`;
     const filePath = join(specialDir, "file-name.txt");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}` } });
+    const task = new FileLoaderTask({ roots: [testDir], defaults: { url: `file://${filePath}` } });
     const result = await task.run();
 
     expect(result.text).toBe(content);
@@ -353,7 +399,7 @@ Bob,35,`;
     const filePath = join(testDir, "large.csv");
     writeFileSync(filePath, csvContent, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}` } });
+    const task = new FileLoaderTask({ roots: [testDir], defaults: { url: `file://${filePath}` } });
     const result = await task.run();
 
     expect(result.csv).toHaveLength(rows);
@@ -371,7 +417,7 @@ Bob,35,`;
     const filePath = join(testDir, "binary.png");
     writeFileSync(filePath, binaryData);
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}` } });
+    const task = new FileLoaderTask({ roots: [testDir], defaults: { url: `file://${filePath}` } });
     const result = await task.run();
 
     expect(result.image).toContain("data:image/png;base64,");
@@ -386,7 +432,7 @@ Bob,35,`;
     const filePath = join(testDir, "progress.txt");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask();
+    const task = new FileLoaderTask({ roots: [testDir] });
 
     // Mock the task runner's updateProgress by accessing the task's progress property
     // Note: Progress updates happen internally via context.updateProgress
@@ -402,7 +448,7 @@ Bob,35,`;
     const filePath = join(testDir, "windows.csv");
     writeFileSync(filePath, csvContent, "utf-8");
 
-    const task = new FileLoaderTask();
+    const task = new FileLoaderTask({ roots: [testDir] });
     const result = await task.run({ url: `file://${filePath}` });
 
     expect(result.csv).toHaveLength(2);
@@ -415,7 +461,7 @@ Bob,35,`;
     const filePath = join(testDir, "mixed.csv");
     writeFileSync(filePath, csvContent, "utf-8");
 
-    const task = new FileLoaderTask();
+    const task = new FileLoaderTask({ roots: [testDir] });
     const result = await task.run({ url: `file://${filePath}` });
 
     expect(result.csv).toHaveLength(2);
@@ -437,7 +483,7 @@ This is the body.`;
     const filePath = join(testDir, "frontmatter.md");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask();
+    const task = new FileLoaderTask({ roots: [testDir] });
     const result = await task.run({ url: `file://${filePath}`, format: "auto" });
 
     expect(result.metadata.format).toBe("markdown");
@@ -455,7 +501,10 @@ This is the body.`;
     const filePath = join(testDir, "no-frontmatter.md");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.frontmatter).toBeUndefined();
@@ -476,7 +525,10 @@ import { getTestingLogger } from "@workglow/util/test";
     const filePath = join(testDir, "page.mdx");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask({ defaults: { url: `file://${filePath}`, format: "auto" } });
+    const task = new FileLoaderTask({
+      roots: [testDir],
+      defaults: { url: `file://${filePath}`, format: "auto" },
+    });
     const result = await task.run();
 
     expect(result.metadata.format).toBe("markdown");
@@ -503,7 +555,7 @@ Body content.`;
     const filePath = join(testDir, "types.md");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask();
+    const task = new FileLoaderTask({ roots: [testDir] });
     const result = await task.run({ url: `file://${filePath}` });
 
     expect(result.frontmatter).toEqual({
@@ -523,7 +575,7 @@ Body content.`;
     const filePath = join(testDir, "test.txt");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask();
+    const task = new FileLoaderTask({ roots: [testDir] });
     const result = await task.run({ url: `file://${filePath}`, format: "text" });
 
     expect(result.frontmatter).toBeUndefined();
@@ -542,7 +594,7 @@ Body.`;
     const filePath = join(testDir, "nested.md");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask();
+    const task = new FileLoaderTask({ roots: [testDir] });
     const result = await task.run({ url: `file://${filePath}` });
 
     expect(result.frontmatter).toEqual({
@@ -559,11 +611,121 @@ Body.`;
     const filePath = join(testDir, "test.markdown");
     writeFileSync(filePath, content, "utf-8");
 
-    const task = new FileLoaderTask();
+    const task = new FileLoaderTask({ roots: [testDir] });
     const result = await task.run({ url: `file://${filePath}`, format: "auto" });
 
     expect(result.metadata.format).toBe("markdown");
     expect(result.metadata.mimeType).toBe("text/markdown");
     expect(result.text).toBe(content);
+  });
+
+  /**
+   * This task was the worst of the three server file tasks: it declared no
+   * entitlement at all, honoured no roots, and reached the filesystem by
+   * `url.slice(7)` — which neither percent-decodes nor rejects a `file://`
+   * host. It now runs the same resolver the grep and sed tasks do.
+   */
+  describe("local path containment", () => {
+    test("refuses a path outside the cwd when no roots are configured", async () => {
+      const filePath = join(testDir, "secret.txt");
+      writeFileSync(filePath, "classified", "utf-8");
+
+      const run = new FileLoaderTask({ defaults: { url: filePath, format: "text" } }).run();
+
+      await expect(run).rejects.toThrow(TaskEntitlementError);
+      await expect(run).rejects.toThrow(process.cwd());
+    });
+
+    test("refuses a path outside the configured roots", async () => {
+      const outside = join(tmpdir(), `fileloader-outside-${Date.now()}.txt`);
+      writeFileSync(outside, "classified", "utf-8");
+
+      try {
+        await expect(
+          new FileLoaderTask({
+            roots: [testDir],
+            defaults: { url: outside, format: "text" },
+          }).run()
+        ).rejects.toThrow(TaskEntitlementError);
+      } finally {
+        rmSync(outside, { force: true });
+      }
+    });
+
+    /**
+     * Containment runs AFTER `realpathSync`, so a link sitting inside the root
+     * cannot be used to read its target outside one.
+     */
+    test("refuses a symlink that escapes the configured roots", async () => {
+      const link = join(testDir, "escape.txt");
+      symlinkSync("/etc/passwd", link);
+
+      await expect(
+        new FileLoaderTask({
+          roots: [testDir],
+          defaults: { url: link, format: "text" },
+        }).run()
+      ).rejects.toThrow(TaskEntitlementError);
+    });
+
+    test("allowAnyRoot restores the unrestricted read", async () => {
+      const filePath = join(testDir, "open.txt");
+      writeFileSync(filePath, "readable", "utf-8");
+
+      const result = await new FileLoaderTask({
+        allowAnyRoot: true,
+        defaults: { url: filePath, format: "text" },
+      }).run();
+
+      expect(result.text).toBe("readable");
+    });
+
+    /**
+     * `slice(7)` left the path percent-encoded, so a name with a space or a
+     * `%` addressed a file that does not exist.
+     */
+    test("parses file:// URLs rather than slicing the scheme", async () => {
+      const filePath = join(testDir, "a b%c.txt");
+      writeFileSync(filePath, "decoded", "utf-8");
+
+      const result = await new FileLoaderTask({
+        roots: [testDir],
+        defaults: { url: `file://${testDir}/a%20b%25c.txt`, format: "text" },
+      }).run();
+
+      expect(result.text).toBe("decoded");
+    });
+
+    test("rejects a file:// URL carrying a remote host", async () => {
+      await expect(
+        new FileLoaderTask({
+          allowAnyRoot: true,
+          defaults: { url: "file://evil.example/etc/passwd", format: "text" },
+        }).run()
+      ).rejects.toThrow(TaskInvalidInputError);
+    });
+
+    test("declares filesystem:read scoped to the resolved path", () => {
+      const filePath = join(testDir, "declared.txt");
+      writeFileSync(filePath, "content", "utf-8");
+
+      const declared = new FileLoaderTask({
+        roots: [testDir],
+        defaults: { url: `file://${filePath}`, format: "text" },
+      }).entitlements().entitlements;
+
+      expect(declared.map((entitlement) => entitlement.id)).toEqual([Entitlements.FILESYSTEM_READ]);
+      expect(declared[0].resources).toEqual([filePath]);
+    });
+
+    test("declares no filesystem:read for an http url", () => {
+      const declared = new FileLoaderTask({
+        defaults: { url: "https://example.com/data.json" },
+      }).entitlements().entitlements;
+
+      expect(declared.map((entitlement) => entitlement.id)).not.toContain(
+        Entitlements.FILESYSTEM_READ
+      );
+    });
   });
 });

--- a/packages/test/src/test/task/FileSedEntitlements.test.ts
+++ b/packages/test/src/test/task/FileSedEntitlements.test.ts
@@ -117,7 +117,7 @@ describe("FileSedTask entitlement enforcement", () => {
     const allowed = join(testDir, "notes.txt");
     writeFileSync(allowed, "alpha\nbravo foo\n", "utf-8");
 
-    const permitted = new TaskGraphRunner(makeGraph(allowed));
+    const permitted = new TaskGraphRunner(makeGraph(allowed, [testDir]));
     await expect(
       permitted.runGraph(
         {},
@@ -125,7 +125,9 @@ describe("FileSedTask entitlement enforcement", () => {
       )
     ).resolves.toBeDefined();
 
-    const denied = new TaskGraphRunner(makeGraph("/etc/passwd"));
+    // Rooted at /etc so containment admits the path and the ENFORCER is what
+    // refuses it — the policy is what this test is about.
+    const denied = new TaskGraphRunner(makeGraph("/etc/passwd", ["/etc"]));
     await expect(
       denied.runGraph(
         {},
@@ -139,6 +141,7 @@ describe("FileSedTask entitlement enforcement", () => {
     writeFileSync(filePath, "bravo foo\n", "utf-8");
 
     const declared = new FileSedTask({
+      roots: [testDir],
       defaults: { url: filePath, pattern: "foo", replacement: "bar" },
     }).entitlements().entitlements;
 
@@ -180,6 +183,7 @@ describe("FileSedTask entitlement enforcement", () => {
     symlinkSync(target, link);
 
     const declared = new FileSedTask({
+      roots: [testDir],
       defaults: { url: `file://${link}`, pattern: "foo", replacement: "bar" },
     }).entitlements().entitlements;
 

--- a/packages/test/src/test/task/FileSedTask.server.test.ts
+++ b/packages/test/src/test/task/FileSedTask.server.test.ts
@@ -36,6 +36,7 @@ describe("FileSedTask (server - local files)", () => {
     writeFileSync(filePath, "alpha\nbravo foo\ncharlie\n", "utf-8");
 
     const result = await new FileSedTask({
+      roots: [testDir],
       defaults: { url: filePath, pattern: "foo", replacement: "bar" },
     }).run();
 
@@ -48,6 +49,7 @@ describe("FileSedTask (server - local files)", () => {
     writeFileSync(filePath, "alpha\nbravo foo\n", "utf-8");
 
     await new FileSedTask({
+      roots: [testDir],
       defaults: { url: filePath, pattern: "foo", replacement: "bar" },
     }).run();
 
@@ -59,6 +61,7 @@ describe("FileSedTask (server - local files)", () => {
     writeFileSync(filePath, "keep\nskip foo\nkeep too\n", "utf-8");
 
     const result = await new FileSedTask({
+      roots: [testDir],
       defaults: { url: `file://${filePath}`, pattern: "foo", replacement: "bar" },
     }).run();
 
@@ -70,6 +73,7 @@ describe("FileSedTask (server - local files)", () => {
     writeFileSync(filePath, "one\r\ntwo foo\r\nthree\r\n", "utf-8");
 
     const result = await new FileSedTask({
+      roots: [testDir],
       defaults: { url: filePath, pattern: "foo", replacement: "bar" },
     }).run();
 
@@ -81,6 +85,7 @@ describe("FileSedTask (server - local files)", () => {
 
     await expect(
       new FileSedTask({
+        roots: [testDir],
         defaults: { url: filePath, pattern: "foo", replacement: "bar" },
       }).run()
     ).rejects.toThrow();
@@ -105,6 +110,7 @@ describe("FileSedTask (server - local files)", () => {
 
     try {
       const result = await new FileSedTask({
+        roots: [testDir],
         defaults: { url: filePath, pattern: "x", replacement: "y", global: true },
       }).run();
 
@@ -122,6 +128,7 @@ describe("FileSedTask (server - local files)", () => {
     writeFileSync(filePath, `short\n${long}\ntail foo\n`, "utf-8");
 
     const result = await new FileSedTask({
+      roots: [testDir],
       defaults: { url: filePath, pattern: "foo", replacement: "bar" },
     }).run();
 
@@ -130,6 +137,43 @@ describe("FileSedTask (server - local files)", () => {
     expect(lines[1]).toHaveLength(DEFAULT_LIMITS.grepMaxLineChars);
     // The rest of the physical line is discarded, not folded into a new one.
     expect(lines[2]).toBe("tail bar");
+  });
+
+  /**
+   * With no `roots` the resolver used to skip containment entirely, and the
+   * `filesystem:read` entitlement is not a backstop for that: it is consulted
+   * only when the embedder runs with `enforceEntitlements` AND registers an
+   * enforcer, neither of which is the default. The default is now the process
+   * working directory.
+   */
+  describe("root containment defaults to the process working directory", () => {
+    test("refuses a path outside the cwd when no roots are configured", async () => {
+      const outside = join(testDir, "notes.txt");
+      writeFileSync(outside, "bravo foo\n", "utf-8");
+
+      const run = new FileSedTask({
+        defaults: { url: outside, pattern: "foo", replacement: "bar" },
+      }).run();
+
+      await expect(run).rejects.toThrow(TaskEntitlementError);
+      await expect(run).rejects.toThrow(process.cwd());
+    });
+
+    /**
+     * The escape hatch is deliberately a separate, explicit statement rather
+     * than something an omitted `roots` implies.
+     */
+    test("allowAnyRoot restores the unrestricted read", async () => {
+      const outside = join(testDir, "notes.txt");
+      writeFileSync(outside, "alpha\nbravo foo\n", "utf-8");
+
+      const result = await new FileSedTask({
+        allowAnyRoot: true,
+        defaults: { url: outside, pattern: "foo", replacement: "bar" },
+      }).run();
+
+      expect(result.text).toBe("alpha\nbravo bar\n");
+    });
   });
 
   test("refuses a path outside the configured roots", async () => {
@@ -188,6 +232,7 @@ describe("FileSedTask (server - local files)", () => {
     writeFileSync(filePath, "alpha\nbravo foo\n", "utf-8");
 
     const result = await new FileSedTask({
+      roots: [testDir],
       defaults: {
         url: `file://${testDir}/a%20b%25c.txt`,
         pattern: "foo",
@@ -260,6 +305,7 @@ describe("FileSedTask (server - local files)", () => {
     test("refuses a character device", async () => {
       await expect(
         new FileSedTask({
+          roots: ["/dev"],
           defaults: { url: "/dev/zero", pattern: "foo", replacement: "bar" },
         }).run()
       ).rejects.toThrow(TaskInvalidInputError);
@@ -285,6 +331,7 @@ describe("FileSedTask (server - local files)", () => {
     const started = Date.now();
     await expect(
       new FileSedTask({
+        roots: [testDir],
         defaults: { url: filePath, pattern: "(\\w|\\d)*$", replacement: "X" },
       }).run()
     ).rejects.toThrow(/budget/);
@@ -296,6 +343,7 @@ describe("FileSedTask (server - local files)", () => {
     writeFileSync(filePath, "2026-08-17\nname: ada\n", "utf-8");
 
     const result = await new FileSedTask({
+      roots: [testDir],
       defaults: {
         url: filePath,
         pattern: "(\\d{4})-(\\d{2})-(\\d{2})|name: (?<who>\\w+)",

--- a/packages/test/src/test/task/RegisterFileSystemTasks.test.ts
+++ b/packages/test/src/test/task/RegisterFileSystemTasks.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TaskRegistry } from "@workglow/task-graph";
+import {
+  FileGrepTask,
+  FileLoaderTask,
+  FileSedTask,
+  registerCommonTasks,
+  registerFileSystemTasks,
+} from "@workglow/tasks";
+import { setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+const FILE_SYSTEM_TASK_TYPES = [FileGrepTask.type, FileLoaderTask.type, FileSedTask.type];
+
+/**
+ * `TaskRegistry` is how a DESERIALIZED graph names a task, and a serialized
+ * node carries its own `config` — so a hostile graph naming `FileGrepTask`
+ * also supplies its own `roots`, and no default the package picks constrains
+ * it. Registration is therefore the boundary: a host that has not asked for
+ * the filesystem tasks must not be able to have one built by type name.
+ */
+describe("filesystem task registration is opt-in", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+
+  function unregisterAll(): void {
+    for (const type of FILE_SYSTEM_TASK_TYPES) TaskRegistry.unregisterTask(type);
+  }
+
+  beforeEach(unregisterAll);
+  afterEach(unregisterAll);
+
+  test("registerCommonTasks leaves the filesystem tasks out of the registry", () => {
+    registerCommonTasks();
+
+    for (const type of FILE_SYSTEM_TASK_TYPES) {
+      expect(TaskRegistry.all.has(type)).toBe(false);
+    }
+  });
+
+  test("registerCommonTasks does not return the filesystem tasks either", () => {
+    const returned = registerCommonTasks().map((task) => task.type);
+
+    for (const type of FILE_SYSTEM_TASK_TYPES) {
+      expect(returned).not.toContain(type);
+    }
+  });
+
+  test("registerFileSystemTasks puts all three in the registry", () => {
+    registerFileSystemTasks();
+
+    expect(TaskRegistry.all.get(FileGrepTask.type)).toBe(FileGrepTask);
+    expect(TaskRegistry.all.get(FileLoaderTask.type)).toBe(FileLoaderTask);
+    expect(TaskRegistry.all.get(FileSedTask.type)).toBe(FileSedTask);
+  });
+
+  test("registerFileSystemTasks returns the three it registered", () => {
+    expect(registerFileSystemTasks().map((task) => task.type)).toEqual(FILE_SYSTEM_TASK_TYPES);
+  });
+
+  /**
+   * The classes stay exported and constructible — only ambient registry
+   * availability moved. An embedder that builds one in its own code is
+   * unaffected by the split.
+   */
+  test("the classes are still exported and constructible without registering", () => {
+    expect(() => new FileGrepTask({ defaults: { url: "x", pattern: "y" } })).not.toThrow();
+    expect(() => new FileLoaderTask({ defaults: { url: "x" } })).not.toThrow();
+    expect(
+      () => new FileSedTask({ defaults: { url: "x", pattern: "y", replacement: "z" } })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## ⚠️ Breaking change, and the migration

Two published behaviours in `@workglow/tasks` change. Both are the fix.

**1. `registerCommonTasks()` no longer registers the filesystem tasks.** In the node and electron builds it used to add `FileGrepTask`, `FileLoaderTask` and `FileSedTask` to `TaskRegistry`. It no longer does.

```ts
import { registerCommonTasks, registerFileSystemTasks } from "@workglow/tasks";

registerCommonTasks();
// Only where every graph that can reach the registry is trusted:
registerFileSystemTasks();
```

The classes are exported exactly as before — constructing one directly is unchanged. Only **ambient registry availability** became opt-in.

**2. A local path must now resolve inside `config.roots`, which defaults to `[process.cwd()]`.** It used to default to no containment at all. An absolute path outside the working directory now needs explicit roots, or the new explicit opt-out:

```ts
new FileGrepTask({ roots: ["/srv/data"], defaults: { url, pattern } });
new FileGrepTask({ allowAnyRoot: true, defaults: { url, pattern } }); // read anything
```

`allowAnyRoot` must be the literal `true`; omitting `roots` never implies it.

In-repo callers of `registerCommonTasks()` (8 sites across examples and tests) use none of the file tasks, so nothing in this repo needed the new call.

---

## Why

### F1 — the server file tasks defaulted to unrestricted filesystem read

`resolveLocalFilePath` skipped containment whenever `roots` was `undefined`, on the stated grounds that *"the enforced control is the `filesystem:read` entitlement"*. It is not. `TaskGraphRunner` consults an enforcer only under `enforceEntitlements`, and `ENTITLEMENT_ENFORCER` has no default factory — so setting the flag without registering one throws. Neither is a default, which leaves exactly two states: **off**, and **explicitly configured**. In the off state an embedder that called `registerCommonTasks()` had a task in the ambient registry that read any path the process could open.

`assertResolvedPathDeclared` did not narrow this. It recomputes the path from the same input through the same resolver — a declare-then-swap guard, not containment — so with no roots both sides agree and every path passes.

**`FileLoaderTask.server` was strictly worse**, and is why the fix cannot stop at `roots`: it declared **no entitlement at all**, honoured no roots, and reached the filesystem via `url.slice(7)`, which neither percent-decodes nor rejects a `file://` host. Fixing grep and sed while leaving it registered would have been theatre. It now runs the same resolver and carries the same `configSchema()` plus static/instance `entitlements()` pair its siblings do. `metadata.url` is still the caller's path, so the output shape is unchanged.

**The registration split is the half that survives untrusted input.** A serialized node is built as `{...item.config, id, defaults}`, so a graph naming `FileGrepTask` supplies its own config and can state `roots: ["/"]` itself — no default this package picks constrains it. The only control left against hostile graph JSON is the type not resolving at all. The cwd default is the defence for the *other* case: a trusting embedder that authored the graph itself.

### F7 — root resolution was order-dependent

`realpathSync(root)` ran inside the `some()` predicate, and `some` short-circuits. Reproduced: `["good", "missing"]` returned true without ever resolving the broken root, while `["missing", "good"]` threw — same config, same input, opposite outcome by array order. Every root is now resolved *before* any containment verdict is taken, so a misconfigured root fails always rather than sometimes. That is both the deterministic direction and the safer one.

The two findings share `LocalFilePath.server.ts`, and F7 is meaningless until F1 makes `roots` load-bearing, so they ship together.

---

## Tests

Every new test was verified to **fail before the source fix and pass after** (source changes stashed, tests kept):

| test | pre-fix failure |
|---|---|
| grep / sed / loader: *refuses a path outside the cwd when no roots are configured* | `promise resolved "{ text: 'classified', …}"` — it read the file |
| grep: *an unresolvable root is rejected regardless of its position* | `promise resolved` for the `[good, missing]` ordering |
| grep: *allowAnyRoot restores the unrestricted read* | `Additional property allowAnyRoot is not allowed` |
| `RegisterFileSystemTasks.test.ts` (all 4 registry assertions) | `registerFileSystemTasks` did not exist; the three types were in the registry after `registerCommonTasks()` |
| loader: containment / symlink-escape / scoped-declaration suite | `Additional property roots is not allowed` — the task supported no roots at all |

New `packages/test/src/test/task/RegisterFileSystemTasks.test.ts` pins both directions of the split and that the classes stay constructible without registering.

~35 existing server tests that constructed these tasks with **no** `roots` now state `roots: [testDir]`. That churn is the point — each one now says which directory it means to read. Two exceptions state their intent differently: the `/dev/zero` non-regular-file tests use `roots: ["/dev"]` so the device is *inside* the root and still refused, and the entitlement tests' `/etc/passwd` denial uses `roots: ["/etc"]` so the **enforcer** is what refuses it rather than containment — otherwise the policy under test would never be consulted.

### Test output (after the fix)

```
 ✓ packages/test/src/test/task/FileGrepTask.server.test.ts
 ✓ packages/test/src/test/task/FileSedTask.server.test.ts
 ✓ packages/test/src/test/task/FileLoaderTask.server.test.ts
 ✓ packages/test/src/test/task/FileGrepEntitlements.test.ts
 ✓ packages/test/src/test/task/FileSedEntitlements.test.ts
 ✓ packages/test/src/test/task/RegisterFileSystemTasks.test.ts

 Test Files  6 passed (6)
      Tests  97 passed (97)
```

Whole `packages/test/src/test/task/` directory: **1216 passed, 24 skipped, 1 failed**. The one failure is `FetchTask.test.ts > an HTTP error cancels the response body instead of abandoning it`, which **fails identically on `main`** with these changes stashed — it is a separate, unreleased finding scoped to a follow-up PR.

Also clean: `turbo run build-types --filter=@workglow/tasks` (5 packages), `eslint` and `prettier` on every changed file, and `tsgo --noEmit` over the six changed test files.

---

## Also updated

- `packages/tasks/README.md` gains a **Filesystem Tasks (server builds)** section naming `registerFileSystemTasks` as the migration and documenting the root policy.
- The `node.ts` / `electron.ts` docblocks explain why registration — not a config default — is the boundary against untrusted graph JSON.
- The `roots` docblock in `LocalFilePathOptions` and both task config interfaces: the old *"undefined means unrestricted — the enforced control is the `filesystem:read` entitlement"* sentence was itself the defect and is replaced with the real rule plus a note that the entitlement path is off unless `enforceEntitlements` is set **with** a registered enforcer.

`electron.ts` carries the identical server registration and is split the same way; `browser.ts` is untouched, since the cross-platform classes reach http(s) through `FetchUrlTask` and touch no filesystem.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGqCtLFGeSJM2nxMbsaDkJ)_