### PR TITLE
fix(web-search): four review findings on #850 — credential double-resolution, key leak, maxResults, routing

### DIFF
--- a/packages/task-graph/src/task-graph/GraphFormatScanner.ts
+++ b/packages/task-graph/src/task-graph/GraphFormatScanner.ts
@@ -8,10 +8,27 @@ import { getObjectSchema, getSchemaFormat } from "../task/InputResolver";
 import type { ITaskGraph } from "./ITaskGraph";
 
 /**
+ * Format annotations whose value names an entry in the credential store.
+ *
+ * `"credential"` is rewritten to the secret by the input resolver before
+ * `execute()` runs. `"credential-key"` is deliberately left alone: it marks a
+ * port whose value is handed to an owned task that resolves it itself, and a
+ * port resolved twice looks the *secret* up as if it were a key, misses, and
+ * sends the request unauthenticated.
+ *
+ * Either way the store has to be reachable for the run, which is what this scan
+ * decides.
+ */
+export const CREDENTIAL_KEY_FORMATS: ReadonlySet<string> = new Set([
+  "credential",
+  "credential-key",
+]);
+
+/**
  * Result of scanning a task graph for credential format annotations.
  */
 export interface GraphFormatScanResult {
-  /** Whether any task in the graph has a `format: "credential"` property in its input or config schema. */
+  /** Whether any task in the graph has a credential-key property in its input or config schema. */
   readonly needsCredentials: boolean;
   /** The set of format strings found (e.g., `"credential"`). */
   readonly credentialFormats: ReadonlySet<string>;
@@ -68,8 +85,8 @@ export function scanGraphForFormat(graph: ITaskGraph, targetFormat: string): boo
  * Scans a task graph for credential requirements.
  *
  * A task only counts as needing credentials when it has a schema property
- * annotated with `format: "credential"` **and** the corresponding value is
- * actually set on the task's config or input defaults (non-empty string).
+ * annotated with one of {@link CREDENTIAL_KEY_FORMATS} **and** the corresponding
+ * value is actually set on the task's config or input defaults (non-empty string).
  * Annotating a schema is not enough — plenty of model configs have
  * `provider_config.credential_key` available but unused (e.g. local ONNX
  * models).
@@ -118,7 +135,12 @@ function collectUsedCredentialFormats(schema: unknown, data: unknown, formats: S
   for (const [propName, propSchema] of Object.entries(properties)) {
     const format = getSchemaFormat(propSchema);
     const value = dataObj[propName];
-    if (format === "credential" && typeof value === "string" && value.length > 0) {
+    if (
+      format !== undefined &&
+      CREDENTIAL_KEY_FORMATS.has(format) &&
+      typeof value === "string" &&
+      value.length > 0
+    ) {
       formats.add(format);
     }
 

--- a/packages/task-graph/src/task-graph/__tests__/GraphFormatScanner.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/GraphFormatScanner.test.ts
@@ -83,6 +83,24 @@ class AnyOfNestedCredentialTask extends Task<any, any> {
   }
 }
 
+/**
+ * The shape of a task that forwards the key to an owned task rather than
+ * consuming the secret itself: the input resolver must leave the port alone,
+ * but the store still has to be unlocked before the run.
+ */
+class UnresolvedCredentialKeyTask extends Task<any, any> {
+  static override readonly type = "UnresolvedCredentialKeyTask";
+
+  static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        credential_key: { type: "string", format: "credential-key" },
+      },
+    } as const satisfies DataPortSchema;
+  }
+}
+
 class NoCredentialTask extends Task<any, any> {
   static override readonly type = "NoCredentialTask";
 
@@ -159,6 +177,21 @@ describe("GraphFormatScanner", () => {
       );
       expect(result.needsCredentials).toBe(true);
       expect(result.credentialFormats.has("credential")).toBe(true);
+    });
+
+    it("detects a credential-key format, which the input resolver leaves alone", () => {
+      const result = scanGraphForCredentials(
+        makeGraph(
+          new UnresolvedCredentialKeyTask({ defaults: { credential_key: "my-key" } as any })
+        )
+      );
+      expect(result.needsCredentials).toBe(true);
+      expect(result.credentialFormats.has("credential-key")).toBe(true);
+    });
+
+    it("ignores a declared-but-unset credential-key", () => {
+      const result = scanGraphForCredentials(makeGraph(new UnresolvedCredentialKeyTask({})));
+      expect(result.needsCredentials).toBe(false);
     });
 
     it("does not detect an empty-string credential value", () => {

--- a/packages/web-search/README.md
+++ b/packages/web-search/README.md
@@ -18,7 +18,7 @@ and validate the node) but **no providers**. Execution happens on a server.
 | `brave`      | `X-Subscription-Token` | no     | no      | via `site:`              | yes         |
 | `tavily`     | bearer token           | yes    | yes     | native                   | yes         |
 | `searxng`    | none (self-hosted)     | no     | no      | via `site:`              | no          |
-| `anthropic`  | vendor SDK             | yes    | no      | native                   | no          |
+| `anthropic`  | vendor SDK             | yes    | no      | native, **one list**     | no          |
 | `openai`     | vendor SDK             | yes    | no      | native, **include only** | no          |
 | `openrouter` | vendor SDK             | yes    | yes     | native                   | no          |
 | `gemini`     | vendor SDK             | yes    | no      | **none**                 | **yes**     |
@@ -34,8 +34,11 @@ import { registerGeminiWebSearchProvider } from "@workglow/google-gemini/web-sea
 ```
 
 Their capability profiles genuinely differ — OpenAI can restrict _to_ domains but not
-_away_ from them, and Gemini is the only one that filters by date while filtering by no
-domain at all. That is why `excludeDomainFilter` is separable from `domainFilter`.
+_away_ from them, Anthropic takes either list but never both in one request, and Gemini is
+the only one that filters by date while filtering by no domain at all. That is why
+`excludeDomainFilter` is separable from `domainFilter`, and why
+`exclusiveDomainDirections` exists: `auto` routing must score a request a provider cannot
+honor as a gap and move on, rather than land on it and throw.
 SearXNG needs `WEB_SEARCH_SEARXNG_URL` (or an explicit base URL) and an instance
 with `format=json` enabled.
 

--- a/packages/web-search/src/IWebSearchProvider.ts
+++ b/packages/web-search/src/IWebSearchProvider.ts
@@ -87,6 +87,18 @@ export interface WebSearchCapabilities {
    */
   readonly excludeDomainFilter?: DomainFilterSupport | undefined;
   /**
+   * `true` when the provider filters in either direction but never both in the
+   * same request — Anthropic's `web_search` tool takes `allowed_domains` or
+   * `blocked_domains` and rejects the pair.
+   *
+   * Without it such a provider over-declares exactly the way
+   * {@link excludeDomainFilter} exists to prevent: both directions look
+   * supported, `unhonorableOptions` finds no gap, `"auto"` routes to it, and
+   * `search()` throws on a request the provider registered right behind it
+   * would have served natively.
+   */
+  readonly exclusiveDomainDirections?: boolean | undefined;
+  /**
    * Date filtering is never emulated. Post-filtering by `publishedDate` breaks
    * `maxResults` and drops every result whose date the provider omitted, so a
    * provider that cannot do it server-side declares `false` and the request is

--- a/packages/web-search/src/WebSearchTask.ts
+++ b/packages/web-search/src/WebSearchTask.ts
@@ -70,7 +70,13 @@ const inputSchema = {
     },
     credential_key: {
       type: "string",
-      format: "credential",
+      // `credential-key`, not `credential`: this port is forwarded to the
+      // `FetchUrlTask` this task owns, and that task's own runner resolves it.
+      // Resolving here too would hand the child the secret as if it were a store
+      // key — the lookup misses, the resolver returns undefined rather than
+      // echoing its input, and the request goes out with no auth header at all.
+      // The scan that unlocks the store still counts this format.
+      format: "credential-key",
       title: "Credential Key",
       description: "Key looked up in the credential store and sent as the provider's API key.",
       "x-ui-hidden": true,

--- a/packages/web-search/src/__tests__/WebSearchCredential.test.ts
+++ b/packages/web-search/src/__tests__/WebSearchCredential.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { scanGraphForCredentials, TaskGraph } from "@workglow/task-graph";
+import type { SafeFetchFn } from "@workglow/tasks";
+import { registerSafeFetch } from "@workglow/tasks";
+import {
+  Container,
+  InMemoryCredentialStore,
+  registerCredentialDefaults,
+  ServiceRegistry,
+  setGlobalCredentialStore,
+} from "@workglow/util";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { BraveWebSearchProvider } from "../providers/BraveWebSearchProvider";
+import { TavilyWebSearchProvider } from "../providers/TavilyWebSearchProvider";
+import { WebSearchProviderRegistry } from "../WebSearchProviderRegistry";
+import { WebSearchTask } from "../WebSearchTask";
+
+const STORE_KEY = "tavily-api-key";
+const SECRET = "tvly-super-secret";
+
+/**
+ * These tests deliberately drive a REAL `FetchUrlTask` — the provider unit
+ * tests all stub `context.own()` with a fake whose `run()` just echoes, which is
+ * exactly why a double credential resolution was invisible to them. Only the
+ * real child task resolves `credential_key`, and only the real one decides
+ * whether an auth header reaches the wire.
+ */
+const mockFetch = vi.fn((_url: string, _options: RequestInit) =>
+  Promise.resolve(
+    new Response(JSON.stringify({ results: [], web: { results: [] } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })
+  )
+);
+const mockSafeFetch: SafeFetchFn = (url, options) => mockFetch(url, options as RequestInit);
+
+async function credentialRegistry(
+  entries: Readonly<Record<string, string>> = { [STORE_KEY]: SECRET }
+): Promise<ServiceRegistry> {
+  const registry = new ServiceRegistry(new Container());
+  registerCredentialDefaults(registry);
+  const store = new InMemoryCredentialStore();
+  for (const [key, value] of Object.entries(entries)) {
+    await store.put(key, value);
+  }
+  setGlobalCredentialStore(store, registry);
+  return registry;
+}
+
+function lastRequestHeaders(): Record<string, string> {
+  const options = mockFetch.mock.calls.at(-1)?.[1] as
+    { headers?: Record<string, string> } | undefined;
+  return options?.headers ?? {};
+}
+
+describe("WebSearchTask credential forwarding", () => {
+  let previousSafeFetch: SafeFetchFn;
+
+  beforeAll(() => {
+    previousSafeFetch = registerSafeFetch(mockSafeFetch);
+  });
+
+  afterAll(() => {
+    registerSafeFetch(previousSafeFetch);
+  });
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    WebSearchProviderRegistry.clear();
+  });
+
+  it("sends the resolved secret as a bearer token for Tavily", async () => {
+    WebSearchProviderRegistry.register(new TavilyWebSearchProvider());
+    const registry = await credentialRegistry();
+
+    await new WebSearchTask().run(
+      { query: "transformer architecture", provider: "tavily", credential_key: STORE_KEY },
+      { registry }
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(lastRequestHeaders().Authorization).toBe(`Bearer ${SECRET}`);
+  });
+
+  it("sends the resolved secret in Brave's own header", async () => {
+    WebSearchProviderRegistry.register(new BraveWebSearchProvider());
+    const registry = await credentialRegistry({ "brave-api-key": SECRET });
+
+    await new WebSearchTask().run(
+      { query: "cats", provider: "brave", credential_key: "brave-api-key" },
+      { registry }
+    );
+
+    expect(lastRequestHeaders()["X-Subscription-Token"]).toBe(SECRET);
+  });
+
+  it("forwards the store key, not an already-resolved secret", async () => {
+    WebSearchProviderRegistry.register(new TavilyWebSearchProvider());
+    const registry = await credentialRegistry();
+    const task = new WebSearchTask();
+
+    await task.run({ query: "cats", provider: "tavily", credential_key: STORE_KEY }, { registry });
+
+    // The port this task hands to its child must still read as the key name.
+    // Resolving it here as well would put the secret on the port, the child
+    // would look the secret up as a key, miss, and send nothing.
+    expect(task.runInputData.credential_key).toBe(STORE_KEY);
+  });
+
+  it("still authenticates on a second run of the same instance", async () => {
+    WebSearchProviderRegistry.register(new TavilyWebSearchProvider());
+    const registry = await credentialRegistry();
+    const task = new WebSearchTask({
+      defaults: { query: "cats", provider: "tavily", credential_key: STORE_KEY },
+    });
+
+    await task.run({}, { registry });
+    expect(lastRequestHeaders().Authorization).toBe(`Bearer ${SECRET}`);
+
+    await task.run({}, { registry });
+    expect(lastRequestHeaders().Authorization).toBe(`Bearer ${SECRET}`);
+  });
+
+  it("sends no Authorization header when the key is not in the store", async () => {
+    WebSearchProviderRegistry.register(new TavilyWebSearchProvider());
+    const registry = await credentialRegistry({});
+
+    await new WebSearchTask().run(
+      { query: "cats", provider: "tavily", credential_key: "absent-key-name" },
+      { registry }
+    );
+
+    const headers = lastRequestHeaders();
+    expect(headers.Authorization).toBeUndefined();
+    // A miss must never thread the key *name* through as if it were the secret.
+    expect(JSON.stringify(headers)).not.toContain("absent-key-name");
+  });
+
+  it("is still seen by the graph credential scan that unlocks the store", () => {
+    const graph = new TaskGraph();
+    graph.addTask(
+      new WebSearchTask({
+        defaults: { query: "cats", provider: "tavily", credential_key: STORE_KEY },
+      })
+    );
+
+    expect(scanGraphForCredentials(graph).needsCredentials).toBe(true);
+  });
+
+  it("reports no credential need when no key is configured", () => {
+    const graph = new TaskGraph();
+    graph.addTask(new WebSearchTask({ defaults: { query: "cats", provider: "searxng" } }));
+
+    expect(scanGraphForCredentials(graph).needsCredentials).toBe(false);
+  });
+});

--- a/packages/web-search/src/__tests__/WebSearchProviderRegistry.test.ts
+++ b/packages/web-search/src/__tests__/WebSearchProviderRegistry.test.ts
@@ -50,6 +50,47 @@ describe("WebSearchProviderRegistry", () => {
     );
   });
 
+  it("skips a one-direction-at-a-time provider for a both-lists request", () => {
+    // The Anthropic shape, registered first because its key is always present.
+    WebSearchProviderRegistry.register(
+      provider("anthropic", { domainFilter: "native", exclusiveDomainDirections: true })
+    );
+    WebSearchProviderRegistry.register(provider("tavily", { domainFilter: "native" }));
+
+    const chosen = WebSearchProviderRegistry.route({
+      query: "c",
+      includeDomains: ["arxiv.org"],
+      excludeDomains: ["spam.net"],
+    });
+
+    // Routing to anthropic here would throw out of search() on a request the
+    // provider behind it serves natively.
+    expect(chosen.name).toBe("tavily");
+  });
+
+  it("still routes to it when only one direction was asked for", () => {
+    WebSearchProviderRegistry.register(
+      provider("anthropic", { domainFilter: "native", exclusiveDomainDirections: true })
+    );
+    WebSearchProviderRegistry.register(provider("tavily", { domainFilter: "native" }));
+    expect(
+      WebSearchProviderRegistry.route({ query: "c", includeDomains: ["arxiv.org"] }).name
+    ).toBe("anthropic");
+  });
+
+  it("names the both-lists constraint when no provider can serve it", () => {
+    WebSearchProviderRegistry.register(
+      provider("anthropic", { domainFilter: "native", exclusiveDomainDirections: true })
+    );
+    expect(() =>
+      WebSearchProviderRegistry.route({
+        query: "c",
+        includeDomains: ["a.com"],
+        excludeDomains: ["b.com"],
+      })
+    ).toThrow(/includeDomains with excludeDomains/);
+  });
+
   it("throws naming the option and the rejected providers when nothing satisfies", () => {
     WebSearchProviderRegistry.register(provider("brave", {}));
     WebSearchProviderRegistry.register(provider("searxng", {}));

--- a/packages/web-search/src/__tests__/capabilityCheck.test.ts
+++ b/packages/web-search/src/__tests__/capabilityCheck.test.ts
@@ -90,6 +90,32 @@ describe("unhonorableOptions", () => {
     ]);
   });
 
+  it("reports a both-lists request against a provider that takes one direction at a time", () => {
+    // Anthropic's web_search tool accepts allowed_domains or blocked_domains
+    // and rejects the pair, so serving each alone is not serving both.
+    const caps = { ...ALL, exclusiveDomainDirections: true };
+    expect(
+      unhonorableOptions(caps, {
+        query: "c",
+        includeDomains: ["arxiv.org"],
+        excludeDomains: ["spam.net"],
+      })
+    ).toEqual(["includeDomains with excludeDomains"]);
+  });
+
+  it("still serves either list alone for such a provider", () => {
+    const caps = { ...ALL, exclusiveDomainDirections: true };
+    expect(unhonorableOptions(caps, { query: "c", includeDomains: ["a.com"] })).toEqual([]);
+    expect(unhonorableOptions(caps, { query: "c", excludeDomains: ["b.com"] })).toEqual([]);
+  });
+
+  it("does not restate the pair when a direction is already refused outright", () => {
+    const caps = { ...NONE, exclusiveDomainDirections: true };
+    expect(
+      unhonorableOptions(caps, { query: "c", includeDomains: ["a.com"], excludeDomains: ["b.com"] })
+    ).toEqual(["includeDomains", "excludeDomains"]);
+  });
+
   it("does not report maxResults — it is clamped, not refused", () => {
     expect(
       unhonorableOptions({ ...NONE, maxResultsCap: 5 }, { query: "c", maxResults: 50 })

--- a/packages/web-search/src/__tests__/limitResults.test.ts
+++ b/packages/web-search/src/__tests__/limitResults.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import type { SearchResult } from "../IWebSearchProvider";
+import { limitResults } from "../limitResults";
+
+const results: readonly SearchResult[] = [
+  { title: "A", url: "https://e/a" },
+  { title: "B", url: "https://e/b" },
+  { title: "C", url: "https://e/c" },
+];
+
+describe("limitResults", () => {
+  it("returns everything when no bound was asked for", () => {
+    expect(limitResults(results, undefined)).toHaveLength(3);
+  });
+
+  it("trims to the bound", () => {
+    expect(limitResults(results, 2).map((r) => r.title)).toEqual(["A", "B"]);
+  });
+
+  it("leaves a shorter list alone rather than padding it", () => {
+    expect(limitResults(results, 10)).toHaveLength(3);
+  });
+
+  it("copies rather than aliasing the provider's array", () => {
+    const copy = limitResults(results, undefined);
+    copy.push({ title: "D", url: "https://e/d" });
+    expect(results).toHaveLength(3);
+  });
+});

--- a/packages/web-search/src/capabilityCheck.ts
+++ b/packages/web-search/src/capabilityCheck.ts
@@ -24,8 +24,22 @@ export function unhonorableOptions(
   // Exclusion support defaults to inclusion support; a provider states it
   // separately only when the two genuinely differ.
   const excludeSupport = capabilities.excludeDomainFilter ?? capabilities.domainFilter;
-  if (wantsDomains && capabilities.domainFilter === false) gaps.push("includeDomains");
-  if (wantsExcludes && excludeSupport === false) gaps.push("excludeDomains");
+  const includeBlocked = wantsDomains && capabilities.domainFilter === false;
+  const excludeBlocked = wantsExcludes && excludeSupport === false;
+  if (includeBlocked) gaps.push("includeDomains");
+  if (excludeBlocked) gaps.push("excludeDomains");
+  // Serving each direction alone is not serving both at once. Reported only
+  // when neither direction is already refused, so the pair does not restate a
+  // gap the caller has been told about.
+  if (
+    wantsDomains &&
+    wantsExcludes &&
+    !includeBlocked &&
+    !excludeBlocked &&
+    capabilities.exclusiveDomainDirections === true
+  ) {
+    gaps.push("includeDomains with excludeDomains");
+  }
   const range = request.dateRange;
   const wantsDates = range !== undefined && (range.start !== undefined || range.end !== undefined);
   if (wantsDates && !capabilities.dateFilter) gaps.push("dateRange");

--- a/packages/web-search/src/common.ts
+++ b/packages/web-search/src/common.ts
@@ -16,6 +16,7 @@ import { WebSearchTask } from "./WebSearchTask";
 
 export * from "./capabilityCheck";
 export * from "./IWebSearchProvider";
+export * from "./limitResults";
 export * from "./providers/BraveWebSearchProvider";
 export * from "./providers/httpSearch";
 export * from "./providers/SearxngWebSearchProvider";

--- a/packages/web-search/src/limitResults.ts
+++ b/packages/web-search/src/limitResults.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SearchResult } from "./IWebSearchProvider";
+
+/**
+ * Trims a provider's results to the caller's `maxResults`.
+ *
+ * `maxResults` is an upper bound on what comes back, and it has to mean that
+ * for every provider — a number the caller sizes a downstream prompt against is
+ * useless if one provider treats it as a search budget and another discards it.
+ *
+ * A provider whose API takes its own result limit still sends it; this is the
+ * backstop for the ones that take none, and the single place the meaning lives.
+ */
+export function limitResults(
+  results: readonly SearchResult[],
+  maxResults: number | undefined
+): SearchResult[] {
+  return maxResults === undefined ? [...results] : results.slice(0, maxResults);
+}

--- a/packages/web-search/src/providers/BraveWebSearchProvider.ts
+++ b/packages/web-search/src/providers/BraveWebSearchProvider.ts
@@ -13,6 +13,7 @@ import type {
   WebSearchRequest,
   WebSearchResponse,
 } from "../IWebSearchProvider";
+import { limitResults } from "../limitResults";
 import { fetchSearchJson } from "./httpSearch";
 
 const BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
@@ -79,6 +80,10 @@ export class BraveWebSearchProvider implements IWebSearchProvider {
       favicon: r.meta_url?.favicon,
     }));
 
-    return { results, query: request.query, usage: { requests: 1 } };
+    return {
+      results: limitResults(results, request.maxResults),
+      query: request.query,
+      usage: { requests: 1 },
+    };
   }
 }

--- a/packages/web-search/src/providers/SearxngWebSearchProvider.ts
+++ b/packages/web-search/src/providers/SearxngWebSearchProvider.ts
@@ -13,6 +13,7 @@ import type {
   WebSearchRequest,
   WebSearchResponse,
 } from "../IWebSearchProvider";
+import { limitResults } from "../limitResults";
 import { trimTrailingSlashes } from "../urlText";
 import { fetchSearchJson } from "./httpSearch";
 
@@ -95,7 +96,10 @@ export class SearxngWebSearchProvider implements IWebSearchProvider {
 
     // SearXNG returns a full page of aggregated results and honors no count
     // parameter, so the cap is applied here.
-    const results = request.maxResults === undefined ? all : all.slice(0, request.maxResults);
-    return { results, query: request.query, usage: { requests: 1 } };
+    return {
+      results: limitResults(all, request.maxResults),
+      query: request.query,
+      usage: { requests: 1 },
+    };
   }
 }

--- a/packages/web-search/src/providers/TavilyWebSearchProvider.ts
+++ b/packages/web-search/src/providers/TavilyWebSearchProvider.ts
@@ -12,6 +12,7 @@ import type {
   WebSearchRequest,
   WebSearchResponse,
 } from "../IWebSearchProvider";
+import { limitResults } from "../limitResults";
 import { fetchSearchJson } from "./httpSearch";
 
 const TAVILY_ENDPOINT = "https://api.tavily.com/search";
@@ -72,7 +73,7 @@ export class TavilyWebSearchProvider implements IWebSearchProvider {
     }));
 
     return {
-      results,
+      results: limitResults(results, request.maxResults),
       answer: request.includeAnswer === true ? payload.answer : undefined,
       query: request.query,
       usage: { requests: 1 },

--- a/providers/anthropic/src/__tests__/AnthropicWebSearchProvider.test.ts
+++ b/providers/anthropic/src/__tests__/AnthropicWebSearchProvider.test.ts
@@ -188,6 +188,14 @@ describe("AnthropicWebSearchProvider", () => {
     expect(tools[0].allowed_domains).toEqual(["arxiv.org"]);
   });
 
+  it("declares that it takes one domain direction at a time", () => {
+    // Without this, `auto` routing scores a both-lists request as servable
+    // here and the run fails on a request another provider would have served.
+    const c = new AnthropicWebSearchProvider({ client: clientReturning().client as never })
+      .capabilities;
+    expect(c.exclusiveDomainDirections).toBe(true);
+  });
+
   it("refuses to send both domain lists, which the API rejects", async () => {
     const { client } = clientReturning(messageWith([{ type: "text", text: "x" }]));
     await expect(

--- a/providers/anthropic/src/__tests__/AnthropicWebSearchProvider.test.ts
+++ b/providers/anthropic/src/__tests__/AnthropicWebSearchProvider.test.ts
@@ -135,6 +135,49 @@ describe("AnthropicWebSearchProvider", () => {
     expect(out.answer).toBe("partial and the rest.");
   });
 
+  it("does not spend maxResults as the model's search budget", async () => {
+    const { create, client } = clientReturning(messageWith([{ type: "text", text: "x" }]));
+    await new AnthropicWebSearchProvider({ client: client as never }).search(
+      { query: "compare X and Y across sources", maxResults: 2 },
+      context
+    );
+    const tools = create.mock.calls[0][0].tools as Array<Record<string, unknown>>;
+    // `max_uses` caps how many searches the model may run, and overrunning it
+    // comes back as a tool error that fails the request. A caller asking for
+    // two results is not asking for the run to fail on the third search.
+    expect(tools[0].max_uses).toBeUndefined();
+  });
+
+  it("sends max_uses only when configured as its own option", async () => {
+    const { create, client } = clientReturning(messageWith([{ type: "text", text: "x" }]));
+    await new AnthropicWebSearchProvider({ client: client as never, maxUses: 3 }).search(
+      { query: "cats", maxResults: 1 },
+      context
+    );
+    const tools = create.mock.calls[0][0].tools as Array<Record<string, unknown>>;
+    expect(tools[0].max_uses).toBe(3);
+  });
+
+  it("bounds the returned results by maxResults", async () => {
+    const { client } = clientReturning(
+      messageWith([
+        {
+          type: "web_search_tool_result",
+          content: [
+            { type: "web_search_result", title: "A", url: "https://e/a" },
+            { type: "web_search_result", title: "B", url: "https://e/b" },
+            { type: "web_search_result", title: "C", url: "https://e/c" },
+          ],
+        },
+      ])
+    );
+    const out = await new AnthropicWebSearchProvider({ client: client as never }).search(
+      { query: "cats", maxResults: 2 },
+      context
+    );
+    expect(out.results.map((r) => r.title)).toEqual(["A", "B"]);
+  });
+
   it("passes includeDomains as allowed_domains", async () => {
     const { create, client } = clientReturning(messageWith([{ type: "text", text: "x" }]));
     await new AnthropicWebSearchProvider({ client: client as never }).search(

--- a/providers/anthropic/src/web-search/AnthropicWebSearchProvider.ts
+++ b/providers/anthropic/src/web-search/AnthropicWebSearchProvider.ts
@@ -14,6 +14,7 @@ import type {
   WebSearchRequest,
   WebSearchResponse,
 } from "@workglow/web-search";
+import { limitResults } from "@workglow/web-search";
 
 /**
  * Dynamic-filtering web search, available on Opus 5/4.8/4.7/4.6 and Sonnet 5/4.6.
@@ -28,6 +29,13 @@ export interface AnthropicWebSearchOptions {
   readonly client?: Anthropic | undefined;
   readonly model?: string | undefined;
   readonly maxTokens?: number | undefined;
+  /**
+   * How many searches the model may run for one request — Anthropic's
+   * `max_uses`. A budget on the work done, not on the results returned, and
+   * exceeding it comes back as a tool error that fails the search. Left unset,
+   * the API applies its own default.
+   */
+  readonly maxUses?: number | undefined;
 }
 
 interface AnthropicSearchResultBlock {
@@ -52,16 +60,22 @@ export class AnthropicWebSearchProvider implements IWebSearchProvider {
   private readonly client: Anthropic;
   private readonly model: string;
   private readonly maxTokens: number;
+  private readonly maxUses: number | undefined;
 
   constructor(options: AnthropicWebSearchOptions = {}) {
     this.client = options.client ?? new Anthropic();
     this.model = options.model ?? DEFAULT_MODEL;
     this.maxTokens = options.maxTokens ?? 16000;
+    this.maxUses = options.maxUses;
   }
 
   async search(request: WebSearchRequest, context: IExecuteContext): Promise<WebSearchResponse> {
     const tool: Record<string, unknown> = { type: WEB_SEARCH_TOOL_TYPE, name: "web_search" };
-    if (request.maxResults !== undefined) tool.max_uses = request.maxResults;
+    // `maxResults` is not `max_uses`. It bounds the results handed back, while
+    // `max_uses` bounds the searches the model may run — and overrunning it is
+    // a tool error that fails the whole request. Mapping one onto the other
+    // turned a result-count hint into "the search worked, then failed".
+    if (this.maxUses !== undefined) tool.max_uses = this.maxUses;
 
     const includes = request.includeDomains ?? [];
     const excludes = request.excludeDomains ?? [];
@@ -105,7 +119,7 @@ export class AnthropicWebSearchProvider implements IWebSearchProvider {
 
       if (message.stop_reason !== "pause_turn") {
         return {
-          results,
+          results: limitResults(results, request.maxResults),
           // Gated on the caller asking, even though the model always produces
           // text: `answer` has to mean the same thing whichever provider routing
           // picked, and Tavily populates it only when requested. Reporting a

--- a/providers/anthropic/src/web-search/AnthropicWebSearchProvider.ts
+++ b/providers/anthropic/src/web-search/AnthropicWebSearchProvider.ts
@@ -53,6 +53,10 @@ export class AnthropicWebSearchProvider implements IWebSearchProvider {
     answer: true,
     content: false,
     domainFilter: "native",
+    // The tool takes allowed_domains or blocked_domains, never the pair — so
+    // routing has to score a both-lists request as a gap and look elsewhere,
+    // rather than land here and throw.
+    exclusiveDomainDirections: true,
     dateFilter: false,
     maxResultsCap: undefined,
   };

--- a/providers/google-gemini/src/web-search/GeminiWebSearchProvider.ts
+++ b/providers/google-gemini/src/web-search/GeminiWebSearchProvider.ts
@@ -15,6 +15,7 @@ import type {
   WebSearchRequest,
   WebSearchResponse,
 } from "@workglow/web-search";
+import { limitResults } from "@workglow/web-search";
 
 const DEFAULT_MODEL = "gemini-3.6-flash";
 /** No lower bound: `timeRangeFilter` rejects an interval with only one side set. */
@@ -123,9 +124,8 @@ export class GeminiWebSearchProvider implements IWebSearchProvider {
       });
     }
 
-    const maxResults = request.maxResults;
     return {
-      results: maxResults === undefined ? results : results.slice(0, maxResults),
+      results: limitResults(results, request.maxResults),
       answer:
         request.includeAnswer === true && typeof response.text === "string" && response.text
           ? response.text

--- a/providers/openai/src/__tests__/OpenAiWebSearchProvider.test.ts
+++ b/providers/openai/src/__tests__/OpenAiWebSearchProvider.test.ts
@@ -95,6 +95,35 @@ describe("OpenAiWebSearchProvider", () => {
     expect(out.usage).toEqual({ inputTokens: 7, outputTokens: 9 });
   });
 
+  it("bounds the returned sources by maxResults", async () => {
+    const { client } = clientReturning({
+      output: [
+        {
+          type: "message",
+          content: [
+            {
+              type: "output_text",
+              text: "…",
+              annotations: [
+                { type: "url_citation", url: "https://e/a", title: "A" },
+                { type: "url_citation", url: "https://e/b", title: "B" },
+                { type: "url_citation", url: "https://e/c", title: "C" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    // The Responses API has no result-count parameter, so a grounded turn cites
+    // as many sources as it likes; dropping the option let that flow into a
+    // downstream prompt at several times the token cost the caller sized for.
+    const out = await new OpenAiWebSearchProvider({ client }).search(
+      { query: "t", maxResults: 2 },
+      context
+    );
+    expect(out.results.map((r) => r.title)).toEqual(["A", "B"]);
+  });
+
   it("gates the answer on includeAnswer", async () => {
     const { client } = clientReturning(PAYLOAD);
     expect(

--- a/providers/openai/src/__tests__/OpenAiWebSearchProvider.test.ts
+++ b/providers/openai/src/__tests__/OpenAiWebSearchProvider.test.ts
@@ -5,7 +5,7 @@
  */
 
 import type { IExecuteContext } from "@workglow/task-graph";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OpenAiWebSearchProvider } from "../web-search/OpenAiWebSearchProvider";
 
 const context = {
@@ -127,5 +127,47 @@ describe("OpenAiWebSearchProvider", () => {
     await expect(
       new OpenAiWebSearchProvider({ client }).search({ query: "t" }, context)
     ).rejects.toThrow(/no output array/);
+  });
+});
+
+/** Reaches the lazily-built client so a test can read the key it was given. */
+interface ClientPeek {
+  getClient(): { apiKey?: string };
+}
+
+describe("OpenAiWebSearchProvider key resolution", () => {
+  let savedOpenAi: string | undefined;
+
+  beforeEach(() => {
+    savedOpenAi = process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (savedOpenAi === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = savedOpenAi;
+    vi.restoreAllMocks();
+  });
+
+  it("constructs without a key, so registration cannot throw out of the vendor SDK", () => {
+    delete process.env.OPENAI_API_KEY;
+    expect(() => new OpenAiWebSearchProvider()).not.toThrow();
+  });
+
+  it("reports a missing key through this repo's named error, not the SDK's", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(new OpenAiWebSearchProvider().search({ query: "t" }, context)).rejects.toThrow(
+      /OPENAI_API_KEY/
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("prefers an explicitly passed apiKey over the environment", () => {
+    process.env.OPENAI_API_KEY = "sk-proj-from-env";
+
+    const provider = new OpenAiWebSearchProvider({ apiKey: "sk-proj-explicit" });
+
+    expect((provider as unknown as ClientPeek).getClient().apiKey).toBe("sk-proj-explicit");
   });
 });

--- a/providers/openai/src/web-search/OpenAiWebSearchProvider.ts
+++ b/providers/openai/src/web-search/OpenAiWebSearchProvider.ts
@@ -14,6 +14,7 @@ import type {
   WebSearchRequest,
   WebSearchResponse,
 } from "@workglow/web-search";
+import { limitResults } from "@workglow/web-search";
 import OpenAI from "openai";
 
 const DEFAULT_MODEL = "gpt-5.5";
@@ -129,7 +130,10 @@ export class OpenAiWebSearchProvider implements IWebSearchProvider {
     }
 
     return {
-      results,
+      // The Responses API takes no result limit of its own — a grounded turn
+      // can cite fifteen sources for a caller who asked for three — so the
+      // bound is applied here rather than dropped.
+      results: limitResults(results, request.maxResults),
       answer:
         request.includeAnswer === true && answerParts.length > 0 ? answerParts.join("") : undefined,
       query: request.query,

--- a/providers/openai/src/web-search/OpenAiWebSearchProvider.ts
+++ b/providers/openai/src/web-search/OpenAiWebSearchProvider.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { resolveApiKey } from "@workglow/ai/provider-utils";
 import type { IExecuteContext } from "@workglow/task-graph";
 import { TaskFailedError } from "@workglow/task-graph";
 import type {
@@ -46,18 +47,37 @@ export class OpenAiWebSearchProvider implements IWebSearchProvider {
     maxResultsCap: undefined,
   };
 
-  private readonly client: OpenAI;
+  private client: OpenAI | undefined;
+  private readonly apiKey: string | undefined;
   private readonly model: string;
   private readonly searchContextSize: "low" | "medium" | "high" | undefined;
 
   constructor(options: OpenAiWebSearchOptions = {}) {
-    this.client = options.client ?? new OpenAI({ apiKey: options.apiKey });
+    this.client = options.client;
+    this.apiKey = options.apiKey;
     this.model = options.model ?? DEFAULT_MODEL;
     this.searchContextSize = options.searchContextSize;
   }
 
+  /**
+   * Built on first search, not in the constructor, so registering the provider
+   * cannot throw out of the vendor SDK on a machine that has no key yet, and a
+   * missing key reports through this repo's named error rather than the SDK's.
+   */
+  private getClient(): OpenAI {
+    this.client ??= new OpenAI({
+      apiKey: resolveApiKey({
+        config: { api_key: this.apiKey },
+        envVar: "OPENAI_API_KEY",
+        providerLabel: "OpenAI",
+      }),
+    });
+    return this.client;
+  }
+
   async search(request: WebSearchRequest, context: IExecuteContext): Promise<WebSearchResponse> {
     context.signal.throwIfAborted();
+    const client = this.getClient();
 
     const tool: Record<string, unknown> = { type: "web_search" };
     if (this.searchContextSize !== undefined) tool.search_context_size = this.searchContextSize;
@@ -65,7 +85,7 @@ export class OpenAiWebSearchProvider implements IWebSearchProvider {
       tool.filters = { allowed_domains: [...request.includeDomains] };
     }
 
-    const response = (await this.client.responses.create({
+    const response = (await client.responses.create({
       model: this.model,
       input: request.query,
       tools: [tool] as never,

--- a/providers/openrouter/src/__tests__/OpenRouterWebSearchProvider.test.ts
+++ b/providers/openrouter/src/__tests__/OpenRouterWebSearchProvider.test.ts
@@ -5,7 +5,7 @@
  */
 
 import type { IExecuteContext } from "@workglow/task-graph";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OpenRouterWebSearchProvider } from "../web-search/OpenRouterWebSearchProvider";
 
 const context = {
@@ -118,5 +118,69 @@ describe("OpenRouterWebSearchProvider", () => {
     await expect(
       new OpenRouterWebSearchProvider({ client }).search({ query: "t" }, context)
     ).rejects.toThrow(/no choices/);
+  });
+});
+
+/** Reaches the lazily-built client so a test can read the key it was given. */
+interface ClientPeek {
+  getClient(): { apiKey?: string; baseURL?: string };
+}
+
+describe("OpenRouterWebSearchProvider key resolution", () => {
+  const OPENAI_SECRET = "sk-proj-a-live-openai-secret";
+  let savedOpenRouter: string | undefined;
+  let savedOpenAi: string | undefined;
+
+  beforeEach(() => {
+    savedOpenRouter = process.env.OPENROUTER_API_KEY;
+    savedOpenAi = process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (savedOpenRouter === undefined) delete process.env.OPENROUTER_API_KEY;
+    else process.env.OPENROUTER_API_KEY = savedOpenRouter;
+    if (savedOpenAi === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = savedOpenAi;
+    vi.restoreAllMocks();
+  });
+
+  it("constructs without a key, so registration cannot throw out of the vendor SDK", () => {
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    expect(() => new OpenRouterWebSearchProvider()).not.toThrow();
+  });
+
+  it("refuses the search rather than spending OPENAI_API_KEY on openrouter.ai", async () => {
+    delete process.env.OPENROUTER_API_KEY;
+    process.env.OPENAI_API_KEY = OPENAI_SECRET;
+    // Nothing may reach the network: the OpenAI SDK's own destructuring default
+    // reads OPENAI_API_KEY, so a request built at all is a request that carries
+    // a live OpenAI secret to a third-party host.
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const search = new OpenRouterWebSearchProvider().search({ query: "cats" }, context);
+
+    await expect(search).rejects.toThrow(/OPENROUTER_API_KEY/);
+    await expect(search).rejects.not.toThrow(new RegExp(OPENAI_SECRET));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("builds the client from OPENROUTER_API_KEY even with OPENAI_API_KEY present", () => {
+    process.env.OPENAI_API_KEY = OPENAI_SECRET;
+    process.env.OPENROUTER_API_KEY = "sk-or-v1-the-openrouter-key";
+
+    const client = (new OpenRouterWebSearchProvider() as unknown as ClientPeek).getClient();
+
+    expect(client.apiKey).toBe("sk-or-v1-the-openrouter-key");
+    expect(client.baseURL).toContain("openrouter.ai");
+  });
+
+  it("prefers an explicitly passed apiKey over the environment", () => {
+    process.env.OPENROUTER_API_KEY = "sk-or-v1-from-env";
+
+    const provider = new OpenRouterWebSearchProvider({ apiKey: "sk-or-v1-explicit" });
+    const client = (provider as unknown as ClientPeek).getClient();
+
+    expect(client.apiKey).toBe("sk-or-v1-explicit");
   });
 });

--- a/providers/openrouter/src/web-search/OpenRouterWebSearchProvider.ts
+++ b/providers/openrouter/src/web-search/OpenRouterWebSearchProvider.ts
@@ -14,6 +14,7 @@ import type {
   WebSearchRequest,
   WebSearchResponse,
 } from "@workglow/web-search";
+import { limitResults } from "@workglow/web-search";
 import OpenAI from "openai";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
@@ -126,7 +127,7 @@ export class OpenRouterWebSearchProvider implements IWebSearchProvider {
     }
 
     return {
-      results,
+      results: limitResults(results, request.maxResults),
       answer:
         request.includeAnswer === true && typeof message.content === "string" && message.content
           ? message.content

--- a/providers/openrouter/src/web-search/OpenRouterWebSearchProvider.ts
+++ b/providers/openrouter/src/web-search/OpenRouterWebSearchProvider.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { resolveApiKey } from "@workglow/ai/provider-utils";
 import type { IExecuteContext } from "@workglow/task-graph";
 import { TaskFailedError } from "@workglow/task-graph";
 import type {
@@ -48,23 +49,42 @@ export class OpenRouterWebSearchProvider implements IWebSearchProvider {
     maxResultsCap: undefined,
   };
 
-  private readonly client: OpenAI;
+  private client: OpenAI | undefined;
+  private readonly apiKey: string | undefined;
   private readonly model: string;
   private readonly engine: string | undefined;
 
   constructor(options: OpenRouterWebSearchOptions = {}) {
-    this.client =
-      options.client ??
-      new OpenAI({
-        apiKey: options.apiKey ?? process.env.OPENROUTER_API_KEY,
-        baseURL: OPENROUTER_BASE_URL,
-      });
+    this.client = options.client;
+    this.apiKey = options.apiKey;
     this.model = options.model ?? DEFAULT_MODEL;
     this.engine = options.engine;
   }
 
+  /**
+   * Built on first search, not in the constructor, so registering the provider
+   * cannot throw out of the vendor SDK on a machine that has no key yet.
+   *
+   * The key is resolved explicitly through {@link resolveApiKey} and passed as a
+   * string. Handing the SDK `undefined` fires its own destructuring default,
+   * which reads `OPENAI_API_KEY` — sending a live OpenAI secret to a third-party
+   * host, with nothing in the code or the error path naming which key went.
+   */
+  private getClient(): OpenAI {
+    this.client ??= new OpenAI({
+      apiKey: resolveApiKey({
+        config: { api_key: this.apiKey },
+        envVar: "OPENROUTER_API_KEY",
+        providerLabel: "OpenRouter",
+      }),
+      baseURL: OPENROUTER_BASE_URL,
+    });
+    return this.client;
+  }
+
   async search(request: WebSearchRequest, context: IExecuteContext): Promise<WebSearchResponse> {
     context.signal.throwIfAborted();
+    const client = this.getClient();
 
     const plugin: Record<string, unknown> = { id: "web" };
     if (this.engine !== undefined) plugin.engine = this.engine;
@@ -72,7 +92,7 @@ export class OpenRouterWebSearchProvider implements IWebSearchProvider {
     if (request.includeDomains?.length) plugin.include_domains = [...request.includeDomains];
     if (request.excludeDomains?.length) plugin.exclude_domains = [...request.excludeDomains];
 
-    const completion = (await this.client.chat.completions.create({
+    const completion = (await client.chat.completions.create({
       model: this.model,
       messages: [{ role: "user", content: request.query }],
       // `plugins` is an OpenRouter extension the OpenAI types do not model.


### PR DESCRIPTION
Stacked on **#850** (`claude/websearch-task-providers-8aik77`) — this PR targets that branch, not `main`.

Four verified review findings on #850, one commit each.

## 1. `credential_key` was resolved twice, so every keyed provider sent its request unauthenticated

`WebSearchTask` declared `credential_key` with `format: "credential"`, so `TaskRunner.resolveSchemas()` rewrote the port to the **secret** before `execute()` ran. `execute()` then forwarded that secret as the owned `FetchUrlTask`'s `credential_key`, and the child's own runner resolved it a second time — looking the secret up as if it were a store key. The store missed, the resolver deliberately returns `undefined` rather than echoing its input, and `streamResolved` saw no credential: `sensitiveHeaders` stayed `undefined` and `applyCredentialToHeaders` added nothing. The README's own Tavily example went out with no `Authorization` header; Brave the same with `X-Subscription-Token`.

The port now carries `format: "credential-key"`, which no input resolver claims, so the key name reaches `execute()` intact and the owned `FetchUrlTask` performs the single resolution. `GraphFormatScanner` counts both formats, so an encrypted store is still unlocked for the run.

Every provider test stubs `context.own()` with a fake object, which is why this shipped — the only test running a real `FetchUrlTask` was the keyless SearXNG integration test. The new test drives the real child task against a real `InMemoryCredentialStore` with `SafeFetch` mocked and asserts the header arrives.

## 2. `OpenRouterWebSearchProvider` could send the caller's `OPENAI_API_KEY` to openrouter.ai

`new OpenAI({ apiKey: options.apiKey ?? process.env.OPENROUTER_API_KEY })` passes `undefined` when neither is set, firing the SDK's own destructuring default (`readEnv('OPENAI_API_KEY') ?? null` in `openai@7`) — so the client authenticated with a live OpenAI secret against a third-party host, with nothing naming which key went.

Both OpenRouter and the sibling OpenAI provider now resolve through `resolveApiKey()`, the repo's single fallback chain, which throws a named error instead. The client is built lazily on first `search()`, so registration cannot throw out of a vendor SDK on a machine with no key yet.

## 3. Anthropic mapped `maxResults` onto `max_uses`, turning a result-count hint into a run failure

`max_uses` bounds how many searches the *model* may run; overrunning it returns a `web_search_tool_result` error block at HTTP 200 that `collect()` turns into a thrown `TaskFailedError`. `{ maxResults: 2 }` on a query needing three searches failed a search that was working. OpenAI had the opposite problem — it never read `maxResults` at all.

`max_uses` is now its own constructor option (`maxUses`), and the bound on results is applied in one shared `limitResults()` helper every provider returns through. API-native limits are still sent; this is the backstop for the APIs that have none.

## 4. `auto` routing could pick Anthropic for a both-domain-lists request it then refuses

The adapter throws when `includeDomains` and `excludeDomains` are both non-empty, but the capability record could not say so — `unhonorableOptions()` found no gap and `route()` returned it, failing a run that a `tavily` registered right behind it serves natively. That is the failure `excludeDomainFilter` was added to prevent, one axis over.

`exclusiveDomainDirections` is the missing axis. It scores as a gap only when both lists are asked for and neither direction is already refused outright, so routing skips such a provider for the pair while still choosing it for either list alone.

## Verification

```
bun run format
  eslint --fix clean; prettier: "All matched files use Prettier code style!"
  git status clean afterwards — nothing needed reformatting

vitest --project web-search --project anthropic --project openai \
       --project openrouter --project google-gemini
  Test Files  17 passed (17)
  Tests      143 passed (143)

bun run build:types
  Tasks: 43 successful, 43 total

bun scripts/test.ts task-graph graph vitest
  Test Files  158 passed (158)
  Tests     1502 passed (1502)
```

Each commit's tree was tested on its own before being committed, not just the tip.

Finding 1's test was confirmed to fail without the fix: reverting the port to `format: "credential"` turns 4 of its 7 cases red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sit7PHmkEw5t3TpesT5g7s


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sit7PHmkEw5t3TpesT5g7s)_