### PR TITLE
Detect DeepSeek billing errors and skip tests on CI, fail locally

### DIFF
--- a/packages/test/src/contract/README.md
+++ b/packages/test/src/contract/README.md
@@ -116,6 +116,37 @@ Capability flags:
 | `IHumanConnector`                       | `contract/human-connector/runHumanConnectorConformance`         | MockHumanConnector, McpElicitationConnector                                |
 | Worker-proxy parity                     | `contract/worker-proxy/runWorkerProxyBoundary`                  | _harness only — no adapters wired yet_                                     |
 
+## Billing failures: skipped on CI, failed locally
+
+Live provider suites run against real accounts, so "we ran out of money" is a
+condition every one of them can hit. `contract/creditExhaustedSkip.ts` detects
+it — 402s, `insufficient_quota`, `insufficient_credits`, DeepSeek's
+`Insufficient Balance`, Anthropic's credit-balance error — and the `it` exported
+from that module (which every conformance assertion imports) decides what to do
+with it:
+
+| where         | behavior | why                                                                                                                                            |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| CI            | skip     | nobody watching a build can top an account up, and one exhausted key would turn every provider suite red for a change that touched no provider |
+| anywhere else | fail     | the developer running the suite IS the person who can act on it                                                                                |
+
+`CI` / `GITHUB_ACTIONS` select the branch; `WORKGLOW_CREDIT_EXHAUSTED_SKIP=1`
+forces the skip locally and `=0` forces the failure on CI.
+
+The detector reads the **message** as well as the numeric status, and that is
+load-bearing rather than belt-and-braces: `classifyProviderError` rebuilds a
+provider error as a `PermanentJobError` carrying the message and neither
+`status` nor `cause`, so by the time a test body catches a DeepSeek 402 the
+number survives only as the `402 Insufficient Balance` text the OpenAI SDK put
+in the message. A status-only detector reads that as an ordinary permanent
+failure — which is exactly how DeepSeek kept failing suites while every other
+provider skipped. Message matching for a bare `402` is anchored to an
+HTTP-shaped position (line start, or after a summary line's colon) so prose
+that merely contains the number is not scavenged as a status.
+
+Rate limits (429 + `rate_limit_exceeded`) are deliberately NOT this: they are
+transient and the retry policy handles them.
+
 ## How to add a new contract suite
 
 1. Pick a contract surface (an interface or abstract base class).

--- a/packages/test/src/contract/creditExhaustedSkip.ts
+++ b/packages/test/src/contract/creditExhaustedSkip.ts
@@ -7,23 +7,44 @@
 import { it as vitestIt } from "vitest";
 
 /**
- * Live provider tests skip (rather than fail) when the account is out of
- * credits. A key being present is not the same as the account being able to
- * pay; HuggingFace / OpenRouter 402s, Anthropic's credit-balance error, and
- * OpenAI's `insufficient_quota` are billing, not product bugs.
+ * Live provider tests treat "the account is out of credits" as a billing
+ * condition rather than a product bug. A key being present is not the same as
+ * the account being able to pay; HuggingFace / OpenRouter 402s, Anthropic's
+ * credit-balance error, DeepSeek's `Insufficient Balance`, and OpenAI's
+ * `insufficient_quota` are all billing.
  *
  * Rate limits (429 + `rate_limit_exceeded`) are NOT this: those are transient
  * and the existing retry policy handles them.
+ *
+ * Where it skips and where it fails is a deliberate split
+ * ({@link creditExhaustionSkipsTest}): on CI it skips for every provider,
+ * because a red build tells a reviewer nothing they can act on; locally it
+ * fails, because the developer running the suite is the one who can top the
+ * account up. `WORKGLOW_CREDIT_EXHAUSTED_SKIP=1` forces the skip locally
+ * (and `=0` forces the failure on CI).
  */
 
 const BILLING_CODES = new Set([
   "insufficient_quota",
   "billing_hard_limit_reached",
   "insufficient_credits",
+  "insufficient_balance",
 ]);
 
 const CREDIT_MESSAGE =
-  /insufficient credits|not enough credits|no credits remaining|out of credits|credit balance is too low|exceeded[\s\S]{0,80}credits|monthly included credits|payment required|exceeded your current quota|check your plan and billing|billing_hard_limit/i;
+  /insufficient credits|not enough credits|no credits remaining|out of credits|insufficient[\s_-]balance|balance is (?:too low|insufficient)|exceeded[\s\S]{0,80}credits|monthly included credits|payment required|exceeded your current quota|check your plan and billing|billing_hard_limit/i;
+
+/**
+ * A 402 that survives only as text. `classifyProviderError` rebuilds the error
+ * as a `PermanentJobError` carrying the message and no `cause`, so by the time
+ * a live test sees a DeepSeek billing failure the numeric `status` is gone and
+ * the OpenAI-SDK message shape (`402 Insufficient Balance`) is all that is
+ * left. Anchored to an HTTP-shaped position — start of a line, or after a
+ * summary line's colon — so prose that merely contains the number
+ * ("Item 402(c)") is not scavenged as a status.
+ */
+const HTTP_402_MESSAGE =
+  /\bHTTP\/?\d?(?:\.\d)?\s*402\b|\bstatus(?:\s*code)?\s*[:=]\s*402\b|\berror code:?\s*402\b|(?:^|:\s+)402\s+[a-z]/im;
 
 export function isCreditExhaustedError(err: unknown): boolean {
   const seen = new Set<unknown>();
@@ -61,11 +82,7 @@ function matchesCreditExhaustion(err: unknown): boolean {
 }
 
 function messageLooksLikeCreditExhaustion(message: string): boolean {
-  return (
-    CREDIT_MESSAGE.test(message) ||
-    /\bHTTP\s*402\b/i.test(message) ||
-    /\bstatus(?:\s*code)?\s*[:=]\s*402\b/i.test(message)
-  );
+  return CREDIT_MESSAGE.test(message) || HTTP_402_MESSAGE.test(message);
 }
 
 function numericStatus(rec: Record<string, unknown>): number | undefined {
@@ -102,6 +119,52 @@ export function creditSkipNote(err: unknown): string {
   return `skipped: provider out of credits (${message})`;
 }
 
+const SKIP_OVERRIDE_ENV = "WORKGLOW_CREDIT_EXHAUSTED_SKIP";
+
+function isTruthyFlag(value: string): boolean {
+  return !/^(?:0|false|off|no)$/i.test(value.trim());
+}
+
+/**
+ * Whether a billing failure skips the test or fails it.
+ *
+ * CI skips: nobody watching a build can top an account up, and one exhausted
+ * key would otherwise turn every provider suite red for a change that touched
+ * none of them — so the leniency is provider-agnostic by construction, keyed on
+ * the environment rather than on which vendor ran out.
+ *
+ * Locally it fails, loudly, because the developer running the suite IS the
+ * person who can act on it — and a silently green local run is how an
+ * exhausted account goes unnoticed until CI is the only thing exercising the
+ * provider at all.
+ *
+ * `WORKGLOW_CREDIT_EXHAUSTED_SKIP` overrides in both directions.
+ */
+export function creditExhaustionSkipsTest(
+  env: Record<string, string | undefined> = process.env
+): boolean {
+  const override = env[SKIP_OVERRIDE_ENV];
+  if (override !== undefined && override.trim() !== "") return isTruthyFlag(override);
+  for (const key of ["CI", "GITHUB_ACTIONS"] as const) {
+    const value = env[key];
+    if (value !== undefined && value.trim() !== "" && isTruthyFlag(value)) return true;
+  }
+  return false;
+}
+
+/**
+ * The local-failure path. Rethrows the provider's own error unchanged — its
+ * identity and stack are what makes the failure diagnosable — after one line
+ * saying why it was not skipped and how to skip it.
+ */
+function reportLocalCreditFailure(err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(
+    `provider out of credits (${message})\n` +
+      `  Failing because this is not CI. Top the account up, or set ${SKIP_OVERRIDE_ENV}=1 to skip instead.`
+  );
+}
+
 export async function runWithCreditSkip<T>(
   ctx: { skip: (note?: string) => void },
   fn: () => Promise<T> | T
@@ -110,6 +173,10 @@ export async function runWithCreditSkip<T>(
     return await fn();
   } catch (err) {
     if (isCreditExhaustedError(err)) {
+      if (!creditExhaustionSkipsTest()) {
+        reportLocalCreditFailure(err);
+        throw err;
+      }
       ctx.skip(creditSkipNote(err));
       // vitest's skip() is `never` (throws). Mocks used in unit tests return.
       return undefined as T;
@@ -118,12 +185,24 @@ export async function runWithCreditSkip<T>(
   }
 }
 
-function wrapFn(fn: (...args: never[]) => unknown): (...args: never[]) => unknown {
+/**
+ * Wraps one test body. This is the seam every conformance assertion actually
+ * runs through (the exported {@link it} proxies each callback through it), so
+ * the CI-skips / locally-fails policy is applied here rather than at each
+ * call site.
+ */
+export function wrapTestBodyForCreditSkip(
+  fn: (...args: never[]) => unknown
+): (...args: never[]) => unknown {
   return async function wrapped(this: unknown, ...args: never[]): Promise<unknown> {
     try {
       return await fn.apply(this, args);
     } catch (err) {
       if (!isCreditExhaustedError(err)) throw err;
+      if (!creditExhaustionSkipsTest()) {
+        reportLocalCreditFailure(err);
+        throw err;
+      }
       const ctx = args[0] as { skip?: (note?: string) => void } | undefined;
       if (ctx && typeof ctx.skip === "function") {
         ctx.skip(creditSkipNote(err));
@@ -140,7 +219,7 @@ function wrapCallable(fn: CallableFunction): CallableFunction {
   return new Proxy(fn, {
     apply(target, thisArg, argArray: unknown[]) {
       const wrapped = argArray.map((arg) =>
-        typeof arg === "function" ? wrapFn(arg as never) : arg
+        typeof arg === "function" ? wrapTestBodyForCreditSkip(arg as never) : arg
       );
       const result = Reflect.apply(target, thisArg, wrapped);
       return typeof result === "function" ? wrapCallable(result) : result;
@@ -155,5 +234,8 @@ function wrapCallable(fn: CallableFunction): CallableFunction {
   });
 }
 
-/** Drop-in `it` for live provider tests: credit/billing errors skip instead of fail. */
+/**
+ * Drop-in `it` for live provider tests: a credit/billing error skips the test on
+ * CI and fails it locally (see {@link creditExhaustionSkipsTest}).
+ */
 export const it = wrapCallable(vitestIt) as typeof vitestIt;

--- a/packages/test/src/test/ai-provider-api/creditExhaustedSkip.test.ts
+++ b/packages/test/src/test/ai-provider-api/creditExhaustedSkip.test.ts
@@ -4,9 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from "vitest";
+import { classifyProviderError } from "@workglow/ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { isCreditExhaustedError, runWithCreditSkip } from "../../contract/creditExhaustedSkip";
+import {
+  creditExhaustionSkipsTest,
+  isCreditExhaustedError,
+  runWithCreditSkip,
+  wrapTestBodyForCreditSkip,
+} from "../../contract/creditExhaustedSkip";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
 
 describe("isCreditExhaustedError", () => {
   it("recognizes HuggingFace Inference 402 included-credits exhaustion", () => {
@@ -30,6 +41,41 @@ describe("isCreditExhaustedError", () => {
         new Error(
           "Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."
         )
+      )
+    ).toBe(true);
+  });
+
+  it("recognizes DeepSeek's 402 Insufficient Balance", () => {
+    const err = Object.assign(new Error("402 Insufficient Balance"), { status: 402 });
+    expect(isCreditExhaustedError(err)).toBe(true);
+  });
+
+  it("recognizes DeepSeek's balance error after classifyProviderError drops the status", () => {
+    // classifyProviderError rebuilds the error as a PermanentJobError carrying
+    // only the message, so neither `status` nor `cause` survives to the test.
+    expect(
+      isCreditExhaustedError(
+        new Error("Provider DEEPSEEK failed for TextGenerationTask: 402 Insufficient Balance")
+      )
+    ).toBe(true);
+  });
+
+  it("recognizes a bare Insufficient Balance message with no status anywhere", () => {
+    expect(isCreditExhaustedError(new Error("Insufficient Balance"))).toBe(true);
+  });
+
+  it("recognizes an insufficient_balance error code", () => {
+    expect(
+      isCreditExhaustedError({
+        error: { message: "unavailable", type: "unknown_error", code: "insufficient_balance" },
+      })
+    ).toBe(true);
+  });
+
+  it("recognizes a 402 on a diagnostics line below the summary line", () => {
+    expect(
+      isCreditExhaustedError(
+        new Error("Provider DEEPSEEK failed for ToolCallingTask\n\n402 Insufficient Balance")
       )
     ).toBe(true);
   });
@@ -94,11 +140,41 @@ describe("isCreditExhaustedError", () => {
 
   it("does not treat a bare 402 in unrelated prose as credit exhaustion", () => {
     expect(isCreditExhaustedError(new Error("Item 402(c) compensation table"))).toBe(false);
+    expect(isCreditExhaustedError(new Error("Sequence length 402 exceeds the limit"))).toBe(false);
+    expect(isCreditExhaustedError(new Error("model deepseek-402 not found"))).toBe(false);
+  });
+});
+
+describe("creditExhaustionSkipsTest", () => {
+  it("skips on CI", () => {
+    expect(creditExhaustionSkipsTest({ CI: "true" })).toBe(true);
+    expect(creditExhaustionSkipsTest({ GITHUB_ACTIONS: "true" })).toBe(true);
+  });
+
+  it("fails locally, so the developer who can top the account up sees it", () => {
+    expect(creditExhaustionSkipsTest({})).toBe(false);
+    expect(creditExhaustionSkipsTest({ CI: "" })).toBe(false);
+    expect(creditExhaustionSkipsTest({ CI: "false" })).toBe(false);
+  });
+
+  it("honors the override in both directions", () => {
+    expect(creditExhaustionSkipsTest({ WORKGLOW_CREDIT_EXHAUSTED_SKIP: "1" })).toBe(true);
+    expect(creditExhaustionSkipsTest({ CI: "true", WORKGLOW_CREDIT_EXHAUSTED_SKIP: "0" })).toBe(
+      false
+    );
+  });
+
+  it("reads process.env by default", () => {
+    vi.stubEnv("CI", "true");
+    vi.stubEnv("WORKGLOW_CREDIT_EXHAUSTED_SKIP", "");
+    expect(creditExhaustionSkipsTest()).toBe(true);
   });
 });
 
 describe("runWithCreditSkip", () => {
-  it("calls skip instead of rethrowing a credit error", async () => {
+  it("calls skip instead of rethrowing a credit error on CI", async () => {
+    vi.stubEnv("CI", "true");
+    vi.stubEnv("WORKGLOW_CREDIT_EXHAUSTED_SKIP", "");
     const notes: string[] = [];
     await runWithCreditSkip({ skip: (note?: string) => notes.push(note ?? "") }, async () => {
       throw Object.assign(new Error("Insufficient credits"), { status: 402 });
@@ -107,7 +183,22 @@ describe("runWithCreditSkip", () => {
     expect(notes[0]).toMatch(/credits/i);
   });
 
+  it("rethrows a credit error locally instead of skipping", async () => {
+    vi.stubEnv("CI", "");
+    vi.stubEnv("GITHUB_ACTIONS", "");
+    vi.stubEnv("WORKGLOW_CREDIT_EXHAUSTED_SKIP", "");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const notes: string[] = [];
+    await expect(
+      runWithCreditSkip({ skip: (note?: string) => notes.push(note ?? "") }, async () => {
+        throw Object.assign(new Error("Insufficient Balance"), { status: 402 });
+      })
+    ).rejects.toThrow("Insufficient Balance");
+    expect(notes).toHaveLength(0);
+  });
+
   it("rethrows a non-credit error", async () => {
+    vi.stubEnv("CI", "true");
     await expect(
       runWithCreditSkip({ skip: () => undefined }, async () => {
         throw new Error("model not found");
@@ -118,5 +209,91 @@ describe("runWithCreditSkip", () => {
   it("returns the body's result when nothing is thrown", async () => {
     const result = await runWithCreditSkip({ skip: () => undefined }, async () => 7);
     expect(result).toBe(7);
+  });
+});
+
+describe("wrapTestBodyForCreditSkip", () => {
+  const deepSeekBillingError = (): Error =>
+    new Error("Provider DEEPSEEK failed for TextGenerationTask: 402 Insufficient Balance");
+
+  it("skips the test body's DeepSeek billing failure on CI", async () => {
+    vi.stubEnv("CI", "true");
+    vi.stubEnv("WORKGLOW_CREDIT_EXHAUSTED_SKIP", "");
+    const notes: string[] = [];
+    const body = wrapTestBodyForCreditSkip(() => {
+      throw deepSeekBillingError();
+    });
+    await (body as (ctx: unknown) => Promise<unknown>)({
+      skip: (note?: string) => notes.push(note ?? ""),
+    });
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toMatch(/out of credits/i);
+  });
+
+  it("fails the test body locally", async () => {
+    vi.stubEnv("CI", "");
+    vi.stubEnv("GITHUB_ACTIONS", "");
+    vi.stubEnv("WORKGLOW_CREDIT_EXHAUSTED_SKIP", "");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const body = wrapTestBodyForCreditSkip(() => {
+      throw deepSeekBillingError();
+    });
+    await expect(
+      (body as (ctx: unknown) => Promise<unknown>)({ skip: () => undefined })
+    ).rejects.toThrow(/Insufficient Balance/);
+  });
+});
+
+/**
+ * The two halves have to agree. `classifyProviderError` rebuilds the provider's
+ * error as a job error carrying the message and nothing else — no `status`, no
+ * `cause` — so a detector that only reads `err.status` sees a plain 402 as an
+ * unknown permanent failure. This is what a live DeepSeek billing failure
+ * actually looks like by the time a test body catches it.
+ */
+describe("a provider billing error survives classifyProviderError", () => {
+  const cases: ReadonlyArray<readonly [string, unknown]> = [
+    // OpenAI-SDK shape (DeepSeek, OpenRouter, xAI): `${status} ${message}`.
+    ["DeepSeek", Object.assign(new Error("402 Insufficient Balance"), { status: 402 })],
+    [
+      "OpenRouter",
+      Object.assign(new Error("402 Insufficient credits"), { status: 402, code: "402" }),
+    ],
+    [
+      "Anthropic",
+      Object.assign(new Error("400 Your credit balance is too low to access the Anthropic API."), {
+        status: 400,
+      }),
+    ],
+    [
+      "OpenAI",
+      Object.assign(new Error("429 You exceeded your current quota"), {
+        status: 429,
+        code: "insufficient_quota",
+      }),
+    ],
+    [
+      "HuggingFace Inference",
+      Object.assign(new Error("You have depleted your monthly included credits."), { status: 402 }),
+    ],
+  ];
+
+  for (const [provider, raw] of cases) {
+    it(`still reads as credit exhaustion for ${provider}`, () => {
+      const classified = classifyProviderError(raw, "TextGenerationTask", provider.toUpperCase());
+      expect(isCreditExhaustedError(classified)).toBe(true);
+    });
+  }
+
+  it("does not read a classified rate limit as credit exhaustion", () => {
+    const classified = classifyProviderError(
+      Object.assign(new Error("429 Rate limit reached, retry after 5"), {
+        status: 429,
+        code: "rate_limit_exceeded",
+      }),
+      "TextGenerationTask",
+      "OPENAI"
+    );
+    expect(isCreditExhaustedError(classified)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Extends credit exhaustion detection to recognize DeepSeek's `Insufficient Balance` error and implements a deliberate split in test behavior: billing failures skip on CI (where no one can top up an account) but fail locally (where the developer running the suite can act on it).

## Key Changes

- **Enhanced billing error detection** (`creditExhaustedSkip.ts`):
  - Added `insufficient_balance` to the set of recognized billing error codes
  - Expanded message regex to match `Insufficient Balance`, `balance is too low`, and related patterns
  - Added `HTTP_402_MESSAGE` regex to detect bare 402 status codes in error messages, anchored to HTTP-shaped positions (line start, after colons) to avoid false positives in prose like "Item 402(c)"
  - Handles the case where `classifyProviderError` rebuilds provider errors as `PermanentJobError` carrying only the message (no `status` or `cause`)

- **CI vs. local behavior split** (`creditExhaustedSkip.ts`):
  - New `creditExhaustionSkipsTest()` function determines whether to skip or fail based on environment
  - Skips on CI (`CI=true` or `GITHUB_ACTIONS=true`)
  - Fails locally by default (so developers see and can fix exhausted accounts)
  - `WORKGLOW_CREDIT_EXHAUSTED_SKIP` environment variable overrides in both directions
  - New `reportLocalCreditFailure()` logs why the test failed and how to skip it

- **Updated test wrapper** (`creditExhaustedSkip.ts`):
  - Renamed `wrapFn` to `wrapTestBodyForCreditSkip` (now exported)
  - Both `runWithCreditSkip()` and `wrapTestBodyForCreditSkip()` now check `creditExhaustionSkipsTest()` before deciding to skip or rethrow
  - Rethrows the original error unchanged (preserving identity and stack) after logging the reason

- **Comprehensive test coverage** (`creditExhaustedSkip.test.ts`):
  - Added tests for DeepSeek's 402 error in various forms (with status, after `classifyProviderError`, bare message)
  - Added tests for `insufficient_balance` error code and 402 on diagnostics lines
  - Added negative tests to ensure bare 402 in unrelated prose is not detected
  - New test suite for `creditExhaustionSkipsTest()` covering CI detection, local behavior, and overrides
  - New test suite for `wrapTestBodyForCreditSkip()` covering both CI and local paths
  - New integration test suite verifying that provider errors survive `classifyProviderError` and are still recognized as billing failures

- **Documentation** (`README.md`):
  - Added section explaining the billing failure behavior, why it differs by environment, and how the message-based detection works around `classifyProviderError`'s error rebuilding

## Implementation Details

The detector reads both numeric `status` and message text because `classifyProviderError` (in the `ai` package) rebuilds provider errors as `PermanentJobError` carrying only the message. By the time a test body catches a DeepSeek 402, the numeric status is gone and only the OpenAI-SDK message shape (`402 Insufficient Balance`) survives. A status-only detector would miss it entirely.

The 402 message regex is anchored to HTTP-shaped positions (line start, after colons, after "error code:") to avoid false positives in prose that merely contains the number (e.g., "Item 402(c) compensation table", "model deepseek-402 not found").

Rate limits (429 + `rate_limit_exceeded`) are deliberately excluded: they are transient and the existing retry policy handles them.

https://claude.ai/code/session_0135ckbpvce2S4ToF4jpdpmp