### PR TITLE
Give a streaming subgraph the run's resource scope

### DIFF
--- a/packages/task-graph/src/task/GraphAsTask.ts
+++ b/packages/task-graph/src/task/GraphAsTask.ts
@@ -281,7 +281,7 @@ export class GraphAsTask<
         .run<Output>(input, {
           parentSignal: context.signal,
           accumulateLeafOutputs: false,
-          registry: this.runner["registry"],
+          ...this.runner.subGraphRunContext,
           enforceEntitlements: this.runConfig?.enforceEntitlements,
           ...this.runner.streamRunOptions,
         })

--- a/packages/task-graph/src/task/GraphAsTaskRunner.ts
+++ b/packages/task-graph/src/task/GraphAsTaskRunner.ts
@@ -46,8 +46,9 @@ export class GraphAsTaskRunner<
       return await this.task.subGraph!.run<Output>(input, {
         parentSignal: this.currentCtx?.abortController.signal,
         outputCache: this.outputCache,
-        registry: this.registry,
-        resourceScope: this.resourceScope,
+        // Same accessor `GraphAsTask.executeStream` reads, so the streaming and
+        // non-streaming paths cannot hand a subgraph different run-scoped state.
+        ...this.subGraphRunContext,
         enforceEntitlements: this.task.runConfig?.enforceEntitlements,
         ...this.streamRunOptions,
       });

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -178,6 +178,27 @@ export class TaskRunner<
   protected resourceScope?: ResourceScope;
 
   /**
+   * The run-scoped context a compound task must hand to a subgraph it runs
+   * itself, rather than letting that subgraph resolve its own.
+   *
+   * Both halves are `protected`, and both are needed off the runner by
+   * {@link GraphAsTask.executeStream}, which runs the subgraph from the TASK
+   * rather than from a runner subclass. Exposed as one accessor so the
+   * streaming path and {@link GraphAsTaskRunner}'s non-streaming path cannot
+   * hand a subgraph different things: a subgraph resolving its own registry
+   * misses a caller's cache overrides, and one minting its own
+   * {@link ResourceScope} owns it — so a cache checkpoint created inside a
+   * streaming group is disposed when that group ends instead of with the run,
+   * and is invisible to every sibling that should have shared it.
+   */
+  public get subGraphRunContext(): {
+    registry: ServiceRegistry;
+    resourceScope: ResourceScope | undefined;
+  } {
+    return { registry: this.registry, resourceScope: this.resourceScope };
+  }
+
+  /**
    * Where a charge that settles after this run finished is reported. Not
    * cleared in `run()`'s `finally` — the whole point is that it fires after
    * the run. It is instead replaced by every `handleStart`, supplied or not:
@@ -1033,9 +1054,11 @@ export class TaskRunner<
    *
    * `lateUsageSink` rides here rather than being threaded per call site
    * because every nested-run site already spreads this — including
-   * `GraphAsTask.executeStream`, which threads neither `registry` nor
-   * `resourceScope` and would otherwise leave a streaming subgraph's late
-   * charge in an inner aggregator the root run never reads.
+   * `GraphAsTask.executeStream`, which would otherwise leave a streaming
+   * subgraph's late charge in an inner aggregator the root run never reads.
+   * (That site takes `registry` and `resourceScope` from
+   * {@link subGraphRunContext} and passes `enforceEntitlements` alongside it;
+   * those are the run-scoped state a subgraph must not resolve for itself.)
    */
   public get streamRunOptions(): Pick<
     IRunConfig,


### PR DESCRIPTION
## The fix

`GraphAsTask.executeStream` runs its subgraph from the **task** rather than from a runner subclass, and threaded `registry` but not `resourceScope`. So a streaming subgraph minted and owned its own scope where the non-streaming `GraphAsTaskRunner` path shares the run's.

The consequence is a cache checkpoint created inside a streaming group being disposed when that group ends rather than with the run — invisible to every sibling that should have shared it. The same graph, run without streaming, behaves correctly. `CacheCheckpointTask`'s documented contract is that checkpoints are run-scoped and disposed with the run's `ResourceScope`, so the streaming path was quietly not honouring it.

Both members are `protected` on `TaskRunner`, and the streaming path reached one of them through `this.runner["registry"]`. They become one `subGraphRunContext` accessor that both paths spread, so neither can hand a subgraph something the other does not.

`streamRunOptions`' JSDoc asserted that `executeStream` "threads neither `registry` nor `resourceScope`", which this change makes half-false — it now points at the accessor instead.

## Rebased onto main

Main has since landed entitlement enforcement in `TaskRunner.ts` — the same file. The two are complementary and now sit side by side: `GraphAsTask.executeStream` and `GraphAsTaskRunner` each spread `subGraphRunContext`, then `enforceEntitlements`, then `streamRunOptions`, so the two paths remain structurally identical, which is the property this accessor exists to hold.

That did make one sentence of the new JSDoc wrong — it called `subGraphRunContext` the only other run-scoped state threaded per call site, and `enforceEntitlements` is now threaded the same way. Corrected in place.

## Verification

Found by review, which could only syntax-check it (no `node_modules` in the checkout). Verified since, on the rebased head:

- `build:types` — 42 of 42 packages pass
- 237 test files across `task-graph`, `task` and `graph` — 2,773 pass, 24 skipped, 0 fail

An earlier revision of this description noted a pre-existing `FileGrepTask` failure seen before the rebase; it does not reproduce on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DfMupAJi2gq9PjcaQJnhs