### PR TITLE
fix(tasks): declare the owned FetchUrlTask entitlements on FileLoaderTask

### DIFF
--- a/packages/tasks/src/task/FileLoaderTask.server.ts
+++ b/packages/tasks/src/task/FileLoaderTask.server.ts
@@ -22,7 +22,7 @@ import {
   localFilePathFromUrl,
   resolveLocalFilePath,
 } from "../util/LocalFilePath.server";
-import { fetchUrlEntitlementsFor, FetchUrlTask } from "./FetchUrlTask";
+import { fetchUrlEntitlementsFor } from "./FetchUrlTask";
 import type {
   FileLoaderTaskConfig,
   FileLoaderTaskInput,
@@ -82,7 +82,7 @@ export class FileLoaderTask extends BaseFileLoaderTask<FileLoaderTaskConfig> {
    * alongside the read this build adds.
    */
   public static override entitlements(): TaskEntitlements {
-    return mergeEntitlements(FetchUrlTask.entitlements(), {
+    return mergeEntitlements(super.entitlements(), {
       entitlements: [
         {
           id: Entitlements.FILESYSTEM_READ,

--- a/packages/tasks/src/task/FileLoaderTask.ts
+++ b/packages/tasks/src/task/FileLoaderTask.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
+import type { IExecuteContext, TaskConfig, TaskEntitlements } from "@workglow/task-graph";
 import { CreateWorkflow, Task, TaskAbortedError, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { FetchUrlResponseType, FetchUrlTaskOutput } from "./FetchUrlTask";
-import { FetchUrlTask } from "./FetchUrlTask";
+import { fetchUrlEntitlementsFor, FetchUrlTask } from "./FetchUrlTask";
 
 let _papaParse: typeof import("papaparse").parse | undefined;
 
@@ -117,6 +117,21 @@ export class FileLoaderTask<Config extends TaskConfig = TaskConfig> extends Task
   public static override title = "File Loader";
   public static override description = "Load documents from URLs (http://, https://)";
   public static override cacheable = true;
+  public static override hasDynamicEntitlements: boolean = true;
+
+  /**
+   * The owned `FetchUrlTask` does the network access, but an owned child is
+   * created inside `execute()` and so is absent from the graph-start snapshot
+   * `computeGraphEntitlements` takes over `graph.getTasks()`. Declaring the
+   * fetch's entitlements here is what puts them in front of the enforcer.
+   */
+  public static override entitlements(): TaskEntitlements {
+    return FetchUrlTask.entitlements();
+  }
+
+  public override entitlements(): TaskEntitlements {
+    return fetchUrlEntitlementsFor(this.runInputData?.url);
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/test/src/test/task/FileLoaderEntitlements.test.ts
+++ b/packages/test/src/test/task/FileLoaderEntitlements.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createPolicyEnforcer,
+  createProfilePolicy,
+  ENTITLEMENT_ENFORCER,
+  Entitlements,
+  TaskEntitlementError,
+  TaskGraph,
+  TaskGraphRunner,
+  TaskRegistry,
+  type IEntitlementEnforcer,
+} from "@workglow/task-graph";
+import { FileLoaderTask as FileLoaderServerTask } from "@workglow/tasks";
+import { Container, ServiceRegistry, setLogger } from "@workglow/util";
+import { getTestingLogger } from "@workglow/util/test";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+// `@workglow/tasks` resolves to the node build under vitest, whose
+// `FileLoaderTask` is the server subclass. The cross-platform base — the class
+// `browser.ts` registers, and the one this fix is about — is only reachable
+// through its own module.
+import { FileLoaderTask } from "../../../../tasks/src/task/FileLoaderTask";
+// Registered on the SOURCE module for the same reason: the base class reaches
+// the source `FetchUrlTask`, whose safeFetch slot is a different instance from
+// the built package's.
+import { registerSafeFetch, type SafeFetchFn } from "../../../../tasks/src/util/SafeFetch";
+
+const METADATA_URL = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
+
+describe("FileLoaderTask entitlement enforcement", () => {
+  const logger = getTestingLogger();
+  setLogger(logger);
+
+  let prevSafeFetch: SafeFetchFn;
+
+  beforeAll(() => {
+    // The enforcer is what is under test, not the network layer.
+    prevSafeFetch = registerSafeFetch(() =>
+      Promise.resolve(
+        new Response('{"ok":true}', {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+    );
+    TaskRegistry.registerTask(FileLoaderTask);
+  });
+
+  afterAll(() => {
+    registerSafeFetch(prevSafeFetch);
+  });
+
+  function makeRegistry(enforcer: IEntitlementEnforcer): ServiceRegistry {
+    const registry = new ServiceRegistry(new Container());
+    registry.register(ENTITLEMENT_ENFORCER, () => enforcer);
+    return registry;
+  }
+
+  function makeGraph(url: string): TaskGraph {
+    const graph = new TaskGraph();
+    graph.addTask(new FileLoaderTask({ id: "loader-node", defaults: { url } }));
+    return graph;
+  }
+
+  /**
+   * The scenario that motivated the declaration. Pre-fix the cross-platform
+   * class declared nothing at all: `computeGraphEntitlements` runs over
+   * `graph.getTasks()` at graph start and saw an empty set, and the
+   * `FetchUrlTask` the task owns inside `execute()` is not in that snapshot —
+   * so it reached the metadata endpoint with `allowPrivate: true`, its own
+   * resolved-destination check satisfied because the child's input url IS the
+   * private one.
+   */
+  test("a profile without network:private denies a metadata-endpoint load", async () => {
+    const enforcer = createPolicyEnforcer(createProfilePolicy("browser"));
+    const runner = new TaskGraphRunner(makeGraph(METADATA_URL));
+
+    await expect(
+      runner.runGraph({}, { registry: makeRegistry(enforcer), enforceEntitlements: true })
+    ).rejects.toThrow(TaskEntitlementError);
+  });
+
+  test("the same profile allows a public load", async () => {
+    const enforcer = createPolicyEnforcer(createProfilePolicy("browser"));
+    const runner = new TaskGraphRunner(makeGraph("https://example.com/data.json"));
+
+    await expect(
+      runner.runGraph({}, { registry: makeRegistry(enforcer), enforceEntitlements: true })
+    ).resolves.toBeDefined();
+  });
+
+  test("declares the fetch entitlements for an http url", () => {
+    const declared = new FileLoaderTask({
+      defaults: { url: "https://example.com/data.json" },
+    }).entitlements().entitlements;
+
+    expect(declared.map((e) => e.id)).toContain(Entitlements.NETWORK_HTTP);
+    // The cross-platform build reaches http(s) through `FetchUrlTask` and
+    // touches no filesystem.
+    expect(declared.map((e) => e.id)).not.toContain(Entitlements.FILESYSTEM_READ);
+  });
+
+  test("declares fail-closed network:private when the url is unknown", () => {
+    const declared = new FileLoaderTask({ defaults: {} as never }).entitlements().entitlements;
+    const ids = declared.map((e) => e.id);
+
+    expect(ids).toContain(Entitlements.NETWORK_PRIVATE);
+    // Unscoped: nothing is known about the destination yet.
+    expect(declared.find((e) => e.id === Entitlements.NETWORK_PRIVATE)?.resources).toBeUndefined();
+  });
+
+  // The server build's static declaration now merges onto `super.entitlements()`
+  // rather than restating `FetchUrlTask.entitlements()`, so pin that the switch
+  // kept both halves.
+  test("the server build still adds filesystem:read on top", () => {
+    const ids = FileLoaderServerTask.entitlements().entitlements.map((e) => e.id);
+
+    expect(ids).toContain(Entitlements.NETWORK_HTTP);
+    expect(ids).toContain(Entitlements.FILESYSTEM_READ);
+  });
+});


### PR DESCRIPTION
## The owned-child snapshot gap

`computeGraphEntitlements` takes its snapshot over `graph.getTasks()` at graph start, before any `execute()` runs. A child created inside `execute()` via `context.own(...)` is therefore never in that snapshot, so its entitlements are invisible to the enforcer unless the owning task declares them itself. That is exactly what `fetchUrlEntitlementsFor` exists for, and its docblock says so.

The cross-platform `FileLoaderTask` owns a `FetchUrlTask` inside `execute()` and declared **nothing at all** — no static `entitlements()`, no instance `entitlements()`, no `hasDynamicEntitlements`.

## Why this one was missed

The recent batch added the owned-child declaration to `FileGrepTask`, `FileSedTask` and `FileLoaderTask.server` — the two grep/sed cross-platform bases and the loader's *server subclass*. The loader's cross-platform base is the one that fell through the gap, and it is the class `browser.ts` registers into `TaskRegistry`, so the build with no filesystem branch at all — the one whose entire surface IS the owned fetch — was the one declaring none of it.

## Failure scenario

Under `enforceEntitlements: true` with a registered enforcer, a graph containing a browser-build `FileLoaderTask` pointed at `http://169.254.169.254/latest/meta-data/…` runs to completion. The enforcer sees an empty declaration for the node; the owned `FetchUrlTask` then runs with `allowPrivate: true` and its own resolved-destination check is satisfied, because the child's input url IS the private one. The link-local metadata endpoint is reached while the task declared neither `network:http` nor `network:private` — the destination the enforcer exists to gate never reaches it.

## The fix

`FileLoaderTask.ts` gains the same three members `FileGrepTask` carries: `hasDynamicEntitlements`, a static `entitlements()` returning `FetchUrlTask.entitlements()`, and an instance `entitlements()` returning `fetchUrlEntitlementsFor(this.runInputData?.url)` — which fails closed to an unscoped `network:private` when the url is not yet known.

`FileLoaderTask.server.ts` now merges its `filesystem:read` onto `super.entitlements()` instead of restating `FetchUrlTask.entitlements()`, matching `FileGrepTask.server.ts` and `FileSedTask.server.ts`. The base now supplies the same value, so this is behaviour-preserving; it removes the second place to edit when `FetchUrlTask`'s declaration changes. `FetchUrlTask` became unused in that file and was dropped from the import. The server's instance `entitlements()`, which already handles the http-vs-path branches, is unchanged.

## Breaking Changes

**Under enforcement, a graph containing a browser-build `FileLoaderTask` that previously ran *because it declared nothing* will now be denied unless the profile grants `network:http` / `network:private`.** That is the fix — the task always did the network access, it just never said so — but it is a behaviour change for any embedder running `enforceEntitlements: true` with a policy that did not grant the fetch. It belongs under a **Breaking Changes** CHANGELOG heading for `@workglow/tasks`, alongside 0.3.48's "contain the server filesystem tasks by default".

The server build's effective declaration is unchanged, and nothing changes for an embedder not running with an enforcer.

## Test

New `packages/test/src/test/task/FileLoaderEntitlements.test.ts`, modelled on `FileGrepEntitlements.test.ts`. `@workglow/tasks` resolves to the node build under vitest, so the cross-platform class is imported from its own module (`../../../../tasks/src/task/FileLoaderTask`) — with the precedent of `HFT_CheckpointSessions.test.ts`. `registerSafeFetch` is stubbed on that same source module, since the source `FetchUrlTask` holds a different safeFetch slot from the built package's; the enforcer is what is under test, not the network.

Five pins: the metadata-endpoint denial, a public load that still resolves, the http declaration (`network:http` and no `filesystem:read`), the fail-closed unscoped `network:private` for an unknown url, and — for the `super.entitlements()` consolidation — that the server build still carries both `network:http` and `filesystem:read`.

Three of the five fail on `main` (verified by stashing the source change), including the enforcement pin:

```
 × a profile without network:private denies a metadata-endpoint load
 × declares the fetch entitlements for an http url
 × declares fail-closed network:private when the url is unknown

AssertionError: promise resolved "[ { id: 'loader-node', …(2) } ]" instead of rejecting
AssertionError: expected [] to include 'network:http'
AssertionError: expected [] to include 'network:private'

 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
```

With the fix, `bun scripts/test.ts task vitest`:

```
Running all tests in sections [task] — 75 file(s)

 Test Files  75 passed (75)
      Tests  1229 passed | 24 skipped (1253)
   Duration  193.95s
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LowBJQsCghLDiHwPN6FgUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LowBJQsCghLDiHwPN6FgUT)_