### PR TITLE
connection transactions: deactivate the ALS store and refuse nesting

### DIFF
--- a/packages/storage/src/browser.ts
+++ b/packages/storage/src/browser.ts
@@ -8,11 +8,21 @@
 
 export * from "./common";
 
+// Connection-mutex seam. Everything below except `ConnectionReentryError` is a
+// provider-package internal, versioned in lockstep with this package rather
+// than covered by semver. Application code should use
+// `withConnectionTransaction` instead.
 export {
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   __resetAlsForTesting,
   ConnectionReentryError,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   getAlsStore,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
+  isSynchronousAls,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   runInTransactionOnConnection,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   runOnConnection,
 } from "./tabular/ConnectionMutex.browser";
 

--- a/packages/storage/src/common-server.ts
+++ b/packages/storage/src/common-server.ts
@@ -8,22 +8,47 @@
 
 export * from "./common";
 
+// Connection-mutex seam. Everything below except `ConnectionReentryError` and
+// `NestedConnectionTransactionError` is a provider-package internal: the
+// vendor storages (`@workglow/sqlite`, `@workglow/postgres`,
+// `@workglow/duckdb`) build their `withConnectionTransaction` support on it
+// and are versioned in lockstep with this package. Application code should use
+// `withConnectionTransaction` instead; these names are not covered by semver.
 export {
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   __resetAlsForTesting,
   ConnectionReentryError,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   getAlsStore,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
+  isSynchronousAls,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   runInTransactionOnConnection,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   runOnConnection,
 } from "./tabular/ConnectionMutex.server";
 
 export {
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
+  activeConnectionTxGroupHandle,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   assertSharedConnectionHandle,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   connectionTxQuery,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
+  deactivateConnectionTxStore,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   discardDeferredPuts,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   enqueueDeferredPut,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   isEnlistedInConnectionTx,
+  NestedConnectionTransactionError,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   runNativeConnectionTransaction,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   setConnectionTxQuery,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   takeDeferredPuts,
 } from "./tabular/runNativeConnectionTransaction";
 

--- a/packages/storage/src/tabular/ConnectionMutex.browser.ts
+++ b/packages/storage/src/tabular/ConnectionMutex.browser.ts
@@ -9,8 +9,13 @@ import { defineConnectionMutex } from "./defineConnectionMutex";
 
 export { ConnectionReentryError } from "./defineConnectionMutex";
 
-export const { runOnConnection, runInTransactionOnConnection, getAlsStore, __resetAlsForTesting } =
-  defineConnectionMutex({
-    ensureAls,
-    __resetAlsForTesting: resetAlsForTesting,
-  });
+export const {
+  runOnConnection,
+  runInTransactionOnConnection,
+  getAlsStore,
+  isSynchronousAls,
+  __resetAlsForTesting,
+} = defineConnectionMutex({
+  ensureAls,
+  __resetAlsForTesting: resetAlsForTesting,
+});

--- a/packages/storage/src/tabular/ConnectionMutex.server.ts
+++ b/packages/storage/src/tabular/ConnectionMutex.server.ts
@@ -9,8 +9,13 @@ import { defineConnectionMutex } from "./defineConnectionMutex";
 
 export { ConnectionReentryError } from "./defineConnectionMutex";
 
-export const { runOnConnection, runInTransactionOnConnection, getAlsStore, __resetAlsForTesting } =
-  defineConnectionMutex({
-    ensureAls,
-    __resetAlsForTesting: resetAlsForTesting,
-  });
+export const {
+  runOnConnection,
+  runInTransactionOnConnection,
+  getAlsStore,
+  isSynchronousAls,
+  __resetAlsForTesting,
+} = defineConnectionMutex({
+  ensureAls,
+  __resetAlsForTesting: resetAlsForTesting,
+});

--- a/packages/storage/src/tabular/__tests__/runNativeConnectionTransaction.test.ts
+++ b/packages/storage/src/tabular/__tests__/runNativeConnectionTransaction.test.ts
@@ -1,0 +1,291 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  __resetAlsForTesting,
+  activeConnectionTxGroupHandle,
+  assertSharedConnectionHandle,
+  connectionTxQuery,
+  enqueueDeferredPut,
+  isEnlistedInConnectionTx,
+  isSynchronousAls,
+  NestedConnectionTransactionError,
+  runNativeConnectionTransaction,
+  setConnectionTxQuery,
+  takeDeferredPuts,
+  type AnyTabularStorage,
+  type ConnectionTransactionHost,
+} from "@workglow/storage";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * A participant stands in for a storage instance: `runNativeConnectionTransaction`
+ * only ever uses it as an identity key, and `assertSharedConnectionHandle` only
+ * reads `sharedConnectionHandle()` and the `table` label.
+ */
+function makeHost(handle: object, table: string): AnyTabularStorage & ConnectionTransactionHost {
+  return {
+    table,
+    sharedConnectionHandle: () => handle,
+    runConnectionTransaction: async <T>(
+      _participants: readonly AnyTabularStorage[],
+      fn: () => Promise<T>
+    ) => fn(),
+  } as unknown as AnyTabularStorage & ConnectionTransactionHost;
+}
+
+interface RunOptions {
+  readonly handle: object;
+  readonly participants: readonly AnyTabularStorage[];
+  readonly fn: () => Promise<unknown>;
+  readonly onDeactivate?: () => void;
+  readonly afterCommit?: () => void;
+  readonly afterRollback?: () => void;
+  readonly begin?: () => void;
+}
+
+function run(options: RunOptions): Promise<unknown> {
+  return runNativeConnectionTransaction({
+    handle: options.handle,
+    participants: options.participants,
+    begin: options.begin ?? ((): void => {}),
+    commit: (): void => {},
+    rollback: (): void => {},
+    onDeactivate: options.onDeactivate,
+    afterCommit: options.afterCommit ?? ((): void => {}),
+    afterRollback: options.afterRollback ?? ((): void => {}),
+    fn: options.fn,
+  });
+}
+
+describe("runNativeConnectionTransaction: the store is deactivated at COMMIT", () => {
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  /**
+   * Registers a continuation from INSIDE the transaction body that runs only
+   * after the transaction has settled. `AsyncLocalStorage` propagates through
+   * promise continuations, so this observer still carries the store — which is
+   * the whole point: an observer called from the test body carries none and
+   * would report "not enlisted" no matter what the code does.
+   */
+  function observeAfterSettle<T>(
+    handle: object,
+    owner: AnyTabularStorage & ConnectionTransactionHost,
+    observe: () => T,
+    begin?: () => void
+  ): Promise<T> {
+    let release!: () => void;
+    const settled = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let observation!: Promise<T>;
+    return run({
+      handle,
+      participants: [owner],
+      begin,
+      fn: async () => {
+        observation = settled.then(observe);
+      },
+    }).then(async () => {
+      release();
+      return observation;
+    });
+  }
+
+  it("stops reporting enlistment once the transaction has settled", async () => {
+    const handle = {};
+    const owner = makeHost(handle, "table_a");
+
+    const after = await observeAfterSettle(handle, owner, () => ({
+      enlisted: isEnlistedInConnectionTx(owner),
+      group: activeConnectionTxGroupHandle(),
+    }));
+
+    expect(after.enlisted).toBe(false);
+    expect(after.group).toBeUndefined();
+  });
+
+  it("clears txQuery even though the caller-context setter cannot", async () => {
+    const handle = {};
+    const owner = makeHost(handle, "table_a");
+    const client = { query: async (): Promise<unknown> => undefined };
+
+    const after = await observeAfterSettle(
+      handle,
+      owner,
+      () => connectionTxQuery(),
+      () => {
+        setConnectionTxQuery(client);
+      }
+    );
+
+    expect(after).toBeUndefined();
+  });
+
+  it("sees the live store from inside the body", async () => {
+    const handle = {};
+    const owner = makeHost(handle, "table_a");
+    const client = { query: async (): Promise<unknown> => undefined };
+
+    await run({
+      handle,
+      participants: [owner],
+      begin: () => setConnectionTxQuery(client),
+      fn: async () => {
+        expect(isEnlistedInConnectionTx(owner)).toBe(true);
+        expect(activeConnectionTxGroupHandle()).toBe(handle);
+        expect(connectionTxQuery()).toBe(client);
+      },
+    });
+  });
+
+  it("runs onDeactivate before afterCommit, and refuses to defer puts there", async () => {
+    const handle = {};
+    const owner = makeHost(handle, "table_a");
+    const order: string[] = [];
+
+    await run({
+      handle,
+      participants: [owner],
+      fn: async () => {
+        enqueueDeferredPut(owner, "during");
+        order.push("body");
+      },
+      onDeactivate: () => order.push("deactivate"),
+      afterCommit: () => {
+        order.push("afterCommit");
+        // The body's put is still drainable here — that is the whole point of
+        // this window — but a NEW put must not be swallowed into a fresh queue.
+        expect(takeDeferredPuts(owner)).toEqual(["during"]);
+        expect(enqueueDeferredPut(owner, "listener-write")).toBe(false);
+      },
+    });
+
+    expect(order).toEqual(["body", "deactivate", "afterCommit"]);
+  });
+
+  it("deactivates on the rollback path too", async () => {
+    const handle = {};
+    const owner = makeHost(handle, "table_a");
+    const order: string[] = [];
+
+    let observe!: () => boolean;
+    await expect(
+      run({
+        handle,
+        participants: [owner],
+        fn: async () => {
+          observe = () => isEnlistedInConnectionTx(owner);
+          throw new Error("boom");
+        },
+        onDeactivate: () => order.push("deactivate"),
+        afterRollback: () => order.push("afterRollback"),
+      })
+    ).rejects.toThrow("boom");
+
+    expect(order).toEqual(["deactivate", "afterRollback"]);
+    expect(observe()).toBe(false);
+  });
+
+  it("deactivates when BEGIN itself fails", async () => {
+    const handle = {};
+    const owner = makeHost(handle, "table_a");
+    const order: string[] = [];
+    let rolledBack = false;
+
+    await expect(
+      runNativeConnectionTransaction({
+        handle,
+        participants: [owner],
+        begin: () => {
+          throw new Error("begin failed");
+        },
+        commit: (): void => {},
+        rollback: () => {
+          rolledBack = true;
+        },
+        onDeactivate: () => order.push("deactivate"),
+        afterCommit: (): void => {},
+        afterRollback: () => order.push("afterRollback"),
+        fn: async () => undefined,
+      })
+    ).rejects.toThrow("begin failed");
+
+    // No BEGIN took, so there is nothing to roll back.
+    expect(rolledBack).toBe(false);
+    expect(order).toEqual(["deactivate"]);
+  });
+});
+
+describe("assertSharedConnectionHandle: nesting guard", () => {
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  it("refuses a second connection transaction on the same handle", async () => {
+    const handle = {};
+    const a = makeHost(handle, "table_a");
+    const b = makeHost(handle, "table_b");
+
+    let nested: unknown;
+    await run({
+      handle,
+      participants: [a, b],
+      fn: async () => {
+        try {
+          assertSharedConnectionHandle(a, [a, b]);
+        } catch (err) {
+          nested = err;
+        }
+      },
+    });
+
+    expect(nested).toBeInstanceOf(NestedConnectionTransactionError);
+    expect((nested as Error).message).toContain("table_a");
+    expect((nested as Error).message).toContain("SAVEPOINT");
+  });
+
+  it("allows a transaction on a different connection to nest", async () => {
+    const outerHandle = {};
+    const innerHandle = {};
+    const outer = makeHost(outerHandle, "outer");
+    const inner = makeHost(innerHandle, "inner");
+
+    let resolved: object | undefined;
+    await run({
+      handle: outerHandle,
+      participants: [outer],
+      fn: async () => {
+        resolved = assertSharedConnectionHandle(inner, [inner]);
+      },
+    });
+
+    expect(resolved).toBe(innerHandle);
+  });
+
+  it("allows a sequential second transaction on the same handle", async () => {
+    const handle = {};
+    const a = makeHost(handle, "table_a");
+
+    await run({ handle, participants: [a], fn: async () => undefined });
+    expect(assertSharedConnectionHandle(a, [a])).toBe(handle);
+  });
+});
+
+describe("isSynchronousAls", () => {
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  it("reports the shim, and not a real AsyncLocalStorage", () => {
+    __resetAlsForTesting(true);
+    expect(isSynchronousAls()).toBe(true);
+    __resetAlsForTesting();
+    expect(isSynchronousAls()).toBe(false);
+  });
+});

--- a/packages/storage/src/tabular/__tests__/withConnectionTransaction.test.ts
+++ b/packages/storage/src/tabular/__tests__/withConnectionTransaction.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  InMemoryTabularStorage,
+  withConnectionTransaction,
+  type AnyTabularStorage,
+} from "@workglow/storage";
+import { getLogger, setLogger, type ILogger } from "@workglow/util";
+import type { DataPortSchemaObject } from "@workglow/util/schema";
+import { getTestingLogger } from "@workglow/util/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const Schema = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    value: { type: "string" },
+  },
+  required: ["name", "value"],
+} as const satisfies DataPortSchemaObject;
+
+const PrimaryKeyNames = ["name"] as const;
+
+async function makeInMemory(): Promise<AnyTabularStorage> {
+  const storage = new InMemoryTabularStorage<typeof Schema, typeof PrimaryKeyNames>(
+    Schema,
+    PrimaryKeyNames
+  );
+  await storage.setupDatabase?.();
+  return storage as unknown as AnyTabularStorage;
+}
+
+describe("withConnectionTransaction: participant list", () => {
+  let previous: ILogger;
+
+  beforeEach(() => {
+    previous = getLogger();
+  });
+
+  afterEach(() => {
+    setLogger(previous ?? getTestingLogger());
+  });
+
+  it("rejects an empty participant list instead of silently running unwrapped", async () => {
+    const fn = vi.fn(async () => "done");
+    await expect(withConnectionTransaction([], fn)).rejects.toThrow(
+      /requires at least one participant/
+    );
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("runs an all-best-effort list unwrapped, and says so at debug", async () => {
+    const debug = vi.fn();
+    const spyLogger = { ...getTestingLogger(), debug } as unknown as ILogger;
+    setLogger(spyLogger);
+
+    const a = await makeInMemory();
+    const b = await makeInMemory();
+    const result = await withConnectionTransaction([a, b], async () => {
+      await a.put({ name: "a", value: "1" });
+      await b.put({ name: "b", value: "2" });
+      return "ok";
+    });
+
+    expect(result).toBe("ok");
+    expect(await a.get({ name: "a" })).toMatchObject({ value: "1" });
+    expect(debug).toHaveBeenCalledWith(
+      expect.stringContaining("best-effort"),
+      expect.objectContaining({ tables: expect.any(Array) })
+    );
+  });
+});

--- a/packages/storage/src/tabular/connectionAls.shared.ts
+++ b/packages/storage/src/tabular/connectionAls.shared.ts
@@ -20,12 +20,32 @@ export interface AlsContext {
   readonly owner: object;
   /** Every storage instance enlisted in this connection-scoped transaction. */
   readonly owners: ReadonlySet<object>;
+  /**
+   * Key of the chain slot this transaction holds. Equal to
+   * {@link groupHandle} on every single-session backend; a real `pg.Pool`
+   * transaction may key its chain on the checked-out client instead, so the
+   * two are separate fields.
+   */
   readonly handle: object;
   /**
+   * The physical connection this transaction owns — the pool/database object
+   * every participant reported from `sharedConnectionHandle()`. Used to group
+   * participants and, with {@link active}, to detect a nested
+   * `withConnectionTransaction` on the same connection.
+   */
+  readonly groupHandle: object;
+  /**
+   * `false` once COMMIT/ROLLBACK has run. The store itself outlives the
+   * transaction — `afterCommit` listeners and any continuation of the body
+   * still see it — so accessors that answer "is a transaction open on this
+   * connection" must consult this flag rather than the store's presence.
+   */
+  active: boolean;
+  /**
    * `put` events deferred until COMMIT of a connection-scoped transaction.
-   * Callers flush this after COMMIT (while the store is still active, via
-   * {@link safeEmit} — not {@link BaseSqlTabularStorage.emitPut}, which would
-   * re-queue).
+   * Callers drain this after COMMIT, once the store has been deactivated, so a
+   * listener that writes in response emits (and commits) normally instead of
+   * queueing onto a fresh buffer nothing drains.
    */
   readonly deferredPuts: WeakMap<object, unknown[]>;
   /**

--- a/packages/storage/src/tabular/defineConnectionMutex.ts
+++ b/packages/storage/src/tabular/defineConnectionMutex.ts
@@ -137,9 +137,15 @@ export interface ConnectionMutexApi {
   readonly runInTransactionOnConnection: <T>(
     handle: object,
     owner: TransactionOwners,
-    fn: () => Promise<T>
+    fn: () => Promise<T>,
+    groupHandle?: object
   ) => Promise<T>;
   readonly getAlsStore: () => AlsContext | undefined;
+  /**
+   * `true` when this runtime carries the store with the synchronous shim,
+   * whose store dies at the first `await` inside the transaction body.
+   */
+  readonly isSynchronousAls: () => boolean;
   readonly __resetAlsForTesting: (useShim?: boolean) => void;
 }
 
@@ -272,11 +278,19 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
    * with `mode === "nested-transaction"` at the transaction-opening call
    * site. The synchronous throw path here is symmetric with `runOnConnection`
    * — the handle state is checked before awaiting ALS.
+   *
+   * `handle` keys the chain slot; `groupHandle` names the physical connection
+   * the transaction owns and defaults to `handle`. They differ only where a
+   * backend wants finer-grained chaining than its connection identity (a real
+   * `pg.Pool` keyed on the checked-out client), and the store records both so
+   * nesting detection can key on the connection while chaining keys on the
+   * slot.
    */
   async function runInTransactionOnConnection<T>(
     handle: object,
     owner: TransactionOwners,
-    fn: () => Promise<T>
+    fn: () => Promise<T>,
+    groupHandle: object = handle
   ): Promise<T> {
     const owners = ownerSet(owner);
     const lead = leadOwner(owners);
@@ -313,15 +327,29 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     const txId = Symbol("connection-tx");
     state.txId = txId;
     state.txOwners = owners;
+    const ctx: AlsContext = {
+      txId,
+      owner: lead,
+      owners,
+      handle,
+      groupHandle,
+      active: true,
+      deferredPuts: new WeakMap(),
+      txQuery: undefined,
+    };
     try {
-      return await store.run(
-        { txId, owner: lead, owners, handle, deferredPuts: new WeakMap(), txQuery: undefined },
-        () => fn()
-      );
+      return await store.run(ctx, () => fn());
     } finally {
       if (state.txId === txId) {
         state.txId = null;
         state.txOwners = null;
+        // Belt-and-braces: the transaction body deactivates the store from
+        // INSIDE the ALS scope (so the mutation is visible to descendants).
+        // A body that threw before reaching that point still leaves a store
+        // reachable from any continuation that captured it, so mark it dead
+        // here too.
+        ctx.active = false;
+        ctx.txQuery = undefined;
       }
       release();
     }
@@ -331,6 +359,7 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     runOnConnection,
     runInTransactionOnConnection,
     getAlsStore: () => als.ensureAls().getStore(),
+    isSynchronousAls: () => als.ensureAls().synchronousOnly === true,
     __resetAlsForTesting: als.__resetAlsForTesting,
   };
 }

--- a/packages/storage/src/tabular/runNativeConnectionTransaction.ts
+++ b/packages/storage/src/tabular/runNativeConnectionTransaction.ts
@@ -4,6 +4,46 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * Backend-agnostic host for `withConnectionTransaction`: one chain slot, one
+ * ALS store, one BEGIN/COMMIT on the shared handle, plus the accessors an
+ * enlisted storage uses to discover that it is inside one.
+ *
+ * ## The store outlives the transaction
+ *
+ * `store.run(...)` is awaited by the mutex, so the ALS store is still reachable
+ * from every continuation of the body and from the `afterCommit` callbacks —
+ * long after COMMIT ran. "Is the store present" is therefore NOT the same
+ * question as "is a transaction open", and answering the second with the first
+ * lets post-commit work believe it is still enlisted: writes route to a
+ * released client, `put` events queue onto a buffer nothing drains.
+ *
+ * {@link AlsContext.active} separates the two. It is cleared by
+ * {@link deactivateConnectionTxStore} from INSIDE the ALS scope (a mutation
+ * made from the caller's context would be invisible here, and the awaited
+ * `store.run` returns into the caller's context), and the accessors below
+ * split on it:
+ *
+ * | accessor                          | honors `active` | why                                     |
+ * | --------------------------------- | --------------- | --------------------------------------- |
+ * | {@link connectionTxQuery}         | yes             | the client is released at deactivation  |
+ * | {@link isEnlistedInConnectionTx}  | yes             | nothing is open to enlist in            |
+ * | {@link enqueueDeferredPut}        | yes             | post-commit emits must not be deferred  |
+ * | {@link activeConnectionTxGroupHandle} | yes         | that is the question it answers         |
+ * | {@link takeDeferredPuts}          | no              | it drains the queue in that very window |
+ * | {@link discardDeferredPuts}       | no              | same, on the rollback path              |
+ *
+ * ## Nesting detection
+ *
+ * {@link assertSharedConnectionHandle} refuses a second connection-scoped
+ * transaction on a connection that already has a live one. Detection is
+ * ALS-store based, so it is precise under a real `AsyncLocalStorage`: only a
+ * genuine async descendant of the open body carries the store. It is ABSENT
+ * under {@link createShimAls}, whose store dies at the body's first `await` —
+ * no server backend selects the shim in production, and the guard's job there
+ * falls back to whatever the backend's own `inTransaction` flag catches.
+ */
+
 import { getAlsStore, runInTransactionOnConnection } from "./ConnectionMutex.server";
 import type { AnyTabularStorage } from "./ITabularStorage";
 import {
@@ -11,24 +51,66 @@ import {
   type ConnectionTransactionHost,
 } from "./withConnectionTransaction";
 
+/**
+ * Thrown when `withConnectionTransaction` is called from inside an open
+ * connection-scoped transaction on the same connection.
+ *
+ * SQLite and PostgreSQL have no autonomous `BEGIN`: the inner call cannot open
+ * a transaction of its own, and running it inside the outer one silently
+ * corrupts the outer boundary (the inner COMMIT commits the outer's work; the
+ * inner teardown clears the outer's transaction flags).
+ */
+export class NestedConnectionTransactionError extends Error {
+  constructor(readonly leadTable: string | undefined) {
+    const lead = leadTable ?? "a storage instance";
+    super(
+      [
+        "Nested withConnectionTransaction on the same connection.",
+        `${lead} opened a connection-scoped transaction while one is already open on this connection.`,
+        "",
+        "Supported refactors:",
+        "  (a) Hoist every participant into the OUTER withConnectionTransaction call — enlisted writes join the open BEGIN, so the inner call is unnecessary.",
+        "  (b) Open a SAVEPOINT for a nested rollback boundary — SQLite/Postgres have no autonomous BEGIN, so a nested boundary is a SAVEPOINT, not a nested transaction.",
+        "  (c) Give the inner work its own connection if it must commit independently of the outer transaction.",
+      ].join("\n")
+    );
+    this.name = "NestedConnectionTransactionError";
+  }
+}
+
+/**
+ * Resolves the connection every participant must share, and refuses a nested
+ * connection-scoped transaction on it.
+ *
+ * Every backend calls this before checking out a client or issuing `BEGIN`, so
+ * it is the single choke point where nesting can be rejected while the outer
+ * transaction is still intact.
+ */
 export function assertSharedConnectionHandle(
-  lead: ConnectionTransactionHost & { readonly table?: string },
+  lead: ConnectionTransactionHost,
   participants: readonly AnyTabularStorage[]
 ): object {
+  const leadTable = storageTable(lead);
   const handle = lead.sharedConnectionHandle();
   if (handle === null) {
     throw new Error(
-      `withConnectionTransaction: ${lead.table ?? "storage"} has no shared connection handle`
+      `withConnectionTransaction: ${leadTable ?? "storage"} has no shared connection handle`
     );
+  }
+  // Identity against THIS connection only: a transaction on a different
+  // database nested inside this one stays legal, and a sequential second
+  // transaction is not nesting (the first store is no longer active).
+  if (activeConnectionTxGroupHandle() === handle) {
+    throw new NestedConnectionTransactionError(leadTable);
   }
   for (const participant of participants) {
     const other = isConnectionTransactionHost(participant)
       ? participant.sharedConnectionHandle()
       : undefined;
     if (other !== handle) {
-      const otherTable = (participant as { readonly table?: string }).table ?? "other";
+      const otherTable = storageTable(participant) ?? "other";
       throw new Error(
-        `withConnectionTransaction: participants do not share a connection handle (${lead.table ?? "storage"} vs ${otherTable})`
+        `withConnectionTransaction: participants do not share a connection handle (${leadTable ?? "storage"} vs ${otherTable})`
       );
     }
   }
@@ -36,43 +118,118 @@ export function assertSharedConnectionHandle(
 }
 
 /**
+ * Best-effort label for an error message. Storage instances carry their table
+ * name on a PROTECTED `table` property, so it cannot be reached through a
+ * public structural type — declaring one in the parameter type made every
+ * concrete storage fail to satisfy it.
+ */
+function storageTable(value: object): string | undefined {
+  const table = (value as { readonly table?: unknown }).table;
+  return typeof table === "string" ? table : undefined;
+}
+
+/**
  * Hosts a connection-scoped transaction: one chain slot, one ALS store, one
- * BEGIN/COMMIT on the shared handle. Callers flush deferred `put` events in
- * `afterCommit` via {@link safeEmit} (not `emitPut`, which would re-queue
- * while the store is still active).
+ * BEGIN/COMMIT on the shared handle.
+ *
+ * The teardown order is load-bearing:
+ *
+ *   commit/rollback → {@link deactivateConnectionTxStore} → `onDeactivate` →
+ *   `afterCommit`/`afterRollback`
+ *
+ * Deferred `put` events are flushed last, with the store already dead and the
+ * backends' `inTransaction` flags already cleared, so a listener that writes in
+ * response commits normally instead of queueing onto a fresh buffer nothing
+ * drains (and, on SQLite, instead of running with no transaction at all).
  */
 export async function runNativeConnectionTransaction<T>(options: {
+  /** The physical connection — used to group participants and detect nesting. */
   readonly handle: object;
+  /**
+   * Key of the chain slot to hold. Defaults to {@link handle}. A backend that
+   * can run genuinely independent transactions on one connection object (a
+   * real `pg.Pool`, whose transactions each own a checked-out client) passes
+   * the finer-grained key here so they do not serialize against each other.
+   */
+  readonly chainHandle?: object;
   readonly participants: readonly AnyTabularStorage[];
   readonly begin: () => Promise<void> | void;
   readonly commit: () => Promise<void> | void;
   readonly rollback: () => Promise<void> | void;
+  /**
+   * Backend teardown that must happen once the transaction is over but before
+   * `put` events are emitted — clearing the participants' `inTransaction`
+   * flags. Runs on every exit path, including a failed `begin`.
+   */
+  readonly onDeactivate?: () => void;
   readonly afterCommit: () => void;
   readonly afterRollback: () => void;
   readonly fn: () => Promise<T>;
 }): Promise<T> {
-  return runInTransactionOnConnection(options.handle, options.participants, async () => {
-    await options.begin();
-    try {
-      const result = await options.fn();
-      await options.commit();
-      options.afterCommit();
-      return result;
-    } catch (err) {
+  const deactivate = (): void => {
+    deactivateConnectionTxStore();
+    options.onDeactivate?.();
+  };
+  return runInTransactionOnConnection(
+    options.chainHandle ?? options.handle,
+    options.participants,
+    async () => {
       try {
-        await options.rollback();
-      } catch {
-        // prefer the original error if rollback fails
+        await options.begin();
+      } catch (err) {
+        // BEGIN never took, so there is nothing to ROLLBACK.
+        deactivate();
+        throw err;
       }
-      options.afterRollback();
-      throw err;
-    }
-  });
+      try {
+        const result = await options.fn();
+        await options.commit();
+        deactivate();
+        options.afterCommit();
+        return result;
+      } catch (err) {
+        try {
+          await options.rollback();
+        } catch {
+          // prefer the original error if rollback fails
+        }
+        deactivate();
+        options.afterRollback();
+        throw err;
+      }
+    },
+    options.handle
+  );
+}
+
+/**
+ * Marks the connection transaction store dead. MUST be called from inside the
+ * ALS scope — from the caller's context `getAlsStore()` returns nothing and
+ * this silently no-ops.
+ *
+ * @internal
+ */
+export function deactivateConnectionTxStore(): void {
+  const store = getAlsStore();
+  if (store === undefined) return;
+  store.active = false;
+  store.txQuery = undefined;
+}
+
+/**
+ * The connection owned by the live connection-scoped transaction on this async
+ * context, or `undefined` when none is open.
+ *
+ * @internal
+ */
+export function activeConnectionTxGroupHandle(): object | undefined {
+  const store = getAlsStore();
+  return store !== undefined && store.active ? store.groupHandle : undefined;
 }
 
 export function enqueueDeferredPut(owner: object, entity: unknown): boolean {
   const store = getAlsStore();
-  if (store === undefined || !store.owners.has(owner)) return false;
+  if (store === undefined || !store.active || !store.owners.has(owner)) return false;
   let queue = store.deferredPuts.get(owner);
   if (queue === undefined) {
     queue = [];
@@ -82,6 +239,7 @@ export function enqueueDeferredPut(owner: object, entity: unknown): boolean {
   return true;
 }
 
+/** Drains the post-commit queue; runs after deactivation, so it ignores `active`. */
 export function takeDeferredPuts(owner: object): unknown[] {
   const store = getAlsStore();
   const queue = store?.deferredPuts.get(owner);
@@ -90,17 +248,19 @@ export function takeDeferredPuts(owner: object): unknown[] {
   return queue;
 }
 
+/** Drops the queue after ROLLBACK; runs after deactivation, so it ignores `active`. */
 export function discardDeferredPuts(owner: object): void {
   getAlsStore()?.deferredPuts.delete(owner);
 }
 
 export function isEnlistedInConnectionTx(owner: object): boolean {
   const store = getAlsStore();
-  return store !== undefined && store.owners.has(owner);
+  return store !== undefined && store.active && store.owners.has(owner);
 }
 
 export function connectionTxQuery(): { query: (...args: never[]) => Promise<unknown> } | undefined {
-  return getAlsStore()?.txQuery;
+  const store = getAlsStore();
+  return store !== undefined && store.active ? store.txQuery : undefined;
 }
 
 export function setConnectionTxQuery(

--- a/packages/storage/src/tabular/withConnectionTransaction.ts
+++ b/packages/storage/src/tabular/withConnectionTransaction.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getLogger } from "@workglow/util";
 import type { AnyTabularStorage } from "./ITabularStorage";
 
 /**
@@ -44,10 +45,20 @@ function dedupeByIdentity(participants: readonly AnyTabularStorage[]): AnyTabula
  * Runs `fn` inside one native transaction spanning every enlisted tabular
  * storage that shares a connection handle.
  *
- * An empty list, or a list of only best-effort backends (InMemory, IndexedDB,
- * FsFolder, …), invokes `fn` with no extra wrapping. Mixing a native-transaction
- * backend with a best-effort backend in one call throws. Participants bound to
- * different connection handles also throw.
+ * An EMPTY participant list throws: a caller that built its list dynamically
+ * and ended up with none asked for atomicity and would silently not get it.
+ *
+ * A list of only best-effort backends (InMemory, IndexedDB, FsFolder, …)
+ * invokes `fn` with NO transaction and no atomicity — those backends have no
+ * native transaction to open. That is deliberate (it keeps one call site
+ * working across a native and a best-effort wiring) and is logged at debug.
+ * Mixing a native-transaction backend with a best-effort backend in one call
+ * throws. Participants bound to different connection handles also throw.
+ *
+ * Calling this from inside an open connection-scoped transaction on the SAME
+ * connection throws `NestedConnectionTransactionError` — SQLite and Postgres
+ * have no autonomous `BEGIN`, so hoist the participants into the outer call or
+ * use a `SAVEPOINT`.
  *
  * Inside `fn`, call ordinary methods on the original storage instances — not a
  * `tx` proxy. Enlisted writes join the open `BEGIN`; a storage that was not
@@ -58,7 +69,9 @@ export async function withConnectionTransaction<T>(
   fn: () => Promise<T>
 ): Promise<T> {
   const unique = dedupeByIdentity(participants);
-  if (unique.length === 0) return fn();
+  if (unique.length === 0) {
+    throw new Error("withConnectionTransaction requires at least one participant");
+  }
 
   const hosts: Array<AnyTabularStorage & ConnectionTransactionHost> = [];
   const bestEffort: AnyTabularStorage[] = [];
@@ -70,7 +83,13 @@ export async function withConnectionTransaction<T>(
     }
   }
 
-  if (hosts.length === 0) return fn();
+  if (hosts.length === 0) {
+    getLogger().debug(
+      "withConnectionTransaction: every participant is a best-effort storage; running without a transaction",
+      { tables: unique.map((p) => (p as { readonly table?: string }).table ?? "unnamed") }
+    );
+    return fn();
+  }
   if (bestEffort.length > 0) {
     throw new Error(
       "withConnectionTransaction: cannot mix native-transaction storages with best-effort storages"

--- a/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
@@ -6,7 +6,12 @@
 
 import { PGlite } from "@electric-sql/pglite";
 import { PostgresTabularStorage } from "@workglow/postgres/storage";
-import { ConnectionReentryError, StorageValidationError } from "@workglow/storage";
+import {
+  ConnectionReentryError,
+  NestedConnectionTransactionError,
+  StorageValidationError,
+  withConnectionTransaction,
+} from "@workglow/storage";
 import { setLogger, uuid4 } from "@workglow/util";
 import type { DataPortSchemaObject } from "@workglow/util/schema";
 import { getTestingLogger } from "@workglow/util/test";
@@ -534,6 +539,32 @@ describe("PostgresTabularStorage", () => {
         expect(await a.get({ name: "n1", type: "x" })).toBeDefined();
         expect(await a.get({ name: "n2", type: "x" })).toBeDefined();
         expect(await a.get({ name: "n3", type: "x" })).toBeDefined();
+      } finally {
+        await pglite.close();
+      }
+    });
+
+    it("withConnectionTransaction refuses to nest on the same connection", async () => {
+      const [a, b, pglite] = await makeSharedPair();
+      try {
+        let nested: unknown;
+        await withConnectionTransaction([a, b], async () => {
+          await a.put({ name: "outer", type: "x", option: "outer", success: true });
+          try {
+            await withConnectionTransaction([a, b], async () => {
+              await b.put({ name: "inner", type: "x", option: "inner", success: true });
+            });
+          } catch (err) {
+            nested = err;
+          }
+        });
+
+        expect(nested).toBeInstanceOf(NestedConnectionTransactionError);
+        expect((nested as Error).message).toContain("SAVEPOINT");
+        // On PGlite the inner BEGIN would only warn, and the inner COMMIT
+        // would commit the outer's work — so the guard must fire before it.
+        expect(await a.get({ name: "outer", type: "x" })).toMatchObject({ option: "outer" });
+        expect(await b.get({ name: "inner", type: "x" })).toBeUndefined();
       } finally {
         await pglite.close();
       }

--- a/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
@@ -7,6 +7,7 @@
 import { Sqlite, SqliteTabularStorage } from "@workglow/sqlite/storage";
 import {
   ConnectionReentryError,
+  NestedConnectionTransactionError,
   StorageValidationError,
   withConnectionTransaction,
 } from "@workglow/storage";
@@ -636,5 +637,90 @@ describe("SqliteTabularStorage shared-connection safety", () => {
     await expect(withConnectionTransaction([a, other], async () => undefined)).rejects.toThrow(
       /do not share a connection handle/
     );
+  });
+
+  it("withConnectionTransaction refuses to nest on the same connection", async () => {
+    const [a, b] = await makeSharedPair();
+
+    let nested: unknown;
+    await withConnectionTransaction([a, b], async () => {
+      await a.put({ name: "outer", type: "x", option: "outer", success: true });
+      try {
+        await withConnectionTransaction([a, b], async () => {
+          await b.put({ name: "inner", type: "x", option: "inner", success: true });
+        });
+      } catch (err) {
+        nested = err;
+      }
+    });
+
+    expect(nested).toBeInstanceOf(NestedConnectionTransactionError);
+    expect((nested as Error).message).toContain("SAVEPOINT");
+    // The inner call must fail BEFORE issuing its own BEGIN, so the outer
+    // transaction is untouched and still commits its own work.
+    expect(await a.get({ name: "outer", type: "x" })).toMatchObject({ option: "outer" });
+    expect(await b.get({ name: "inner", type: "x" })).toBeUndefined();
+  });
+
+  it("a rejected nested transaction leaves the outer transaction able to write", async () => {
+    const [a, b] = await makeSharedPair();
+
+    await withConnectionTransaction([a, b], async () => {
+      await expect(withConnectionTransaction([a, b], async () => undefined)).rejects.toBeInstanceOf(
+        NestedConnectionTransactionError
+      );
+      // A write AFTER the rejected nesting attempt must still join the outer
+      // BEGIN — the failed inner call must not have cleared `inTransaction`.
+      await a.put({ name: "after-nested", type: "x", option: "va", success: true });
+      await b.put({ name: "after-nested", type: "x", option: "vb", success: true });
+      throw new Error("forced rollback");
+    }).catch((err: unknown) => {
+      expect((err as Error).message).toBe("forced rollback");
+    });
+
+    expect(await a.get({ name: "after-nested", type: "x" })).toBeUndefined();
+    expect(await b.get({ name: "after-nested", type: "x" })).toBeUndefined();
+  });
+
+  it("withConnectionTransaction on a DIFFERENT database may nest", async () => {
+    const [a, b] = await makeSharedPair();
+    const [c, d] = await makeSharedPair();
+
+    await withConnectionTransaction([a, b], async () => {
+      await a.put({ name: "outer", type: "x", option: "outer", success: true });
+      await withConnectionTransaction([c, d], async () => {
+        await c.put({ name: "inner", type: "x", option: "inner", success: true });
+      });
+    });
+
+    expect(await a.get({ name: "outer", type: "x" })).toMatchObject({ option: "outer" });
+    expect(await c.get({ name: "inner", type: "x" })).toMatchObject({ option: "inner" });
+  });
+
+  it("a deferred put listener that writes commits, and its own put event fires", async () => {
+    const [a, b] = await makeSharedPair();
+
+    const seen: string[] = [];
+    let writing = false;
+    b.on("put", (entity: { name: string }) => {
+      seen.push(entity.name);
+      if (writing) return;
+      writing = true;
+      // A listener reacting to the flushed commit event by writing back
+      // through the same storage: the write must take its own transaction and
+      // its own `put` event must reach this listener rather than being queued
+      // onto a buffer nothing drains.
+      void b.put({ name: "marker", type: "x", option: "from-listener", success: true });
+    });
+
+    await withConnectionTransaction([a, b], async () => {
+      await b.put({ name: "in-tx", type: "x", option: "vb", success: true });
+    });
+
+    await vi.waitFor(() => expect(seen).toContain("marker"));
+    expect(seen[0]).toBe("in-tx");
+    expect(await b.get({ name: "marker", type: "x" })).toMatchObject({
+      option: "from-listener",
+    });
   });
 });

--- a/providers/duckdb/src/storage/DuckDbTabularStorage.ts
+++ b/providers/duckdb/src/storage/DuckDbTabularStorage.ts
@@ -168,10 +168,14 @@ export class DuckDbTabularStorage<
       },
       commit: async () => {
         await db.exec("COMMIT");
-        for (const sibling of siblings) sibling.inTransaction = false;
       },
       rollback: async () => {
         await db.exec("ROLLBACK");
+      },
+      // Clearing `inTransaction` here rather than only in the trailing
+      // `.finally` is what lets a deferred `put` listener's own write take its
+      // own BEGIN: `afterCommit` runs before the promise settles.
+      onDeactivate: () => {
         for (const sibling of siblings) sibling.inTransaction = false;
       },
       afterCommit: () => {
@@ -182,6 +186,8 @@ export class DuckDbTabularStorage<
       },
       fn,
     }).finally(() => {
+      // Belt-and-braces: `onDeactivate` already ran on every path through
+      // runNativeConnectionTransaction, including a failed BEGIN.
       for (const sibling of siblings) sibling.inTransaction = false;
     });
   }

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -950,7 +950,9 @@ export class PostgresTabularStorage<
           fn,
         });
       } finally {
-        setConnectionTxQuery(undefined);
+        // The ALS store's txQuery is cleared from inside the ALS scope by
+        // runNativeConnectionTransaction; clearing it here would run in the
+        // caller's context, where there is no store to reach.
         client.release();
       }
     }
@@ -964,10 +966,14 @@ export class PostgresTabularStorage<
       },
       commit: async () => {
         await this.pool.query("COMMIT");
-        for (const sibling of siblings) sibling.inTransaction = false;
       },
       rollback: async () => {
         await this.pool.query("ROLLBACK");
+      },
+      // Clearing `inTransaction` here rather than only in the trailing
+      // `.finally` is what lets a deferred `put` listener's own write take its
+      // own BEGIN: `afterCommit` runs before the promise settles.
+      onDeactivate: () => {
         for (const sibling of siblings) sibling.inTransaction = false;
       },
       afterCommit: () => {
@@ -978,6 +984,8 @@ export class PostgresTabularStorage<
       },
       fn,
     }).finally(() => {
+      // Belt-and-braces: `onDeactivate` already ran on every path through
+      // runNativeConnectionTransaction, including a failed BEGIN.
       for (const sibling of siblings) sibling.inTransaction = false;
     });
   }

--- a/providers/sqlite/src/storage/SqliteTabularStorage.ts
+++ b/providers/sqlite/src/storage/SqliteTabularStorage.ts
@@ -126,6 +126,12 @@ export class SqliteTabularStorage<
       rollback: () => {
         this.db.exec("ROLLBACK");
       },
+      // Clearing `inTransaction` here rather than only in the trailing
+      // `.finally` is what lets a deferred `put` listener's own write take its
+      // own BEGIN: `afterCommit` runs before the promise settles.
+      onDeactivate: () => {
+        for (const sibling of siblings) sibling.inTransaction = false;
+      },
       afterCommit: () => {
         for (const sibling of siblings) sibling.flushAlsDeferredPuts();
       },
@@ -134,6 +140,8 @@ export class SqliteTabularStorage<
       },
       fn,
     }).finally(() => {
+      // Belt-and-braces: `onDeactivate` already ran on every path through
+      // runNativeConnectionTransaction, including a failed BEGIN.
       for (const sibling of siblings) sibling.inTransaction = false;
     });
   }


### PR DESCRIPTION
Stacked on #842 (`claude/multi-repo-transactions-708`). This is **PR A** of a three-PR sequence; it is the blocking one for the downstream `withConnectionTransaction` consumers.

## The CRITICAL defect: `withConnectionTransaction` has no nesting guard

A nested `withConnectionTransaction` call made from an already-enlisted owner is classified `"inline"` by the connection mutex (`defineConnectionMutex.ts`), which returns `fn()` with **no store scope of its own**. The inner `runNativeConnectionTransaction` therefore re-runs `begin()` inside the outer transaction's still-live ALS store. There is no autonomous `BEGIN` in SQLite or PostgreSQL, so the outer transaction boundary is corrupted — differently on each backend, and silently on two of the three:

| backend | what happens today |
| --- | --- |
| **SQLite** | The inner `BEGIN` throws from *outside* the `try` in `runNativeConnectionTransaction`, so **no `ROLLBACK` runs**. The inner teardown's trailing `.finally` then clears `inTransaction` on the **outer's** participants, so every later write in the outer body silently takes its own `BEGIN` — outside the transaction it believes it is in. |
| **PGlite** | The nested `BEGIN` only warns. The inner **`COMMIT` commits the outer's work**, and the outer's eventual `ROLLBACK` is a no-op. Data that was supposed to roll back is durable. |
| **real `pg.Pool`** | The inner call checks out a **second client** and `setConnectionTxQuery` overwrites the shared (still-active) store's `txQuery`; the inner teardown then clears it. The outer's remaining writes fall through `db` to `this.pool` and **autocommit** on arbitrary pooled clients. |

Verified end to end: the new SQLite integration test fails on the base branch with `SqliteError: cannot start a transaction within a transaction`, and the new PGlite one fails with `expected undefined to be an instance of NestedConnectionTransactionError` — i.e. the nested call raises nothing at all.

### Root cause, shared with two other defects

`store.run(...)` is awaited by the mutex, so the ALS store is still reachable from every continuation of the transaction body **and** from the `afterCommit` callbacks — long after `COMMIT` ran. Every accessor treated *"a store is present"* as *"a transaction is open"*, which is what makes the nesting case reachable and also causes:

- **`setConnectionTxQuery(undefined)` never runs.** The pool branch's `finally` sits outside `runNativeConnectionTransaction`, so its continuation executes in the **caller's** async context where `getAlsStore()` is `undefined` and the setter early-returns. The store survived with `txQuery` bound to a client that had already been `release()`d back to the pool.
- **`flushAlsDeferredPuts` emits inside the still-active store.** A `put` listener that writes in response re-entered `enqueueDeferredPut`, which — still active, owner still enlisted — pushed onto a **fresh queue nothing drains**. On SQLite that listener's write also still saw `inTransaction === true` (cleared only by the trailing `.finally`), so it skipped its own `BEGIN` and ran with **no transaction at all**.

## The fix

**Structural.** `AlsContext` gains two fields:

- `active` — `false` once `COMMIT`/`ROLLBACK` has run. Cleared by `deactivateConnectionTxStore()` called from **inside** the ALS scope (a mutation from the caller's context would not be visible to descendants); the mutex's own `finally` additionally mutates the context object directly as a backstop for a body that threw before reaching the deactivation point.
- `groupHandle` — the physical connection, kept separate from `handle` (the chain-slot key). `runInTransactionOnConnection` takes an optional 4th `groupHandle` param, defaulting to `handle`, so nesting detection can key on connection identity while chaining keys on the slot. `runNativeConnectionTransaction` gains the matching `chainHandle` option.

**Accessor gating** — the split is deliberate and documented in the module header:

| accessor | honors `active` | why |
| --- | --- | --- |
| `connectionTxQuery` | yes | the client is released at deactivation |
| `isEnlistedInConnectionTx` | yes | nothing is open to enlist in |
| `enqueueDeferredPut` | yes | post-commit emits must not be deferred |
| `activeConnectionTxGroupHandle` | yes | that is the question it answers |
| `takeDeferredPuts` | **no** | it drains the queue in that very window |
| `discardDeferredPuts` | **no** | same, on the rollback path |

**The guard.** Every backend calls `assertSharedConnectionHandle` first, and before `pool.connect()` / `BEGIN`, so it is the single choke point where nesting can be refused while the outer transaction is still intact. It now throws `NestedConnectionTransactionError` when `activeConnectionTxGroupHandle() === handle`. Three properties are load-bearing:

- keyed on `groupHandle`, not the chain key, so the pool path stays covered once PR B re-keys the chain onto the client;
- identity against **this** connection only, so a transaction on a *different* database may still nest;
- gated on `active`, so a *sequential* second transaction is not nesting.

**Teardown order** is now `commit`/`rollback` → deactivate → `onDeactivate` (new option; backends clear `inTransaction` here) → `afterCommit`/`afterRollback`, on every exit path including a failed `BEGIN` (which correctly issues no `ROLLBACK`). Backends keep their trailing `.finally` as belt-and-braces. That ordering is what makes a deferred-put listener's own write commit normally and emit its own event.

**Smaller items in scope:** `withConnectionTransaction([])` now throws instead of silently running `fn` unwrapped (a dynamically-built list that came out empty asked for atomicity and would not get it); an all-best-effort list keeps its documented no-op but now logs it at debug; the provider-package seam exports in `common-server.ts` / `browser.ts` are annotated `@internal` with a comment above each group; the now-dead `setConnectionTxQuery(undefined)` is removed from the pool branch.

### One fix outside the plan

`assertSharedConnectionHandle`'s parameter declared `& { readonly table?: string }`. `table` is `protected` on every concrete storage, so it cannot satisfy a public structural type — **all three provider packages failed `build-types` on the base branch** with `TS2345`. The label is now read through the same cast the rest of the function already used. `@workglow/sqlite`, `@workglow/postgres` and `@workglow/duckdb` all build types clean again.

## Tests

Every test below was verified in **both** directions — run against a deliberately degraded (pre-fix) implementation with the test files unchanged, then against the fix.

New `packages/storage/src/tabular/__tests__/runNativeConnectionTransaction.test.ts` (9 tests). The observers are registered as promise continuations from **inside** the transaction body, because an observer called from the test body carries no store and would report "not enlisted" no matter what the code does:

- enlistment / `txQuery` / `activeConnectionTxGroupHandle` all go dead once the transaction settles
- `onDeactivate` runs before `afterCommit`; the body's queued put is still drainable there but a *new* put is refused
- deactivation on the rollback path, and on a failed `BEGIN` (asserting no `ROLLBACK` is attempted)
- the nesting guard: refuses same-handle, permits a different connection, permits a sequential second transaction
- `isSynchronousAls()` distinguishes the shim from a real `AsyncLocalStorage`

New `packages/storage/src/tabular/__tests__/withConnectionTransaction.test.ts` (2 tests): empty list rejects and never calls `fn`; all-best-effort resolves and logs at debug.

`SqliteTabularStorage.integration.test.ts` (4 new): nesting rejected with the outer's own write still committing; a write *after* a rejected nesting attempt still joins the outer `BEGIN` and still rolls back with it; a transaction on a second `Sqlite.Database` may nest; a `put` listener that writes back through the same storage persists **and** its own `put` event fires.

`PostgresTabularStorage.integration.test.ts` (1 new): the PGlite mirror of the nesting rejection.

```
# unit, after the fix
 Test Files  2 passed (2)
      Tests  12 passed (12)

# unit, against the degraded pre-fix implementation
     × stops reporting enlistment once the transaction has settled
     × clears txQuery even though the caller-context setter cannot
     × runs onDeactivate before afterCommit, and refuses to defer puts there
     × deactivates on the rollback path too
     × deactivates when BEGIN itself fails
     × refuses a second connection transaction on the same handle
     × rejects an empty participant list instead of silently running unwrapped
     × runs an all-best-effort list unwrapped, and says so at debug
      Tests  8 failed | 4 passed (12)

# SQLite integration, against the degraded pre-fix implementation
     × withConnectionTransaction refuses to nest on the same connection
       AssertionError: expected SqliteError: cannot start a transaction w… to be an instance of NestedConnectionTransactionError
     × a rejected nested transaction leaves the outer transaction able to write
     × a deferred put listener that writes commits, and its own put event fires
       AssertionError: expected [ 'in-tx' ] to include 'marker'

# PGlite integration, against the degraded pre-fix implementation
     × withConnectionTransaction refuses to nest on the same connection
       AssertionError: expected undefined to be an instance of NestedConnectionTransactionError
```

Full suites, after the fix (Node 24.19, `bun scripts/test.ts storage unit vitest` plus the integration files by name):

```
storage unit section:            Test Files  46 passed | 1 skipped (47)   Tests  826 passed | 14 skipped (840)
--project storage:               Test Files  22 passed | 1 skipped (23)   Tests  355 passed | 2 skipped (357)
Sqlite + DuckDb integration:     Test Files  2 passed (2)                 Tests  336 passed | 2 skipped (338)
Postgres + Scoped integration:   Test Files  3 passed (3)                 Tests  171 passed | 1 skipped (172)
build-types (storage, sqlite, postgres, duckdb):   6 successful, 6 total
eslint on every touched path:    clean
```

One pre-existing note: `PostgresTabularStorage.integration.test.ts > shared-connection safety (PGlite path) > sibling single-op throws …` exceeds the 15 s default timeout in this container. Confirmed identical on the base branch with these changes stashed — PGlite instantiation alone is slower than the timeout here; it passes at `--testTimeout=120000`.

## Downstream impact (embarc-data #53/#55)

The `withConnectionTransaction(participants, fn)` signature is unchanged, but **four behaviors change**:

1. **`withConnectionTransaction([])` now throws.** Guard dynamically-built participant lists before calling.
2. **Nested `withConnectionTransaction` on the same handle now throws `NestedConnectionTransactionError`.** Hoist the inner participants into the outer call (enlisted writes join the open `BEGIN`, so the inner call is unnecessary), or use a `SAVEPOINT`.
3. `storage.withTransaction()` inside a connection transaction will throw on Postgres — embarc-data reverted to exactly this pattern in `b038de3`. **(PR B, not this PR.)** Ordinary `put`/`putBulk` join the transaction and need no change.
4. Two concurrent connection transactions on one `pg.Pool` will run in **parallel** instead of serializing, so overlapping writes can hit real row-lock contention. **(PR B, not this PR.)**

`sec` / `embarc-data` on SQLite exercise only the single-session path. On Postgres they build a real `pg.Pool`, so the entire pool path is live for them and is currently untested. Findings 1, 2 and 8 (this PR) must land before #53/#55 are correct at all; findings 4, 5 and 7 (PR B) must land before either is deployed against Postgres.

## Sequencing

- **PR A — this one.** Shared structural change + nesting guard + empty-list throw + `@internal`. Backend-agnostic, fully testable on SQLite + PGlite. **Blocking for downstream.**
- **PR B** — real `pg.Pool`: parallel transactions (`chainHandle`), `isSynchronousAls()` fail-fast, `withTransaction`-inside rejection, poisoned-client release. Depends on this PR; confined to `PostgresTabularStorage.ts`. The `chainHandle` / `onDeactivate` / `isSynchronousAls` plumbing added here is unused until then, by design — splitting it out would mean changing these same signatures twice.
- **PR C** — cover the real `pg.Pool` path: an env-gated block plus a `postgres:16` CI service. Every line of the pool branch is currently unexecuted (`PGlite as unknown as Pool` exposes no `connect()`, so `serializeOps` is always true, and no `PG_URL`-style variable exists anywhere in the repo).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGqCtLFGeSJM2nxMbsaDkJ)_