### PR TITLE
fix(node-llama-cpp): stop embedding GGUFs advertising chat-session capabilities

### DIFF
--- a/packages/test/src/contract/ai-provider/assertions/inferAdvertisesRegistered.ts
+++ b/packages/test/src/contract/ai-provider/assertions/inferAdvertisesRegistered.ts
@@ -10,6 +10,10 @@ import { expect } from "vitest";
  * A registered run-fn capability that `inferCapabilities` never returns is
  * unreachable for any model whose record was populated by inference — the
  * path the catalog exists to serve.
+ *
+ * The inferred sets are unioned across the provider's fixtures, so this
+ * answers "is this capability reachable at all" and says nothing about any one
+ * model; {@link assertInferServesInferred} is the per-model direction.
  */
 export function assertInferAdvertisesRegistered(
   name: string,

--- a/packages/test/src/contract/ai-provider/assertions/inferServesInferred.ts
+++ b/packages/test/src/contract/ai-provider/assertions/inferServesInferred.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from "vitest";
+
+/** One fixture model id paired with the capabilities `inferCapabilities` returns for it. */
+export interface InferredForModel {
+  readonly id: string;
+  readonly capabilities: readonly string[];
+}
+
+/**
+ * `vision-input` says how a model accepts input rather than a call the provider
+ * can be asked to run. The other modifiers ride along inside a generation
+ * run-fn's `serves` (`["text.generation", "tool-use"]`), but nothing registers
+ * `vision-input`, so it annotates the record and is never a lookup key.
+ */
+const MARKER_CAPABILITIES: ReadonlySet<string> = new Set(["vision-input"]);
+
+/**
+ * Capabilities whose run-fn acts on a chat session, and only the generative
+ * run-fns ever open one. `serves` is registered per provider rather than per
+ * model, so the subset check alone cannot see that a model without
+ * `text.generation` has no session to warm or free.
+ */
+const SESSION_CAPABILITIES: ReadonlySet<string> = new Set(["cache.checkpoint", "session.dispose"]);
+
+/**
+ * The per-model direction of {@link assertInferAdvertisesRegistered}: that one
+ * unions the inferred sets across a provider's fixtures, which answers "is this
+ * capability reachable at all" and passes a branch that advertises a capability
+ * no run-fn can serve *for that model*. Such a model clears
+ * `modelMeetsRequires` during selection and fails inside the provider instead,
+ * with the capability message it would have gotten replaced by whatever the
+ * provider throws.
+ */
+export function assertInferServesInferred(
+  name: string,
+  registered: readonly (readonly string[])[],
+  inferred: readonly InferredForModel[]
+): void {
+  const unservable: string[] = [];
+  for (const { id, capabilities } of inferred) {
+    const inferredSet = new Set(capabilities);
+    for (const capability of capabilities) {
+      if (MARKER_CAPABILITIES.has(capability)) continue;
+      const servable = registered.some(
+        (serves) => serves.includes(capability) && serves.every((cap) => inferredSet.has(cap))
+      );
+      if (!servable) {
+        unservable.push(`${id}: ${capability} — no run-fn serves it within this model's set`);
+      } else if (SESSION_CAPABILITIES.has(capability) && !inferredSet.has("text.generation")) {
+        unservable.push(`${id}: ${capability} — no session without text.generation`);
+      }
+    }
+  }
+  expect(
+    unservable,
+    `${name} infers capabilities it cannot serve for that model:\n  ${unservable.join("\n  ")}`
+  ).toEqual([]);
+}

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCppProvider.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCppProvider.test.ts
@@ -34,6 +34,11 @@ describe("LlamaCppQueuedProvider.inferCapabilities", () => {
     const caps = provider.inferCapabilities(model("nomic-embed-text-v1.5.Q4_K_M.gguf"));
     expect(caps).toContain("text.embedding");
     expect(caps).not.toContain("text.generation");
+    // Both act on a chat session an embedding GGUF has no wrapper to build:
+    // advertised, either one clears model selection and throws inside the
+    // provider instead of being rejected with a capability message.
+    expect(caps).not.toContain("cache.checkpoint");
+    expect(caps).not.toContain("session.dispose");
   });
 
   it("defaults to full generative for any other GGUF", () => {

--- a/packages/test/src/test/ai-provider/inferAdvertisesRegistered.test.ts
+++ b/packages/test/src/test/ai-provider/inferAdvertisesRegistered.test.ts
@@ -23,6 +23,8 @@ import { _testOnly as xai } from "@workglow/xai/ai";
 import { describe, it } from "vitest";
 
 import { assertInferAdvertisesRegistered } from "../../contract/ai-provider/assertions/inferAdvertisesRegistered";
+import type { InferredForModel } from "../../contract/ai-provider/assertions/inferServesInferred";
+import { assertInferServesInferred } from "../../contract/ai-provider/assertions/inferServesInferred";
 
 function model(
   provider: string,
@@ -46,61 +48,80 @@ function servesOf(
   return specs.map((spec) => spec.serves);
 }
 
-describe("inferCapabilities advertises every registered capability", () => {
-  it.each([
-    {
-      name: "anthropic",
-      registered: servesOf(anthropic.ANTHROPIC_RUN_FN_SPECS),
-      inferred: ["claude-sonnet-5"].map((id) =>
-        new anthropic.AnthropicQueuedProvider(anthropic.ANTHROPIC_RUN_FNS).inferCapabilities(
-          model("ANTHROPIC", id)
-        )
-      ),
-    },
-    {
-      name: "openai",
-      registered: servesOf(openai.OPENAI_RUN_FN_SPECS),
-      inferred: ["gpt-4o", "text-embedding-3-small", "dall-e-3", "gpt-image-1"].map((id) =>
-        new openai.OpenAiQueuedProvider(openai.OPENAI_RUN_FNS).inferCapabilities(
-          model("OPENAI", id)
-        )
-      ),
-    },
-    {
-      name: "google-gemini",
-      registered: servesOf(gemini.GEMINI_RUN_FN_SPECS),
-      inferred: [
+/**
+ * Keeps each fixture id beside the capabilities inferred for it — the
+ * per-model assertion needs both, and deriving one from the other here is what
+ * stops the two lists drifting apart.
+ */
+function inferEach(
+  ids: readonly string[],
+  infer: (id: string) => readonly Capability[]
+): readonly InferredForModel[] {
+  return ids.map((id) => ({ id, capabilities: infer(id) }));
+}
+
+const PROVIDER_CASES: readonly {
+  readonly name: string;
+  readonly registered: readonly (readonly string[])[];
+  readonly inferred: readonly InferredForModel[];
+}[] = [
+  {
+    name: "anthropic",
+    registered: servesOf(anthropic.ANTHROPIC_RUN_FN_SPECS),
+    inferred: inferEach(["claude-sonnet-5"], (id) =>
+      new anthropic.AnthropicQueuedProvider(anthropic.ANTHROPIC_RUN_FNS).inferCapabilities(
+        model("ANTHROPIC", id)
+      )
+    ),
+  },
+  {
+    name: "openai",
+    registered: servesOf(openai.OPENAI_RUN_FN_SPECS),
+    inferred: inferEach(["gpt-4o", "text-embedding-3-small", "dall-e-3", "gpt-image-1"], (id) =>
+      new openai.OpenAiQueuedProvider(openai.OPENAI_RUN_FNS).inferCapabilities(model("OPENAI", id))
+    ),
+  },
+  {
+    name: "google-gemini",
+    registered: servesOf(gemini.GEMINI_RUN_FN_SPECS),
+    inferred: inferEach(
+      [
         "gemini-2.5-pro",
         "gemini-embedding-001",
         "imagen-4.0-generate-001",
         "gemini-3.1-flash-image",
-      ].map((id) =>
+      ],
+      (id) =>
         new gemini.GoogleGeminiQueuedProvider(gemini.GEMINI_RUN_FNS).inferCapabilities(
           model("GOOGLE_GEMINI", id)
         )
-      ),
-    },
-    {
-      name: "xai",
-      registered: servesOf(xai.XAI_RUN_FN_SPECS),
-      inferred: ["grok-4", "grok-2-image-1212"].map((id) =>
-        new xai.XaiQueuedProvider(xai.XAI_RUN_FNS).inferCapabilities(model("XAI", id))
-      ),
-    },
-    {
-      name: "deepseek",
-      registered: servesOf(deepseek.DEEPSEEK_RUN_FN_SPECS),
-      inferred: ["deepseek-v4-flash"].map((id) =>
-        new deepseek.DeepSeekQueuedProvider(deepseek.DEEPSEEK_RUN_FNS).inferCapabilities(
-          model("DEEPSEEK", id)
-        )
-      ),
-    },
-    {
-      name: "openrouter",
-      registered: servesOf(openrouter.OPENROUTER_RUN_FN_SPECS),
-      inferred: [
-        new openrouter.OpenRouterQueuedProvider(openrouter.OPENROUTER_RUN_FNS).inferCapabilities(
+    ),
+  },
+  {
+    name: "xai",
+    registered: servesOf(xai.XAI_RUN_FN_SPECS),
+    inferred: inferEach(["grok-4", "grok-2-image-1212"], (id) =>
+      new xai.XaiQueuedProvider(xai.XAI_RUN_FNS).inferCapabilities(model("XAI", id))
+    ),
+  },
+  {
+    name: "deepseek",
+    registered: servesOf(deepseek.DEEPSEEK_RUN_FN_SPECS),
+    inferred: inferEach(["deepseek-v4-flash"], (id) =>
+      new deepseek.DeepSeekQueuedProvider(deepseek.DEEPSEEK_RUN_FNS).inferCapabilities(
+        model("DEEPSEEK", id)
+      )
+    ),
+  },
+  {
+    name: "openrouter",
+    registered: servesOf(openrouter.OPENROUTER_RUN_FN_SPECS),
+    inferred: [
+      {
+        id: "openai/gpt-5",
+        capabilities: new openrouter.OpenRouterQueuedProvider(
+          openrouter.OPENROUTER_RUN_FNS
+        ).inferCapabilities(
           model("OPENROUTER", "openai/gpt-5", {
             metadata: {
               architecture: { input_modalities: ["text"] },
@@ -108,90 +129,97 @@ describe("inferCapabilities advertises every registered capability", () => {
             },
           })
         ),
-      ],
-    },
-    {
-      name: "huggingface-transformers",
-      registered: servesOf(hft.HFT_RUN_FN_SPECS),
-      inferred: (
-        [
-          ["onnx-community/Llama-3.2-1B-Instruct-q4f16"],
-          ["Xenova/all-MiniLM-L6-v2", { pipeline_task: "feature-extraction" }],
-          ["Xenova/modnet", { pipeline_task: "background-removal" }],
-          ["Xenova/bge-reranker-base"],
-          ["Xenova/language-detection"],
-          ["Xenova/clip-vit-base-patch32"],
-          ["Xenova/distilbert-base-uncased", { pipeline_task: "text-classification" }],
-          ["Xenova/bert-base-ner", { pipeline_task: "token-classification" }],
-          ["Xenova/bert-base-uncased", { pipeline_task: "fill-mask" }],
-          ["Xenova/t5-small", { pipeline_task: "translation" }],
-          ["Xenova/distilbert-base-cased-distilled-squad", { pipeline_task: "question-answering" }],
-          ["Xenova/segformer", { pipeline_task: "image-segmentation" }],
-          ["Xenova/vit-gpt2", { pipeline_task: "image-to-text" }],
-          ["Xenova/yolos-tiny", { pipeline_task: "object-detection" }],
-        ] as const
-      ).map(([id, pc]) =>
-        new hft.HuggingFaceTransformersQueuedProvider(hft.HFT_RUN_FNS).inferCapabilities(
-          model("HF_TRANSFORMERS_ONNX", id, pc ? { provider_config: pc } : {})
-        )
-      ),
-    },
-    {
-      name: "huggingface-inference",
-      registered: servesOf(hfi.HFI_RUN_FN_SPECS),
-      inferred: [
+      },
+    ],
+  },
+  {
+    name: "huggingface-transformers",
+    registered: servesOf(hft.HFT_RUN_FN_SPECS),
+    inferred: (
+      [
+        ["onnx-community/Llama-3.2-1B-Instruct-q4f16"],
+        ["Xenova/all-MiniLM-L6-v2", { pipeline_task: "feature-extraction" }],
+        ["Xenova/modnet", { pipeline_task: "background-removal" }],
+        ["Xenova/bge-reranker-base"],
+        ["Xenova/language-detection"],
+        ["Xenova/clip-vit-base-patch32"],
+        ["Xenova/distilbert-base-uncased", { pipeline_task: "text-classification" }],
+        ["Xenova/bert-base-ner", { pipeline_task: "token-classification" }],
+        ["Xenova/bert-base-uncased", { pipeline_task: "fill-mask" }],
+        ["Xenova/t5-small", { pipeline_task: "translation" }],
+        ["Xenova/distilbert-base-cased-distilled-squad", { pipeline_task: "question-answering" }],
+        ["Xenova/segformer", { pipeline_task: "image-segmentation" }],
+        ["Xenova/vit-gpt2", { pipeline_task: "image-to-text" }],
+        ["Xenova/yolos-tiny", { pipeline_task: "object-detection" }],
+      ] as const
+    ).map(([id, pc]) => ({
+      id,
+      capabilities: new hft.HuggingFaceTransformersQueuedProvider(
+        hft.HFT_RUN_FNS
+      ).inferCapabilities(model("HF_TRANSFORMERS_ONNX", id, pc ? { provider_config: pc } : {})),
+    })),
+  },
+  {
+    name: "huggingface-inference",
+    registered: servesOf(hfi.HFI_RUN_FN_SPECS),
+    inferred: inferEach(
+      [
         "mistralai/Mistral-7B-Instruct-v0.3",
         "Xenova/all-MiniLM-L6-v2",
         "black-forest-labs/FLUX.1-dev",
-      ].map((id) =>
+      ],
+      (id) =>
         new hfi.HfInferenceQueuedProvider(hfi.HFI_RUN_FNS).inferCapabilities(
           model("HF_INFERENCE", id)
         )
-      ),
-    },
-    {
-      name: "node-llama-cpp",
-      registered: servesOf(llamaCpp.LLAMACPP_RUN_FN_SPECS),
-      inferred: ["Mistral-7B-Instruct-v0.3.Q4_K_M.gguf", "nomic-embed-text-v1.5.Q4_K_M.gguf"].map(
-        (id) =>
-          new llamaCpp.LlamaCppQueuedProvider(llamaCpp.LLAMACPP_RUN_FNS).inferCapabilities(
-            model("LOCAL_LLAMACPP", id)
-          )
-      ),
-    },
-    {
-      name: "llamacpp-server",
-      registered: servesOf(llamaServer.LLAMACPP_SERVER_RUN_FN_SPECS),
-      inferred: ["llama-3-8b-q4_k_m.gguf", "nomic-embed-text.gguf"].map((id) =>
-        new llamaServer.LlamaCppServerQueuedProvider(
-          llamaServer.buildLlamaCppServerRunFns({})
-        ).inferCapabilities(model("LOCAL_LLAMACPP_SERVER", id))
-      ),
-    },
-    {
-      name: "ollama",
-      registered: servesOf(ollama.OLLAMA_RUN_FN_SPECS),
-      inferred: ["llama3.2", "nomic-embed-text", "llava"].map((id) =>
-        new ollama.OllamaQueuedProvider(ollama.OLLAMA_RUN_FNS).inferCapabilities(
-          model("OLLAMA", id)
+    ),
+  },
+  {
+    name: "node-llama-cpp",
+    registered: servesOf(llamaCpp.LLAMACPP_RUN_FN_SPECS),
+    inferred: inferEach(
+      ["Mistral-7B-Instruct-v0.3.Q4_K_M.gguf", "nomic-embed-text-v1.5.Q4_K_M.gguf"],
+      (id) =>
+        new llamaCpp.LlamaCppQueuedProvider(llamaCpp.LLAMACPP_RUN_FNS).inferCapabilities(
+          model("LOCAL_LLAMACPP", id)
         )
-      ),
-    },
-    {
-      name: "chrome-ai",
-      registered: servesOf(chromeAi.WEB_BROWSER_RUN_FN_SPECS),
-      inferred: [
+    ),
+  },
+  {
+    name: "llamacpp-server",
+    registered: servesOf(llamaServer.LLAMACPP_SERVER_RUN_FN_SPECS),
+    inferred: inferEach(["llama-3-8b-q4_k_m.gguf", "nomic-embed-text.gguf"], (id) =>
+      new llamaServer.LlamaCppServerQueuedProvider(
+        llamaServer.buildLlamaCppServerRunFns({})
+      ).inferCapabilities(model("LOCAL_LLAMACPP_SERVER", id))
+    ),
+  },
+  {
+    name: "ollama",
+    registered: servesOf(ollama.OLLAMA_RUN_FN_SPECS),
+    inferred: inferEach(["llama3.2", "nomic-embed-text", "llava"], (id) =>
+      new ollama.OllamaQueuedProvider(ollama.OLLAMA_RUN_FNS).inferCapabilities(model("OLLAMA", id))
+    ),
+  },
+  {
+    name: "chrome-ai",
+    registered: servesOf(chromeAi.WEB_BROWSER_RUN_FN_SPECS),
+    inferred: inferEach(
+      [
         "chrome-prompt",
         "chrome-summarizer",
         "chrome-rewriter",
         "chrome-translator",
         "chrome-language-detector",
-      ].map((id) => chromeAi.inferWebBrowserCapabilities(model("WEB_BROWSER", id))),
-    },
-    {
-      name: "tf-mediapipe",
-      registered: servesOf(tfmp.TFMP_RUN_FN_SPECS),
-      inferred: [
+      ],
+      (id) => chromeAi.inferWebBrowserCapabilities(model("WEB_BROWSER", id))
+    ),
+  },
+  {
+    name: "tf-mediapipe",
+    registered: servesOf(tfmp.TFMP_RUN_FN_SPECS),
+    inferred: inferEach(
+      [
         "gemma3-1b-it-int4-web.task",
         "gesture_recognizer.task",
         "face_landmarker.task",
@@ -204,29 +232,47 @@ describe("inferCapabilities advertises every registered capability", () => {
         "universal_sentence_encoder.tflite",
         "bert_classifier.tflite",
         "language_detector.tflite",
-      ].map((id) =>
+      ],
+      (id) =>
         new tfmp.TensorFlowMediaPipeQueuedProvider(tfmp.TFMP_RUN_FNS).inferCapabilities(
           model("TENSORFLOW_MEDIAPIPE", id)
         )
-      ),
-    },
-    {
-      name: "cactus",
-      registered: cactus.CACTUS_RUN_FNS.map((r) => r.serves),
-      inferred: [
-        new cactus.CactusQueuedProvider().inferCapabilities(model("LOCAL_CACTUS", "needle-26m")),
-      ],
-    },
-    {
-      name: "stable-diffusion-server",
-      registered: servesOf(sdCpp.STABLE_DIFFUSION_CPP_RUN_FN_SPECS),
-      inferred: ["sd-1.5.gguf"].map((id) =>
-        new sdCpp.StableDiffusionCppQueuedProvider(
-          sdCpp.buildStableDiffusionCppRunFns({})
-        ).inferCapabilities(model("LOCAL_STABLE_DIFFUSION_CPP", id))
-      ),
-    },
-  ])("$name", ({ name, registered, inferred }) => {
-    assertInferAdvertisesRegistered(name, registered, inferred);
-  });
+    ),
+  },
+  {
+    name: "cactus",
+    registered: cactus.CACTUS_RUN_FNS.map((r) => r.serves),
+    inferred: inferEach(["needle-26m"], (id) =>
+      new cactus.CactusQueuedProvider().inferCapabilities(model("LOCAL_CACTUS", id))
+    ),
+  },
+  {
+    name: "stable-diffusion-server",
+    registered: servesOf(sdCpp.STABLE_DIFFUSION_CPP_RUN_FN_SPECS),
+    inferred: inferEach(["sd-1.5.gguf"], (id) =>
+      new sdCpp.StableDiffusionCppQueuedProvider(
+        sdCpp.buildStableDiffusionCppRunFns({})
+      ).inferCapabilities(model("LOCAL_STABLE_DIFFUSION_CPP", id))
+    ),
+  },
+];
+
+describe("inferCapabilities and registered run-fns agree", () => {
+  it.each(PROVIDER_CASES)(
+    "$name advertises every registered capability",
+    ({ name, registered, inferred }) => {
+      assertInferAdvertisesRegistered(
+        name,
+        registered,
+        inferred.map((entry) => entry.capabilities)
+      );
+    }
+  );
+
+  it.each(PROVIDER_CASES)(
+    "$name infers only what it can serve for that model",
+    ({ name, registered, inferred }) => {
+      assertInferServesInferred(name, registered, inferred);
+    }
+  );
 });

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Capabilities.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Capabilities.ts
@@ -39,15 +39,17 @@ export function inferLlamaCppCapabilities(model: CapabilityHints): readonly Capa
   const baseName = (id.split("/").pop() ?? id).toLowerCase();
 
   if (/embed|minilm|bge-|gte-|e5-/i.test(baseName)) {
+    // No "cache.checkpoint" / "session.dispose": both act on a chat session,
+    // which an embedding GGUF has no chat wrapper to build. Advertised, they
+    // clear model selection and throw inside the provider; withheld, selection
+    // rejects the model and says why.
     return [
       "text.embedding",
-      "cache.checkpoint",
       "model.count-tokens",
       "model.download",
       "model.download-remove",
       "model.info",
       "model.search",
-      "session.dispose",
     ];
   }
 


### PR DESCRIPTION
Fixes #858.

## The bug

The embedding branch of `inferLlamaCppCapabilities` (`providers/node-llama-cpp/src/ai/common/LlamaCpp_Capabilities.ts:41`) returned `"cache.checkpoint"` and `"session.dispose"`. Both act on a `LlamaChatSession`, which an embedding GGUF has no chat wrapper to build:

```
inferLlamaCppCapabilities("nomic-embed-text-v1.5.Q4_K_M.gguf")  → cache.checkpoint
modelMeetsRequires(model, CacheCheckpointTask.requires)          → true
LlamaCpp_CacheCheckpoint_Stream → new LlamaChatSession(...) + setChatHistory()
```

Selection succeeded and the run-fn threw inside the provider, where before the model was rejected with a capability message that named the reason. Only the generative run-fns ever call `setLlamaCppSession`, so `session.dispose` had nothing to free here either. The sibling `llamacpp-server` provider's embedding branch already returns the minimal set, which is what makes this one the outlier.

## Why the existing conformance test missed it

`assertInferAdvertisesRegistered` `.flat()`s both sides before comparing, so the property asserted is `⋃ᵢ registeredᵢ ⊆ ⋃ⱼ inferredⱼ` — "is this capability reachable at all", deliberately not "is it honest for this model". The generative fixture supplies both capabilities on its own, which is the proof the over-advertisement was never needed to satisfy it.

## The paired assertion

`assertInferServesInferred` (new, in `packages/test/src/contract/ai-provider/assertions/inferServesInferred.ts`) is the per-model direction: for each fixture id, every inferred capability must have a registered run-fn whose **whole** `serves` set that model satisfies. Two rules sit beside it, each measured against all fifteen providers' fixtures rather than assumed:

- **`vision-input` is excluded.** Nothing registers it — the other modifiers ride along inside a generation run-fn's `serves`, but this one annotates the record and is never a lookup key. It was the only capability needing an exclusion.
- **`cache.checkpoint` and `session.dispose` additionally require `text.generation`.** `serves` is registered per provider, not per model, so the subset check alone happily accepts a singleton `["cache.checkpoint"]` registration for a model with no session to warm or free — exactly the shape of the bug above. Without this rule the fix would land unpinned.

`inferAdvertisesRegistered.test.ts` now keeps each fixture id beside its inferred set and runs both assertions; every fixture id is unchanged. A unit-level pin also went into `LlamaCppProvider.test.ts`.

## Verification

Test-the-test by injection, not just by reading:

- Reinstating both capabilities fails the new assertion naming the id and the reason — `nomic-embed-text-v1.5.Q4_K_M.gguf: cache.checkpoint — no session without text.generation` (and the same for `session.dispose`).
- Adding an unservable `tool-use` to the embedding branch trips the other branch — `tool-use — no run-fn serves it within this model's set`.

| Check | Result |
| --- | --- |
| `bun scripts/test.ts provider vitest` | 44 files, 538 passed |
| `bun scripts/test.ts provider-nodellama vitest` (real CPU inference) | 10 files, 99 passed / 4 skipped |
| `turbo run build-types --filter=@workglow/test` | 38 tasks successful |
| `bun scripts/test.ts --check-sections` | every test file reachable |
| prettier + eslint on changed files | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7AjBSKYkszexVBZoSUppw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7AjBSKYkszexVBZoSUppw)_