### PR TITLE
fix(storage): keep connection-transaction put deferral off the ALS store

### DIFF
--- a/packages/storage/src/tabular/__tests__/runNativeConnectionTransaction.test.ts
+++ b/packages/storage/src/tabular/__tests__/runNativeConnectionTransaction.test.ts
@@ -8,7 +8,9 @@ import {
   activeConnectionTxGroupHandle,
   assertSharedConnectionHandle,
   connectionTxQuery,
+  discardAllDeferredPuts,
   enqueueDeferredPut,
+  flushDeferredPuts,
   isEnlistedInConnectionTx,
   NestedConnectionTransactionError,
   runNativeConnectionTransaction,
@@ -18,7 +20,7 @@ import {
   type ConnectionTransactionHost,
 } from "@workglow/storage";
 import { __resetAlsForTesting, isSynchronousAls } from "@workglow/storage/test";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 /**
  * A participant stands in for a storage instance: `runNativeConnectionTransaction`
@@ -36,6 +38,36 @@ function makeHost(handle: object, table: string): AnyTabularStorage & Connection
   } as unknown as AnyTabularStorage & ConnectionTransactionHost;
 }
 
+/**
+ * A participant that records what a `put` subscriber would observe.
+ *
+ * `emitPut` is what every SQL backend's own `emitPut` does — offer the entity
+ * to the deferral buffer, emit immediately when it is refused — so these tests
+ * fail for exactly the reason a browser app would show rows that never
+ * committed.
+ */
+interface RecordingParticipant extends ConnectionTransactionHost {
+  readonly observed: unknown[];
+  readonly emitPut: (entity: unknown) => void;
+  readonly emitCommittedPut: (entity: unknown) => void;
+}
+
+function makeParticipant(handle: object, table: string): AnyTabularStorage & RecordingParticipant {
+  const observed: unknown[] = [];
+  const participant = {
+    ...makeHost(handle, table),
+    observed,
+    emitPut(entity: unknown): void {
+      if (enqueueDeferredPut(participant, entity)) return;
+      observed.push(entity);
+    },
+    emitCommittedPut(entity: unknown): void {
+      observed.push(entity);
+    },
+  } as unknown as AnyTabularStorage & RecordingParticipant;
+  return participant;
+}
+
 interface RunOptions {
   readonly handle: object;
   readonly participants: readonly AnyTabularStorage[];
@@ -44,12 +76,14 @@ interface RunOptions {
   readonly afterCommit?: () => void;
   readonly afterRollback?: () => void;
   readonly begin?: () => void;
+  readonly ownsSession?: boolean;
 }
 
 function run(options: RunOptions): Promise<unknown> {
   return runNativeConnectionTransaction({
     handle: options.handle,
     participants: options.participants,
+    ownsSession: options.ownsSession ?? true,
     begin: options.begin ?? ((): void => {}),
     commit: (): void => {},
     rollback: (): void => {},
@@ -201,6 +235,7 @@ describe("runNativeConnectionTransaction: the store is deactivated at COMMIT", (
       runNativeConnectionTransaction({
         handle,
         participants: [owner],
+        ownsSession: true,
         begin: () => {
           throw new Error("begin failed");
         },
@@ -273,6 +308,126 @@ describe("assertSharedConnectionHandle: nesting guard", () => {
 
     await run({ handle, participants: [a], fn: async () => undefined });
     expect(assertSharedConnectionHandle(a, [a])).toBe(handle);
+  });
+});
+
+/**
+ * Deferral must not be keyed off the ALS store. The browser bundle installs
+ * {@link createShimAls}, which restores its store as soon as the synchronous
+ * portion of the callback returns — that is the first `await` inside
+ * `runNativeConnectionTransaction`, namely `await begin()`. Every participant
+ * `put` after that point runs with no store at all, so a store-keyed buffer
+ * would emit each one immediately and leave the flush/discard pass draining
+ * nothing. Both runtimes therefore run the same cases here; the shim one is
+ * what a browser app on SQLite-WASM or PGlite actually gets.
+ */
+const alsModes = [
+  { name: "real AsyncLocalStorage", useShim: false },
+  { name: "the browser's synchronous shim", useShim: true },
+] as const;
+
+describe.each(alsModes)("put deferral on $name", ({ useShim }) => {
+  beforeEach(() => {
+    __resetAlsForTesting(useShim);
+  });
+
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  it("holds a put until COMMIT, then emits it exactly once", async () => {
+    const handle = {};
+    const participant = makeParticipant(handle, "table_a");
+    let observedInBody: readonly unknown[] = ["unset"];
+
+    await run({
+      handle,
+      participants: [participant],
+      fn: async () => {
+        // Past the body's first await: the shim's store is already gone.
+        await Promise.resolve();
+        participant.emitPut("row-1");
+        observedInBody = [...participant.observed];
+      },
+      afterCommit: () => flushDeferredPuts([participant]),
+    });
+
+    expect(observedInBody).toEqual([]);
+    expect(participant.observed).toEqual(["row-1"]);
+  });
+
+  it("never lets a subscriber observe a put that rolls back", async () => {
+    const handle = {};
+    const participant = makeParticipant(handle, "table_a");
+
+    await expect(
+      run({
+        handle,
+        participants: [participant],
+        fn: async () => {
+          await Promise.resolve();
+          participant.emitPut("row-1");
+          throw new Error("boom");
+        },
+        afterRollback: () => discardAllDeferredPuts([participant]),
+      })
+    ).rejects.toThrow("boom");
+
+    expect(participant.observed).toEqual([]);
+  });
+});
+
+/**
+ * `ownsSession: false` is the real-`pg.Pool` arm, which never runs in a browser
+ * — so unlike the cases above it is exercised on the real `AsyncLocalStorage`
+ * only, and the reset here is explicit rather than inherited.
+ */
+describe("put deferral when the transaction does not own the session", () => {
+  beforeEach(() => {
+    __resetAlsForTesting();
+  });
+
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  /**
+   * A real `pg.Pool` transaction holds one checked-out client while unrelated
+   * callers keep writing through the pool and committing at once. Their rows
+   * survive this transaction's ROLLBACK, so their `put` events must fire
+   * straight away rather than joining a buffer that may be discarded.
+   */
+  it("emits a put from a caller that never entered the body", async () => {
+    const handle = {};
+    const participant = makeParticipant(handle, "table_a");
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let started!: () => void;
+    const bodyStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+
+    const tx = run({
+      handle,
+      participants: [participant],
+      ownsSession: false,
+      fn: async () => {
+        participant.emitPut("enlisted");
+        started();
+        await gate;
+      },
+      afterCommit: () => flushDeferredPuts([participant]),
+    });
+
+    await bodyStarted;
+    participant.emitPut("outsider");
+    expect(participant.observed).toEqual(["outsider"]);
+
+    release();
+    await tx;
+    expect(participant.observed).toEqual(["outsider", "enlisted"]);
   });
 });
 

--- a/packages/storage/src/tabular/connectionAls.shared.ts
+++ b/packages/storage/src/tabular/connectionAls.shared.ts
@@ -57,22 +57,6 @@ export interface AlsContext {
    */
   active: boolean;
   /**
-   * `true` only while a connection-scoped transaction (see
-   * `runNativeConnectionTransaction`) is deferring `put` events. A plain
-   * `withTransaction` installs a store too, but buffers its events on the `tx`
-   * proxy and never drains {@link deferredPuts} — so without this flag a `put`
-   * that reaches the base `emitPut` in that window is queued and silently
-   * lost. Set from INSIDE the ALS scope, and cleared at deactivation.
-   */
-  deferPuts: boolean;
-  /**
-   * `put` events deferred until COMMIT of a connection-scoped transaction.
-   * Callers drain this after COMMIT, once the store has been deactivated, so a
-   * listener that writes in response emits (and commits) normally instead of
-   * queueing onto a fresh buffer nothing drains.
-   */
-  readonly deferredPuts: WeakMap<object, unknown[]>;
-  /**
    * Dedicated query handle for a real `pg.Pool` transaction. Enlisted
    * Postgres storages route writes through this so every participant shares
    * one client. Written after the store is created, once the client is

--- a/packages/storage/src/tabular/defineConnectionMutex.ts
+++ b/packages/storage/src/tabular/defineConnectionMutex.ts
@@ -384,8 +384,6 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
       handle,
       groupHandle,
       active: true,
-      deferPuts: false,
-      deferredPuts: new WeakMap(),
       txQuery: undefined,
       // `store.run` shadows the enclosing store; keep a link to it so accessors
       // can still see a transaction open on another connection.
@@ -403,7 +401,6 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
         // reachable from any continuation that captured it, so mark it dead
         // here too.
         ctx.active = false;
-        ctx.deferPuts = false;
         ctx.txQuery = undefined;
       }
       release();

--- a/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
+++ b/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
@@ -15,8 +15,8 @@
  * from every continuation of the body and from the `afterCommit` callbacks —
  * long after COMMIT ran. "Is the store present" is therefore NOT the same
  * question as "is a transaction open", and answering the second with the first
- * lets post-commit work believe it is still enlisted: writes route to a
- * released client, `put` events queue onto a buffer nothing drains.
+ * lets post-commit work believe it is still enlisted, routing its writes to a
+ * released client.
  *
  * {@link AlsContext.active} separates the two. It is cleared by
  * {@link deactivateConnectionTxStore} from INSIDE the ALS scope (a mutation
@@ -24,19 +24,30 @@
  * `store.run` returns into the caller's context), and the accessors below
  * split on it:
  *
- * | accessor                          | honors `active` | why                                     |
- * | --------------------------------- | --------------- | --------------------------------------- |
- * | {@link connectionTxQuery}         | yes             | the client is released at deactivation  |
- * | {@link isEnlistedInConnectionTx}  | yes             | nothing is open to enlist in            |
- * | {@link enqueueDeferredPut}        | yes             | post-commit emits must not be deferred  |
- * | {@link activeConnectionTxGroupHandle} | yes         | that is the question it answers         |
- * | {@link takeDeferredPuts}          | no              | it drains the queue in that very window |
- * | {@link discardDeferredPuts}       | no              | same, on the rollback path              |
+ * | accessor                          | honors `active` | why                                    |
+ * | --------------------------------- | --------------- | -------------------------------------- |
+ * | {@link connectionTxQuery}         | yes             | the client is released at deactivation |
+ * | {@link isEnlistedInConnectionTx}  | yes             | nothing is open to enlist in           |
+ * | {@link activeConnectionTxGroupHandle} | yes         | that is the question it answers        |
  *
- * {@link enqueueDeferredPut} additionally requires `AlsContext.deferPuts`,
- * which only this host sets: a plain `withTransaction` installs a store too but
- * buffers its events on the `tx` proxy and never drains the ALS queue, so a
- * `put` enqueued against that store would be silently dropped.
+ * ## `put` deferral does not live on the store
+ *
+ * {@link enqueueDeferredPut} and the flush/discard pass read a per-participant
+ * buffer this module registers for the life of the transaction, NOT the ALS
+ * store. Under {@link createShimAls} — the browser's ALS — the store is
+ * restored as soon as the synchronous portion of the callback returns, which is
+ * the first `await` inside {@link runNativeConnectionTransaction} (`await
+ * begin()`). A store-keyed buffer therefore stops answering for every
+ * participant `put` the body makes, each one fires while the transaction can
+ * still ROLLBACK, and the flush drains nothing. Cross-instance re-entry
+ * (`HandleState.txOwners`) is handle-state based for the same reason.
+ *
+ * The exception is a transaction that does NOT own its participants' session —
+ * a real `pg.Pool`, which checks out one client while unrelated callers keep
+ * writing through the pool and committing at once. Their rows survive this
+ * transaction's ROLLBACK, so `ownsSession: false` narrows deferral to writers
+ * that actually joined it, which is the same ALS-scoped question that arm's
+ * routing already asks.
  *
  * ## The innermost store is not the only store
  *
@@ -146,6 +157,19 @@ export interface RunNativeConnectionTransactionOptions<T> {
    */
   readonly chainHandle?: object;
   readonly participants: readonly AnyTabularStorage[];
+  /**
+   * `true` when this transaction owns the participants' only session, so every
+   * write they make necessarily joins it — SQLite, DuckDB, PGlite. Deferral is
+   * then unconditional for the duration, which is what carries it across an
+   * `await` on a runtime whose ALS store cannot.
+   *
+   * A real `pg.Pool` transaction passes `false`: it holds one checked-out
+   * client while unrelated callers keep writing through the pool and
+   * committing at once, and those rows survive this transaction's ROLLBACK.
+   * Deferral there follows the same ALS-scoped enlistment test the pool arm's
+   * own query routing uses.
+   */
+  readonly ownsSession: boolean;
   readonly begin: () => Promise<void> | void;
   readonly commit: () => Promise<void> | void;
   readonly rollback: () => Promise<void> | void;
@@ -176,6 +200,76 @@ export function defineNativeConnectionTransaction(
   mutex: Pick<ConnectionMutexApi, "getAlsStore" | "runInTransactionOnConnection">
 ): NativeConnectionTransactionApi {
   const { getAlsStore, runInTransactionOnConnection } = mutex;
+
+  /**
+   * One participant's deferred `put` events, held for the life of one
+   * transaction. Registered against the storage instance rather than the ALS
+   * store so it stays readable after an `await` on either runtime.
+   */
+  interface DeferralBuffer {
+    /**
+     * Cleared at deactivation, before the queue is drained: a listener that
+     * writes in response to a flushed `put` must emit, not queue onto a buffer
+     * nothing will drain again.
+     */
+    deferring: boolean;
+    readonly ownsSession: boolean;
+    readonly entities: unknown[];
+  }
+
+  /** The buffers registered for one transaction, by participant. */
+  interface DeferralScope {
+    readonly buffers: ReadonlyMap<object, DeferralBuffer>;
+  }
+
+  /**
+   * Innermost-first buffers per participant. A stack rather than a single slot
+   * because {@link runInTransactionOnConnection} runs an enlisted owner's
+   * nested transaction inline to surface a clearer downstream error, and the
+   * inner one's drain must not take the outer one's queue with it.
+   */
+  const deferralStacks = new WeakMap<object, DeferralBuffer[]>();
+
+  function currentDeferralBuffer(owner: object): DeferralBuffer | undefined {
+    const stack = deferralStacks.get(owner);
+    return stack === undefined ? undefined : stack[stack.length - 1];
+  }
+
+  function removeDeferralBuffer(owner: object, buffer: DeferralBuffer): void {
+    const stack = deferralStacks.get(owner);
+    if (stack === undefined) return;
+    const index = stack.lastIndexOf(buffer);
+    if (index !== -1) stack.splice(index, 1);
+    if (stack.length === 0) deferralStacks.delete(owner);
+  }
+
+  function armDeferredPuts(
+    participants: readonly AnyTabularStorage[],
+    ownsSession: boolean
+  ): DeferralScope {
+    const buffers = new Map<object, DeferralBuffer>();
+    for (const participant of participants) {
+      const buffer: DeferralBuffer = { deferring: true, ownsSession, entities: [] };
+      buffers.set(participant, buffer);
+      const stack = deferralStacks.get(participant);
+      if (stack === undefined) deferralStacks.set(participant, [buffer]);
+      else stack.push(buffer);
+    }
+    return { buffers };
+  }
+
+  /** Stops accepting puts while leaving the queue readable by the flush pass. */
+  function stopDeferringPuts(scope: DeferralScope): void {
+    for (const buffer of scope.buffers.values()) buffer.deferring = false;
+  }
+
+  /**
+   * Unregisters this transaction's buffers, including any the backend's
+   * `afterCommit`/`afterRollback` never drained.
+   */
+  function releaseDeferredPuts(scope: DeferralScope): void {
+    for (const [owner, buffer] of scope.buffers) removeDeferralBuffer(owner, buffer);
+  }
 
   /**
    * First store in the chain satisfying `match`.
@@ -255,44 +349,49 @@ export function defineNativeConnectionTransaction(
   async function runNativeConnectionTransaction<T>(
     options: RunNativeConnectionTransactionOptions<T>
   ): Promise<T> {
-    const deactivate = (): void => {
-      deactivateConnectionTxStore();
-      options.onDeactivate?.();
-    };
     return runInTransactionOnConnection(
       options.chainHandle ?? options.handle,
       options.participants,
       async () => {
-        // Inside the ALS scope: from here on the base `emitPut` may queue.
-        enableDeferredPuts();
+        // The transaction is open: from here on the base `emitPut` queues.
+        const scope = armDeferredPuts(options.participants, options.ownsSession);
+        const deactivate = (): void => {
+          deactivateConnectionTxStore();
+          stopDeferringPuts(scope);
+          options.onDeactivate?.();
+        };
         try {
-          await options.begin();
-        } catch (err) {
-          // BEGIN never took, so there is nothing to ROLLBACK.
-          deactivate();
-          throw err;
-        }
-        let result: T;
-        try {
-          result = await options.fn();
-          await options.commit();
-        } catch (err) {
           try {
-            await options.rollback();
-          } catch {
-            // prefer the original error if rollback fails
+            await options.begin();
+          } catch (err) {
+            // BEGIN never took, so there is nothing to ROLLBACK.
+            deactivate();
+            throw err;
           }
+          let result: T;
+          try {
+            result = await options.fn();
+            await options.commit();
+          } catch (err) {
+            try {
+              await options.rollback();
+            } catch {
+              // prefer the original error if rollback fails
+            }
+            deactivate();
+            options.afterRollback();
+            throw err;
+          }
+          // Deliberately outside the try: COMMIT has already taken, so a throw
+          // from teardown or from a `put`-flush listener must not issue a
+          // ROLLBACK against a connection with no open transaction and report
+          // the committed work as failed.
           deactivate();
-          options.afterRollback();
-          throw err;
+          options.afterCommit();
+          return result;
+        } finally {
+          releaseDeferredPuts(scope);
         }
-        // Deliberately outside the try: COMMIT has already taken, so a throw
-        // from teardown or from a `put`-flush listener must not issue a ROLLBACK
-        // against a connection with no open transaction and report the committed
-        // work as failed.
-        deactivate();
-        options.afterCommit();
-        return result;
       },
       options.handle
     );
@@ -309,20 +408,7 @@ export function defineNativeConnectionTransaction(
     const store = getAlsStore();
     if (store === undefined) return;
     store.active = false;
-    store.deferPuts = false;
     store.txQuery = undefined;
-  }
-
-  /**
-   * Opts this store into `put` deferral. MUST be called from inside the ALS
-   * scope. Only a connection-scoped transaction drains {@link takeDeferredPuts},
-   * so only it may enqueue: a plain `withTransaction` installs a store of its
-   * own and buffers events on the `tx` proxy, and a `put` queued against that
-   * store would never be flushed.
-   */
-  function enableDeferredPuts(): void {
-    const store = getAlsStore();
-    if (store !== undefined) store.deferPuts = true;
   }
 
   /**
@@ -345,29 +431,25 @@ export function defineNativeConnectionTransaction(
   }
 
   function enqueueDeferredPut(owner: object, entity: unknown): boolean {
-    const store = findStore((ctx) => ctx.active && ctx.deferPuts && ctx.owners.has(owner));
-    if (store === undefined) return false;
-    let queue = store.deferredPuts.get(owner);
-    if (queue === undefined) {
-      queue = [];
-      store.deferredPuts.set(owner, queue);
-    }
-    queue.push(entity);
+    const buffer = currentDeferralBuffer(owner);
+    if (buffer === undefined || !buffer.deferring) return false;
+    if (!buffer.ownsSession && !isEnlistedInConnectionTx(owner)) return false;
+    buffer.entities.push(entity);
     return true;
   }
 
-  /** Drains the post-commit queue; runs after deactivation, so it ignores `active`. */
+  /** Drains the post-commit queue; runs after deactivation, so it ignores `deferring`. */
   function takeDeferredPuts(owner: object): unknown[] {
-    const store = findStore((ctx) => ctx.deferredPuts.has(owner));
-    const queue = store?.deferredPuts.get(owner);
-    if (store === undefined || queue === undefined) return [];
-    store.deferredPuts.delete(owner);
-    return queue;
+    const buffer = currentDeferralBuffer(owner);
+    if (buffer === undefined) return [];
+    removeDeferralBuffer(owner, buffer);
+    return buffer.entities;
   }
 
-  /** Drops the queue after ROLLBACK; runs after deactivation, so it ignores `active`. */
+  /** Drops the queue after ROLLBACK; runs after deactivation, so it ignores `deferring`. */
   function discardDeferredPuts(owner: object): void {
-    findStore((ctx) => ctx.deferredPuts.has(owner))?.deferredPuts.delete(owner);
+    const buffer = currentDeferralBuffer(owner);
+    if (buffer !== undefined) removeDeferralBuffer(owner, buffer);
   }
 
   function isEnlistedInConnectionTx(owner: object): boolean {
@@ -394,8 +476,9 @@ export function defineNativeConnectionTransaction(
   /**
    * Emits every `put` a participant deferred, now that COMMIT has taken.
    *
-   * Goes through `emitCommittedPut` rather than the participant's own `emitPut`,
-   * which would see the store still installed and queue the event straight back.
+   * Goes through `emitCommittedPut` rather than the participant's own
+   * `emitPut`: these events have already cleared deferral and must reach
+   * subscribers whatever buffering `emitPut` is currently doing.
    */
   function flushDeferredPuts(participants: readonly AnyTabularStorage[]): void {
     for (const member of members(participants)) {
@@ -439,6 +522,7 @@ export function defineNativeConnectionTransaction(
     return runNativeConnectionTransaction({
       handle,
       participants: options.participants,
+      ownsSession: true,
       begin: async () => {
         setActive(true);
         await options.exec("BEGIN");

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -944,6 +944,11 @@ export class PostgresTabularStorage<
           // connection for nesting detection.
           chainHandle: client,
           participants,
+          // The pool keeps serving unrelated callers on other clients while
+          // this transaction runs, and their rows survive its ROLLBACK — so
+          // deferral must follow enlistment rather than cover the participants
+          // wholesale.
+          ownsSession: false,
           begin: async () => {
             setConnectionTxQuery({ query: client.query.bind(client) });
             await client.query("BEGIN");


### PR DESCRIPTION
## The bug

`withConnectionTransaction` deferred participant `put` events entirely through the AsyncLocalStorage store: `enableDeferredPuts()` set `deferPuts` on `getAlsStore()`, and `enqueueDeferredPut()` returned `false` unless it could walk back to an `active && deferPuts` store.

On the **browser** entry the ALS is `createShimAls()`, whose `current` is restored the moment the synchronous portion of `store.run(ctx, () => fn())` returns — that is the first `await` inside `runNativeConnectionTransaction`, namely `await options.begin()`. Every participant `put` after that point reached `emitPut` (`SqliteTabularStorage`, `PostgresTabularStorage`, `DuckDbTabularStorage`), got `false` from `enqueueDeferredPut`, and fired **immediately**; `flushDeferredPuts` / `discardAllDeferredPuts` then drained an empty queue.

Concrete failure: a browser app on SQLite-WASM (or PGlite) runs `withConnectionTransaction([docs, chunks], …)`, a subscriber to `put` updates the UI, the body throws, ROLLBACK runs — the UI now shows rows that do not exist, and nothing signals it. That breaks the guarantee the module's own docs state ("listeners never observe rows that are about to roll back"), and it is the one property the plain `withTransaction` path *does* keep on the browser, because that path buffers on the `tx` proxy rather than on the ALS.

The gap was undocumented and untested — every existing deferral test ran on the real `AsyncLocalStorage`.

## The fix

Deferral is now **ALS-independent**, the way cross-instance re-entry already is (`HandleState.txOwners` in `defineConnectionMutex.ts` is deliberately handle-state based for exactly this reason).

`runNativeConnectionTransaction` registers a `DeferralBuffer` per participant for the life of the transaction, keyed on the storage instance in a factory-scoped `WeakMap`:

- `enqueueDeferredPut(owner, entity)` reads that buffer — readable after an `await` on either runtime.
- `takeDeferredPuts` / `discardDeferredPuts` drain and unregister **the same** buffer the puts landed in.
- `deactivate()` clears `deferring` before `onDeactivate`/`afterCommit`, so a listener writing in response to a flushed `put` still emits rather than queueing onto a buffer nothing will drain again (the existing ordering test pins this).
- A `finally` releases any buffer a backend never drained, so nothing outlives its transaction.
- The registry is a per-owner **stack**, so an inline nested transaction's drain cannot take an outer one's queue with it.

`AlsContext.deferPuts` / `AlsContext.deferredPuts` are gone — one source of truth, no dead fields.

### Why shape (a) and not (b)

`setConnectionTransactionActive(true)` installing a per-instance buffer was the alternative, but the real-`pg.Pool` arm deliberately never flags its participants (`inTransaction` means "a BEGIN is open on my session", and setting it there would misroute `putBulk` and `withTransaction`). Hanging the buffer off the transaction covers both arms. It is also keyed the way `enqueueDeferredPut` is actually called — that function receives only the storage instance, and `HandleState` lives in a `WeakMap` keyed by connection handle, unreachable from an owner.

### `ownsSession`

`RunNativeConnectionTransactionOptions` gains a required `ownsSession: boolean`.

- `true` (SQLite, DuckDB, PGlite, via `runSingleSessionConnectionTransaction`): the transaction owns the participants' only session, so every write they make necessarily joins it and deferral is unconditional for the duration. This is what carries deferral across an `await` on the shim.
- `false` (real `pg.Pool`): the transaction holds one checked-out client while unrelated callers keep writing through the pool and committing at once — those rows survive its ROLLBACK, so their `put` must fire straight away. Deferral there follows the same ALS-scoped enlistment test that arm's own query routing (`connectionTxQuery` / `isEnlistedInConnectionTx`) already uses. Without this the fix would have regressed the documented "leaves a concurrent caller outside the transaction body alone" property into deferring — and, on rollback, **dropping** — a committed row's event.

## New coverage

`packages/storage/src/tabular/__tests__/runNativeConnectionTransaction.test.ts`:

- A `describe.each` over `__resetAlsForTesting(false)` and `__resetAlsForTesting(true)` runs the deferral cases on **both** runtimes, with a comment explaining the shim-vs-real-ALS distinction:
  - puts inside a committed connection transaction are deferred, then flushed exactly once;
  - puts inside a rolled-back connection transaction are never observed by a subscriber.
- A recording participant whose `emitPut` mirrors what the SQL backends do (offer to the buffer, emit when refused), so the test fails for exactly the reason a browser app would show uncommitted rows.
- One test pinning the `ownsSession: false` shape: a caller that never entered the transaction body still emits immediately.

**Verified the two shim cases fail against the unfixed code** before the fix landed:

```
FAIL  put deferral on 'the browser\'s synchronous shim' > holds a put until COMMIT, then emits it exactly once
AssertionError: expected [ 'row-1' ] to deeply equal []
FAIL  put deferral on 'the browser\'s synchronous shim' > never lets a subscriber observe a put that rolls back
AssertionError: expected [ 'row-1' ] to deeply equal []
Tests  2 failed | 13 passed (15)
```

## Verification

| Check | Result |
| --- | --- |
| `bun run format-check` | All matched files use the correct format (2352 files) |
| `bun run lint` | clean, exit 0 |
| `bun run build:types` | 42 successful, 42 total |
| `tsc --noEmit` on the test file (excluded from `build:types`) | 0 errors |
| `vitest run packages/storage/src/tabular/__tests__` | 11 files, 201 passed / 1 skipped |
| `vitest run` Sqlite + Postgres + DuckDb tabular integration suites (`WORKGLOW_TEST_TIER=all`) | 3 files, 514 passed / 3 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdZebeeuQjgQTUszAjJDLb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdZebeeuQjgQTUszAjJDLb)_