### PR TITLE
Remove dev-link script and update documentation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -318,5 +318,5 @@ build output is never deleted) and rebuilds; `--no-build` skips the rebuild.
 `publish-workspaces.ts` refuses any workspace still containing stubs.
 
 `bun run link-all` / `unlink-all` register every workspace for `bun link` consumers (sec,
-embarc-data, builder). For the full libs → sec → embarc-data chain run `bun run dev-link`
-here, or `bun ./dev-link.ts` from the parent `workglow/` folder.
+embarc-data, builder). The full libs → sec → embarc-data chain is driven from embarc-data:
+run `bun run dev-link` there, or `bun ./dev-link.ts` from the parent `workglow/` folder.

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "use-source": "bun ./scripts/bunsrc-workspace.ts source",
     "use-dist": "bun ./scripts/bunsrc-workspace.ts dist",
     "link-all": "bun ./scripts/link-all.ts link",
-    "unlink-all": "bun ./scripts/link-all.ts unlink",
-    "dev-link": "bun ./scripts/dev-link-workglow.ts"
+    "unlink-all": "bun ./scripts/link-all.ts unlink"
   },
   "dependencies": {
     "caniuse-lite": "^1.0.30001809"


### PR DESCRIPTION
## Summary
Removes the `dev-link` npm script from the root workspace and updates documentation to clarify that the full linking workflow is now driven from the `embarc-data` package rather than from the root.

## Changes
- **package.json**: Removed the `"dev-link"` script entry that referenced `bun ./scripts/dev-link-workglow.ts`
- **.claude/CLAUDE.md**: Updated the documentation for `link-all`/`unlink-all` to reflect that the full libs → sec → embarc-data chain is now driven from `embarc-data` rather than from the root workspace

## Details
The `dev-link` script was a convenience wrapper at the root level for orchestrating the full linking chain across multiple workspaces. This responsibility has been consolidated into the `embarc-data` package, which now owns the `dev-link` workflow. Users should run `bun run dev-link` from the `embarc-data` directory instead, or invoke `bun ./dev-link.ts` from the parent `workglow/` folder if needed.

https://claude.ai/code/session_01BQxv9q3JjThYAPgZAgQF5T