### PR TITLE
Fix the run-answer reader closing fd 4, and make the filesystem-task drop visible at the call site

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -278,7 +278,7 @@ math, tensor types.
 
 `InputTask`, `OutputTask`, `LambdaTask`, `DelayTask`, `FetchUrlTask`, `JavaScriptTask`,
 `JsonTask`, `MergeTask`, `SplitTask`, `ArrayTask`, MCP tasks, scalar/vector math.
-Register with `registerCommonTasks()`.
+Register with `registerCommonTasks({ fileSystemTasks })` — the flag is required, and decides whether `FileGrepTask`/`FileLoaderTask`/`FileSedTask` are resolvable by type name (and so nameable by graph JSON the host did not author).
 
 ## Testing
 

--- a/docs/technical/20-task-registry.md
+++ b/docs/technical/20-task-registry.md
@@ -30,7 +30,7 @@ applications, per-request task allow-lists) are handled by a parallel **dependen
 | Dynamic instantiation from serialized data | `getTaskConstructors()` + `new taskClass(config)`                   |
 | Scoped / sandboxed registries              | `TASK_CONSTRUCTORS` DI token per `ServiceRegistry`                  |
 | Schema-driven input resolution             | `format: "tasks"` input resolver and compactor                      |
-| Batch registration of built-in tasks       | `registerBaseTasks()`, `registerCommonTasks()`, `registerAiTasks()` |
+| Batch registration of built-in tasks       | `registerBaseTasks()`, `registerCommonTasks(options)`, `registerAiTasks()` |
 
 ---
 
@@ -377,7 +377,7 @@ package:
 | Function                | Package                | Tasks registered                                                                                                                                                                                                              |
 | ----------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `registerBaseTasks()`   | `@workglow/task-graph` | `GraphAsTask`, `ConditionalTask`, `FallbackTask`, `MapTask`, `WhileTask`, `ReduceTask`                                                                                                                                        |
-| `registerCommonTasks()` | `@workglow/tasks`      | ~50 utility tasks: `DelayTask`, `FetchUrlTask`, `JavaScriptTask`, `LambdaTask`, `MergeTask`, `SplitTask`, string/scalar/vector math tasks, MCP tasks, `JsonPathTask`, `RegexTask`, `TemplateTask`, `DateFormatTask`, and more |
+| `registerCommonTasks(options)` | `@workglow/tasks`      | ~50 utility tasks: `DelayTask`, `FetchUrlTask`, `JavaScriptTask`, `LambdaTask`, `MergeTask`, `SplitTask`, string/scalar/vector math tasks, MCP tasks, `JsonPathTask`, `RegexTask`, `TemplateTask`, `DateFormatTask`, and more |
 | `registerAiTasks()`     | `@workglow/ai`         | ~40 AI tasks: `TextGenerationTask`, `TextEmbeddingTask`, `ImageClassificationTask`, `ChunkRetrievalTask`, `AgentTask`, `ToolCallingTask`, `StructuredGenerationTask`, and more                                                |
 
 ### Typical application bootstrap
@@ -389,7 +389,9 @@ import { registerAiTasks } from "@workglow/ai";
 
 // Register all built-in tasks
 registerBaseTasks();
-registerCommonTasks();
+// `fileSystemTasks` is required: it decides whether FileGrepTask/FileLoaderTask/
+// FileSedTask are resolvable by type name, including from graph JSON you did not author.
+registerCommonTasks({ fileSystemTasks: false });
 registerAiTasks();
 
 // Register application-specific tasks
@@ -535,7 +537,7 @@ function resolveTaskType(name: string): ITaskConstructor<any, any, any> | undefi
 | Function                | Package                | Description                                                                                                                                                         |
 | ----------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `registerBaseTasks()`   | `@workglow/task-graph` | Registers flow-control tasks: `GraphAsTask`, `ConditionalTask`, `FallbackTask`, `MapTask`, `WhileTask`, `ReduceTask`. Returns the array of registered constructors. |
-| `registerCommonTasks()` | `@workglow/tasks`      | Registers ~50 utility, string, scalar, vector, and MCP tasks. Returns the array of registered constructors.                                                         |
+| `registerCommonTasks(options)` | `@workglow/tasks`      | Registers ~50 utility, string, scalar, vector, and MCP tasks, plus the three filesystem tasks when `options.fileSystemTasks` is true. Returns the array of registered constructors.                                                         |
 | `registerAiTasks()`     | `@workglow/ai`         | Registers ~40 AI tasks spanning text, image, RAG, vision, and agent categories. Returns the array of registered constructors.                                       |
 
 ### Input resolver / compactor

--- a/examples/cli/src/bootstrap.ts
+++ b/examples/cli/src/bootstrap.ts
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { registerAiTasks, setGlobalModelRepository } from "@workglow/ai";
+import { setGlobalModelRepository } from "@workglow/ai";
 import { registerHuggingFaceTransformers } from "@workglow/huggingface-transformers/ai";
-import { registerBaseTasks, registerBuiltInTransforms } from "@workglow/task-graph";
-import { registerCommonTasks } from "@workglow/tasks";
 import {
   ChainedCredentialStore,
   EnvCredentialStore,
@@ -29,6 +27,7 @@ import { registerWebCommand } from "./commands/web";
 import { registerWorkflowCommand } from "./commands/workflow";
 import { loadConfig } from "./config";
 import { lazyStore } from "./keyring";
+import { registerCliTasks } from "./registerCliTasks";
 import { ensureRunReporting } from "./run-events/runReporting";
 import { seedSamplesIfRepoEmpty } from "./samples/chatSample";
 import { createModelRepository, createWorkflowRepository } from "./storage";
@@ -79,10 +78,7 @@ export interface WorkglowCliOptions {
 export async function runWorkglowCli(options: WorkglowCliOptions = {}): Promise<void> {
   const program = options.program ?? defaultProgram;
 
-  registerBaseTasks();
-  registerCommonTasks();
-  registerAiTasks();
-  registerBuiltInTransforms();
+  registerCliTasks();
   await options.registerTasks?.();
 
   // Lazy encrypted store (unlocked on demand) + env var fallback.

--- a/examples/cli/src/registerCliTasks.ts
+++ b/examples/cli/src/registerCliTasks.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { registerAiTasks } from "@workglow/ai";
+import { registerBaseTasks, registerBuiltInTransforms } from "@workglow/task-graph";
+import { registerCommonTasks } from "@workglow/tasks";
+
+/**
+ * Fills the ambient `TaskRegistry` with the surface the CLI resolves type names
+ * against — `task list`, `task run`, the web console, and every stored workflow
+ * loaded back from the repository.
+ *
+ * The filesystem tasks are part of it. This binary runs graphs its own operator
+ * wrote, on that operator's machine and with that operator's rights, and a
+ * saved workflow naming `FileLoaderTask` has to keep loading. An embedder that
+ * runs graphs it did not author registers a narrower set instead of calling
+ * this.
+ *
+ * Its own module rather than a few lines inside the boot sequence so the set is
+ * assertable without standing up a program, a config directory and a model
+ * repository.
+ */
+export function registerCliTasks(): void {
+  registerBaseTasks();
+  registerCommonTasks({ fileSystemTasks: true });
+  registerAiTasks();
+  registerBuiltInTransforms();
+}

--- a/examples/cli/src/run-events/RunEventHumanConnector.ts
+++ b/examples/cli/src/run-events/RunEventHumanConnector.ts
@@ -29,7 +29,7 @@ export class RunEventHumanConnector implements IHumanConnector {
   ) {}
 
   /**
-   * The reader is opened per outstanding request and closed with the last one.
+   * The reader is opened per outstanding request and released with the last one.
    *
    * Kept open for the life of the process it does exactly one thing beyond
    * reading: it holds the event loop, so a child that has finished its work

--- a/examples/cli/src/run-events/runEventChannel.test.ts
+++ b/examples/cli/src/run-events/runEventChannel.test.ts
@@ -4,7 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  fstatSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -59,5 +67,42 @@ describe("readRunAnswerLines", () => {
   it("is absent when nothing is answering", () => {
     expect(readRunAnswerLines("", () => {})).toBeUndefined();
     expect(readRunAnswerLines("nonsense", () => {})).toBeUndefined();
+  });
+
+  /**
+   * The parent opens the answers descriptor once and holds it for the whole
+   * run, while the child opens a reader per question. Stopping a reader must
+   * therefore detach from the descriptor, not close it: a closed fd frees its
+   * NUMBER for the next `open()` anywhere in the process, so the following
+   * reader would attach to whatever took the slot and the release after that
+   * would close that unrelated file.
+   */
+  it("leaves a descriptor it was handed open when the reader stops", async () => {
+    const file = join(mkdtempSync(join(tmpdir(), "wg-answers-fd-")), "answers.ndjson");
+    writeFileSync(file, '{"requestId":"a"}\n', "utf8");
+    const fd = openSync(file, "r");
+    try {
+      const lines: string[] = [];
+      const stop = readRunAnswerLines(`fd:${fd}`, (line) => lines.push(line));
+      expect(stop).toBeDefined();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      stop!();
+      expect(lines).toEqual(['{"requestId":"a"}']);
+
+      // fstat is how we ask whether the descriptor is still ours: it throws
+      // EBADF once the number has been returned to the process.
+      expect(() => fstatSync(fd)).not.toThrow();
+
+      // And the descriptor is still usable, which is the part the connector
+      // depends on when a run asks a second question.
+      appendFileSync(file, '{"requestId":"b"}\n', "utf8");
+      const stopAgain = readRunAnswerLines(`fd:${fd}`, (line) => lines.push(line));
+      expect(stopAgain).toBeDefined();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      stopAgain!();
+      expect(lines).toEqual(['{"requestId":"a"}', '{"requestId":"b"}']);
+    } finally {
+      closeSync(fd);
+    }
   });
 });

--- a/examples/cli/src/run-events/runEventChannel.ts
+++ b/examples/cli/src/run-events/runEventChannel.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { closeSync, createReadStream, openSync, writeSync } from "node:fs";
+import { closeSync, createReadStream, openSync, read, writeSync } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
 import type { RunEvent } from "./RunEventTypes";
 
 export interface RunEventSink {
@@ -89,35 +90,119 @@ export function installRunEventChannel(target: string): RunEventSink | undefined
 }
 
 /**
+ * One long-lived reader per parent-owned descriptor.
+ *
+ * The descriptor outlives every individual question, so its unfinished line and
+ * any line that arrived between questions live here rather than in a per-reader
+ * closure — a reader that started fresh each time would drop both.
+ */
+interface AnswerFdReader {
+  readonly listeners: Set<(line: string) => void>;
+  /** Holds back a multi-byte character split across two reads. */
+  readonly decoder: StringDecoder;
+  /** Text decoded but not yet terminated by a newline. */
+  partial: string;
+  /** Whole lines that arrived while nobody was listening. */
+  readonly queued: string[];
+  /** A read is outstanding; issuing a second one would interleave the bytes. */
+  reading: boolean;
+}
+
+const answerFdReaders = new Map<number, AnswerFdReader>();
+
+const ANSWER_CHUNK_BYTES = 64 * 1024;
+
+function deliverAnswerLine(reader: AnswerFdReader, line: string): void {
+  if (reader.listeners.size === 0) {
+    reader.queued.push(line);
+    return;
+  }
+  for (const listener of [...reader.listeners]) listener(line);
+}
+
+/**
+ * Issues one read at a time, and only while somebody is waiting on an answer.
+ *
+ * Stopping between questions is the whole reason this is a loop we drive rather
+ * than a stream: the parent holds its end of the pipe for the entire run, so a
+ * read left outstanding counts toward the child's event loop and the process
+ * never exits — the command finishes in a second and the console waits forever
+ * on an exit that never comes. (`unref` is not the way out: a Socket built on
+ * the fd unrefs but delivers nothing under Bun.)
+ */
+function pumpAnswerFd(fd: number, reader: AnswerFdReader): void {
+  if (reader.reading || reader.listeners.size === 0) return;
+  reader.reading = true;
+  const chunk = Buffer.allocUnsafe(ANSWER_CHUNK_BYTES);
+  try {
+    read(fd, chunk, 0, chunk.length, null, (error, bytesRead) => {
+      reader.reading = false;
+      // Zero bytes is EOF on a file and a closed writer on a pipe; either way
+      // there is nothing more to take until somebody asks again.
+      if (error || bytesRead === 0) return;
+      reader.partial += reader.decoder.write(chunk.subarray(0, bytesRead));
+      let index = reader.partial.indexOf("\n");
+      while (index >= 0) {
+        deliverAnswerLine(reader, reader.partial.slice(0, index));
+        reader.partial = reader.partial.slice(index + 1);
+        index = reader.partial.indexOf("\n");
+      }
+      pumpAnswerFd(fd, reader);
+    });
+  } catch {
+    reader.reading = false;
+  }
+}
+
+/**
  * Reads NDJSON answer lines from the descriptor the parent named. Returns a
  * stop function, or undefined when nothing is listening.
  *
- * Open this only while an answer is actually expected — see
- * {@link openAnswerReaderWhilePending}. The parent holds its end of the pipe
- * for the whole run, so a reader left open counts toward the child's event
- * loop and the process cannot exit: the command finishes in a second and the
- * console waits forever on an exit that never comes. (`unref` is not the way
- * out — a Socket built on the fd unrefs but delivers nothing under Bun.)
+ * Stop and start it freely: a descriptor the parent handed us belongs to the
+ * parent and is never closed here. `fs` read streams close theirs on
+ * `destroy()` even with `autoClose: false`, and a closed number is handed
+ * straight back to the process — so the next `open()` (a database, a model
+ * cache, the log) takes the slot, the next question reads that file instead of
+ * the parent's answers, and the release after it closes that subsystem's
+ * descriptor. Hence the explicit read loop.
  */
 export function readRunAnswerLines(
   target: string,
   onLine: (line: string) => void
 ): (() => void) | undefined {
   if (!target) return undefined;
-  let stream: ReturnType<typeof createReadStream> | undefined;
-  try {
-    if (target.startsWith("fd:")) {
-      const fd = Number.parseInt(target.slice(3), 10);
-      if (!Number.isInteger(fd) || fd < 0) return undefined;
-      stream = createReadStream("", { fd, encoding: "utf8" });
-    } else if (target.startsWith("file:")) {
-      stream = createReadStream(target.slice(5), { encoding: "utf8" });
+
+  if (target.startsWith("fd:")) {
+    const fd = Number.parseInt(target.slice(3), 10);
+    if (!Number.isInteger(fd) || fd < 0) return undefined;
+    let reader = answerFdReaders.get(fd);
+    if (!reader) {
+      reader = {
+        listeners: new Set(),
+        decoder: new StringDecoder("utf8"),
+        partial: "",
+        queued: [],
+        reading: false,
+      };
+      answerFdReaders.set(fd, reader);
     }
+    const active = reader;
+    active.listeners.add(onLine);
+    while (active.queued.length > 0) onLine(active.queued.shift()!);
+    pumpAnswerFd(fd, active);
+    return () => {
+      active.listeners.delete(onLine);
+    };
+  }
+
+  // A file we opened ourselves, so the stream owns the descriptor it made.
+  if (!target.startsWith("file:")) return undefined;
+  let source: ReturnType<typeof createReadStream>;
+  try {
+    source = createReadStream(target.slice(5), { encoding: "utf8" });
   } catch {
     return undefined;
   }
-  if (!stream) return undefined;
-  const source = stream;
   source.on("error", () => {});
   let buffer = "";
   source.on("data", (chunk: string | Buffer) => {
@@ -142,7 +227,12 @@ export function getRunEventSink(): RunEventSink | undefined {
   return installed;
 }
 
-/** Test seam: drops the installed sink so one test file cannot leak into the next. */
+/**
+ * Test seam: drops the installed sink so one test file cannot leak into the
+ * next. The answer readers go with it — they are keyed by descriptor number,
+ * and a test that closes its own fd frees that number for the next test's.
+ */
 export function resetRunEventChannelForTesting(): void {
   installed = undefined;
+  answerFdReaders.clear();
 }

--- a/examples/cli/src/test/browser-workflow.test.ts
+++ b/examples/cli/src/test/browser-workflow.test.ts
@@ -54,7 +54,7 @@ describe.skipIf(!chromeAvailable)("Browser workflow end-to-end", () => {
       },
     };
 
-    registerCommonTasks();
+    registerCommonTasks({ fileSystemTasks: true });
     await registerCliBrowserDeps(config);
   }, 30_000);
 

--- a/examples/cli/src/test/registerCliTasks.test.ts
+++ b/examples/cli/src/test/registerCliTasks.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createGraphFromGraphJSON, TaskGraph, TaskRegistry } from "@workglow/task-graph";
+import { FileGrepTask, FileLoaderTask, FileSedTask } from "@workglow/tasks";
+import { beforeAll, describe, expect, it } from "vitest";
+import { registerCliTasks } from "../registerCliTasks";
+
+beforeAll(() => registerCliTasks());
+
+/**
+ * These names are the CLI's published surface, not an implementation detail:
+ * `workglow task run <type>` takes one, and every workflow the repository holds
+ * stores one per node. A type that stops being registered stops resolving, and
+ * a stored graph that names it stops loading — with nothing at the call site to
+ * say so. The list is therefore pinned here rather than left to whatever the
+ * task packages happen to register.
+ */
+describe("the CLI's task surface", () => {
+  it("registers the filesystem tasks", () => {
+    expect(TaskRegistry.all.get(FileLoaderTask.type)).toBe(FileLoaderTask);
+    expect(TaskRegistry.all.get(FileGrepTask.type)).toBe(FileGrepTask);
+    expect(TaskRegistry.all.get(FileSedTask.type)).toBe(FileSedTask);
+  });
+
+  it("registers the utility and base tasks the commands are built on", () => {
+    for (const type of [
+      "InputTask",
+      "OutputTask",
+      "LambdaTask",
+      "JsonTask",
+      "FetchUrlTask",
+      "MergeTask",
+      "DelayTask",
+    ]) {
+      expect(TaskRegistry.all.has(type)).toBe(true);
+    }
+  });
+
+  /**
+   * The failure this guards is a stored workflow, not a fresh graph: the JSON
+   * on disk names `FileLoaderTask` as a string and nothing else, so an
+   * unregistered type surfaces as a workflow that no longer opens.
+   */
+  it("loads a saved graph that names a filesystem task", () => {
+    const graph = new TaskGraph();
+    graph.addTask(new FileLoaderTask({ id: "load", defaults: { url: "notes.txt" } } as any));
+
+    const rebuilt = createGraphFromGraphJSON(graph.toJSON());
+
+    expect(rebuilt.getTask("load")).toBeInstanceOf(FileLoaderTask);
+  });
+});

--- a/examples/cli/src/test/samples.test.ts
+++ b/examples/cli/src/test/samples.test.ts
@@ -27,7 +27,7 @@ import {
 
 beforeAll(() => {
   registerBaseTasks();
-  registerCommonTasks();
+  registerCommonTasks({ fileSystemTasks: true });
   registerAiTasks();
 });
 

--- a/examples/cli/src/web/RunRegistry.test.ts
+++ b/examples/cli/src/web/RunRegistry.test.ts
@@ -6,9 +6,12 @@
 
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { RunRegistry } from "./RunRegistry";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 /** A stand-in CLI: reports two events on the fd it was handed, then exits. */
 function fakeBinary(dir: string, extra = ""): readonly string[] {
@@ -29,6 +32,50 @@ function fakeBinary(dir: string, extra = ""): readonly string[] {
 
 function settle(ms = 600): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(done: () => boolean, timeoutMs = 15_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!done() && Date.now() < deadline) await settle(50);
+}
+
+/**
+ * A stand-in CLI that asks two questions over fd 4, using the real reader the
+ * child ships with — the point of the exercise is that the second reader still
+ * has a descriptor to attach to. Node strips the types out of the imported
+ * `.ts` source, so the child runs the module under test rather than a copy.
+ */
+function promptingBinary(dir: string): readonly string[] {
+  const script = join(dir, "prompter.mjs");
+  const channel = join(HERE, "../run-events/runEventChannel.ts");
+  writeFileSync(
+    script,
+    `import { readRunAnswerLines } from ${JSON.stringify(channel)};
+     import { writeSync } from "node:fs";
+     const answers = process.env.WORKGLOW_RUN_ANSWERS ?? "";
+     const emit = (event) => writeSync(3, JSON.stringify(event) + "\\n");
+     function ask(requestId) {
+       return new Promise((resolve) => {
+         let stop;
+         stop = readRunAnswerLines(answers, (line) => {
+           const parsed = JSON.parse(line);
+           if (parsed.requestId !== requestId) return;
+           stop?.();
+           resolve(parsed);
+         });
+         if (!stop) { resolve({ content: "no-reader" }); return; }
+         emit({ k: "human_request", requestId, kind: "elicit", message: requestId, schema: undefined, data: undefined });
+       });
+     }
+     const first = await ask("q1");
+     emit({ k: "log", level: "info", text: "answered " + first.content });
+     const second = await ask("q2");
+     emit({ k: "log", level: "info", text: "answered " + second.content });
+     emit({ k: "run_end", state: "completed", error: undefined, output: undefined });
+     process.exit(0);`,
+    "utf8"
+  );
+  return [process.execPath, script];
 }
 
 describe("RunRegistry", () => {
@@ -93,6 +140,47 @@ describe("RunRegistry", () => {
     await settle();
     const logs = run.events.flatMap((e) => (e.event.k === "log" ? [e.event.text] : []));
     expect(logs).toContain("printed by the command");
+    registry.closeAll();
+  });
+
+  /**
+   * The prompt after the first one is the interesting one: the child releases
+   * its answers reader as soon as a question settles, and the run hangs forever
+   * if releasing it took the descriptor down with it.
+   */
+  it("answers a run that asks twice", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wg-runs-"));
+    const registry = new RunRegistry({ binary: promptingBinary(dir), cwd: dir, logDir: dir });
+    const run = registry.start({ path: ["demo"], args: [], options: {} });
+
+    const delivered: boolean[] = [];
+    const asked = new Set<string>();
+    registry.subscribe(run.id, 0, (record) => {
+      const event = record.event;
+      if (event.k !== "human_request" || asked.has(event.requestId)) return;
+      asked.add(event.requestId);
+      void registry
+        .answerHuman(run.id, { requestId: event.requestId, content: `${event.requestId}-ok` })
+        .then((ok) => delivered.push(ok));
+    });
+
+    await waitFor(() => run.endedAt !== undefined);
+
+    const logs = run.events.flatMap((e) => (e.event.k === "log" ? [e.event.text] : []));
+    expect([...asked]).toEqual(["q1", "q2"]);
+    expect(logs).toContain("answered q1-ok");
+    expect(logs).toContain("answered q2-ok");
+    expect(delivered).toEqual([true, true]);
+    expect(run.state).toBe("completed");
+    registry.closeAll();
+  }, 30_000);
+
+  it("reports an answer to a run that already ended as undelivered", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wg-runs-"));
+    const registry = new RunRegistry({ binary: fakeBinary(dir), cwd: dir, logDir: dir });
+    const run = registry.start({ path: ["demo"], args: ["x"], options: {} });
+    await settle();
+    expect(await registry.answerHuman(run.id, { requestId: "q1" })).toBe(false);
     registry.closeAll();
   });
 

--- a/examples/cli/src/web/RunRegistry.ts
+++ b/examples/cli/src/web/RunRegistry.ts
@@ -152,21 +152,29 @@ export class RunRegistry {
     return true;
   }
 
-  answerHuman(id: string, response: unknown): boolean {
+  /**
+   * Resolves to whether the answer actually reached the child.
+   *
+   * The write is asynchronous, so the liveness check above it proves nothing:
+   * a child that exits in between fails the write with EPIPE, and only the
+   * write callback knows that happened. Reporting delivery before the flush
+   * tells the page an answer landed when nobody read it. (The EPIPE itself
+   * arrives as an `error` event on a stream nobody else listens to, which Node
+   * throws — `start` installs the listener that keeps it from taking the
+   * console down.)
+   */
+  answerHuman(id: string, response: unknown): Promise<boolean> {
     const child = this.children.get(id);
-    if (!child || !isAlive(child)) return false;
+    if (!child || !isAlive(child)) return Promise.resolve(false);
     const answers = child.stdio[4] as Writable | undefined;
-    if (!answers || answers.destroyed) return false;
-    // The child can still exit between the liveness check and the write, and
-    // an EPIPE arrives as an `error` event on a stream nobody listens to —
-    // which Node throws, taking the whole console down because someone
-    // answered a prompt a moment too late. (`start` installs the listener.)
-    try {
-      answers.write(`${JSON.stringify(response)}\n`);
-    } catch {
-      return false;
-    }
-    return true;
+    if (!answers || answers.destroyed) return Promise.resolve(false);
+    return new Promise<boolean>((resolve) => {
+      try {
+        answers.write(`${JSON.stringify(response)}\n`, (error) => resolve(!error));
+      } catch {
+        resolve(false);
+      }
+    });
   }
 
   /** Replays what the subscriber missed, then streams the rest. */

--- a/examples/cli/src/web/handler.ts
+++ b/examples/cli/src/web/handler.ts
@@ -239,7 +239,7 @@ export async function handleWebRequest(request: WebRequest, ctx: WebContext): Pr
       } catch {
         return json(400, { error: "malformed answer" });
       }
-      return json(200, { delivered: ctx.registry.answerHuman(id, payload) });
+      return json(200, { delivered: await ctx.registry.answerHuman(id, payload) });
     }
     if (action === "/panels") {
       const panels = listWebPanels(run.invocation);

--- a/examples/web/src/App.tsx
+++ b/examples/web/src/App.tsx
@@ -43,7 +43,7 @@ import {
 // this module finishes evaluating (static imports with TLA evaluate fully
 // before the importer's body).
 registerBaseTasks();
-registerCommonTasks();
+registerCommonTasks({ fileSystemTasks: true });
 registerAiTasks();
 
 const JsonEditor = lazy(async () => {

--- a/examples/web/src/main.tsx
+++ b/examples/web/src/main.tsx
@@ -25,7 +25,12 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 
 installDevToolsFormatters();
 const tasks = [...registerBaseTasks()];
-[Workflow, ...tasks, ...registerCommonTasks(), ...registerAiTasks()].forEach((item) => {
+[
+  Workflow,
+  ...tasks,
+  ...registerCommonTasks({ fileSystemTasks: true }),
+  ...registerAiTasks(),
+].forEach((item) => {
   (window as any)[item.name] = item;
 });
 

--- a/packages/tasks/README.md
+++ b/packages/tasks/README.md
@@ -569,22 +569,28 @@ const result = await task.run();
 The Node and Electron builds ship three tasks that read the local filesystem —
 `FileGrepTask`, `FileLoaderTask` and `FileSedTask`.
 
-**They are not registered by default.** `registerCommonTasks()` deliberately
-leaves them out of `TaskRegistry`, because the registry is what a _deserialized_
+**Every host says whether it wants them.** `registerCommonTasks()` takes a
+required `fileSystemTasks` flag, because the registry is what a _deserialized_
 graph resolves a task type through, and a serialized node supplies its own
 `config` — so a graph naming `FileGrepTask` also names its own `roots`, and no
 default this package picks can constrain it. The only control that survives
-untrusted graph JSON is the task not being resolvable at all.
-
-A host that intends to expose them opts in:
+untrusted graph JSON is the task not being resolvable at all. There is no
+default either way: a default would hand every host the filesystem tasks, or
+take them from a host whose stored workflows already name them, with nothing at
+the call site to say so.
 
 ```typescript
-import { registerCommonTasks, registerFileSystemTasks } from "@workglow/tasks";
+import { registerCommonTasks } from "@workglow/tasks";
 
-registerCommonTasks();
-// Only where every graph reaching the registry is trusted:
-registerFileSystemTasks();
+// A server that runs graph JSON it did not author:
+registerCommonTasks({ fileSystemTasks: false });
+
+// A local CLI or desktop app, where every graph reaching the registry is trusted:
+registerCommonTasks({ fileSystemTasks: true });
 ```
+
+`registerFileSystemTasks()` adds the three on their own, for a host that
+registers its task surface in pieces.
 
 The classes are exported either way, so constructing one directly needs no
 registration:

--- a/packages/tasks/src/browser.ts
+++ b/packages/tasks/src/browser.ts
@@ -14,16 +14,32 @@ export * from "./task/FileGrepTask";
 export * from "./task/FileLoaderTask";
 export * from "./task/FileSedTask";
 
+import type { ITaskConstructor } from "@workglow/task-graph";
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";
+import type { RegisterCommonTasksOptions } from "./registerTaskOptions";
 import { FileGrepTask } from "./task/FileGrepTask";
 import { FileLoaderTask } from "./task/FileLoaderTask";
 import { FileSedTask } from "./task/FileSedTask";
 
-export const registerCommonTasks = () => {
-  const tasks = registerCommonTasksFn();
+/**
+ * The browser filesystem tasks read through whatever `url` resolves to in the
+ * page, so there is no ambient disk for them to reach — but the registry is
+ * still what stored graph JSON resolves a type name through, and a host that
+ * ships this entry and the node one must not get two different surfaces from
+ * the same call.
+ */
+export const registerFileSystemTasks = (): ITaskConstructor<any, any, any>[] => {
   TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
   TaskRegistry.registerTask(FileSedTask);
-  return [...tasks, FileGrepTask, FileLoaderTask, FileSedTask];
+  return [FileGrepTask, FileLoaderTask, FileSedTask];
+};
+
+export const registerCommonTasks = (
+  options: RegisterCommonTasksOptions
+): ITaskConstructor<any, any, any>[] => {
+  const tasks: ITaskConstructor<any, any, any>[] = [...registerCommonTasksFn()];
+  if (options.fileSystemTasks) tasks.push(...registerFileSystemTasks());
+  return tasks;
 };

--- a/packages/tasks/src/common.ts
+++ b/packages/tasks/src/common.ts
@@ -87,6 +87,7 @@ export * from "./task/vector/VectorNormalizeTask";
 export * from "./task/vector/VectorScaleTask";
 export * from "./task/vector/VectorSubtractTask";
 export * from "./task/vector/VectorSumTask";
+export * from "./registerTaskOptions";
 export * from "./util/BoundedRegexRunner";
 export * from "./util/regexSafety";
 export * from "./util/SafeFetch";

--- a/packages/tasks/src/electron.ts
+++ b/packages/tasks/src/electron.ts
@@ -26,30 +26,13 @@ export {
 } from "./task/FileSedTask";
 export type { SedBatchResult, SedLineSubstituter, SedOptions } from "./task/FileSedTask";
 
+import type { ITaskConstructor } from "@workglow/task-graph";
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";
+import type { RegisterCommonTasksOptions } from "./registerTaskOptions";
 import { FileGrepTask } from "./task/FileGrepTask.server";
 import { FileLoaderTask } from "./task/FileLoaderTask.server";
 import { FileSedTask } from "./task/FileSedTask.server";
-
-/**
- * Registers the tasks that are safe to have in the ambient registry on a
- * server.
- *
- * The three filesystem tasks are NOT among them, and their absence is the
- * point. `TaskRegistry` is what a deserialized graph resolves a task type
- * through, and a serialized node carries its own `config` — so a graph that
- * names `FileGrepTask` also states its own `roots`, and no default this
- * package picks can constrain it. The only control that survives untrusted
- * JSON is the task not being resolvable at all.
- *
- * A host that intends to expose them opts in with
- * {@link registerFileSystemTasks}. The classes are exported either way, so
- * constructing one directly is unchanged.
- */
-export const registerCommonTasks = () => {
-  return registerCommonTasksFn();
-};
 
 /**
  * Adds the filesystem tasks to the ambient registry, making them resolvable by
@@ -60,9 +43,24 @@ export const registerCommonTasks = () => {
  * `process.cwd()`, but a serialized node supplies its own config: registration
  * is the boundary, containment is the backstop behind it.
  */
-export const registerFileSystemTasks = () => {
+export const registerFileSystemTasks = (): ITaskConstructor<any, any, any>[] => {
   TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
   TaskRegistry.registerTask(FileSedTask);
   return [FileGrepTask, FileLoaderTask, FileSedTask];
+};
+
+/**
+ * Registers the utility tasks, and the filesystem tasks when the host asks for
+ * them — see {@link RegisterCommonTasksOptions.fileSystemTasks}.
+ *
+ * The classes are exported whichever way the flag goes, so constructing one
+ * directly is never affected; only resolution by type name is.
+ */
+export const registerCommonTasks = (
+  options: RegisterCommonTasksOptions
+): ITaskConstructor<any, any, any>[] => {
+  const tasks: ITaskConstructor<any, any, any>[] = [...registerCommonTasksFn()];
+  if (options.fileSystemTasks) tasks.push(...registerFileSystemTasks());
+  return tasks;
 };

--- a/packages/tasks/src/node.ts
+++ b/packages/tasks/src/node.ts
@@ -28,30 +28,13 @@ export {
 } from "./task/FileSedTask";
 export type { SedBatchResult, SedLineSubstituter, SedOptions } from "./task/FileSedTask";
 
+import type { ITaskConstructor } from "@workglow/task-graph";
 import { TaskRegistry } from "@workglow/task-graph";
 import { registerCommonTasks as registerCommonTasksFn } from "./common";
+import type { RegisterCommonTasksOptions } from "./registerTaskOptions";
 import { FileGrepTask } from "./task/FileGrepTask.server";
 import { FileLoaderTask } from "./task/FileLoaderTask.server";
 import { FileSedTask } from "./task/FileSedTask.server";
-
-/**
- * Registers the tasks that are safe to have in the ambient registry on a
- * server.
- *
- * The three filesystem tasks are NOT among them, and their absence is the
- * point. `TaskRegistry` is what a deserialized graph resolves a task type
- * through, and a serialized node carries its own `config` — so a graph that
- * names `FileGrepTask` also states its own `roots`, and no default this
- * package picks can constrain it. The only control that survives untrusted
- * JSON is the task not being resolvable at all.
- *
- * A host that intends to expose them opts in with
- * {@link registerFileSystemTasks}. The classes are exported either way, so
- * constructing one directly is unchanged.
- */
-export const registerCommonTasks = () => {
-  return registerCommonTasksFn();
-};
 
 /**
  * Adds the filesystem tasks to the ambient registry, making them resolvable by
@@ -62,9 +45,24 @@ export const registerCommonTasks = () => {
  * `process.cwd()`, but a serialized node supplies its own config: registration
  * is the boundary, containment is the backstop behind it.
  */
-export const registerFileSystemTasks = () => {
+export const registerFileSystemTasks = (): ITaskConstructor<any, any, any>[] => {
   TaskRegistry.registerTask(FileGrepTask);
   TaskRegistry.registerTask(FileLoaderTask);
   TaskRegistry.registerTask(FileSedTask);
   return [FileGrepTask, FileLoaderTask, FileSedTask];
+};
+
+/**
+ * Registers the utility tasks, and the filesystem tasks when the host asks for
+ * them — see {@link RegisterCommonTasksOptions.fileSystemTasks}.
+ *
+ * The classes are exported whichever way the flag goes, so constructing one
+ * directly is never affected; only resolution by type name is.
+ */
+export const registerCommonTasks = (
+  options: RegisterCommonTasksOptions
+): ITaskConstructor<any, any, any>[] => {
+  const tasks: ITaskConstructor<any, any, any>[] = [...registerCommonTasksFn()];
+  if (options.fileSystemTasks) tasks.push(...registerFileSystemTasks());
+  return tasks;
 };

--- a/packages/tasks/src/registerTaskOptions.ts
+++ b/packages/tasks/src/registerTaskOptions.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * What a host wants in the ambient `TaskRegistry`.
+ *
+ * `fileSystemTasks` is required rather than defaulted, and that is the whole
+ * point of the option: the registry is what a DESERIALIZED graph resolves a
+ * task type through, so which types are registered decides what stored JSON can
+ * name. A default either quietly hands every host the filesystem tasks, or
+ * quietly takes them away from a host whose saved workflows already name them —
+ * both are invisible at the call site. Stating it makes the choice a compile
+ * error until the host has made it.
+ */
+export interface RegisterCommonTasksOptions {
+  /**
+   * Whether `FileGrepTask`, `FileLoaderTask` and `FileSedTask` join the
+   * registry, making them resolvable by type name.
+   *
+   * `true` only where every graph reaching the registry is trusted: a
+   * serialized node supplies its own `config`, so a graph naming `FileGrepTask`
+   * also states its own `roots` and no default this package picks constrains
+   * it. Registration is the boundary; the tasks' own containment is the
+   * backstop behind it.
+   */
+  readonly fileSystemTasks: boolean;
+}

--- a/packages/test/src/binding/RegisterTasks.ts
+++ b/packages/test/src/binding/RegisterTasks.ts
@@ -10,6 +10,6 @@ import { registerCommonTasks } from "@workglow/tasks";
 
 export const registerTasks = () => {
   registerBaseTasks();
-  registerCommonTasks();
+  registerCommonTasks({ fileSystemTasks: false });
   registerAiTasks();
 };

--- a/packages/test/src/test/task-graph/GraphToWorkflowCode.test.ts
+++ b/packages/test/src/test/task-graph/GraphToWorkflowCode.test.ts
@@ -33,7 +33,7 @@ import { registerCommonTasks } from "@workglow/tasks";
 
 export const registerTasks = () => {
   registerBaseTasks();
-  registerCommonTasks();
+  registerCommonTasks({ fileSystemTasks: false });
   registerAiTasks();
 };
 

--- a/packages/test/src/test/task-graph/Transforms.integration.test.ts
+++ b/packages/test/src/test/task-graph/Transforms.integration.test.ts
@@ -23,7 +23,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 describe("Transforms end-to-end", () => {
   beforeAll(() => {
     registerBaseTasks();
-    registerCommonTasks();
+    registerCommonTasks({ fileSystemTasks: false });
     registerBuiltInTransforms();
   });
 

--- a/packages/test/src/test/task/RegisterFileSystemTasks.test.ts
+++ b/packages/test/src/test/task/RegisterFileSystemTasks.test.ts
@@ -37,7 +37,7 @@ describe("filesystem task registration is opt-in", () => {
   afterEach(unregisterAll);
 
   test("registerCommonTasks leaves the filesystem tasks out of the registry", () => {
-    registerCommonTasks();
+    registerCommonTasks({ fileSystemTasks: false });
 
     for (const type of FILE_SYSTEM_TASK_TYPES) {
       expect(TaskRegistry.all.has(type)).toBe(false);
@@ -45,11 +45,34 @@ describe("filesystem task registration is opt-in", () => {
   });
 
   test("registerCommonTasks does not return the filesystem tasks either", () => {
-    const returned = registerCommonTasks().map((task) => task.type);
+    const returned = registerCommonTasks({ fileSystemTasks: false }).map((task) => task.type);
 
     for (const type of FILE_SYSTEM_TASK_TYPES) {
       expect(returned).not.toContain(type);
     }
+  });
+
+  /**
+   * The option is the whole point of the split: a host asking for the wider
+   * surface says so in one place, and one that does not is a compile error away
+   * from finding out — rather than discovering at runtime that a stored graph
+   * no longer deserializes.
+   */
+  test("registerCommonTasks with fileSystemTasks registers and returns all three", () => {
+    const returned = registerCommonTasks({ fileSystemTasks: true }).map((task) => task.type);
+
+    for (const type of FILE_SYSTEM_TASK_TYPES) {
+      expect(TaskRegistry.all.has(type)).toBe(true);
+      expect(returned).toContain(type);
+    }
+  });
+
+  test("the common tasks come back either way", () => {
+    const narrow = registerCommonTasks({ fileSystemTasks: false }).map((task) => task.type);
+    unregisterAll();
+    const wide = registerCommonTasks({ fileSystemTasks: true }).map((task) => task.type);
+
+    expect(wide).toEqual([...narrow, ...FILE_SYSTEM_TASK_TYPES]);
   });
 
   test("registerFileSystemTasks puts all three in the registry", () => {


### PR DESCRIPTION
Two review findings in the CLI and `@workglow/tasks`.

## 1. The run-answer reader closed the parent's fd 4

`readRunAnswerLines` built its reader as `fs.createReadStream("", { fd })`, and the `destroy()` it returned as the stop function **closed fd 4** — a descriptor the parent handed the child and that `RunEventHumanConnector` reopens once per outstanding question. So every prompt after the first opened a read stream on a closed descriptor, the `error` was swallowed by `source.on("error", () => {})`, and no answer line was ever delivered: a run that asks two questions hung forever on the second. Once closed, the number is also handed back to the process, so a later `open()` (SQLite db, model cache, NDJSON log) can land on 4 — the second prompt then reads bytes from an unrelated file and the next release closes *that* subsystem's descriptor, surfacing as `EBADF` far from the cause. `installRunEventChannel` in the same file already states the rule the read side was breaking: "A descriptor the parent handed us belongs to the parent."

`autoClose: false` is **not** sufficient — verified on Node 22: `autoClose` only controls `autoDestroy`, and an explicit `destroy()` closes the fd regardless. So the `fd:` branch now drives its own `fs.read` loop instead of a stream:

- one read outstanding at a time, issued **only while a listener is waiting** — which is what still lets the child exit between questions (a read left outstanding on a pipe the parent holds open keeps the event loop alive, the original reason the reader is per-question);
- the descriptor is never closed, so stopping and restarting is free;
- reader state is now per **descriptor** rather than per question, so an unfinished line, a line that arrives between questions, and a multi-byte character split across two reads all survive a release.

The `file:` branch is unchanged — that stream owns the descriptor it opened.

Separately, `RunRegistry.answerHuman` returned `{ delivered: true }` unconditionally while the write was still in flight, so the console reported success for an answer EPIPE had eaten. It now returns a `Promise<boolean>` resolved from the `write` callback; `handler.ts` awaits it.

## 2. `registerCommonTasks()` silently stopped registering the filesystem tasks

The export kept its name, signature and return type when `FileGrepTask` / `FileLoaderTask` / `FileSedTask` moved behind `registerFileSystemTasks()` — so the narrowing was invisible at every call site, and no caller of the new export existed outside its own tests. After upgrade `workglow task run FileLoaderTask` reports an unknown type, and any saved workflow whose serialized graph names one fails to deserialize. `browser.ts` still registered all three, so the builds disagreed about which type names resolve.

`registerCommonTasks` now takes a **required** `{ fileSystemTasks: boolean }` in `node.ts`, `electron.ts` and `browser.ts` alike (`RegisterCommonTasksOptions`, in its own module). A required field is the point: there is no default that could quietly hand a host the filesystem tasks or quietly take them from a host whose stored workflows already name them. The containment rationale is preserved — a host that does not ask still does not get them; `registerFileSystemTasks()` remains for hosts that register in pieces.

The CLI asks. `registerCliTasks()` (`examples/cli/src/registerCliTasks.ts`) is now the one place the binary's task surface is stated, and `runWorkglowCli` calls it — its own module so the surface is assertable without standing up a program, a config directory and a model repository.

In-repo callers updated: `examples/web` (was registering all three in the browser build — unchanged behaviour), `packages/test`'s bindings and two graph tests (`false`, unchanged behaviour). Docs updated: `packages/tasks/README.md`, `docs/technical/20-task-registry.md`, `.claude/CLAUDE.md`.

## Tests

- `runEventChannel.test.ts` — "leaves a descriptor it was handed open when the reader stops": reads through an fd the test owns, releases the reader, asserts `fstatSync(fd)` does not throw, then appends and reads again through the **same** fd.
- `RunRegistry.test.ts` — "answers a run that asks twice": a real child process asks two questions over a real fd 4, using the actual `readRunAnswerLines` (Node strips the types out of the imported `.ts`, so the child runs the module under test rather than a copy). Asserts both answers round-trip and both `answerHuman` calls report delivery. Also "reports an answer to a run that already ended as undelivered".
- Both of the above were confirmed to **fail** against `origin/main`'s `runEventChannel.ts` and pass with the fix.
- `registerCliTasks.test.ts` — pins the CLI's registered surface: the three filesystem types, the utility types the commands are built on, and that a graph naming `FileLoaderTask` still round-trips through `createGraphFromGraphJSON`.
- `RegisterFileSystemTasks.test.ts` — extended for the option in both directions.

## Verification

```
bun run format
  → All matched files use Prettier code style!

bun run build:types
  → Tasks: 42 successful, 42 total

bun scripts/test.ts cli task graph vitest
  → Test Files  164 passed | 1 skipped (165)
  →      Tests  2015 passed | 25 skipped (2040)

bun scripts/test.ts web scripts vitest
  → Test Files  6 passed (6)
  →      Tests  22 passed (22)

bun scripts/test.ts --check-sections
  → Every test file is discovered and reachable by section+kind selection.
```

Note for downstream embedders (builder, sec): `registerCommonTasks()` is now a compile error without the argument. That is the intended signal — pick `{ fileSystemTasks: true }` to keep the current surface, `false` to narrow it deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sit7PHmkEw5t3TpesT5g7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sit7PHmkEw5t3TpesT5g7s)_