### PR TITLE
fix(web-search): name a credential for a provider, fill Brave's open date bound, and thread abort

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -233,12 +233,25 @@ honor it and the adapter would throw after selection rather than before.
 
 Date filtering is **never emulated** — post-filtering by `publishedDate` breaks `maxResults`
 and drops every result whose date the provider omitted, so `dateFilter: false` means such a
-request is refused rather than approximated.
+request is refused rather than approximated. The other half of that rule is that a provider
+declaring `dateFilter: true` has to send something for every range this task accepts: both
+Brave's `freshness` and Gemini's `timeRangeFilter` take a closed interval, so a half-open
+range is filled at the open end. Dropping it reports a bound as honored on a search that ran
+unfiltered, which is worse than refusing the request.
 
 `provider` is a required input with no default, mirroring `response_type` on `FetchUrlTask` —
 which provider serves a request decides its cost, rate limit and quality. `"auto"` opts into
 capability routing; the provider that ran is always reported on the `provider` output port. A
 **pinned** provider that cannot honor an option throws rather than rerouting.
+
+**A credential is named for a provider, never for the request.** `credential_keys` maps
+provider name → credential-store key, and the key sent is the one named for the provider that
+runs, so a key issued for one vendor cannot reach another; routing prefers a provider a key is
+named for, since naming one states which vendors the caller holds a key for. The single
+`credential_key` port stays for a pinned provider, where the vendor is unambiguous, and is
+refused with `"auto"` — routing picks the vendor at run time, so an unnamed key would go
+wherever it landed. `scanGraphForCredentials` reads the map through its `additionalProperties`
+value schema, which is what still unlocks the store for the run.
 
 Seven providers ship: `brave`, `tavily`, `searxng` here; `anthropic`, `openai`, `openrouter`,
 `gemini` as a `./web-search` subpath on their vendor package, registered explicitly
@@ -252,6 +265,8 @@ per-attempt timeouts and the response cache. They do **not** inherit the queue's
 secret included), so every keyed provider runs inline, and bounding a `MapTask` fan-out against
 a metered quota is the caller's job. The grounded adapters live in their vendor packages and
 use the vendor SDK, which is what keeps this package free of any dependency on `@workglow/ai`.
+Each hands `context.signal` to the SDK call, not just to a `throwIfAborted()` before it —
+otherwise an aborted run leaves a grounded turn in flight and pays for it.
 
 Two Anthropic-specific traps the adapter handles: a `web_search_tool_result` block carries a
 **list** on success and an error **object** on failure — at HTTP 200, raising nothing — so

--- a/packages/task-graph/src/task-graph/GraphFormatScanner.ts
+++ b/packages/task-graph/src/task-graph/GraphFormatScanner.ts
@@ -35,9 +35,20 @@ export interface GraphFormatScanResult {
 }
 
 /**
+ * The value schema of a map port — `additionalProperties` written as a schema
+ * rather than a boolean. A port holding a map of credential keys annotates the
+ * format there, where the per-property walk never looks.
+ */
+function getMapValueSchema(schema: unknown): unknown {
+  if (typeof schema !== "object" || schema === null) return undefined;
+  const additional = (schema as Record<string, unknown>).additionalProperties;
+  return typeof additional === "object" && additional !== null ? additional : undefined;
+}
+
+/**
  * Recursively walks a JSON Schema's properties looking for any property whose
- * format annotation matches `targetFormat`. Handles nested objects and
- * `oneOf`/`anyOf` wrappers.
+ * format annotation matches `targetFormat`. Handles nested objects, map values
+ * and `oneOf`/`anyOf` wrappers.
  */
 function schemaHasFormat(schema: unknown, targetFormat: string): boolean {
   if (typeof schema !== "object" || schema === null) return false;
@@ -48,6 +59,8 @@ function schemaHasFormat(schema: unknown, targetFormat: string): boolean {
     for (const propSchema of Object.values(properties)) {
       const format = getSchemaFormat(propSchema);
       if (format === targetFormat) return true;
+
+      if (getSchemaFormat(getMapValueSchema(propSchema)) === targetFormat) return true;
 
       // Recurse into nested object schemas
       const objectSchema = getObjectSchema(propSchema);
@@ -117,10 +130,19 @@ export function scanGraphForCredentials(graph: ITaskGraph): GraphFormatScanResul
   };
 }
 
+/** Whether a map value holds at least one non-empty string. */
+function hasNonEmptyStringValue(data: unknown): boolean {
+  if (typeof data !== "object" || data === null) return false;
+  return Object.values(data as Record<string, unknown>).some(
+    (value) => typeof value === "string" && value.length > 0
+  );
+}
+
 /**
  * Walk schema and data in parallel. When a property is annotated with a
  * credential format AND the corresponding data value is a non-empty string,
- * record the format. Recurses into nested object schemas.
+ * record the format. A map port annotated on its value schema counts the same
+ * way, once it holds an entry. Recurses into nested object schemas.
  */
 function collectUsedCredentialFormats(schema: unknown, data: unknown, formats: Set<string>): void {
   if (typeof schema === "boolean" || typeof schema !== "object" || schema === null) return;
@@ -142,6 +164,15 @@ function collectUsedCredentialFormats(schema: unknown, data: unknown, formats: S
       value.length > 0
     ) {
       formats.add(format);
+    }
+
+    const mapValueFormat = getSchemaFormat(getMapValueSchema(propSchema));
+    if (
+      mapValueFormat !== undefined &&
+      CREDENTIAL_KEY_FORMATS.has(mapValueFormat) &&
+      hasNonEmptyStringValue(value)
+    ) {
+      formats.add(mapValueFormat);
     }
 
     // Recurse into nested object schemas with the matching nested data

--- a/packages/task-graph/src/task-graph/__tests__/GraphFormatScanner.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/GraphFormatScanner.test.ts
@@ -101,6 +101,27 @@ class UnresolvedCredentialKeyTask extends Task<any, any> {
   }
 }
 
+/**
+ * A port holding a MAP of credential keys — the format is annotated on the
+ * `additionalProperties` value schema, since the key names are not known ahead
+ * of time (they are provider names supplied by the caller).
+ */
+class MapCredentialKeyTask extends Task<any, any> {
+  static override readonly type = "MapCredentialKeyTask";
+
+  static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        credential_keys: {
+          type: "object",
+          additionalProperties: { type: "string", format: "credential-key" },
+        },
+      },
+    } as const satisfies DataPortSchema;
+  }
+}
+
 class NoCredentialTask extends Task<any, any> {
   static override readonly type = "NoCredentialTask";
 
@@ -187,6 +208,31 @@ describe("GraphFormatScanner", () => {
       );
       expect(result.needsCredentials).toBe(true);
       expect(result.credentialFormats.has("credential-key")).toBe(true);
+    });
+
+    it("detects a credential-key annotated on a map's value schema", () => {
+      // The key names are provider names the caller chooses, so the format can
+      // only be declared on `additionalProperties`. Missed there, the store is
+      // never unlocked and every keyed request goes out unauthenticated.
+      const result = scanGraphForCredentials(
+        makeGraph(new MapCredentialKeyTask({ defaults: { credential_keys: { tavily: "k" } } }))
+      );
+      expect(result.needsCredentials).toBe(true);
+      expect(result.credentialFormats.has("credential-key")).toBe(true);
+    });
+
+    it("ignores an empty credential-key map", () => {
+      const result = scanGraphForCredentials(
+        makeGraph(new MapCredentialKeyTask({ defaults: { credential_keys: {} } }))
+      );
+      expect(result.needsCredentials).toBe(false);
+    });
+
+    it("ignores a credential-key map whose only entry is an empty string", () => {
+      const result = scanGraphForCredentials(
+        makeGraph(new MapCredentialKeyTask({ defaults: { credential_keys: { tavily: "" } } }))
+      );
+      expect(result.needsCredentials).toBe(false);
     });
 
     it("ignores a declared-but-unset credential-key", () => {
@@ -292,6 +338,12 @@ describe("GraphFormatScanner", () => {
 
     it("returns true for oneOf credential format", () => {
       expect(scanGraphForFormat(makeGraph(new OneOfCredentialTask({})), "credential")).toBe(true);
+    });
+
+    it("returns true for a format annotated on a map's value schema", () => {
+      expect(scanGraphForFormat(makeGraph(new MapCredentialKeyTask({})), "credential-key")).toBe(
+        true
+      );
     });
   });
 });

--- a/packages/web-search/README.md
+++ b/packages/web-search/README.md
@@ -64,6 +64,28 @@ always reported on the `provider` output port.
 A pinned provider that cannot honor an option throws rather than quietly
 rerouting or ignoring the option.
 
+## Credentials
+
+`credential_key` names one credential-store entry and belongs with a **pinned**
+provider, where the vendor receiving it is settled before the run. With `"auto"`
+it is refused: routing chooses the vendor at run time, so an unnamed key would be
+sent wherever routing landed.
+
+Name the key per provider instead, and `"auto"` stays usable:
+
+```ts
+const out = await new WebSearchTask().run({
+  query: "transformer architecture",
+  provider: "auto",
+  includeAnswer: true,
+  credential_keys: { tavily: "tavily-api-key", brave: "brave-api-key" },
+});
+```
+
+The key sent is the one named for the provider that actually runs, so a key
+issued for one vendor cannot reach another; routing prefers a provider a key is
+named for, and a provider none was named for is simply searched unauthenticated.
+
 ## Adding a provider
 
 Implement `IWebSearchProvider` and register it:

--- a/packages/web-search/src/WebSearchProviderRegistry.ts
+++ b/packages/web-search/src/WebSearchProviderRegistry.ts
@@ -44,12 +44,21 @@ class Registry {
    * Picks a registered provider that can serve every option the request states,
    * in registration order.
    *
+   * A provider named in `credentialed` is considered first. Naming a credential
+   * key for a provider states which vendors the caller actually holds a key for,
+   * and only a key named for the provider that runs is ever sent — so without
+   * this, routing lands on a provider with no key and the request goes out
+   * unauthenticated while a usable one sits behind it.
+   *
    * The failure message names which option ruled out which provider: with
    * several registered, "nothing satisfies this request" leaves an operator with
    * no way to tell whether to add a key, register another provider, or drop an
    * option.
    */
-  route(request: WebSearchRequest): IWebSearchProvider {
+  route(
+    request: WebSearchRequest,
+    credentialed: ReadonlySet<string> = new Set()
+  ): IWebSearchProvider {
     const candidates = this.list();
     if (candidates.length === 0) {
       throw new TaskConfigurationError(
@@ -57,8 +66,15 @@ class Registry {
           "from a server runtime, or register one with registerWebSearchProvider()."
       );
     }
+    const ordered =
+      credentialed.size === 0
+        ? candidates
+        : [
+            ...candidates.filter((c) => credentialed.has(c.name)),
+            ...candidates.filter((c) => !credentialed.has(c.name)),
+          ];
     const rejected: string[] = [];
-    for (const candidate of candidates) {
+    for (const candidate of ordered) {
       const gaps = unhonorableOptions(candidate.capabilities, request);
       if (gaps.length === 0) return candidate;
       rejected.push(`${candidate.name} (cannot serve: ${gaps.join(", ")})`);

--- a/packages/web-search/src/WebSearchTask.ts
+++ b/packages/web-search/src/WebSearchTask.ts
@@ -78,7 +78,20 @@ const inputSchema = {
       // The scan that unlocks the store still counts this format.
       format: "credential-key",
       title: "Credential Key",
-      description: "Key looked up in the credential store and sent as the provider's API key.",
+      description:
+        "Key looked up in the credential store and sent as the provider's API key. Only " +
+        "valid alongside a pinned provider — with 'auto' the vendor is not known yet, so " +
+        "name the key per provider in credential_keys instead.",
+      "x-ui-hidden": true,
+    },
+    credential_keys: {
+      type: "object",
+      additionalProperties: { type: "string", format: "credential-key" },
+      title: "Credential Keys",
+      description:
+        "Credential-store keys by provider name. The key sent is the one named for the " +
+        "provider that runs, so a key issued for one vendor never reaches another, and " +
+        "routing prefers a provider a key is named for.",
       "x-ui-hidden": true,
     },
   },
@@ -138,6 +151,24 @@ export type WebSearchTaskOutput = {
   count: number;
   usage?: WebSearchUsage | undefined;
 };
+
+function namedProviders(keys: Readonly<Record<string, string>> | undefined): ReadonlySet<string> {
+  return new Set(Object.keys(keys ?? {}));
+}
+
+/**
+ * The credential handed to a provider is the one named for that provider.
+ *
+ * Under `"auto"` a key named for nothing in particular is never forwarded: the
+ * vendor is chosen at run time, so the secret would go wherever routing landed.
+ * A pinned provider is unambiguous, so the bare `credential_key` still serves it.
+ */
+function credentialKeyFor(provider: string, input: WebSearchTaskInput): string | undefined {
+  return (
+    input.credential_keys?.[provider] ??
+    (input.provider === "auto" ? undefined : input.credential_key)
+  );
+}
 
 export class WebSearchTask extends Task<WebSearchTaskInput, WebSearchTaskOutput> {
   static override readonly type = "WebSearchTask";
@@ -200,6 +231,9 @@ export class WebSearchTask extends Task<WebSearchTaskInput, WebSearchTaskOutput>
     input: WebSearchTaskInput,
     context: IExecuteContext
   ): Promise<WebSearchTaskOutput> {
+    // No credential on the base request: which provider serves it is not settled
+    // until routing has run, and a key attached before then is a key attached to
+    // whichever vendor routing happens to pick.
     const baseRequest: WebSearchRequest = {
       query: input.query,
       maxResults: input.maxResults,
@@ -208,11 +242,13 @@ export class WebSearchTask extends Task<WebSearchTaskInput, WebSearchTaskOutput>
       dateRange: input.dateRange,
       includeAnswer: input.includeAnswer,
       includeContent: input.includeContent,
-      credentialKey: input.credential_key,
     };
 
-    const provider = this.resolveProvider(input.provider, baseRequest);
-    const request = this.adaptRequest(provider, baseRequest);
+    const provider = this.resolveProvider(input, baseRequest);
+    const request = this.adaptRequest(provider, {
+      ...baseRequest,
+      credentialKey: credentialKeyFor(provider.name, input),
+    });
 
     await context.updateProgress(undefined, `Searching via ${provider.name}`);
     const response = await provider.search(request, context);
@@ -232,8 +268,21 @@ export class WebSearchTask extends Task<WebSearchTaskInput, WebSearchTaskOutput>
    * cost and quota, so an option it cannot serve is an error rather than a
    * reroute to a provider the caller did not ask to be billed for.
    */
-  private resolveProvider(name: string, request: WebSearchRequest): IWebSearchProvider {
-    if (name === "auto") return WebSearchProviderRegistry.route(request);
+  private resolveProvider(
+    input: WebSearchTaskInput,
+    request: WebSearchRequest
+  ): IWebSearchProvider {
+    const name = input.provider;
+    if (name === "auto") {
+      if (input.credential_key !== undefined) {
+        throw new TaskConfigurationError(
+          "WebSearchTask: credential_key cannot be combined with provider 'auto'. Routing " +
+            "picks the vendor at run time, so an unnamed key would be sent to whichever one " +
+            "it landed on. Name it per provider in credential_keys instead."
+        );
+      }
+      return WebSearchProviderRegistry.route(request, namedProviders(input.credential_keys));
+    }
     const provider = WebSearchProviderRegistry.require(name);
     const gaps = unhonorableOptions(provider.capabilities, request);
     if (gaps.length > 0) {

--- a/packages/web-search/src/__tests__/BraveWebSearchProvider.test.ts
+++ b/packages/web-search/src/__tests__/BraveWebSearchProvider.test.ts
@@ -105,10 +105,23 @@ describe("BraveWebSearchProvider", () => {
     expect(url.searchParams.get("freshness")).toBe(`2026-01-01to${today}`);
   });
 
-  it("sends no freshness for an end-only range it cannot express", async () => {
+  it("opens the start of an end-only date range rather than dropping the filter", async () => {
     const seen = vi.fn();
     await new BraveWebSearchProvider().search(
       { query: "cats", dateRange: { end: "2026-06-01" } },
+      contextWithResponse(BRAVE_PAYLOAD, seen)
+    );
+    const url = new URL((seen.mock.calls[0][0] as { url: string }).url);
+    // Dropping it would run the search unfiltered while `dateFilter: true` says
+    // the bound was honored, so the caller gets undated results reported as a
+    // successful date-bounded search.
+    expect(url.searchParams.get("freshness")).toBe("1970-01-01to2026-06-01");
+  });
+
+  it("sends no freshness when neither end of the range is set", async () => {
+    const seen = vi.fn();
+    await new BraveWebSearchProvider().search(
+      { query: "cats", dateRange: {} },
       contextWithResponse(BRAVE_PAYLOAD, seen)
     );
     const url = new URL((seen.mock.calls[0][0] as { url: string }).url);

--- a/packages/web-search/src/__tests__/WebSearchCredential.test.ts
+++ b/packages/web-search/src/__tests__/WebSearchCredential.test.ts
@@ -143,11 +143,75 @@ describe("WebSearchTask credential forwarding", () => {
     expect(JSON.stringify(headers)).not.toContain("absent-key-name");
   });
 
+  it("never sends a Tavily-named key to Brave when routing chooses the provider", async () => {
+    // Brave registers first, so insertion-order routing lands on it. The key is
+    // named for tavily and nothing else, and a secret issued for one vendor
+    // reaching another is not recoverable by rotating anything but that key.
+    WebSearchProviderRegistry.register(new BraveWebSearchProvider());
+    WebSearchProviderRegistry.register(new TavilyWebSearchProvider());
+    const registry = await credentialRegistry();
+
+    const out = await new WebSearchTask().run(
+      { query: "cats", provider: "auto", credential_keys: { tavily: STORE_KEY } },
+      { registry }
+    );
+
+    expect(out.provider).toBe("tavily");
+    const [url, options] = mockFetch.mock.calls.at(-1) ?? [];
+    expect(url).toContain("api.tavily.com");
+    expect(JSON.stringify(options)).not.toContain("X-Subscription-Token");
+    for (const [calledUrl, calledOptions] of mockFetch.mock.calls) {
+      if (String(calledUrl).includes("brave")) {
+        expect(JSON.stringify(calledOptions)).not.toContain(SECRET);
+      }
+    }
+  });
+
+  it("sends no key at all when routing lands on a provider none was named for", async () => {
+    WebSearchProviderRegistry.register(new BraveWebSearchProvider());
+    const registry = await credentialRegistry();
+
+    const out = await new WebSearchTask().run(
+      { query: "cats", provider: "auto", credential_keys: { tavily: STORE_KEY } },
+      { registry }
+    );
+
+    // An unauthenticated search that fails is recoverable; the Tavily secret
+    // arriving at Brave is not.
+    expect(out.provider).toBe("brave");
+    expect(JSON.stringify(mockFetch.mock.calls.at(-1))).not.toContain(SECRET);
+  });
+
+  it("refuses a bare credential_key alongside provider 'auto'", async () => {
+    WebSearchProviderRegistry.register(new BraveWebSearchProvider());
+    WebSearchProviderRegistry.register(new TavilyWebSearchProvider());
+    const registry = await credentialRegistry();
+
+    await expect(
+      new WebSearchTask().run(
+        { query: "cats", provider: "auto", credential_key: STORE_KEY },
+        { registry }
+      )
+    ).rejects.toThrow(/credential_keys/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("is still seen by the graph credential scan that unlocks the store", () => {
     const graph = new TaskGraph();
     graph.addTask(
       new WebSearchTask({
         defaults: { query: "cats", provider: "tavily", credential_key: STORE_KEY },
+      })
+    );
+
+    expect(scanGraphForCredentials(graph).needsCredentials).toBe(true);
+  });
+
+  it("is still seen by that scan when the key is named in the per-provider map", () => {
+    const graph = new TaskGraph();
+    graph.addTask(
+      new WebSearchTask({
+        defaults: { query: "cats", provider: "auto", credential_keys: { tavily: STORE_KEY } },
       })
     );
 

--- a/packages/web-search/src/__tests__/WebSearchTask.test.ts
+++ b/packages/web-search/src/__tests__/WebSearchTask.test.ts
@@ -125,6 +125,89 @@ describe("WebSearchTask", () => {
     expect(out.query).toBe("cats site:a.com");
   });
 
+  it("hands a provider only the credential named for it", async () => {
+    const brave = vi.fn();
+    const tavily = vi.fn();
+    WebSearchProviderRegistry.register(fake("brave", {}, brave));
+    WebSearchProviderRegistry.register(fake("tavily", {}, tavily));
+
+    await new WebSearchTask().run({
+      query: "cats",
+      provider: "tavily",
+      credential_keys: { brave: "brave-key", tavily: "tavily-key" },
+    });
+
+    expect(brave).not.toHaveBeenCalled();
+    expect(tavily).toHaveBeenCalledWith(expect.objectContaining({ credentialKey: "tavily-key" }));
+  });
+
+  it("routes to the provider a credential is named for, not the first registered", async () => {
+    const seen = vi.fn();
+    WebSearchProviderRegistry.register(fake("brave", {}));
+    WebSearchProviderRegistry.register(fake("tavily", {}, seen));
+
+    const out = await new WebSearchTask().run({
+      query: "cats",
+      provider: "auto",
+      credential_keys: { tavily: "tavily-key" },
+    });
+
+    expect(out.provider).toBe("tavily");
+    expect(seen).toHaveBeenCalledWith(expect.objectContaining({ credentialKey: "tavily-key" }));
+  });
+
+  it("prefers a credentialed provider only among those that can serve the request", async () => {
+    const seen = vi.fn();
+    WebSearchProviderRegistry.register(fake("brave", { answer: true }, seen));
+    WebSearchProviderRegistry.register(fake("tavily", {}));
+
+    // The named provider cannot synthesize an answer, so the preference yields
+    // to the capability check rather than overriding it.
+    const out = await new WebSearchTask().run({
+      query: "cats",
+      provider: "auto",
+      includeAnswer: true,
+      credential_keys: { tavily: "tavily-key" },
+    });
+
+    expect(out.provider).toBe("brave");
+    expect(seen).toHaveBeenCalledWith(expect.objectContaining({ credentialKey: undefined }));
+  });
+
+  it("sends no credential to a routed provider none was named for", async () => {
+    const seen = vi.fn();
+    WebSearchProviderRegistry.register(fake("brave", {}, seen));
+
+    await new WebSearchTask().run({
+      query: "cats",
+      provider: "auto",
+      credential_keys: { tavily: "tavily-key" },
+    });
+
+    expect(seen).toHaveBeenCalledWith(expect.objectContaining({ credentialKey: undefined }));
+  });
+
+  it("refuses an unnamed credential_key with provider auto", async () => {
+    WebSearchProviderRegistry.register(fake("brave", {}));
+    await expect(
+      new WebSearchTask().run({ query: "cats", provider: "auto", credential_key: "some-key" })
+    ).rejects.toThrow(/credential_keys/);
+  });
+
+  it("lets the per-provider map override the bare key for a pinned provider", async () => {
+    const seen = vi.fn();
+    WebSearchProviderRegistry.register(fake("tavily", {}, seen));
+
+    await new WebSearchTask().run({
+      query: "cats",
+      provider: "tavily",
+      credential_key: "fallback-key",
+      credential_keys: { tavily: "tavily-key" },
+    });
+
+    expect(seen).toHaveBeenCalledWith(expect.objectContaining({ credentialKey: "tavily-key" }));
+  });
+
   it("reports zero results as success, not failure", async () => {
     WebSearchProviderRegistry.register({
       name: "empty",

--- a/packages/web-search/src/providers/BraveWebSearchProvider.ts
+++ b/packages/web-search/src/providers/BraveWebSearchProvider.ts
@@ -26,13 +26,25 @@ interface BraveResult {
   readonly meta_url?: { readonly favicon?: string };
 }
 
-/** Brave's `freshness` takes `YYYY-MM-DDtoYYYY-MM-DD`; an open end is left off. */
+/** No lower bound: `freshness` takes a closed interval and accepts any start date. */
+const OPEN_INTERVAL_START = "1970-01-01";
+
+function isoDay(value: string | undefined): string | undefined {
+  const day = value?.slice(0, 10);
+  return day === undefined || day.length === 0 ? undefined : day;
+}
+
+/**
+ * Brave's `freshness` takes `YYYY-MM-DDtoYYYY-MM-DD`. Either side of this task's
+ * `dateRange` may be open, so the missing one is filled rather than dropped —
+ * dropping it sends the search unfiltered while `dateFilter: true` reports the
+ * bound as honored.
+ */
 function freshnessParam(range: WebSearchDateRange): string | undefined {
-  const start = range.start?.slice(0, 10);
-  const end = range.end?.slice(0, 10);
-  if (start && end) return `${start}to${end}`;
-  if (start) return `${start}to${new Date().toISOString().slice(0, 10)}`;
-  return undefined;
+  const start = isoDay(range.start);
+  const end = isoDay(range.end);
+  if (start === undefined && end === undefined) return undefined;
+  return `${start ?? OPEN_INTERVAL_START}to${end ?? new Date().toISOString().slice(0, 10)}`;
 }
 
 export class BraveWebSearchProvider implements IWebSearchProvider {

--- a/providers/anthropic/src/__tests__/AnthropicWebSearchProvider.test.ts
+++ b/providers/anthropic/src/__tests__/AnthropicWebSearchProvider.test.ts
@@ -196,6 +196,24 @@ describe("AnthropicWebSearchProvider", () => {
     expect(c.exclusiveDomainDirections).toBe(true);
   });
 
+  it("hands the abort signal to every request, not just the loop condition", async () => {
+    const { create, client } = clientReturning(
+      messageWith([{ type: "text", text: "partial " }], "pause_turn"),
+      messageWith([{ type: "text", text: "and the rest." }])
+    );
+    const controller = new AbortController();
+    await new AnthropicWebSearchProvider({ client: client as never }).search({ query: "cats" }, {
+      ...context,
+      signal: controller.signal,
+    } as IExecuteContext);
+    // Checking the signal between turns only stops the next one from starting;
+    // without the SDK option the request already in flight runs to completion
+    // and is billed at max_tokens.
+    for (const call of create.mock.calls) {
+      expect((call[1] as { signal?: AbortSignal }).signal).toBe(controller.signal);
+    }
+  });
+
   it("refuses to send both domain lists, which the API rejects", async () => {
     const { client } = clientReturning(messageWith([{ type: "text", text: "x" }]));
     await expect(

--- a/providers/anthropic/src/web-search/AnthropicWebSearchProvider.ts
+++ b/providers/anthropic/src/web-search/AnthropicWebSearchProvider.ts
@@ -106,12 +106,18 @@ export class AnthropicWebSearchProvider implements IWebSearchProvider {
     // answer is silently truncated with no error raised anywhere.
     for (let attempt = 0; attempt <= MAX_PAUSE_RESUMES; attempt++) {
       context.signal.throwIfAborted();
-      const message = (await this.client.messages.create({
-        model: this.model,
-        max_tokens: this.maxTokens,
-        tools: [tool] as never,
-        messages: messages as never,
-      })) as {
+      const message = (await this.client.messages.create(
+        {
+          model: this.model,
+          max_tokens: this.maxTokens,
+          tools: [tool] as never,
+          messages: messages as never,
+        },
+        // Checking the signal only bounds how many turns start. Handing it to
+        // the SDK is what stops the one already in flight, which is where the
+        // tokens are being spent.
+        { signal: context.signal }
+      )) as {
         content: readonly unknown[];
         stop_reason?: string;
         usage?: { input_tokens?: number; output_tokens?: number };

--- a/providers/google-gemini/src/__tests__/GeminiWebSearchProvider.test.ts
+++ b/providers/google-gemini/src/__tests__/GeminiWebSearchProvider.test.ts
@@ -52,6 +52,20 @@ describe("GeminiWebSearchProvider", () => {
     expect(c.content).toBe(false);
   });
 
+  it("hands the abort signal to the SDK, not just to a check before it", async () => {
+    const seen = vi.fn();
+    const { client } = clientReturning(PAYLOAD, seen);
+    const controller = new AbortController();
+    await new GeminiWebSearchProvider({ client }).search({ query: "cats" }, {
+      ...context,
+      signal: controller.signal,
+    } as IExecuteContext);
+    // Without it an aborted run leaves a grounded turn in flight, and the run
+    // is billed for tokens nobody will read.
+    const body = seen.mock.calls[0][0] as { config: { abortSignal?: AbortSignal } };
+    expect(body.config.abortSignal).toBe(controller.signal);
+  });
+
   it("enables the googleSearch tool", async () => {
     const seen = vi.fn();
     const { client } = clientReturning(PAYLOAD, seen);

--- a/providers/google-gemini/src/web-search/GeminiWebSearchProvider.ts
+++ b/providers/google-gemini/src/web-search/GeminiWebSearchProvider.ts
@@ -92,7 +92,7 @@ export class GeminiWebSearchProvider implements IWebSearchProvider {
     const response = (await this.client.models.generateContent({
       model: this.model,
       contents: request.query,
-      config: { tools: [{ googleSearch }] },
+      config: { tools: [{ googleSearch }], abortSignal: context.signal },
     } as never)) as {
       text?: string;
       candidates?: readonly {

--- a/providers/openai/src/__tests__/OpenAiWebSearchProvider.test.ts
+++ b/providers/openai/src/__tests__/OpenAiWebSearchProvider.test.ts
@@ -49,7 +49,7 @@ const PAYLOAD = {
 };
 
 function clientReturning(payload: unknown, spy?: (body: unknown) => void) {
-  const create = vi.fn(async (body: unknown) => {
+  const create = vi.fn(async (body: unknown, _options?: unknown) => {
     spy?.(body);
     return payload;
   });
@@ -84,6 +84,18 @@ describe("OpenAiWebSearchProvider", () => {
     );
     const tools = (seen.mock.calls[0][0] as { tools: Array<Record<string, never>> }).tools;
     expect(tools[0].filters).toEqual({ allowed_domains: ["arxiv.org"] });
+  });
+
+  it("hands the abort signal to the SDK, not just to a check before it", async () => {
+    const { create, client } = clientReturning(PAYLOAD);
+    const controller = new AbortController();
+    await new OpenAiWebSearchProvider({ client }).search({ query: "cats" }, {
+      ...context,
+      signal: controller.signal,
+    } as IExecuteContext);
+    // Without it an aborted run leaves a grounded turn in flight, and the run
+    // is billed for tokens nobody will read.
+    expect((create.mock.calls[0][1] as { signal?: AbortSignal }).signal).toBe(controller.signal);
   });
 
   it("de-duplicates a source cited at several spans", async () => {

--- a/providers/openai/src/web-search/OpenAiWebSearchProvider.ts
+++ b/providers/openai/src/web-search/OpenAiWebSearchProvider.ts
@@ -86,11 +86,14 @@ export class OpenAiWebSearchProvider implements IWebSearchProvider {
       tool.filters = { allowed_domains: [...request.includeDomains] };
     }
 
-    const response = (await client.responses.create({
-      model: this.model,
-      input: request.query,
-      tools: [tool] as never,
-    } as never)) as {
+    const response = (await client.responses.create(
+      {
+        model: this.model,
+        input: request.query,
+        tools: [tool] as never,
+      } as never,
+      { signal: context.signal }
+    )) as {
       output?: readonly {
         type?: string;
         content?: readonly { type?: string; text?: string; annotations?: readonly UrlCitation[] }[];

--- a/providers/openrouter/src/__tests__/OpenRouterWebSearchProvider.test.ts
+++ b/providers/openrouter/src/__tests__/OpenRouterWebSearchProvider.test.ts
@@ -38,7 +38,7 @@ const PAYLOAD = {
 };
 
 function clientReturning(payload: unknown, spy?: (body: unknown) => void) {
-  const create = vi.fn(async (body: unknown) => {
+  const create = vi.fn(async (body: unknown, _options?: unknown) => {
     spy?.(body);
     return payload;
   });
@@ -53,6 +53,18 @@ describe("OpenRouterWebSearchProvider", () => {
     expect(c.answer).toBe(true);
     expect(c.content).toBe(true);
     expect(c.dateFilter).toBe(false);
+  });
+
+  it("hands the abort signal to the SDK, not just to a check before it", async () => {
+    const { create, client } = clientReturning(PAYLOAD);
+    const controller = new AbortController();
+    await new OpenRouterWebSearchProvider({ client }).search({ query: "cats" }, {
+      ...context,
+      signal: controller.signal,
+    } as IExecuteContext);
+    // Without it an aborted run leaves a grounded turn in flight, and the run
+    // is billed for tokens nobody will read.
+    expect((create.mock.calls[0][1] as { signal?: AbortSignal }).signal).toBe(controller.signal);
   });
 
   it("enables the web plugin and passes both domain lists", async () => {

--- a/providers/openrouter/src/web-search/OpenRouterWebSearchProvider.ts
+++ b/providers/openrouter/src/web-search/OpenRouterWebSearchProvider.ts
@@ -93,12 +93,15 @@ export class OpenRouterWebSearchProvider implements IWebSearchProvider {
     if (request.includeDomains?.length) plugin.include_domains = [...request.includeDomains];
     if (request.excludeDomains?.length) plugin.exclude_domains = [...request.excludeDomains];
 
-    const completion = (await client.chat.completions.create({
-      model: this.model,
-      messages: [{ role: "user", content: request.query }],
-      // `plugins` is an OpenRouter extension the OpenAI types do not model.
-      ...({ plugins: [plugin] } as Record<string, unknown>),
-    } as never)) as {
+    const completion = (await client.chat.completions.create(
+      {
+        model: this.model,
+        messages: [{ role: "user", content: request.query }],
+        // `plugins` is an OpenRouter extension the OpenAI types do not model.
+        ...({ plugins: [plugin] } as Record<string, unknown>),
+      } as never,
+      { signal: context.signal }
+    )) as {
       choices?: ReadonlyArray<{
         message?: { content?: string | null; annotations?: readonly UrlCitationAnnotation[] };
       }>;


### PR DESCRIPTION
Targets **`claude/websearch-task-providers-8aik77`**, the head branch of #850, so these fixes fold into that PR rather than landing on `main` separately.

Three findings from a review of #850.

> **Rebased 2026-09-02.** #850 has been rebased onto `origin/main` (linear, 20 commits), so this branch no longer carries a merge commit and its diff is now just the one fix commit — 18 files, down from 473. A fourth finding (the new package's `build-types` calling `tsgo`, removed by main's TypeScript 7 migration) moved into #850's rebase, where it belongs: the four vendor `package.json`s resolved to `tsc` as merge conflicts, and `packages/web-search/package.json` is a new file that could not conflict, so it was fixed there for consistency rather than here.

## 1. `provider: "auto"` sent the caller's key to whichever vendor routing picked

`WebSearchTask.execute()` copied `credential_key` onto `baseRequest.credentialKey` **before** a provider was chosen. `route()` selects purely on `unhonorableOptions(...)` and returns the first registered provider in insertion order, and the built-ins register brave → tavily → searxng — so `{ query, provider: "auto", credential_key: "tavily-api-key" }` routed to **Brave**, which put the resolved Tavily secret on its `X-Subscription-Token` header to `api.search.brave.com`. Nothing warned, and the caller could not know which vendor received the secret.

Routing is now credential-aware rather than just refusing the combination:

- A new `credential_keys` input maps **provider name → credential-store key**. The key handed to a provider is the one named for that provider, so a key issued for one vendor cannot reach another.
- `route()` takes the set of named providers and considers them first — naming a key states which vendors the caller holds a key for, so `"auto"` no longer picks a keyless provider while a usable one sits behind it. The preference yields to the capability check, never overrides it.
- A bare `credential_key` combined with `"auto"` is **refused** with a `TaskConfigurationError` naming `credential_keys`. It remains valid with a pinned provider, where the vendor is settled before the run.
- Routing lands on a provider no key was named for → the request goes out unauthenticated. An unauthenticated search that fails is recoverable; a secret arriving at the wrong vendor is not.

One supporting change in `@workglow/task-graph`: `scanGraphForCredentials` / `scanGraphForFormat` now also read a credential format annotated on a map's `additionalProperties` value schema. Without it the new port is invisible to the scan that unlocks the credential store, and every keyed `"auto"` run would go out unauthenticated — the same silent failure in a different place.

Tests: `WebSearchCredential.test.ts` drives a real `FetchUrlTask` and asserts a Tavily-named credential never reaches Brave (and never appears on any Brave call), that a routed provider with no named key gets none, and that `auto` + `credential_key` throws before any fetch. `WebSearchTask.test.ts` covers per-provider targeting, the routing preference and its subordination to capabilities. `GraphFormatScanner.test.ts` covers the map-valued port, including empty maps and empty values.

## 2. Brave declared `dateFilter: true` but silently dropped an end-only range

`freshnessParam` returned `undefined` when only `range.end` was set, so no `freshness` parameter was sent and the request ran **unfiltered** — while `dateFilter: true` meant `unhonorableOptions` found no gap, a pinned `brave` request passed, and `"auto"` would route end-only date requests here. The caller got undated results reported as a successful date-bounded search, which is exactly what the capability record exists to prevent.

The open end is now filled, mirroring what this branch already does for Gemini's `timeRangeFilter` (`OPEN_INTERVAL_START`): `freshness` takes a closed interval and accepts an arbitrary start date, so an end-only range becomes `1970-01-01to<end>`. An entirely empty range still sends nothing. The test that locked in the silent drop now asserts the filled range.

## 3. No abort signal reached any grounded provider's SDK call

All four grounded providers called `context.signal.throwIfAborted()` and then issued the SDK request with no signal. A Ctrl-C or graph abort mid-turn cancelled nothing: the request stayed in flight and the run was billed for tokens nobody would read — worst for Anthropic, which runs up to `MAX_PAUSE_RESUMES + 1` requests at `max_tokens: 16000`. Every other Anthropic run-fn in the repo threads it, so this was a deviation rather than a choice.

Option names verified against the installed SDKs:

| Provider | SDK | Option |
| --- | --- | --- |
| Anthropic | `@anthropic-ai/sdk` 0.123.0 | `messages.create(params, { signal })` |
| OpenAI | `openai` 7.8.0 | `responses.create(params, { signal })` |
| OpenRouter | `openai` 7.8.0 | `chat.completions.create(params, { signal })` |
| Gemini | `@google/genai` 2.20.0 | `config.abortSignal` |

Each provider gains a test asserting the signal reaches the SDK; the Anthropic one checks **every** request of a resumed paused turn, not just the first.

## Verification

Re-run after the rebase, on `ad6b411e6`:

```
$ bun run format-check
All matched files use the correct format.
Finished in 258ms on 2392 files using 4 threads.

$ bun run build:types
 Tasks:    43 successful, 43 total

$ oxlint --type-aware --deny-warnings packages providers
(exit 0, no findings)

$ vitest run --project web-search --project anthropic --project openai \
    --project openrouter --project google-gemini --project task-graph
 Test Files  121 passed (121)
      Tests  1153 passed (1153)
```

The new tests were also run against the pre-fix sources to confirm they are not vacuous: 9 of them fail there (7 credential/routing, 1 abort signal, 1 Brave date range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdZebeeuQjgQTUszAjJDLb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdZebeeuQjgQTUszAjJDLb)_