### PR TITLE
fix(tasks): accept optional groups in the regex screen and bound RegexTask matching

### DIFF
--- a/packages/tasks/src/common.ts
+++ b/packages/tasks/src/common.ts
@@ -87,6 +87,7 @@ export * from "./task/vector/VectorNormalizeTask";
 export * from "./task/vector/VectorScaleTask";
 export * from "./task/vector/VectorSubtractTask";
 export * from "./task/vector/VectorSumTask";
+export * from "./util/BoundedRegexRunner";
 export * from "./util/regexSafety";
 export * from "./util/SafeFetch";
 export * from "./util/UrlClassifier";

--- a/packages/tasks/src/electron.ts
+++ b/packages/tasks/src/electron.ts
@@ -9,6 +9,7 @@
 import "./codec.node";
 import "./task/image/registerImageTextRenderer.node";
 import "./util/SafeFetch.server";
+import "./util/BoundedRegex.server";
 
 export * from "./common";
 export * from "./task/FileGrepTask.server";

--- a/packages/tasks/src/node.ts
+++ b/packages/tasks/src/node.ts
@@ -11,6 +11,7 @@ import "./task/image/registerImageTextRenderer.node";
 // Install the DNS-resolving, connection-pinning SafeFetch implementation.
 // This side-effect import must happen before FetchUrlTask is used.
 import "./util/SafeFetch.server";
+import "./util/BoundedRegex.server";
 
 export * from "./common";
 export * from "./task/FileGrepTask.server";

--- a/packages/tasks/src/task/RegexTask.ts
+++ b/packages/tasks/src/task/RegexTask.ts
@@ -7,35 +7,28 @@
 import type { IExecuteContext, IExecutePreviewContext, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
-import { assertSafeRegexPattern } from "../util/regexSafety";
+import { getRegexRunnerFactory } from "../util/BoundedRegexRunner";
+import { compileSafeRegex } from "../util/regexSafety";
 
 function executeRegex(input: { value: string; pattern: string; flags?: string }): {
   match: boolean;
   matches: string[];
 } {
-  assertSafeRegexPattern(input.pattern);
-
   const flags = input.flags ?? "";
-  const regex = new RegExp(input.pattern, flags);
+  const runner = getRegexRunnerFactory()(compileSafeRegex(input.pattern, flags));
 
   if (flags.includes("g")) {
-    const allMatches = Array.from(input.value.matchAll(new RegExp(input.pattern, flags)));
-    return {
-      match: allMatches.length > 0,
-      matches: allMatches.map((m) => m[0]),
-    };
+    const matches = runner.execAll(input.value);
+    return { match: matches.length > 0, matches };
   }
 
-  const result = regex.exec(input.value);
-  if (!result) {
+  const result = runner.exec(input.value);
+  if (result === undefined) {
     return { match: false, matches: [] as string[] };
   }
 
   // Return full match + captured groups
-  return {
-    match: true,
-    matches: result.slice(0),
-  };
+  return { match: true, matches: result as string[] };
 }
 
 const inputSchema = {

--- a/packages/tasks/src/util/BoundedRegex.server.ts
+++ b/packages/tasks/src/util/BoundedRegex.server.ts
@@ -5,7 +5,10 @@
  */
 
 import { TaskInvalidInputError } from "@workglow/task-graph";
+import { SECURITY_LIMITS } from "@workglow/util";
 import { createContext, Script } from "node:vm";
+import type { RegexRunnerFactory } from "./BoundedRegexRunner";
+import { registerRegexRunnerFactory } from "./BoundedRegexRunner";
 
 /**
  * Matches lines against a regex under an interruptible wall-clock budget.
@@ -221,3 +224,95 @@ export function createBoundedRegexReplacer(
     return { texts: [...scope.out], counts: [...scope.counts] };
   };
 }
+
+/**
+ * One value, one regex — the shape {@link RegexTask} needs, where the batching
+ * the other helpers do has nothing to amortize over.
+ *
+ * The context and script are module-level and shared across every runner: a
+ * fresh `createContext` per call site costs ~0.74 ms against ~0.16 ms for a
+ * reused one, and a task that evaluates a single value per run pays that on
+ * every run. `re` and `value` are assigned per call instead.
+ */
+const execContext = createContext({
+  re: undefined as RegExp | undefined,
+  value: "",
+  all: false,
+  matched: false,
+  out: [] as (string | undefined)[],
+});
+
+// Wrapped so `result` is not redeclared in the context's global scope on the
+// second call — same reason as {@link createBoundedRegexExtractor}.
+const execScript = new Script(`(function () {
+  out.length = 0;
+  matched = false;
+  re.lastIndex = 0;
+  if (all) {
+    let result;
+    while ((result = re.exec(value)) !== null) {
+      if (result[0].length === 0) {
+        re.lastIndex++;
+        continue;
+      }
+      out.push(result[0]);
+      if (!re.global) break;
+    }
+    matched = out.length > 0;
+  } else {
+    const result = re.exec(value);
+    if (result !== null) {
+      matched = true;
+      const parts = Array.prototype.slice.call(result);
+      for (let i = 0; i < parts.length; i++) out.push(parts[i]);
+    }
+  }
+})();`);
+
+interface ExecScope {
+  re: RegExp;
+  value: string;
+  all: boolean;
+  matched: boolean;
+  out: (string | undefined)[];
+}
+
+/**
+ * Builds a {@link RegexRunnerFactory} that runs each match under an
+ * interruptible wall-clock budget, for the same reason and with the same
+ * residual as {@link createBoundedRegexMatcher}.
+ */
+export function createBoundedRegexExecutor(timeoutMs: number): RegexRunnerFactory {
+  return (regex) => {
+    const scope = execContext as unknown as ExecScope;
+
+    const run = (value: string, all: boolean): void => {
+      scope.re = regex;
+      scope.value = value;
+      scope.all = all;
+      try {
+        execScript.runInContext(execContext, { timeout: timeoutMs });
+      } catch {
+        // Deliberately not a TaskTimeoutError: that extends TaskAbortedError and
+        // would report the run as aborted rather than failed by bad input.
+        throw new TaskInvalidInputError(
+          `Regex matching exceeded its ${timeoutMs}ms budget for pattern /${regex.source}/ — ` +
+            `the pattern backtracks catastrophically on this input. Simplify the pattern.`
+        );
+      }
+    };
+
+    return {
+      exec: (value) => {
+        run(value, false);
+        return scope.matched ? [...scope.out] : undefined;
+      },
+      execAll: (value) => {
+        run(value, true);
+        return [...scope.out] as string[];
+      },
+    };
+  };
+}
+
+registerRegexRunnerFactory(createBoundedRegexExecutor(SECURITY_LIMITS.regexMatchBatchTimeoutMs));

--- a/packages/tasks/src/util/BoundedRegexRunner.ts
+++ b/packages/tasks/src/util/BoundedRegexRunner.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Seam for running a single regex against a single value.
+ *
+ * The shape screen in `regexSafety.ts` is a heuristic, not a decision
+ * procedure — `^(a?b?)*$` passes it and still backtracks catastrophically. What
+ * contains that is a wall-clock budget at match time, which needs a `vm` and so
+ * cannot live in the browser build. The Node/Bun/Electron entrypoints register
+ * the bounded implementation (see `BoundedRegex.server.ts`); the browser default
+ * matches unbounded, where a hostile pattern blocks that tab rather than the
+ * process hosting a local API.
+ */
+
+/** Runs one compiled regex against one value. */
+export interface RegexRunner {
+  /**
+   * The full match followed by its capture groups, or `undefined` when the
+   * pattern did not match. An unmatched optional group stays `undefined` in
+   * place rather than being dropped, so group indices keep their meaning.
+   */
+  readonly exec: (value: string) => (string | undefined)[] | undefined;
+  /** Every non-empty full match, for a regex carrying the `g` flag. */
+  readonly execAll: (value: string) => string[];
+}
+
+export type RegexRunnerFactory = (regex: RegExp) => RegexRunner;
+
+/** Advances past a zero-length match so the scan cannot stall on it. */
+function execAllUnbounded(regex: RegExp, value: string): string[] {
+  const matches: string[] = [];
+  regex.lastIndex = 0;
+  let result = regex.exec(value);
+  while (result !== null) {
+    if (result[0].length === 0) {
+      regex.lastIndex++;
+    } else {
+      matches.push(result[0]);
+    }
+    if (!regex.global) break;
+    result = regex.exec(value);
+  }
+  return matches;
+}
+
+/** Plain, unbounded matching on the calling thread. */
+export const defaultRegexRunnerFactory: RegexRunnerFactory = (regex) => ({
+  exec: (value) => {
+    regex.lastIndex = 0;
+    const result = regex.exec(value);
+    return result === null ? undefined : (result.slice(0) as (string | undefined)[]);
+  },
+  execAll: (value) => execAllUnbounded(regex, value),
+});
+
+let currentFactory: RegexRunnerFactory = defaultRegexRunnerFactory;
+
+/**
+ * Register a platform-specific runner factory. The Node/Bun entrypoints call
+ * this at module load time to install the budgeted implementation from
+ * `BoundedRegex.server.ts`.
+ *
+ * Returns the previously registered factory so callers can safely restore it
+ * after a temporary override.
+ */
+export function registerRegexRunnerFactory(fn: RegexRunnerFactory): RegexRunnerFactory {
+  const previousFactory = currentFactory;
+  currentFactory = fn;
+  return previousFactory;
+}
+
+export function getRegexRunnerFactory(): RegexRunnerFactory {
+  return currentFactory;
+}
+
+/** Restores the default unbounded implementation. */
+export function resetRegexRunnerFactory(): void {
+  currentFactory = defaultRegexRunnerFactory;
+}

--- a/packages/tasks/src/util/regexSafety.ts
+++ b/packages/tasks/src/util/regexSafety.ts
@@ -21,6 +21,30 @@ function isUnboundedRepetitionAt(pattern: string, index: number): boolean {
   return UNBOUNDED_REPETITION_RE.test(pattern);
 }
 
+/** `{n}` / `{n,}` / `{n,m}` starting exactly at an index, sticky for the same reason. */
+const COUNTED_REPETITION_RE = /\{(\d+)(?:,(\d*))?\}/y;
+
+/**
+ * True when the quantifier at `index` permits TWO OR MORE repetitions, which is
+ * what turns a quantifying group body into a backtracking blow-up.
+ *
+ * `?` and `{0,1}` do not: they bound the group to at most one repetition, so
+ * `(\.\d+)?` stays linear no matter what its body quantifies. `{10}` does, even
+ * though it is bounded — `(a+){10}` is measurably catastrophic.
+ */
+function quantifierAllowsRepeat(pattern: string, index: number): boolean {
+  const char = pattern[index];
+  if (char === "*" || char === "+") return true;
+  if (char !== "{") return false;
+  COUNTED_REPETITION_RE.lastIndex = index;
+  const counted = COUNTED_REPETITION_RE.exec(pattern);
+  if (counted === null) return false;
+  const [, min, max] = counted;
+  if (max === undefined) return Number(min) >= 2;
+  if (max === "") return true;
+  return Number(max) >= 2;
+}
+
 interface PatternScan {
   /** Every `[` in the source, including literals inside a class. */
   readonly bracketCount: number;
@@ -80,10 +104,7 @@ function scanPattern(pattern: string): PatternScan {
         continue;
       }
 
-      const next = pattern[index + 1];
-      const groupIsQuantified = next === "*" || next === "+" || next === "?" || next === "{";
-
-      if (bodyQuantifies && groupIsQuantified) {
+      if (bodyQuantifies && quantifierAllowsRepeat(pattern, index + 1)) {
         nestedQuantifiers = true;
       }
 

--- a/packages/test/src/test/task/RegexSafety.test.ts
+++ b/packages/test/src/test/task/RegexSafety.test.ts
@@ -20,7 +20,7 @@ describe("assertSafeRegexPattern", () => {
   });
 
   it("rejects nested quantifiers", () => {
-    for (const pattern of ["(a+)+", "(a*)+", "(a+)*", "(a+)?", "(a+){2}", "((b|c+))+"]) {
+    for (const pattern of ["(a+)+", "(a*)+", "(a+)*", "(a+){2}", "((b|c+))+"]) {
       expect(() => assertSafeRegexPattern(pattern)).toThrow(/nested quantifiers/);
     }
   });
@@ -139,5 +139,68 @@ describe("hasUnsafeRegexShape", () => {
 
   it("still catches a class branch that can match empty", () => {
     expect(hasUnsafeRegexShape("([a-z]*|[A-Z])+")).toBe(true);
+  });
+
+  /**
+   * A group made optional is bounded to at most ONE repetition, so its body's
+   * own `+` has nothing to backtrack against — `(X)?` is linear whatever `X`
+   * quantifies. Reading `?` as "the group is quantified" rejected the most
+   * ordinary shapes there are: an optional decimal part, an optional comment
+   * line, an optional trailing capture.
+   */
+  it.each([
+    "^-?\\d+(\\.\\d+)?$",
+    "^-?\\d+(?:\\.\\d+)?$",
+    "(\\w+)?",
+    "^(#.*)?$",
+    "(\\s+)?end",
+    "(https?://\\S+)?",
+    "(ERROR|WARN)\\s+(\\w+)?",
+    "(a+)?",
+    "(?<year>\\d+)?",
+    "(a+){1}",
+    "(a+){0,1}",
+    "(a+){foo}",
+    "(?:\\r?\\n)+",
+    "^(?:https?://)?(www\\.)?example\\.com",
+  ])("accepts the optional group %s", (pattern) => {
+    expect(hasUnsafeRegexShape(pattern)).toBe(false);
+  });
+
+  /**
+   * The rule is "does the quantifier permit two or more repetitions", NOT "is
+   * it a real `{n,}`/`{n,m}`". The cheaper-looking variant — reuse the existing
+   * comma-requiring `isUnboundedRepetitionAt` — would accept every one of
+   * these; `(a+){10}` measured 46 318 ms against a 41-character input.
+   */
+  it.each(["(a+){2}", "(a+){2,3}", "(a+){10}", "(a+){2,}"])(
+    "still rejects the counted repetition %s",
+    (pattern) => {
+      expect(hasUnsafeRegexShape(pattern)).toBe(true);
+    }
+  );
+
+  /**
+   * The inner `(a+)?` no longer trips the rule on its own, but a group whose
+   * body quantifies still counts as a quantifier for whatever encloses it — so
+   * the outer `+` over it is caught exactly as before.
+   */
+  it("still rejects an optional quantifying group under an outer quantifier", () => {
+    expect(hasUnsafeRegexShape("((a+)?)+")).toBe(true);
+  });
+
+  it("stays linear on a newly accepted optional group", () => {
+    // The screen is what changed, so compile exactly what it now accepts.
+    const pattern = "^-?\\d+(\\.\\d+)?$";
+    expect(hasUnsafeRegexShape(pattern)).toBe(false);
+    const regex = new RegExp(pattern);
+    expect(regex.exec("-12.5")?.[1]).toBe(".5");
+
+    // The optional group bounds itself to one repetition, so a long non-match
+    // is a single failed scan rather than an exponential search.
+    const value = "1".repeat(200_000) + "!";
+    const started = performance.now();
+    expect(regex.test(value)).toBe(false);
+    expect(performance.now() - started).toBeLessThan(200);
   });
 });

--- a/packages/test/src/test/task/RegexTask.test.ts
+++ b/packages/test/src/test/task/RegexTask.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { TaskStatus } from "@workglow/task-graph";
+import { TaskInvalidInputError, TaskStatus } from "@workglow/task-graph";
 import { RegexTask } from "@workglow/tasks";
 import { setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
@@ -96,5 +96,27 @@ describe("RegexTask", () => {
   it("should complete with COMPLETED status", async () => {
     await task.run({ value: "abc", pattern: "abc" });
     expect(task.status).toBe(TaskStatus.COMPLETED);
+  });
+
+  /**
+   * The shape screen never sees this one: no group here quantifies, and no
+   * alternation overlaps, so it passes `assertSafeRegexPattern` both before and
+   * after the optional-group relaxation. What stops it is the match budget the
+   * runner applies — unbounded it measured 5 829 ms on this input, against a
+   * 1 000 ms budget. Bun honours a `vm` timeout coarsely, hence the headroom.
+   */
+  it("fails a catastrophically backtracking pattern instead of blocking", async () => {
+    const started = performance.now();
+    await expect(
+      task.run({ value: "ab".repeat(28) + "!", pattern: "^((a?)(b?))*$" })
+    ).rejects.toThrow(TaskInvalidInputError);
+    expect(performance.now() - started).toBeLessThan(5_000);
+  });
+
+  /** `(\.\d+)?` bounds the group to one repetition; the screen used to read the `?` as unsafe. */
+  it("accepts a decimal pattern the shape screen used to reject", async () => {
+    const result = await task.run({ value: "-12.5", pattern: "^-?\\d+(\\.\\d+)?$" });
+    expect(result.match).toBe(true);
+    expect(result.matches[0]).toBe("-12.5");
   });
 });


### PR DESCRIPTION
Two coupled issues in the ReDoS defence. They ship together because fixing the first makes the second worse.

## 1. The shape screen rejected safe, common patterns

`scanPattern` (`packages/tasks/src/util/regexSafety.ts`) treated `?` — and a bare `{` — after `)` as "the group is quantified", so any group whose body contains `+`/`*` and is then made optional tripped `nestedQuantifiers`. `(X)?` bounds the group to **at most one** repetition, so there is nothing for the engine to backtrack over and the match stays linear. A pure false positive, and it gated three user-facing tasks: `FileGrepTask`, `FileSedTask`, `RegexTask`.

Confirmed rejected-but-safe before this change:

```
^-?\d+(\.\d+)?$    ^-?\d+(?:\.\d+)?$    (\w+)?    ^(#.*)?$
(\s+)?end          (https?://\S+)?      (ERROR|WARN)\s+(\w+)?
```

The correct predicate is **"does the quantifier permit two or more repetitions"**, added as `quantifierAllowsRepeat` beside `isUnboundedRepetitionAt` (which is left alone — it answers the *body* question, "can this match variable lengths", where `X{10}` is fixed-length and fine).

The tempting cheaper variant — reuse `isUnboundedRepetitionAt` for the group test, i.e. require a real `{n,}`/`{n,m}` instead of a bare `{` — was **rejected**: its regex requires a comma, so it would start **accepting** `(a+){10}`, **measured at 46,318 ms against a 41-character input**, and would flip the existing must-reject case `(a+){2}`. `it.each(["(a+){2}", "(a+){2,3}", "(a+){10}", "(a+){2,}"])` pins that.

Sticky `exec` throughout, never `test(pattern.slice(...))` — slicing per character is the quadratic shape the module opens by explaining it exists to avoid.

### Newly accepted (all verified against the real module)

`^-?\d+(\.\d+)?$`, `^-?\d+(?:\.\d+)?$`, `(\w+)?`, `^(#.*)?$`, `(\s+)?end`, `(https?://\S+)?`, `(ERROR|WARN)\s+(\w+)?`, `(a+)?`, `(?<year>\d+)?`, `(a+){1}`, `(a+){0,1}`, `(a+){foo}` — plus the already-passing `(\d)?`, `^(\d{4})-(\d{2})-(\d{2})$`, `(foo|far)+`, `([a-z]|[A-Z])*`, `foo.*bar`, `(a\+)+`, `([*+])+`, `(?:\r?\n)+`, `^(?:https?://)?(www\.)?example\.com`.

### Still rejected (all verified)

`(a+)+`, `(a*)+`, `(a+)*`, `(a+){2}`, `((b|c+))+`, `(a+)+$`, `(a*)*$`, `(x+x+)+y`, `([a-z]+)+$`, `((a)*)*$`, `(\d+)+$`, `(a|a)*$`, `(?:a|a)*$`, `(a|a|a)+$`, `^(a|ab)+$`, `(a*|b)+$`, `(a{2,})*$`, `([a-z]|[a-z])*`, `\[(a+)+]`, `([a-z]*|[A-Z])+`, `(a+){2,3}`, `(a+){10}`, `(a+){2,}`, `((a+)?)+`.

`((a+)?)+` is the interesting one: the inner `(a+)?` no longer trips the rule, but "a quantifying group counts as a quantifier for whatever encloses it" still marks the outer group, so it stays rejected. Pinned by its own test.

One intentional expectation flip: `"(a+)?"` was removed from `it("rejects nested quantifiers")`.

## 2. `RegexTask` matched unbounded

`RegexTask` called `assertSafeRegexPattern` and then `new RegExp` + `exec`/`matchAll` on the calling thread. The screen's own JSDoc says a `false` is **not** a safety guarantee and that the enforced containment is the match budget in `createBoundedRegexMatcher` — which `RegexTask` never used. `^(a?b?)*$` passes the screen (no group quantifies, no alternation overlaps) and **measured 31,714 ms against `"ab".repeat(28) + "!"`**. `executePreview` ran the same unbounded code. Relaxing the screen widens what reaches this path, hence one PR.

**A `RegexTask.server` subclass is not viable**: `TaskRegistry.registerTask` throws on a second class for the same `type`, and `RegexTask` is registered from `common.ts`. So this uses the injection seam the package already has for `safeFetch` (`SafeFetch.ts` + `SafeFetch.server.ts` tail + a side-effect import in `node.ts`):

- **`util/BoundedRegexRunner.ts`** (new, cross-platform) — `RegexRunner` / `RegexRunnerFactory`, plus `registerRegexRunnerFactory` / `getRegexRunnerFactory` / `resetRegexRunnerFactory`, the same three-function shape as `SafeFetch.ts`. `defaultRegexRunnerFactory` does the plain unbounded exec: the browser default, where a hostile pattern blocks the tab rather than a host process — the trade-off already documented on `FileGrepTask.createLineMatcher`.
- **`util/BoundedRegex.server.ts`** — `createBoundedRegexExecutor(timeoutMs)`, using **one module-level** `createContext` + `Script` with `re` assigned per call. Measured: shared context 0.16 ms/call vs 0.74 ms for a fresh one, and `RegexTask` evaluates a single value per run, so the per-call-site context `createBoundedRegexMatcher` builds is the wrong shape here. Results are copied out with `Array.prototype.slice.call(r)` so an unmatched optional group stays `undefined` in place rather than being dropped; the zero-length-match `lastIndex++` guard is reused from `createBoundedRegexExtractor`. Timeout throws `TaskInvalidInputError` with the existing message shape — deliberately not `TaskTimeoutError`, which extends `TaskAbortedError` and would report the run aborted rather than failed by bad input. The file ends with the `registerRegexRunnerFactory(...)` call at `SECURITY_LIMITS.regexMatchBatchTimeoutMs`.
- **`node.ts` / `electron.ts`** — side-effect import next to `SafeFetch.server`. **`common.ts`** re-exports the runner module.
- **`RegexTask.ts`** — `executeRegex` now uses `compileSafeRegex` (so a bad *flag* raises `TaskInvalidInputError` instead of a raw `SyntaxError`) and takes its matcher from `getRegexRunnerFactory()`. This also collapses the double `new RegExp` the global path was doing. Both `execute` and `executePreview` go through it.

## Tests

`^((a?)(b?))*$` is the budget test pattern precisely because it is invisible to the screen **both before and after** this change — it proves the budget, not the screen. Unbounded it measures **5,829 ms** against `"ab".repeat(28) + "!"`; the budget is 1,000 ms. It now terminates at ~1,007 ms. Bun honours a `vm` timeout coarsely, so the assertion leaves headroom at 5,000 ms.

The nine existing `RegexTask` assertions are the regression suite for the runner swap and pass unchanged.

```
 ✓ RegexSafety.test.ts > assertSafeRegexPattern > rejects nested quantifiers
 ✓ RegexSafety.test.ts > hasUnsafeRegexShape > accepts the optional group ^-?\d+(\.\d+)?$
 ✓ RegexSafety.test.ts > hasUnsafeRegexShape > accepts the optional group (a+)?
 ✓ RegexSafety.test.ts > hasUnsafeRegexShape > still rejects the counted repetition (a+){10}
 ✓ RegexSafety.test.ts > hasUnsafeRegexShape > still rejects an optional quantifying group under an outer quantifier
 ✓ RegexSafety.test.ts > hasUnsafeRegexShape > stays linear on a newly accepted optional group 4ms
 ✓ RegexTask.test.ts   > RegexTask > fails a catastrophically backtracking pattern instead of blocking 1009ms
 ✓ RegexTask.test.ts   > RegexTask > accepts a decimal pattern the shape screen used to reject 1ms

 Test Files  2 passed (2)
      Tests  61 passed (61)
```

Full section, against the built `dist` (`bun run build:packages` then `bun scripts/test.ts task vitest`):

```
Running all tests in sections [task] — 74 file(s)

 Test Files  74 passed (74)
      Tests  1246 passed | 24 skipped (1270)
   Duration  217.45s
```

`bunx tsc -p packages/tasks/tsconfig.json --noEmit` is clean, and `bun run format` reports no changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LowBJQsCghLDiHwPN6FgUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LowBJQsCghLDiHwPN6FgUT)_