### PR TITLE
fix(ai): make the effort policies a gate rather than UI metadata

### DIFF
--- a/packages/ai/src/model/ModelEffort.ts
+++ b/packages/ai/src/model/ModelEffort.ts
@@ -55,20 +55,95 @@ export function enabledEffortsForModel(
 }
 
 /**
- * Whether `model.effort` should be mapped onto a provider request. Native
- * `provider_config` knobs always win separately; this only gates the coarse dial.
+ * Resolves the effort to map onto a provider request, or `undefined` when the
+ * coarse dial does not apply. Returning the value rather than a boolean is what
+ * lets a call site use it without re-asserting the type. Native
+ * `provider_config` knobs always win separately; this only gates the dial.
  */
-export function isModelEffortEnabled(
+export function resolveEnabledEffort(
   model: object | undefined,
   policy: ModelEffortPolicy | undefined
-): boolean {
-  if (model === undefined) return false;
+): ModelEffort | undefined {
+  if (model === undefined) return undefined;
   const effort = (model as { effort?: unknown }).effort;
-  if (!isModelEffort(effort)) return false;
+  if (!isModelEffort(effort)) return undefined;
   const enabled = enabledEffortsForModel(model, policy);
-  return enabled === undefined || enabled.includes(effort);
+  if (enabled !== undefined && !enabled.includes(effort)) return undefined;
+  return effort;
 }
 
 export function effortPlaceholder(policy: ModelEffortPolicy | undefined): string {
   return policy?.default !== undefined ? `Default: ${policy.default}` : "Default";
+}
+
+/** Every level, no class default — the shape a provider uses to say "unrestricted". */
+export const EFFORT_POLICY_ALL = {
+  supported: MODEL_EFFORTS,
+  default: undefined,
+} as const satisfies ModelEffortPolicy;
+
+/** No level at all — the model does not take a reasoning dial. */
+export const EFFORT_POLICY_NONE = {
+  supported: [],
+  default: undefined,
+} as const satisfies ModelEffortPolicy;
+
+/** Reads the provider-side model id a policy matches on. Empty when unset. */
+export function readModelName(model: object | undefined): string {
+  const config = (model as { provider_config?: { model_name?: unknown } } | undefined)
+    ?.provider_config;
+  return String(config?.model_name ?? "").trim();
+}
+
+/** Matches a provider model id. A function covers what a regex cannot express. */
+export type EffortIdMatcher = RegExp | ((id: string) => boolean);
+
+export interface EffortPolicyRule {
+  readonly when: EffortIdMatcher | readonly EffortIdMatcher[];
+  readonly policy: ModelEffortPolicy;
+}
+
+export interface EffortPolicySpec {
+  /** Evaluated in order; the first rule whose matcher accepts the id wins. */
+  readonly rules: readonly EffortPolicyRule[];
+  /**
+   * Used for an id no rule matched **and** for a model carrying no id at all.
+   * One answer for both on purpose: a policy that reads an absent id as
+   * permissive and an unrecognized one as restrictive is stating two different
+   * things about the same amount of knowledge.
+   */
+  readonly fallback: ModelEffortPolicy;
+}
+
+export type ModelEffortPolicyFn = (model: object | undefined) => ModelEffortPolicy;
+
+function matches(matcher: EffortIdMatcher, id: string): boolean {
+  return typeof matcher === "function" ? matcher(id) : matcher.test(id);
+}
+
+function toMatchers(
+  when: EffortIdMatcher | readonly EffortIdMatcher[]
+): readonly EffortIdMatcher[] {
+  return when instanceof RegExp || typeof when === "function" ? [when] : when;
+}
+
+/**
+ * Builds a provider's class-level effort policy from id matchers. Every
+ * provider answers the same question — "does this model id take the coarse
+ * dial, and what is its default?" — so only the matchers belong to the
+ * provider; the lookup, the id read and the fallback rule do not.
+ */
+export function makeEffortPolicy(spec: EffortPolicySpec): ModelEffortPolicyFn {
+  const rules = spec.rules.map((rule) => ({
+    matchers: toMatchers(rule.when),
+    policy: rule.policy,
+  }));
+  return (model: object | undefined): ModelEffortPolicy => {
+    const id = readModelName(model);
+    if (id.length === 0) return spec.fallback;
+    for (const rule of rules) {
+      if (rule.matchers.some((matcher) => matches(matcher, id))) return rule.policy;
+    }
+    return spec.fallback;
+  };
 }

--- a/packages/ai/src/model/ModelSchema.ts
+++ b/packages/ai/src/model/ModelSchema.ts
@@ -8,16 +8,27 @@ import type { DataPortSchemaObject } from "@workglow/util/worker";
 import type { ModelEffort } from "./ModelEffort";
 
 export {
+  EFFORT_POLICY_ALL,
+  EFFORT_POLICY_NONE,
   effortPlaceholder,
   enabledEffortsForModel,
   isModelEffort,
-  isModelEffortEnabled,
+  makeEffortPolicy,
   MODEL_EFFORTS,
   readEffortOptions,
+  readModelName,
+  resolveEnabledEffort,
   sanitizeEffortOptions,
   stampEffortOptions,
 } from "./ModelEffort";
-export type { ModelEffort, ModelEffortPolicy } from "./ModelEffort";
+export type {
+  EffortIdMatcher,
+  EffortPolicyRule,
+  EffortPolicySpec,
+  ModelEffort,
+  ModelEffortPolicy,
+  ModelEffortPolicyFn,
+} from "./ModelEffort";
 
 /**
  * A model configuration suitable for task/job inputs.

--- a/packages/ai/src/model/__tests__/ModelEffort.test.ts
+++ b/packages/ai/src/model/__tests__/ModelEffort.test.ts
@@ -5,13 +5,18 @@
  */
 
 import { describe, expect, it } from "vitest";
+import type { ModelEffort } from "../ModelEffort";
 import {
+  EFFORT_POLICY_ALL,
+  EFFORT_POLICY_NONE,
   MODEL_EFFORTS,
   effortPlaceholder,
   enabledEffortsForModel,
   isModelEffort,
-  isModelEffortEnabled,
+  makeEffortPolicy,
   readEffortOptions,
+  readModelName,
+  resolveEnabledEffort,
   sanitizeEffortOptions,
   stampEffortOptions,
 } from "../ModelEffort";
@@ -84,21 +89,86 @@ describe("enabledEffortsForModel", () => {
   });
 });
 
-describe("isModelEffortEnabled", () => {
+describe("resolveEnabledEffort", () => {
   const policy = { supported: ["low", "high"] as const, default: "low" as const };
 
-  it("is false when effort is unset or the enabled list excludes it", () => {
-    expect(isModelEffortEnabled({}, policy)).toBe(false);
-    expect(isModelEffortEnabled({ effort: "medium" }, policy)).toBe(false);
-    expect(isModelEffortEnabled({ effort: "high", effort_options: [] }, policy)).toBe(false);
-    expect(isModelEffortEnabled({ effort: "high" }, { supported: [], default: undefined })).toBe(
-      false
-    );
+  it("is undefined when effort is unset, unknown, or the enabled list excludes it", () => {
+    expect(resolveEnabledEffort(undefined, policy)).toBeUndefined();
+    expect(resolveEnabledEffort({}, policy)).toBeUndefined();
+    expect(resolveEnabledEffort({ effort: "xhigh" }, policy)).toBeUndefined();
+    expect(resolveEnabledEffort({ effort: "medium" }, policy)).toBeUndefined();
+    expect(resolveEnabledEffort({ effort: "high", effort_options: [] }, policy)).toBeUndefined();
+    expect(resolveEnabledEffort({ effort: "high" }, EFFORT_POLICY_NONE)).toBeUndefined();
   });
 
-  it("is true when effort is in the enabled list, or when nothing restricts it", () => {
-    expect(isModelEffortEnabled({ effort: "high" }, policy)).toBe(true);
-    expect(isModelEffortEnabled({ effort: "ultra" }, undefined)).toBe(true);
+  it("returns the effort itself when enabled, or when nothing restricts it", () => {
+    expect(resolveEnabledEffort({ effort: "high" }, policy)).toBe("high");
+    expect(resolveEnabledEffort({ effort: "ultra" }, undefined)).toBe("ultra");
+  });
+
+  // The point of returning the value: a caller indexes its own map with it and
+  // needs no `as ModelEffort` to do so.
+  it("narrows to ModelEffort so callers need no cast", () => {
+    const effort = resolveEnabledEffort({ effort: "low" }, policy);
+    const budgets: Record<ModelEffort, number> = {
+      none: 0,
+      low: 1,
+      medium: 2,
+      high: 3,
+      extra: 4,
+      ultra: 5,
+    };
+    expect(effort === undefined ? -1 : budgets[effort]).toBe(1);
+  });
+});
+
+describe("readModelName", () => {
+  it("trims the provider-side id and reads an absent one as empty", () => {
+    expect(readModelName({ provider_config: { model_name: "  gpt-5  " } })).toBe("gpt-5");
+    expect(readModelName({ provider_config: {} })).toBe("");
+    expect(readModelName({})).toBe("");
+    expect(readModelName(undefined)).toBe("");
+  });
+});
+
+describe("makeEffortPolicy", () => {
+  const REASONING = { supported: MODEL_EFFORTS, default: "medium" } as const;
+  const policy = makeEffortPolicy({
+    rules: [
+      { when: /^text-embedding/i, policy: EFFORT_POLICY_NONE },
+      { when: [/^gpt-5/i, (id) => id.startsWith("o3")], policy: REASONING },
+    ],
+    fallback: EFFORT_POLICY_ALL,
+  });
+
+  it("takes the first matching rule, by regex or predicate", () => {
+    expect(policy({ provider_config: { model_name: "text-embedding-3-small" } })).toEqual(
+      EFFORT_POLICY_NONE
+    );
+    expect(policy({ provider_config: { model_name: "gpt-5.6-sol" } })).toEqual(REASONING);
+    expect(policy({ provider_config: { model_name: "o3-mini" } })).toEqual(REASONING);
+  });
+
+  // The asymmetry this replaces: an absent id answered "every level" while an
+  // unrecognized one answered "none", two different claims from the same
+  // amount of knowledge.
+  it("answers an absent id and an unrecognized one with the same fallback", () => {
+    expect(policy({ provider_config: { model_name: "brand-new-model" } })).toEqual(
+      EFFORT_POLICY_ALL
+    );
+    expect(policy({ provider_config: { model_name: "" } })).toEqual(EFFORT_POLICY_ALL);
+    expect(policy({})).toEqual(EFFORT_POLICY_ALL);
+    expect(policy(undefined)).toEqual(EFFORT_POLICY_ALL);
+  });
+
+  it("carries a restrictive fallback just as faithfully", () => {
+    const strict = makeEffortPolicy({
+      rules: [{ when: /^grok/i, policy: REASONING }],
+      fallback: EFFORT_POLICY_NONE,
+    });
+    expect(strict({ provider_config: { model_name: "grok-4" } })).toEqual(REASONING);
+    expect(strict({ provider_config: { model_name: "llama-3" } })).toEqual(EFFORT_POLICY_NONE);
+    expect(strict(undefined)).toEqual(EFFORT_POLICY_NONE);
   });
 });
 

--- a/packages/test/src/test/ai-provider-api/CloudEffortPolicy.test.ts
+++ b/packages/test/src/test/ai-provider-api/CloudEffortPolicy.test.ts
@@ -16,33 +16,53 @@ function cfg(provider: string, model_name: string) {
 }
 
 describe("anthropicEffortPolicy", () => {
-  it("returns all levels with no default when the name is empty", () => {
-    expect(anthropicEffortPolicy(cfg(ANTHROPIC, ""))).toEqual({
-      supported: [...MODEL_EFFORTS],
-      default: undefined,
-    });
-  });
-
   it("treats parsed Claude ids as all six with default none", () => {
     expect(anthropicEffortPolicy(cfg(ANTHROPIC, "claude-sonnet-5"))).toEqual({
       supported: [...MODEL_EFFORTS],
       default: "none",
     });
+    expect(anthropicEffortPolicy(cfg(ANTHROPIC, "claude-3-7-sonnet-20250219"))?.default).toBe(
+      "none"
+    );
   });
 
-  it("returns no levels for a non-Claude id", () => {
-    expect(anthropicEffortPolicy(cfg(ANTHROPIC, "not-claude"))?.supported).toEqual([]);
+  // The gateway spellings reach this provider through the `baseURL` seam. They
+  // do not parse as native ids, and denying whatever the parser declined took
+  // the dial away from them silently.
+  it("keeps the dial on gateway-prefixed spellings of a thinking generation", () => {
+    expect(
+      anthropicEffortPolicy(cfg(ANTHROPIC, "us.anthropic.claude-sonnet-4-20250514-v1:0"))?.supported
+    ).toEqual([...MODEL_EFFORTS]);
+    expect(
+      anthropicEffortPolicy(cfg(ANTHROPIC, "global.anthropic.claude-opus-4-1@20250805"))?.supported
+    ).toEqual([...MODEL_EFFORTS]);
+  });
+
+  // An id nothing recognizes is likelier a spelling this package has not seen
+  // than a model without thinking, and the legacy `thinking.type = "enabled"`
+  // path already handles it — so it keeps the dial rather than losing it.
+  it("keeps the dial on an unrecognized id, and on a model with no id at all", () => {
+    expect(anthropicEffortPolicy(cfg(ANTHROPIC, "not-claude"))?.supported).toEqual([
+      ...MODEL_EFFORTS,
+    ]);
+    expect(anthropicEffortPolicy(cfg(ANTHROPIC, ""))?.supported).toEqual([...MODEL_EFFORTS]);
+  });
+
+  // Extended thinking arrived in 3.7: everything below it 400s on a thinking
+  // field, gateway spelling included.
+  it("returns no levels for generations that predate extended thinking", () => {
+    expect(anthropicEffortPolicy(cfg(ANTHROPIC, "claude-3-5-haiku-20241022"))?.supported).toEqual(
+      []
+    );
+    expect(anthropicEffortPolicy(cfg(ANTHROPIC, "claude-3-haiku-20240307"))?.supported).toEqual([]);
+    expect(anthropicEffortPolicy(cfg(ANTHROPIC, "claude-2.1"))?.supported).toEqual([]);
+    expect(
+      anthropicEffortPolicy(cfg(ANTHROPIC, "anthropic.claude-3-5-sonnet-20241022-v2:0"))?.supported
+    ).toEqual([]);
   });
 });
 
 describe("geminiEffortPolicy", () => {
-  it("returns all levels with no default when the name is empty", () => {
-    expect(geminiEffortPolicy(cfg(GOOGLE_GEMINI, ""))).toEqual({
-      supported: [...MODEL_EFFORTS],
-      default: undefined,
-    });
-  });
-
   it("treats text gemini models as all six with default none", () => {
     expect(geminiEffortPolicy(cfg(GOOGLE_GEMINI, "gemini-3.5-flash"))).toEqual({
       supported: [...MODEL_EFFORTS],
@@ -57,37 +77,79 @@ describe("geminiEffortPolicy", () => {
     );
     expect(geminiEffortPolicy(cfg(GOOGLE_GEMINI, "gemini-3.1-flash-image"))?.supported).toEqual([]);
   });
+
+  it("answers an unrecognized id and an absent one the same way", () => {
+    expect(geminiEffortPolicy(cfg(GOOGLE_GEMINI, "palm-2"))?.supported).toEqual([]);
+    expect(geminiEffortPolicy(cfg(GOOGLE_GEMINI, ""))?.supported).toEqual([]);
+  });
 });
 
 describe("deepseekEffortPolicy", () => {
-  it("returns all levels with no default when the name is empty", () => {
-    expect(deepseekEffortPolicy(cfg(DEEPSEEK, ""))).toEqual({
-      supported: [...MODEL_EFFORTS],
-      default: undefined,
-    });
-  });
-
-  it("treats deepseek-v4 as all six with default high", () => {
+  it("treats the v4 family as all six with default high", () => {
     expect(deepseekEffortPolicy(cfg(DEEPSEEK, "deepseek-v4-flash"))).toEqual({
       supported: [...MODEL_EFFORTS],
       default: "high",
     });
+    expect(deepseekEffortPolicy(cfg(DEEPSEEK, "deepseek-v5"))?.default).toBe("high");
   });
 
-  it("returns no levels for other DeepSeek ids", () => {
+  // `deepseek-reasoner` is the vendor's own name for the thinking model, and
+  // matching only `deepseek-v4` dropped the dial on it.
+  it("treats deepseek-reasoner and the r-series as reasoning", () => {
+    expect(deepseekEffortPolicy(cfg(DEEPSEEK, "deepseek-reasoner"))).toEqual({
+      supported: [...MODEL_EFFORTS],
+      default: "high",
+    });
+    expect(deepseekEffortPolicy(cfg(DEEPSEEK, "deepseek-r1"))?.supported).toEqual([
+      ...MODEL_EFFORTS,
+    ]);
+  });
+
+  it("returns no levels for the non-thinking chat id, an unknown id, and an absent one", () => {
     expect(deepseekEffortPolicy(cfg(DEEPSEEK, "deepseek-chat"))?.supported).toEqual([]);
+    expect(deepseekEffortPolicy(cfg(DEEPSEEK, "deepseek-v3"))?.supported).toEqual([]);
+    expect(deepseekEffortPolicy(cfg(DEEPSEEK, ""))?.supported).toEqual([]);
   });
 });
 
 describe("openrouterEffortPolicy", () => {
-  it("returns all levels with no default for empty and named ids", () => {
-    expect(openrouterEffortPolicy(cfg(OPENROUTER, ""))).toEqual({
-      supported: [...MODEL_EFFORTS],
-      default: undefined,
-    });
+  // OpenRouter's catalogue is open-ended and it drops a parameter the routed
+  // model does not take, so an unrecognized id keeps every level.
+  it("returns all levels for text ids, including ones it does not recognize", () => {
     expect(openrouterEffortPolicy(cfg(OPENROUTER, "openai/gpt-5"))).toEqual({
       supported: [...MODEL_EFFORTS],
       default: undefined,
     });
+    expect(openrouterEffortPolicy(cfg(OPENROUTER, "openai/gpt-4o"))?.supported).toEqual([
+      ...MODEL_EFFORTS,
+    ]);
+    expect(openrouterEffortPolicy(cfg(OPENROUTER, "newvendor/unheard-of"))?.supported).toEqual([
+      ...MODEL_EFFORTS,
+    ]);
+    expect(openrouterEffortPolicy(cfg(OPENROUTER, ""))?.supported).toEqual([...MODEL_EFFORTS]);
+  });
+
+  // Returning every level unconditionally made the gate at the call site a
+  // no-op: an embedding id has no `reasoning` field to carry the dial.
+  it("returns no levels for the non-text modalities", () => {
+    expect(
+      openrouterEffortPolicy(cfg(OPENROUTER, "openai/text-embedding-3-small"))?.supported
+    ).toEqual([]);
+    expect(openrouterEffortPolicy(cfg(OPENROUTER, "qwen/qwen3-embedding-8b"))?.supported).toEqual(
+      []
+    );
+    expect(openrouterEffortPolicy(cfg(OPENROUTER, "mistralai/mistral-embed"))?.supported).toEqual(
+      []
+    );
+    expect(
+      openrouterEffortPolicy(cfg(OPENROUTER, "black-forest-labs/flux-1.1-pro"))?.supported
+    ).toEqual([]);
+    expect(
+      openrouterEffortPolicy(cfg(OPENROUTER, "google/gemini-2.5-flash-image"))?.supported
+    ).toEqual([]);
+    expect(openrouterEffortPolicy(cfg(OPENROUTER, "openai/whisper-1"))?.supported).toEqual([]);
+    expect(
+      openrouterEffortPolicy(cfg(OPENROUTER, "openai/omni-moderation-latest"))?.supported
+    ).toEqual([]);
   });
 });

--- a/packages/test/src/test/ai-provider-api/DeepSeekProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/DeepSeekProvider.test.ts
@@ -159,13 +159,27 @@ describe("resolveMaxTokens", () => {
     );
   });
 
-  it("does not map model.effort on models the policy rejects", () => {
+  // One function, two branches, and only one of them consulted the policy: a
+  // model it had just declared has no reasoning was still paid the full default
+  // allowance on top of the caller's budget, whether or not effort was set.
+  it("pays no allowance on a model the policy says does not reason", () => {
     const nonThinking = {
       ...thinkingModel,
-      effort: "ultra",
       provider_config: { model_name: "deepseek-chat" },
     };
-    expect(resolveMaxTokens(nonThinking as never, 4096)).toBe(
+    expect(resolveMaxTokens({ ...nonThinking, effort: "ultra" } as never, 4096)).toBe(4096);
+    expect(resolveMaxTokens(nonThinking as never, 4096)).toBe(4096);
+  });
+
+  // `deepseek-reasoner` is the vendor's own name for the thinking model, and
+  // the policy used to deny it — so the dial fell through to the flat default.
+  it("maps model.effort on deepseek-reasoner", () => {
+    const reasoner = {
+      ...thinkingModel,
+      provider_config: { model_name: "deepseek-reasoner" },
+    };
+    expect(resolveMaxTokens({ ...reasoner, effort: "low" } as never, 4096)).toBe(4096 + 4096);
+    expect(resolveMaxTokens(reasoner as never, 4096)).toBe(
       4096 + DEEPSEEK_DEFAULT_REASONING_ALLOWANCE
     );
   });

--- a/packages/test/src/test/ai-provider-api/OpenAiEffortPolicy.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenAiEffortPolicy.test.ts
@@ -13,11 +13,14 @@ function cfg(model_name: string) {
 }
 
 describe("openaiEffortPolicy", () => {
-  it("returns all levels with no default when the name is empty", () => {
+  // OpenAI 400s on `reasoning` for the chat models that do not take it, so an
+  // id this list does not place answers the same way an absent one does.
+  it("returns no levels for an unrecognized id and for an absent one", () => {
     expect(openaiEffortPolicy({ provider: OPENAI, provider_config: { model_name: "" } })).toEqual({
-      supported: [...MODEL_EFFORTS],
+      supported: [],
       default: undefined,
     });
+    expect(openaiEffortPolicy(cfg("babbage-002"))?.supported).toEqual([]);
   });
 
   it("treats gpt-5 and o-series as reasoning with default medium", () => {

--- a/packages/test/src/test/ai-provider-api/OpenRouter_RequestParams.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouter_RequestParams.test.ts
@@ -76,6 +76,21 @@ describe("buildOpenRouterExtras", () => {
     ).toEqual({ reasoning: { effort: "low" } });
   });
 
+  // The policy used to return every level for every id, which left this branch
+  // unable to reject anything: an embedding model was handed a `reasoning`.
+  it("does not map model.effort onto a non-text model", () => {
+    expect(
+      buildOpenRouterExtras(
+        cfg({ model_name: "openai/text-embedding-3-small" }, { effort: "high" })
+      )
+    ).toEqual({});
+    expect(
+      buildOpenRouterExtras(
+        cfg({ model_name: "black-forest-labs/flux-1.1-pro" }, { effort: "high" })
+      )
+    ).toEqual({});
+  });
+
   it("does not map model.effort when effort_options is empty", () => {
     expect(
       buildOpenRouterExtras(

--- a/packages/test/src/test/ai-provider-api/XaiEffortPolicy.test.ts
+++ b/packages/test/src/test/ai-provider-api/XaiEffortPolicy.test.ts
@@ -18,11 +18,9 @@ function cfg(model_name: string, extra?: Partial<XaiModelConfig>): XaiModelConfi
 }
 
 describe("xaiEffortPolicy", () => {
-  it("returns all levels with no default when the name is empty", () => {
-    expect(xaiEffortPolicy(cfg(""))).toEqual({
-      supported: [...MODEL_EFFORTS],
-      default: undefined,
-    });
+  it("returns no levels for an unrecognized id and for an absent one", () => {
+    expect(xaiEffortPolicy(cfg(""))).toEqual({ supported: [], default: undefined });
+    expect(xaiEffortPolicy(cfg("llama-3-70b"))?.supported).toEqual([]);
   });
 
   it("treats reasoning Grok ids as all six with default medium", () => {

--- a/packages/test/src/test/ai-provider/Anthropic_Thinking.test.ts
+++ b/packages/test/src/test/ai-provider/Anthropic_Thinking.test.ts
@@ -59,9 +59,41 @@ describe("buildAnthropicThinkingParams", () => {
     ).toEqual({ max_tokens: 4096 });
   });
 
-  it("does not map model.effort on ids the policy rejects", () => {
+  // The documented fallback for an id nothing parses is the legacy budget, and
+  // it has to stay reachable from `model.effort`: a policy that denied whatever
+  // the parser declined dropped the setting before this path could run.
+  it("routes an unparsed id — a gateway spelling included — to the legacy budget", () => {
     expect(
       buildAnthropicThinkingParams(model({ model_name: "not-a-claude", effort: "high" }), 4096)
+    ).toEqual({
+      thinking: { type: "enabled", budget_tokens: 2048 },
+      max_tokens: 4096 + 2048,
+    });
+    expect(
+      buildAnthropicThinkingParams(
+        model({ model_name: "us.anthropic.claude-sonnet-4-20250514-v1:0", effort: "high" }),
+        4096
+      )
+    ).toEqual({
+      thinking: { type: "enabled", budget_tokens: 2048 },
+      max_tokens: 4096 + 2048,
+    });
+  });
+
+  // Extended thinking arrived in Claude 3.7; sending any thinking field to an
+  // older generation is a 400, so the policy denies the dial there.
+  it("does not map model.effort on a generation that predates thinking", () => {
+    expect(
+      buildAnthropicThinkingParams(
+        model({ model_name: "claude-3-5-haiku-20241022", effort: "high" }),
+        4096
+      )
+    ).toEqual({ max_tokens: 4096 });
+    expect(
+      buildAnthropicThinkingParams(
+        model({ model_name: "anthropic.claude-3-5-sonnet-20241022-v2:0", effort: "high" }),
+        4096
+      )
     ).toEqual({ max_tokens: 4096 });
   });
 

--- a/providers/anthropic/src/ai/common/Anthropic_EffortPolicy.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_EffortPolicy.ts
@@ -4,22 +4,44 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MODEL_EFFORTS, type ModelConfig, type ModelEffortPolicy } from "@workglow/ai/worker";
+import {
+  EFFORT_POLICY_NONE,
+  makeEffortPolicy,
+  MODEL_EFFORTS,
+  type ModelEffortPolicy,
+  type ModelEffortPolicyFn,
+} from "@workglow/ai/worker";
 import { parseAnthropicModelId } from "./Anthropic_RequestParams";
 
-const ALL = { supported: MODEL_EFFORTS, default: undefined } as const satisfies ModelEffortPolicy;
 const CLAUDE = { supported: MODEL_EFFORTS, default: "none" } as const satisfies ModelEffortPolicy;
-const NONE = { supported: [], default: undefined } as const satisfies ModelEffortPolicy;
 
-function modelName(model: ModelConfig): string {
-  return String(
-    (model.provider_config as { model_name?: string } | undefined)?.model_name ?? ""
-  ).trim();
+/**
+ * Gateways prefix the vendor onto the id (`us.anthropic.claude-…`,
+ * `anthropic.claude-…`) and suffix a revision (`…-v1:0`). Stripping the prefix
+ * grades those spellings on the same generation rule as a native id, instead of
+ * having them fall out of the parser as "not a Claude id at all".
+ */
+const GATEWAY_PREFIX = /^(?:[a-z0-9-]+\.)*anthropic\./i;
+
+/** Extended thinking arrived in Claude 3.7; older generations 400 on any thinking field. */
+function isPreThinkingClaude(id: string): boolean {
+  const parsed = parseAnthropicModelId(id.replace(GATEWAY_PREFIX, ""));
+  if (parsed === undefined) return false;
+  if (parsed.major !== 3) return parsed.major < 3;
+  return (parsed.minor ?? 0) < 7;
 }
 
-export function anthropicEffortPolicy(model: ModelConfig): ModelEffortPolicy {
-  const id = modelName(model);
-  if (!id) return ALL;
-  if (parseAnthropicModelId(id) !== undefined) return CLAUDE;
-  return NONE;
-}
+/**
+ * Anthropic serves one family, and every generation from 3.7 up takes the
+ * coarse dial on one path or the other, so only the generations that predate
+ * thinking are denied. An id this package cannot parse is far likelier to be a
+ * spelling it has not seen than a model without thinking, so it keeps the dial:
+ * {@link anthropicSupportsAdaptiveThinking} already routes an unparsed id to the
+ * legacy `thinking.type = "enabled"` budget, which is the safe landing. Denying
+ * whatever the parser declined made that fallback unreachable from
+ * `model.effort` — the setting was dropped before anything could use it.
+ */
+export const anthropicEffortPolicy: ModelEffortPolicyFn = makeEffortPolicy({
+  rules: [{ when: isPreThinkingClaude, policy: EFFORT_POLICY_NONE }],
+  fallback: CLAUDE,
+});

--- a/providers/anthropic/src/ai/common/Anthropic_Thinking.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Thinking.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isModelEffort, isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
+import { resolveEnabledEffort, type ModelEffort } from "@workglow/ai/worker";
 import { getLogger } from "@workglow/util/worker";
 import { anthropicEffortPolicy } from "./Anthropic_EffortPolicy";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
@@ -96,13 +96,8 @@ export function buildAnthropicThinkingParams(
     return result;
   }
 
-  const effort = model?.effort;
-  if (
-    model === undefined ||
-    !isModelEffortEnabled(model, anthropicEffortPolicy(model)) ||
-    !isModelEffort(effort) ||
-    effort === "none"
-  ) {
+  const effort = resolveEnabledEffort(model, anthropicEffortPolicy(model));
+  if (effort === undefined || effort === "none") {
     return { max_tokens: maxTokens };
   }
 

--- a/providers/deepseek/src/ai/common/DeepSeek_Client.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_Client.ts
@@ -5,7 +5,7 @@
  */
 
 import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
-import { isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
+import { resolveEnabledEffort, type ModelEffort } from "@workglow/ai/worker";
 import { deepseekEffortPolicy } from "./DeepSeek_EffortPolicy";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
 
@@ -132,8 +132,11 @@ export const DEEPSEEK_DEFAULT_REASONING_ALLOWANCE = 16_384;
  * Turns the caller's answer-token budget into DeepSeek's `max_tokens`. Thinking
  * models bill `reasoning_tokens` against the same budget, so the wire value has
  * to cover both. Native `reasoning_allowance` wins over `model.effort`; when
- * neither is set the shared default allowance applies. Undefined budget stays
- * undefined, leaving DeepSeek's default.
+ * neither is set the shared default allowance applies — but only to a model the
+ * policy says reasons at all. Both branches read the one policy: paying the
+ * default allowance on a model it has just declared has no reasoning spends a
+ * whole extra `max_tokens` budget on tokens that are never generated.
+ * Undefined budget stays undefined, leaving DeepSeek's default.
  */
 export function resolveMaxTokens(
   model: DeepSeekModelConfig | undefined,
@@ -141,14 +144,15 @@ export function resolveMaxTokens(
 ): number | undefined {
   if (maxTokens === undefined) return undefined;
   const configured = model?.provider_config?.reasoning_allowance;
-  let allowance: number;
-  if (typeof configured === "number") {
-    allowance = configured;
-  } else if (model && isModelEffortEnabled(model, deepseekEffortPolicy(model))) {
-    allowance = EFFORT_TO_REASONING_ALLOWANCE[model.effort as ModelEffort];
-  } else {
-    allowance = DEEPSEEK_DEFAULT_REASONING_ALLOWANCE;
-  }
+  if (typeof configured === "number") return maxTokens + Math.max(0, configured);
+  const policy = deepseekEffortPolicy(model);
+  const effort = resolveEnabledEffort(model, policy);
+  const allowance =
+    effort !== undefined
+      ? EFFORT_TO_REASONING_ALLOWANCE[effort]
+      : policy.supported.length === 0
+        ? 0
+        : DEEPSEEK_DEFAULT_REASONING_ALLOWANCE;
   return maxTokens + Math.max(0, allowance);
 }
 

--- a/providers/deepseek/src/ai/common/DeepSeek_EffortPolicy.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_EffortPolicy.ts
@@ -4,21 +4,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MODEL_EFFORTS, type ModelConfig, type ModelEffortPolicy } from "@workglow/ai/worker";
+import {
+  EFFORT_POLICY_NONE,
+  makeEffortPolicy,
+  MODEL_EFFORTS,
+  type ModelEffortPolicy,
+  type ModelEffortPolicyFn,
+} from "@workglow/ai/worker";
 
-const ALL = { supported: MODEL_EFFORTS, default: undefined } as const satisfies ModelEffortPolicy;
-const V4 = { supported: MODEL_EFFORTS, default: "high" } as const satisfies ModelEffortPolicy;
-const NONE = { supported: [], default: undefined } as const satisfies ModelEffortPolicy;
+const REASONING = {
+  supported: MODEL_EFFORTS,
+  default: "high",
+} as const satisfies ModelEffortPolicy;
 
-function modelName(model: ModelConfig): string {
-  return String(
-    (model.provider_config as { model_name?: string } | undefined)?.model_name ?? ""
-  ).trim();
+/** V4 is the first family that reasons on every id; before it the mode is the id. */
+function isReasoningDeepSeekFamily(id: string): boolean {
+  const version = /^deepseek-v(\d+)/i.exec(id);
+  return version !== null && Number(version[1]) >= 4;
 }
 
-export function deepseekEffortPolicy(model: ModelConfig): ModelEffortPolicy {
-  const id = modelName(model);
-  if (!id) return ALL;
-  if (/^deepseek-v4/i.test(id)) return V4;
-  return NONE;
-}
+/**
+ * DeepSeek splits thinking by id rather than by parameter: `deepseek-reasoner`
+ * is the thinking mode of the weights `deepseek-chat` serves without it, and
+ * the V4 family reasons on every id. Matching `deepseek-v4` alone dropped the
+ * dial on `deepseek-reasoner` — the vendor's own name for the thinking model —
+ * while {@link resolveMaxTokens} still paid it the full default allowance.
+ */
+export const deepseekEffortPolicy: ModelEffortPolicyFn = makeEffortPolicy({
+  rules: [
+    {
+      when: [isReasoningDeepSeekFamily, /^deepseek-reasoner/i, /^deepseek-r\d/i],
+      policy: REASONING,
+    },
+  ],
+  fallback: EFFORT_POLICY_NONE,
+});

--- a/providers/google-gemini/src/ai/common/Gemini_Client.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Client.ts
@@ -6,7 +6,7 @@
 
 import type { GoogleGenAI } from "@google/genai";
 import { resolveApiKey } from "@workglow/ai/provider-utils";
-import { isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
+import { resolveEnabledEffort, type ModelEffort } from "@workglow/ai/worker";
 import { geminiEffortPolicy } from "./Gemini_EffortPolicy";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 
@@ -125,9 +125,8 @@ export function getModelName(model: GeminiModelConfig | undefined): string {
 export function getThinkingBudget(model: GeminiModelConfig | undefined): number | undefined {
   const configured = model?.provider_config?.thinking_budget;
   if (typeof configured === "number") return configured;
-  if (model && isModelEffortEnabled(model, geminiEffortPolicy(model))) {
-    return EFFORT_TO_THINKING_BUDGET[model.effort as ModelEffort];
-  }
+  const effort = resolveEnabledEffort(model, geminiEffortPolicy(model));
+  if (effort !== undefined) return EFFORT_TO_THINKING_BUDGET[effort];
   return undefined;
 }
 

--- a/providers/google-gemini/src/ai/common/Gemini_EffortPolicy.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_EffortPolicy.ts
@@ -4,30 +4,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MODEL_EFFORTS, type ModelConfig, type ModelEffortPolicy } from "@workglow/ai/worker";
+import {
+  EFFORT_POLICY_NONE,
+  makeEffortPolicy,
+  MODEL_EFFORTS,
+  type ModelEffortPolicy,
+  type ModelEffortPolicyFn,
+} from "@workglow/ai/worker";
 
-const ALL = { supported: MODEL_EFFORTS, default: undefined } as const satisfies ModelEffortPolicy;
 const TEXT = { supported: MODEL_EFFORTS, default: "none" } as const satisfies ModelEffortPolicy;
-const NONE = { supported: [], default: undefined } as const satisfies ModelEffortPolicy;
 
-function modelName(model: ModelConfig): string {
-  return String(
-    (model.provider_config as { model_name?: string } | undefined)?.model_name ?? ""
-  ).trim();
-}
-
-export function geminiEffortPolicy(model: ModelConfig): ModelEffortPolicy {
-  const id = modelName(model);
-  if (!id) return ALL;
-  if (
-    /^gemini-embedding/i.test(id) ||
-    /^text-embedding/i.test(id) ||
-    /^embedding-/i.test(id) ||
-    /^imagen-/i.test(id) ||
-    /^gemini-.*-image(?:-|$)/i.test(id)
-  ) {
-    return NONE;
-  }
-  if (/^gemini-/i.test(id)) return TEXT;
-  return NONE;
-}
+/**
+ * Gemini rejects `thinkingConfig` on the models that do not think, so an id
+ * outside the `gemini-` text families keeps the plain path — including the
+ * embedding and image ids denied above, which share that prefix.
+ */
+export const geminiEffortPolicy: ModelEffortPolicyFn = makeEffortPolicy({
+  rules: [
+    {
+      when: [
+        /^gemini-embedding/i,
+        /^text-embedding/i,
+        /^embedding-/i,
+        /^imagen-/i,
+        /^gemini-.*-image(?:-|$)/i,
+      ],
+      policy: EFFORT_POLICY_NONE,
+    },
+    { when: /^gemini-/i, policy: TEXT },
+  ],
+  fallback: EFFORT_POLICY_NONE,
+});

--- a/providers/openai/src/ai/common/OpenAI_Client.ts
+++ b/providers/openai/src/ai/common/OpenAI_Client.ts
@@ -5,7 +5,7 @@
  */
 
 import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
-import { isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
+import { resolveEnabledEffort, type ModelEffort } from "@workglow/ai/worker";
 import { openaiEffortPolicy } from "./OpenAI_EffortPolicy";
 import type { OpenAiModelConfig } from "./OpenAI_ModelSchema";
 
@@ -132,9 +132,8 @@ export function getReasoningConfig(
   if (reasoning && (reasoning.effort !== undefined || reasoning.mode !== undefined)) {
     return reasoning;
   }
-  if (model && isModelEffortEnabled(model, openaiEffortPolicy(model))) {
-    return { effort: EFFORT_TO_OPENAI[model.effort as ModelEffort] };
-  }
+  const effort = resolveEnabledEffort(model, openaiEffortPolicy(model));
+  if (effort !== undefined) return { effort: EFFORT_TO_OPENAI[effort] };
   return undefined;
 }
 

--- a/providers/openai/src/ai/common/OpenAI_EffortPolicy.ts
+++ b/providers/openai/src/ai/common/OpenAI_EffortPolicy.ts
@@ -1,28 +1,32 @@
 /**
  * @license
- * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MODEL_EFFORTS, type ModelConfig, type ModelEffortPolicy } from "@workglow/ai/worker";
+import {
+  EFFORT_POLICY_NONE,
+  makeEffortPolicy,
+  MODEL_EFFORTS,
+  type ModelEffortPolicy,
+  type ModelEffortPolicyFn,
+} from "@workglow/ai/worker";
 
-const ALL = { supported: MODEL_EFFORTS, default: undefined } as const satisfies ModelEffortPolicy;
 const REASONING = {
   supported: MODEL_EFFORTS,
   default: "medium",
 } as const satisfies ModelEffortPolicy;
-const NONE = { supported: [], default: undefined } as const satisfies ModelEffortPolicy;
 
-function modelName(model: ModelConfig): string {
-  return String(
-    (model.provider_config as { model_name?: string } | undefined)?.model_name ?? ""
-  ).trim();
-}
-
-export function openaiEffortPolicy(model: ModelConfig): ModelEffortPolicy {
-  const id = modelName(model);
-  if (!id) return ALL;
-  if (/^text-embedding/i.test(id) || /^gpt-image/i.test(id) || /^dall-e/i.test(id)) return NONE;
-  if (/^gpt-5/i.test(id) || /^o[134]/i.test(id)) return REASONING;
-  return NONE;
-}
+/**
+ * OpenAI rejects `reasoning` with a 400 on the chat models that do not take it,
+ * and those — `gpt-4o`, `gpt-4.1`, `chatgpt-*` — are most of what does not match
+ * a rule here, so an unrecognized id keeps the plain no-reasoning path. A new
+ * reasoning family is one entry below rather than a live request that 400s.
+ */
+export const openaiEffortPolicy: ModelEffortPolicyFn = makeEffortPolicy({
+  rules: [
+    { when: [/^text-embedding/i, /^gpt-image/i, /^dall-e/i], policy: EFFORT_POLICY_NONE },
+    { when: [/^gpt-5/i, /^o[134]/i], policy: REASONING },
+  ],
+  fallback: EFFORT_POLICY_NONE,
+});

--- a/providers/openrouter/src/ai/common/OpenRouter_EffortPolicy.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_EffortPolicy.ts
@@ -4,10 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MODEL_EFFORTS, type ModelConfig, type ModelEffortPolicy } from "@workglow/ai/worker";
+import {
+  EFFORT_POLICY_ALL,
+  EFFORT_POLICY_NONE,
+  makeEffortPolicy,
+  type ModelEffortPolicyFn,
+} from "@workglow/ai/worker";
 
-const ALL = { supported: MODEL_EFFORTS, default: undefined } as const satisfies ModelEffortPolicy;
+/**
+ * OpenRouter ids are `vendor/model[:variant]`, so a family name can sit either
+ * at the start or straight after the slash. These are the modalities that have
+ * no `reasoning` field to carry the dial at all.
+ */
+const NON_TEXT_MODALITIES = [
+  /embedding/i,
+  /(?:^|[/-])embed(?:$|[-:])/i,
+  /(?:^|\/)(?:dall-e|gpt-image|imagen|flux|sdxl|stable-diffusion|playground|recraft|ideogram|kandinsky)/i,
+  /-image(?:$|[-:])/i,
+  /(?:^|\/)(?:whisper|tts)(?:$|[-:])/i,
+  /(?:^|\/)rerank/i,
+  /moderation/i,
+];
 
-export function openrouterEffortPolicy(_model: ModelConfig): ModelEffortPolicy {
-  return ALL;
-}
+/**
+ * OpenRouter's catalogue is open-ended and it drops a parameter the routed
+ * model does not accept rather than rejecting the request, so an id no rule
+ * recognizes keeps the dial. What it cannot do is make a non-text model reason,
+ * and returning every level for every id — embeddings and image models
+ * included — left the gate at the call site a literal no-op.
+ */
+export const openrouterEffortPolicy: ModelEffortPolicyFn = makeEffortPolicy({
+  rules: [{ when: NON_TEXT_MODALITIES, policy: EFFORT_POLICY_NONE }],
+  fallback: EFFORT_POLICY_ALL,
+});

--- a/providers/openrouter/src/ai/common/OpenRouter_RequestParams.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_RequestParams.ts
@@ -5,7 +5,7 @@
  */
 
 import type { TextGenerationTaskInput } from "@workglow/ai";
-import { isModelEffortEnabled, toOpenAIMessages, type ModelEffort } from "@workglow/ai/worker";
+import { resolveEnabledEffort, toOpenAIMessages, type ModelEffort } from "@workglow/ai/worker";
 import type { OpenRouterProviderConfig } from "./OpenRouter_Client";
 import { getModelName } from "./OpenRouter_Client";
 import { openrouterEffortPolicy } from "./OpenRouter_EffortPolicy";
@@ -69,8 +69,9 @@ export function buildOpenRouterExtras(
   const extras: Record<string, unknown> = {};
   if (pc?.provider_routing) extras.provider = pc.provider_routing;
   if (pc?.reasoning) extras.reasoning = pc.reasoning;
-  else if (model && isModelEffortEnabled(model, openrouterEffortPolicy(model))) {
-    extras.reasoning = mapEffortToOpenRouterReasoning(model.effort as ModelEffort);
+  else {
+    const effort = resolveEnabledEffort(model, openrouterEffortPolicy(model));
+    if (effort !== undefined) extras.reasoning = mapEffortToOpenRouterReasoning(effort);
   }
   if (pc?.web_search) {
     extras.plugins = [pc.web_search === true ? { id: "web" } : { id: "web", ...pc.web_search }];

--- a/providers/xai/src/ai/common/Xai_Client.ts
+++ b/providers/xai/src/ai/common/Xai_Client.ts
@@ -5,7 +5,7 @@
  */
 
 import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
-import { isModelEffortEnabled, type ModelEffort } from "@workglow/ai/worker";
+import { resolveEnabledEffort, type ModelEffort } from "@workglow/ai/worker";
 import { xaiEffortPolicy } from "./Xai_EffortPolicy";
 import type { XaiModelConfig } from "./Xai_ModelSchema";
 
@@ -129,8 +129,7 @@ export function getXaiReasoningEffort(model: XaiModelConfig | undefined): string
     const trimmed = native.trim();
     if (XAI_REASONING_EFFORTS.has(trimmed)) return trimmed;
   }
-  if (model && isModelEffortEnabled(model, xaiEffortPolicy(model))) {
-    return EFFORT_TO_XAI[model.effort as ModelEffort];
-  }
+  const effort = resolveEnabledEffort(model, xaiEffortPolicy(model));
+  if (effort !== undefined) return EFFORT_TO_XAI[effort];
   return undefined;
 }

--- a/providers/xai/src/ai/common/Xai_EffortPolicy.ts
+++ b/providers/xai/src/ai/common/Xai_EffortPolicy.ts
@@ -4,25 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MODEL_EFFORTS, type ModelConfig, type ModelEffortPolicy } from "@workglow/ai/worker";
+import {
+  EFFORT_POLICY_NONE,
+  makeEffortPolicy,
+  MODEL_EFFORTS,
+  type ModelEffortPolicy,
+  type ModelEffortPolicyFn,
+} from "@workglow/ai/worker";
 
-const ALL = { supported: MODEL_EFFORTS, default: undefined } as const satisfies ModelEffortPolicy;
 const REASONING = {
   supported: MODEL_EFFORTS,
   default: "medium",
 } as const satisfies ModelEffortPolicy;
-const NONE = { supported: [], default: undefined } as const satisfies ModelEffortPolicy;
 
-function modelName(model: ModelConfig): string {
-  return String(
-    (model.provider_config as { model_name?: string } | undefined)?.model_name ?? ""
-  ).trim();
-}
-
-export function xaiEffortPolicy(model: ModelConfig): ModelEffortPolicy {
-  const id = modelName(model);
-  if (!id) return ALL;
-  if (/(?:^|-)image(?:-|$)/i.test(id) || /non-reasoning/i.test(id)) return NONE;
-  if (/^grok/i.test(id)) return REASONING;
-  return NONE;
-}
+/**
+ * xAI serves reasoning only on the Grok text ids, and rejects
+ * `reasoning_effort` elsewhere, so an id outside them keeps the plain path.
+ */
+export const xaiEffortPolicy: ModelEffortPolicyFn = makeEffortPolicy({
+  rules: [
+    { when: [/(?:^|-)image(?:-|$)/i, /non-reasoning/i], policy: EFFORT_POLICY_NONE },
+    { when: /^grok/i, policy: REASONING },
+  ],
+  fallback: EFFORT_POLICY_NONE,
+});


### PR DESCRIPTION
Fixes #859. Also takes #807 item 8.

The six provider effort policies became a request-time contract when every provider started gating `model.effort` on them, but the predicates behind the gate were still the advisory UI metadata they had been written as. Three of them silently dropped a user's setting.

## 1. The gate narrows the type

`isModelEffortEnabled` returned a `boolean` that narrowed nothing, so five of six call sites cast `model.effort as ModelEffort` and the sixth re-checked the type instead. It is replaced by:

```ts
resolveEnabledEffort(model, policy): ModelEffort | undefined
```

Every cast and the redundant `isModelEffort` check are gone. No other package referenced the old export.

## 2. The three defective predicates

**anthropic** — no longer denies whatever `parseAnthropicModelId` declines. It strips the gateway prefix (`us.anthropic.`, `anthropic.`, …) so those spellings grade on the same generation rule as a native id, denies only the generations that predate extended thinking (below 3.7, which 400 on any thinking field — including their Bedrock spellings), and keeps the dial on anything it cannot place. That is what makes the documented "unparsed ids stay on the legacy path" fallback in `Anthropic_Thinking.ts` reachable from `model.effort` again.

**deepseek** — `deepseek-reasoner` and the r-series now match, and the v4 test is a version comparison rather than a literal. The sibling branch was the other half of the defect: `resolveMaxTokens` now reads the same policy in both branches, so a model the policy says does not reason is paid **0** allowance rather than the flat 16,384. The old test asserting `deepseek-chat` + `effort: "ultra"` → `4096 + DEFAULT_ALLOWANCE` was encoding that bug; it now asserts `4096`.

**openrouter** — no longer returns every level for every id, which had left its gate a literal no-op (an embedding model was handed a `reasoning` field). It denies the non-text modalities — embeddings, image, audio, rerank, moderation — and keeps a permissive fallback, which its open-ended catalogue needs and which is sound because OpenRouter drops a parameter the routed model does not take.

## 3. `makeEffortPolicy`

`makeEffortPolicy({ rules, fallback })` lives in `@workglow/ai` beside `EFFORT_POLICY_ALL` / `EFFORT_POLICY_NONE` and `readModelName`. A rule matches on a `RegExp` or a predicate — the predicate is what keeps anthropic's generation check and deepseek's version comparison on the shared surface. Each provider file is now its matchers plus its fallback; the duplicated `modelName` helper, the repeated policy literals and the imperative bodies are gone (135 → 117 code lines across the six, and most of what remains is import blocks).

## On the `if (!id) return ALL` asymmetry

The spec's single `fallback` answers an absent id and an unrecognized one alike, so a policy no longer states two different things about the same amount of knowledge.

I resolved it **restrictively** for openai / gemini / xai / deepseek rather than permissively, and said so in each file. Permissive was the direction the issue's framing implied, but it breaks the common case: `gpt-4o` matches no openai rule, and a permissive fallback would attach `reasoning.effort` to it — a 400 on a very ordinary model. Silently dropping the dial on a genuinely new reasoning id is a soft degradation fixed by one regex; the 400 is a hard failure. Anthropic (single family) and openrouter (open catalogue, vendor drops unsupported params) get permissive fallbacks, each with the reason stated where it applies.

## Not changed

`parseAnthropicModelId` itself is untouched. Making it gateway-aware would also change `anthropicSupportsAdaptiveThinking` and `anthropicSupportsSampling` for those ids — wider than this issue asks — and keeping the parser conservative is exactly what routes a gateway id to the legacy thinking path. Worth its own change if sampling params should start being sent for Bedrock spellings.

## Verification

- `bun scripts/test.ts unit provider provider-api ai vitest` — 1410 passed, 1 skipped, 133 files
- `bun scripts/test.ts unit provider provider-api ai bun` — 1396 passed, 0 failed, 129 files
- `turbo run build-types` clean for `@workglow/ai`, the six providers, and `@workglow/test` (which typechecks the test files)
- `prettier --write` and `eslint --fix` clean on every changed file

New coverage: `resolveEnabledEffort`, `readModelName` and `makeEffortPolicy` unit tests; anthropic gateway spellings and pre-3.7 generations; `deepseek-reasoner` through both `resolveMaxTokens` branches; openrouter non-text modalities through the policy and through `buildOpenRouterExtras`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U72UCdMJz6LtYjupofUDTU)_