### PR TITLE
ci: run ESLint in CI, behind a cached turbo task

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,6 +19,7 @@ bun run test:bun           # Bun native tests only
 bun run test:vitest        # Vitest tests only
 bun test <testfilename>    # One test file
 
+bun run lint               # ESLint across every workspace (Turbo-cached); CI runs this
 bun run format             # ESLint fix + Prettier write
 bun run clean              # Remove dist, node_modules, .turbo, tsbuildinfo
 ```

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,27 @@ jobs:
       - name: Test discovery guard
         run: bun scripts/test.ts --check-sections
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun i
+      # The only thing that runs ESLint under CI. `prepare` skips husky when $CI
+      # is set, so the pre-commit hook -- which `--no-verify` bypasses anyway --
+      # is otherwise ESLint's sole invoker, and the `error`-level rules in
+      # eslint.config.js can never fail a build.
+      #
+      # Deliberately not `needs: build`: the config sets no `parserOptions.project`,
+      # so no rule reads type information and nothing has to be compiled first.
+      - name: Lint
+        run: bun run lint
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,48 @@ import regexpPlugin from "eslint-plugin-regexp";
 import { defineConfig } from "eslint/config";
 import globals from "globals";
 
+// Main-thread-only state from `@workglow/util`. A worker bundle evaluates these
+// modules against its own `globalServiceRegistry`, so the import resolves to a
+// different, empty registry at runtime.
+const WORKER_MAIN_THREAD_STATE_PATHS = [
+  {
+    name: "@workglow/util",
+    importNames: ["globalServiceRegistry", "getGlobalCredentialStore", "setGlobalCredentialStore"],
+    message:
+      "Main-thread-only state is unavailable in workers. Resolve it in the task class (e.g. AiTask.getJobInput()) and pass it through the serialized job input.",
+  },
+  {
+    name: "@workglow/util/worker",
+    importNames: ["globalServiceRegistry"],
+    message:
+      "Main-thread-only state is unavailable in workers. Resolve it in the task class (e.g. AiTask.getJobInput()) and pass it through the serialized job input.",
+  },
+];
+
+// Effort helpers that resolve identically from `@workglow/ai/worker`, which is
+// what keeps the 50+ task classes out of a worker bundle. `allowTypeImports`
+// keeps `import type { ModelEffort } from "@workglow/ai"` legal, which matters
+// because those types sit beside every one of these value imports.
+const AI_BARREL_EFFORT_PATHS = [
+  {
+    name: "@workglow/ai",
+    importNames: [
+      "MODEL_EFFORTS",
+      "isModelEffort",
+      "sanitizeEffortOptions",
+      "readEffortOptions",
+      "stampEffortOptions",
+      "enabledEffortsForModel",
+      "effortPlaceholder",
+    ],
+    allowTypeImports: true,
+    message:
+      "Import effort helpers from @workglow/ai/worker. The root barrel " +
+      "pulls all task classes and a second copy of AiProviderRegistry / " +
+      "CheckpointRegistry into the worker bundle.",
+  },
+];
+
 export default defineConfig(
   {
     ignores: ["**/dist", "**/storybook-static", "**/node_modules"],
@@ -65,76 +107,35 @@ export default defineConfig(
     },
   },
   {
+    // Provider `src/ai/common/**` files are re-exported from each provider's
+    // `runtime.ts`, so they are evaluated inside worker bundles.
+    //
+    // Restricted by NAME rather than by path: several files in this directory
+    // legitimately import error classes and task types the worker barrel does
+    // not re-export yet, and a path-wide restriction would only buy a wall of
+    // eslint-disable comments.
+    files: ["providers/*/src/ai/common/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": ["error", { paths: AI_BARREL_EFFORT_PATHS }],
+    },
+  },
+  {
     // `*_JobRunFns.ts` files execute inside workers, which have an isolated
     // runtime with their own `globalServiceRegistry`. Importing main-thread-only
     // state (the global service registry or credential stores) resolves against a
     // different, empty registry at runtime. Resolve such state in the task class on
     // the main thread and pass it through the serialized job input instead.
+    //
+    // Must stay AFTER the `src/ai/common/**` block and repeat its paths: every
+    // run-fn in the repo also lives in that directory, and a later block REPLACES
+    // a rule's options rather than merging them. Spelling this as the base
+    // `no-restricted-imports` while the block above turned that rule off is what
+    // silently disabled this restriction on every file it was written to guard.
     files: ["**/*_JobRunFns.ts"],
     rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          paths: [
-            {
-              name: "@workglow/util",
-              importNames: [
-                "globalServiceRegistry",
-                "getGlobalCredentialStore",
-                "setGlobalCredentialStore",
-              ],
-              message:
-                "Main-thread-only state is unavailable in workers. Resolve it in the task class (e.g. AiTask.getJobInput()) and pass it through the serialized job input.",
-            },
-            {
-              name: "@workglow/util/worker",
-              importNames: ["globalServiceRegistry"],
-              message:
-                "Main-thread-only state is unavailable in workers. Resolve it in the task class (e.g. AiTask.getJobInput()) and pass it through the serialized job input.",
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
-    // Provider `src/ai/common/**` files are re-exported from each provider's
-    // `runtime.ts`, so they are evaluated inside worker bundles.
-    // `@workglow/ai/worker` exists to keep the 50+ task classes out of those
-    // bundles; the effort helpers below resolve identically from it.
-    //
-    // Restricted by NAME rather than by path: several files in this directory
-    // legitimately import error classes and task types the worker barrel does
-    // not re-export yet, and a path-wide restriction would only buy a wall of
-    // eslint-disable comments. `allowTypeImports` keeps `import type
-    // { ModelEffort } from "@workglow/ai"` legal, which matters because those
-    // types sit beside every one of these value imports.
-    files: ["providers/*/src/ai/common/**/*.ts"],
-    rules: {
-      "no-restricted-imports": "off",
       "@typescript-eslint/no-restricted-imports": [
         "error",
-        {
-          paths: [
-            {
-              name: "@workglow/ai",
-              importNames: [
-                "MODEL_EFFORTS",
-                "isModelEffort",
-                "sanitizeEffortOptions",
-                "readEffortOptions",
-                "stampEffortOptions",
-                "enabledEffortsForModel",
-                "effortPlaceholder",
-              ],
-              allowTypeImports: true,
-              message:
-                "Import effort helpers from @workglow/ai/worker. The root barrel " +
-                "pulls all task classes and a second copy of AiProviderRegistry / " +
-                "CheckpointRegistry into the worker bundle.",
-            },
-          ],
-        },
+        { paths: [...WORKER_MAIN_THREAD_STATE_PATHS, ...AI_BARREL_EFFORT_PATHS] },
       ],
     },
   }

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -23,6 +23,7 @@
     "build-js-worker-hft": "bun build --target=node --packages=external --outdir ./dist ./src/worker_hft.ts",
     "build-lib": "bun build --target=bun --packages=external --outdir ./dist ./src/lib.ts",
     "build-types": "rm -f tsconfig.tsbuildinfo && tsgo",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "vitest run --config ../../vitest.config.ts --project cli",
     "test:watch": "vitest",
     "build-web": "bun build --target=browser --minify --outdir ./dist/web ./src/web/client/main.tsx && cp src/web/client/index.html src/web/client/app.css dist/web/"

--- a/examples/eval/package.json
+++ b/examples/eval/package.json
@@ -21,6 +21,7 @@
     "build-js": "bun build --target=bun --packages=external --outdir ./dist ./src/workglow-eval.ts",
     "build-js-worker-hft": "bun build --target=node --packages=external --outdir ./dist ./src/worker_hft.ts",
     "build-types": "rm -f tsconfig.tsbuildinfo && tsgo",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "vitest run --config ../../vitest.config.ts --project eval",
     "test:watch": "vitest",
     "build-js-worker-llamacpp": "bun build --target=node --packages=external --outdir ./dist ./src/worker_llamacpp.ts"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "clean": "rm -rf node_modules packages/*/node_modules packages/*/*tsbuildinfo packages/*/dist packages/*/src/**/*\\.d\\.ts packages/*/src/**/*\\.map integrations/*/node_modules integrations/*/dist integrations/*/src/**/*\\.d\\.ts integrations/*/src/**/*\\.map examples/*/node_modules examples/*/dist examples/*/src/**/*\\.d\\.ts examples/*/src/**/*\\.map .turbo */*/.turbo",
     "dev": "turbo run dev --concurrency=15",
     "docs": "typedoc",
+    "lint": "turbo run lint --concurrency=15",
     "format": "eslint --fix && prettier \"{packages,providers,examples}/*/src/**/*.{js,ts,tsx,json}\" --check --write",
     "build:release": "turbo run build-js build-types --concurrency=15",
     "test": "bun scripts/test.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -63,6 +63,15 @@
         "dist/**/*.js.map"
       ]
     },
+    "lint": {
+      "inputs": [
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "package.json",
+        "$TURBO_ROOT$/eslint.config.js"
+      ],
+      "outputs": []
+    },
     "test": {
       "dependsOn": [
         "build-types",


### PR DESCRIPTION
Closes #857.

## The gap

`.github/workflows/` ran no lint step, so the 40 per-package `lint` scripts had no caller: `turbo.json` declared no `lint` task, the root `package.json` no `lint` script, and `prepare` skips husky under `$CI` — leaving the pre-commit hook, which `--no-verify` bypasses, as ESLint's only invoker.

## Commit 1 — wire ESLint into CI

- **`turbo.json`** — a `lint` task with `outputs: []` and `$TURBO_ROOT$/eslint.config.js` as an input. No `dependsOn`: the config sets no `parserOptions.project`, so no rule reads type information and nothing needs building first. Without the config in `inputs`, a rule change would replay a stale pass.
- **root `package.json`** — `"lint": "turbo run lint --concurrency=15"`.
- **`.github/workflows/test.yml`** — a `lint` job shaped like `test-discovery` and likewise independent of `build`.
- **`examples/cli` and `examples/eval`** were the only two of 42 workspaces without a `lint` script. A root eslint run already covered their 187 files, but a turbo fan-out would have skipped them silently, so both now carry the same script as the other 40.

## Commit 2 — a rule that could never have fired

While checking the new job had teeth, the worker-boundary `no-restricted-imports` rule — the one #857 names as added *after* a real violation reached main — turned out to resolve to **severity 0 on all 15 `_JobRunFns.ts` files**, i.e. every file it exists to guard. A later block matching `providers/*/src/ai/common/**` sets that base rule to `"off"` (it needs the `@typescript-eslint` extension rule for a different restriction), and every run-fn lives under that directory. Importing `globalServiceRegistry` into a run-fn linted clean.

Both blocks now spell the restriction with the `@typescript-eslint` extension rule, with the run-fn block placed last and carrying both path sets — flat config *replaces* a rule's options rather than merging them, so the more specific block has to restate what it still wants. The two path lists are lifted to named consts to keep that restatement one line.

This is in scope rather than a drive-by: landing the CI job without it would have shipped a lint gate that provably could not catch the violation it was written for.

## Verification

| Check | Result |
| --- | --- |
| Cold-cache `bun run lint` | 42/42 tasks pass, ~54s on 4 cores |
| Warm cache | `FULL TURBO`, 71ms |
| Cache granularity | one source edit invalidates exactly one package |
| `eslint.config.js` content change | invalidates all 42 (stale-pass guard works) |
| `consistent-type-imports` violation | exit 1 |
| worker-boundary violation | exit 1 (**exit 0 before commit 2**) |
| ai-barrel effort-helper violation | exit 1 |
| Rule scoping after fix | `error` + all 3 paths on all 15 run-fns; non-run-fn `ai/common` files keep the `@workglow/ai` restriction alone; ordinary files unaffected |

## Note

The 40 existing `lint` scripts pass `--ext ts,tsx`, which ESLint 10 tolerates but ignores under flat config (confirmed it restricts nothing — `packages/util` lints the same 146 files either way). Left alone and matched in the two new scripts, rather than touching 40 files outside this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfCFDgy5phprZzjF45Nmjm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfCFDgy5phprZzjF45Nmjm)_