### PR TITLE
fix(sqlite): stop SqliteAiVectorStorage.putBulk deadlocking on its own chain slot

### DIFF
--- a/providers/sqlite/src/storage/SqliteAiVectorStorage.ts
+++ b/providers/sqlite/src/storage/SqliteAiVectorStorage.ts
@@ -17,7 +17,6 @@ import {
   getMetadataProperty,
   getVectorProperty,
   matchesFilter,
-  runOnConnection,
   validateVectorEntities,
 } from "@workglow/storage";
 import type {
@@ -487,17 +486,10 @@ export class SqliteAiVectorStorage<
       return super._putBulkInternal(entities);
     }
 
-    // Route the vector-encoding write through the shared connection chain so
-    // two SqliteAiVectorStorage instances that wrap the same underlying handle
-    // (or one vector storage and one plain SqliteTabularStorage) queue on the
-    // same lock instead of racing on the shared connection. Skip when we are
-    // already inside an outer `withTransaction` — the chain lock is held there.
-    const dbWithFlag = this.database as unknown as { readonly inTransaction?: boolean };
-    const alreadyInTx = this.inTransaction || dbWithFlag.inTransaction === true;
-    const handle = this.connectionHandle();
-    if (handle !== null && !alreadyInTx) {
-      return runOnConnection(handle, this, () => this.runVectorPutBulkOnHandle(entities));
-    }
+    // The shared connection chain slot is already held by whoever reached
+    // here: the public `putBulk` takes it in `guardedWrite`, and a call
+    // arriving through the `tx` proxy runs inside the transaction that holds
+    // it. Re-taking it here would await a slot only this call can release.
     return this.runVectorPutBulkOnHandle(entities);
   }
 


### PR DESCRIPTION
## Summary

`SqliteAiVectorStorage.putBulk` takes the shared connection-chain slot **twice**, and the inner take awaits a promise that only resolves after the inner call returns. Four vector tests hang for their full 60 s timeout, and the poisoned handle then hangs `afterEach`'s `deleteAll()` on a 15 s hook timeout.

This removes the redundant inner take, restoring symmetry with `SqliteTabularStorage._putBulkInternal`.

## Root cause

Two things independently take the chain slot for one logical write:

- the public `putBulk` takes it in `guardedWrite` (added with the connection-mutex work), and
- `_putBulkInternal` took it again via `runOnConnection` (present since `3bfca03fd`, when it was the *only* take and therefore correct).

The inner `runOnConnection` awaits the outer holder's promise. That promise resolves only when the outer call returns — which cannot happen until the inner one does. A call arriving through the `tx` proxy is in the same position: it runs inside a transaction that already holds the slot.

Whoever reaches `_putBulkInternal` already holds the slot, so it must not re-take it.

```diff
-    const dbWithFlag = this.database as unknown as { readonly inTransaction?: boolean };
-    const alreadyInTx = this.inTransaction || dbWithFlag.inTransaction === true;
-    const handle = this.connectionHandle();
-    if (handle !== null && !alreadyInTx) {
-      return runOnConnection(handle, this, () => this.runVectorPutBulkOnHandle(entities));
-    }
     return this.runVectorPutBulkOnHandle(entities);
```

`1 file changed, 4 insertions(+), 12 deletions(-)`.

## Provenance

This is a pre-existing regression on this branch, not a defect in #845. It was introduced by `1eef8dbb8` — the first commit of this branch — and stayed hidden because the branch's `build-types` job was broken, so every test job was skipped.

Bisect over `bun scripts/test.ts vitest integration storage`:

| commit | result |
| --- | --- |
| `2a9aeba80` (parent) | 21 passed, 4.8 s |
| `1eef8dbb8` | **4 failed, 218.7 s** |
| `ff4b97196` | 4 failed |
| `4b22a8545` | 4 failed |
| `4b22a8545` + this fix | 21 passed |

## Verification

Red/green on this exact tree, same command, fix stashed and restored:

**Without the fix**

```
× putBulk + similaritySearch returns inserted vectors at distance 0        60059ms (retry x1)
× putBulk persists vectors as Float32Array via getAll                      60060ms (retry x1)
× mixed put + putBulk yields identical similaritySearch ordering           60078ms (retry x1)
× does not deadlock external putBulk queued behind a running withTransaction 34034ms (retry x1)
Error: Hook timed out in 15000ms.
Error: deadlock-timeout
Test Files  1 failed | 25 passed (26)
     Tests  4 failed | 1275 passed | 31 skipped (1310)
```

**With the fix**

```
Test Files  26 passed (26)
     Tests  1279 passed | 31 skipped (1310)
```
46.29 s.

Note the fourth failing test — `does not deadlock external putBulk queued behind a running withTransaction` — is the branch's own regression test for this property, failing on the branch that added it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGqCtLFGeSJM2nxMbsaDkJ)_