### PR TITLE
fix(tasks): bound sedLines with a search deadline and restore the node export surface

### DIFF
--- a/packages/tasks/src/electron.ts
+++ b/packages/tasks/src/electron.ts
@@ -12,9 +12,18 @@ import "./util/SafeFetch.server";
 
 export * from "./common";
 export * from "./task/FileGrepTask.server";
-export { grepLines, linesFromText } from "./task/FileGrepTask";
+export { createMatcher, grepLines, linesFromText } from "./task/FileGrepTask";
+export type { GrepLineMatcher, GrepOptions } from "./task/FileGrepTask";
 export * from "./task/FileLoaderTask.server";
 export * from "./task/FileSedTask.server";
+export {
+  createSedExpander,
+  createSedRegex,
+  createSubstituter,
+  expandReplacement,
+  sedLines,
+} from "./task/FileSedTask";
+export type { SedBatchResult, SedLineSubstituter, SedOptions } from "./task/FileSedTask";
 
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";

--- a/packages/tasks/src/node.ts
+++ b/packages/tasks/src/node.ts
@@ -14,9 +14,18 @@ import "./util/SafeFetch.server";
 
 export * from "./common";
 export * from "./task/FileGrepTask.server";
-export { grepLines, linesFromText } from "./task/FileGrepTask";
+export { createMatcher, grepLines, linesFromText } from "./task/FileGrepTask";
+export type { GrepLineMatcher, GrepOptions } from "./task/FileGrepTask";
 export * from "./task/FileLoaderTask.server";
 export * from "./task/FileSedTask.server";
+export {
+  createSedExpander,
+  createSedRegex,
+  createSubstituter,
+  expandReplacement,
+  sedLines,
+} from "./task/FileSedTask";
+export type { SedBatchResult, SedLineSubstituter, SedOptions } from "./task/FileSedTask";
 
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";

--- a/packages/tasks/src/task/FileSedTask.ts
+++ b/packages/tasks/src/task/FileSedTask.ts
@@ -105,7 +105,7 @@ const outputSchema = {
       type: "boolean",
       title: "Truncated",
       description:
-        "Output stopped before EOF because an output cap was reached or an input line was capped",
+        "Output stopped before EOF because an output cap or the search deadline was reached, or an input line was capped",
     },
   },
   required: ["text", "replacementCount", "linesChanged", "truncated"],
@@ -332,10 +332,16 @@ export function expandReplacement(replacement: string, args: unknown[]): string 
 /**
  * Substitutes over `lines` in batches of {@link SECURITY_LIMITS.regexMatchBatchLines}.
  *
- * Abort is checked once per BATCH, not per line: a single `String.replace` is
- * uninterruptible, so a per-line check bought nothing a hostile pattern could
- * not ignore. The granularity that matters is therefore the batch, and the
- * substituter itself bounds how long one batch may run.
+ * Abort and the overall search deadline are checked once per BATCH, not per
+ * line: a single `String.replace` is uninterruptible, so a per-line check
+ * bought nothing a hostile pattern could not ignore. The granularity that
+ * matters is therefore the batch, and the substituter itself bounds how long
+ * one batch may run.
+ *
+ * The deadline is what stops a run under `onlyChangedLines`, where the output
+ * caps are skipped for every unchanged line: a pattern that matches nothing
+ * emits nothing, so without it EOF would be the only stopping condition and a
+ * huge source would be read to the end.
  */
 export async function sedLines(
   lines: AsyncIterable<string>,
@@ -364,6 +370,7 @@ export async function sedLines(
   const maxOutputChars = options.maxOutputChars ?? DEFAULT_LIMITS.grepMaxOutputChars;
 
   const iterator = lines[Symbol.asyncIterator]();
+  const deadline = Date.now() + DEFAULT_LIMITS.grepMaxSearchMs;
   const maxLineChars = DEFAULT_LIMITS.grepMaxLineChars;
   const batch: string[] = [];
   let exhausted = false;
@@ -393,6 +400,10 @@ export async function sedLines(
 
       if (signal?.aborted) {
         throw new TaskAbortedError("Task aborted");
+      }
+      if (Date.now() > deadline) {
+        truncated = true;
+        break outer;
       }
 
       const budget =

--- a/packages/test/src/test/task/FileSedTask.test.ts
+++ b/packages/test/src/test/task/FileSedTask.test.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FileSedTask, registerSafeFetch, type SafeFetchFn } from "@workglow/tasks";
-import { DEFAULT_LIMITS, setLogger } from "@workglow/util";
+import { FileSedTask, registerSafeFetch, sedLines, type SafeFetchFn } from "@workglow/tasks";
+import { DEFAULT_LIMITS, SECURITY_LIMITS, setLogger } from "@workglow/util";
 import { getTestingLogger } from "@workglow/util/test";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -451,6 +451,64 @@ describe("FileSedTask", () => {
         replacement: "bar",
       },
     }).run();
+
+    expect(result).toEqual({
+      text: "",
+      replacementCount: 0,
+      linesChanged: 0,
+      truncated: false,
+    });
+  });
+
+  test("stops at the search deadline under onlyChangedLines", async () => {
+    // The fixture is finite so a regression fails on the assertions below
+    // rather than wedging the run: without the deadline the generator is
+    // simply drained and `truncated` comes back false.
+    const total = SECURITY_LIMITS.regexMatchBatchLines * 4;
+    let produced = 0;
+
+    vi.useFakeTimers();
+    try {
+      async function* source(): AsyncGenerator<string> {
+        for (let index = 0; index < total; index++) {
+          produced++;
+          // Time passes only once the first batch is under way, so the
+          // deadline trips at a batch boundary rather than before a single
+          // line has been read.
+          if (produced === 1) {
+            vi.advanceTimersByTime(DEFAULT_LIMITS.grepMaxSearchMs + 1);
+          }
+          yield `line ${index}`;
+        }
+      }
+
+      const result = await sedLines(source(), "NEVERMATCHES", "x", {
+        onlyChangedLines: true,
+      });
+
+      expect(result.truncated).toBe(true);
+      expect(result.text).toBe("");
+      expect(result.replacementCount).toBe(0);
+      // Abandoned at the first batch boundary, not drained.
+      expect(produced).toBe(SECURITY_LIMITS.regexMatchBatchLines);
+      expect(produced).toBeLessThan(total);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("does not report truncation for a short unchanged run", async () => {
+    // Guards the deadline check from reporting truncation where nothing was
+    // dropped: ten unchanged lines emit nothing and still reach EOF.
+    async function* source(): AsyncGenerator<string> {
+      for (let index = 0; index < 10; index++) {
+        yield `line ${index}`;
+      }
+    }
+
+    const result = await sedLines(source(), "NEVERMATCHES", "x", {
+      onlyChangedLines: true,
+    });
 
     expect(result).toEqual({
       text: "",

--- a/packages/test/src/test/task/TasksNodeExports.test.ts
+++ b/packages/test/src/test/task/TasksNodeExports.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  GrepLineMatcher,
+  GrepOptions,
+  SedBatchResult,
+  SedLineSubstituter,
+  SedOptions,
+} from "@workglow/tasks";
+import {
+  createMatcher,
+  createSedExpander,
+  createSedRegex,
+  createSubstituter,
+  expandReplacement,
+  grepLines,
+  linesFromText,
+  sedLines,
+} from "@workglow/tasks";
+import { describe, expect, test } from "vitest";
+
+/*
+ * `browser.ts` re-exports the whole grep/sed modules while the server
+ * entrypoints hand-pick names, so the two surfaces drift silently: an import
+ * that resolves under the browser condition fails to resolve under node, and
+ * nothing notices until a CLI or Electron build breaks. Static imports are
+ * deliberate — this file fails to TYPE-CHECK as well as to run when a name is
+ * dropped from `node.ts` / `electron.ts`.
+ */
+describe("@workglow/tasks node export surface", () => {
+  test("exports the grep helpers", () => {
+    expect(typeof createMatcher).toBe("function");
+    expect(typeof grepLines).toBe("function");
+    expect(typeof linesFromText).toBe("function");
+  });
+
+  test("exports the sed helpers", () => {
+    expect(typeof createSedExpander).toBe("function");
+    expect(typeof createSedRegex).toBe("function");
+    expect(typeof createSubstituter).toBe("function");
+    expect(typeof expandReplacement).toBe("function");
+    expect(typeof sedLines).toBe("function");
+  });
+
+  test("exports the grep and sed types", () => {
+    const grepOptions: GrepOptions = {};
+    const sedOptions: SedOptions = {};
+
+    const matcher: GrepLineMatcher = createMatcher("foo", grepOptions);
+    const substituter: SedLineSubstituter = createSubstituter("foo", "bar", sedOptions);
+    const batch: SedBatchResult = substituter.substituteBatch(["foo"], 1);
+
+    expect(matcher.matchBatch(["foo"])).toEqual([true]);
+    expect(batch.texts).toEqual(["bar"]);
+    expect(batch.counts).toEqual([1]);
+  });
+});


### PR DESCRIPTION
Two independent defects in the grep/sed pair in `@workglow/tasks`.

## 1 — `sedLines` had no overall search deadline

`grepLines` computes `deadline = Date.now() + DEFAULT_LIMITS.grepMaxSearchMs` and breaks when it passes. `sedLines` had no equivalent: its only bounds were the per-batch substituter timeout and the output caps. Under `onlyChangedLines: true` the cap checks are **skipped** for unchanged lines — the `continue` fires before the `maxOutputLines` / `maxOutputChars` tests — so a run that changes nothing had no stopping condition but EOF. `FileSedTask.server.ts` feeds `sedLines` a `linesFromStream`, so this was a real unbounded local-file scan:

```ts
fileSed({ url: "/var/log/huge.log", pattern: "NEVERMATCHES", replacement: "x", onlyChangedLines: true })
```

On a 100 GB file that streams the whole file, holds a task slot for hours, and then reports `truncated: false`.

The fix reuses `DEFAULT_LIMITS.grepMaxSearchMs` rather than adding a limits key — `sedLines` already reuses `grepMaxLineChars`, `grepMaxOutputLines` and `grepMaxOutputChars`, and a new key would drag a `@workglow/util` change into a `@workglow/tasks` fix.

**Why the check sits where it does.** It is placed after the existing abort check and before the `budget` computation — that is, after the batch has been filled from the iterator and before it is substituted, identical to grep. Because the batch is non-empty and entirely unprocessed at that point, something was definitively left unread, so `truncated = true` is unconditionally correct.

**Why sed needs no `sawMoreInput` reconciliation.** Grep carries that extra step because its stop reasons include the output caps, which *reject* the line they stopped on — grep therefore has to look ahead to decide whether the early stop actually dropped anything. The deadline is not such a reason: it stops on a whole unprocessed batch, so the answer is already known and no lookahead is needed.

## 2 — node/electron dropped most of the grep/sed public surface

`browser.ts` does `export * from "./task/FileGrepTask"` and `"./task/FileSedTask"`. The server entrypoints only `export *` from the two `.server` files (which re-export just the Config/Input/Output types, the class and the helper fn) plus a hand-picked `{ grepLines, linesFromText }` — and nothing at all from sed.

Missing from both `node.ts` and `electron.ts`: `GrepOptions`, `GrepLineMatcher`, `createMatcher`, `SedOptions`, `SedBatchResult`, `SedLineSubstituter`, `createSedRegex`, `createSedExpander`, `createSubstituter`, `expandReplacement`, `sedLines`.

So `import type { SedOptions } from "@workglow/tasks"` type-checked and ran under the browser condition and failed to resolve under node — a build that works in the web example and breaks in the CLI and Electron shells.

The export lists **must stay explicit**: `export *` from both grep modules would collide on `FileGrepTask` / `fileGrep`, and both sed modules on `FileSedTask` / `fileSed`. The remaining names were checked against `common.ts` and the `.server` files and collide with nothing.

A structurally better fix — lifting the platform-neutral helpers into `grepLines.ts` / `sedLines.ts` that both entrypoints `export *` — removes the drift permanently but touches every importer, so it was deliberately deferred. The new guard test stands in for it: it fails to type-check *and* at runtime the moment a name is dropped from an entrypoint again.

## Tests

`packages/test/src/test/task/FileSedTask.test.ts`

- **`stops at the search deadline under onlyChangedLines`** — drives `sedLines` directly with a finite counting generator against a non-matching pattern. `vi.useFakeTimers()` advances past `DEFAULT_LIMITS.grepMaxSearchMs` while the first batch is being filled, so the deadline trips at a batch boundary. Asserts `truncated === true` and that the generator was abandoned at `SECURITY_LIMITS.regexMatchBatchLines` lines rather than drained. The fixture is finite on purpose, so a regression fails on the assertions instead of wedging CI.
- **`does not report truncation for a short unchanged run`** — a 10-line non-matching `onlyChangedLines` run still returns `truncated: false`, `text: ""`, guarding the new check from firing where nothing was dropped.

New `packages/test/src/test/task/TasksNodeExports.test.ts` — static named imports of all eleven symbols from `@workglow/tasks`, plus type-only uses (`const grepOptions: GrepOptions = {}`, `const sedOptions: SedOptions = {}`). This fails both to type-check and at runtime on `main`.

## Verification

Both new tests were confirmed to fail without the corresponding fix:

- with the deadline removed (exports fix in place): `stops at the search deadline under onlyChangedLines` fails `expected false to be true` in 38 ms — bounded, not hung — while the short-run test still passes;
- with the entrypoints reverted: `TasksNodeExports.test.ts` fails with `createMatcher is not a function` / `typeof createSedExpander === "undefined"`.

With both fixes:

```
$ bun scripts/test.ts task vitest
Running all tests in sections [task] — 75 file(s)
 Test Files  75 passed (75)
      Tests  1229 passed | 24 skipped (1253)
   Duration  194.81s

$ bun run typecheck:tests
typecheck packages/ai/tsconfig.test.json
typecheck packages/job-queue/tsconfig.test.json
typecheck packages/knowledge-base/tsconfig.test.json
typecheck packages/mcp/tsconfig.test.json
typecheck packages/storage/tsconfig.test.json
typecheck packages/task-graph/tsconfig.test.json
typecheck packages/util/tsconfig.test.json
```

`packages/test` has no `tsconfig.test.json`, so that script does not cover the new test files; they are type-checked by `packages/test`'s own `tsconfig.json` (`include: ["src/**/*"]`), run clean via `tsgo` and as part of `bun run build:packages`. `bun run format` reports `All matched files use Prettier code style!`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LowBJQsCghLDiHwPN6FgUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LowBJQsCghLDiHwPN6FgUT)_