### PR TITLE
Fix connection mutex to queue unrelated concurrent callers

### DIFF
--- a/packages/storage/src/tabular/__tests__/ConnectionMutex.test.ts
+++ b/packages/storage/src/tabular/__tests__/ConnectionMutex.test.ts
@@ -12,7 +12,7 @@ import {
 import { __resetAlsForTesting } from "@workglow/storage/test";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-describe("ConnectionMutex F1: cross-instance re-entry is ALS-independent", () => {
+describe("ConnectionMutex F1: re-entry is classified from the async context", () => {
   afterEach(() => {
     __resetAlsForTesting();
   });
@@ -90,49 +90,107 @@ describe("ConnectionMutex F1: cross-instance re-entry is ALS-independent", () =>
       expect(innerRan).toBe(true);
     });
 
-    it("runOnConnection throws ConnectionReentryError when a sibling instance calls during a transaction", async () => {
-      const handle = {};
-      const ownerA = { table: "table_a" };
-      const ownerB = { table: "table_b" };
+    it.skipIf(!useShim)(
+      "the shim still refuses an unrelated concurrent caller, which it cannot tell from a descendant",
+      async () => {
+        const handle = {};
+        const ownerA = { table: "table_a" };
+        const ownerB = { table: "table_b" };
 
-      let releaseTx: () => void = () => {};
-      const txCanFinish = new Promise<void>((resolve) => {
-        releaseTx = resolve;
-      });
-      let signalTxStarted: () => void = () => {};
-      const txStarted = new Promise<void>((resolve) => {
-        signalTxStarted = resolve;
-      });
+        let releaseTx: () => void = () => {};
+        const txCanFinish = new Promise<void>((resolve) => {
+          releaseTx = resolve;
+        });
+        let signalTxStarted: () => void = () => {};
+        const txStarted = new Promise<void>((resolve) => {
+          signalTxStarted = resolve;
+        });
 
-      const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
-        // signal runs *inside* als.run's synchronous entry, which is after
-        // state.txOwner has been set. Awaiting txStarted below guarantees
-        // the sibling call sees the established transaction owner.
-        signalTxStarted();
-        await txCanFinish;
-      });
-      await txStarted;
+        const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
+          // signal runs *inside* als.run's synchronous entry, which is after
+          // state.txOwners has been set. Awaiting txStarted below guarantees
+          // the sibling call sees the established transaction owner.
+          signalTxStarted();
+          await txCanFinish;
+        });
+        await txStarted;
 
-      const start = Date.now();
-      let error: unknown;
-      try {
-        await runOnConnection(handle, ownerB, async () => "unreachable");
-      } catch (err) {
-        error = err;
+        const start = Date.now();
+        let error: unknown;
+        try {
+          await runOnConnection(handle, ownerB, async () => "unreachable");
+        } catch (err) {
+          error = err;
+        }
+        const elapsed = Date.now() - start;
+
+        expect(error).toBeInstanceOf(ConnectionReentryError);
+        expect((error as ConnectionReentryError).mode).toBe("sibling-op");
+        expect((error as ConnectionReentryError).activeTable).toBe("table_a");
+        expect((error as ConnectionReentryError).blockedTable).toBe("table_b");
+        // Chain-waiting would deadlock on this runtime, so the shim refuses
+        // rather than queues: the throw is immediate, not a chain wait.
+        expect(elapsed).toBeLessThan(200);
+
+        releaseTx();
+        await txPromise;
       }
-      const elapsed = Date.now() - start;
+    );
 
-      expect(error).toBeInstanceOf(ConnectionReentryError);
-      expect((error as ConnectionReentryError).mode).toBe("sibling-op");
-      expect((error as ConnectionReentryError).activeTable).toBe("table_a");
-      expect((error as ConnectionReentryError).blockedTable).toBe("table_b");
-      // No hang: even on the shim path the throw is synchronous relative to
-      // the pending outer tx (no chain wait needed).
-      expect(elapsed).toBeLessThan(200);
+    it.skipIf(useShim)(
+      "an unenlisted unrelated concurrent caller waits for the transaction instead of being refused",
+      async () => {
+        // The regression: the writer is started BEFORE the critical section and
+        // is not an async descendant of the body, so its write cannot escape the
+        // BEGIN. Refusing it lands a ConnectionReentryError in a task that did
+        // nothing wrong, which is what made the primitive unusable in any
+        // concurrent process. Under a real ALS the absent store is what proves
+        // it is unrelated, so it queues on the chain and runs after COMMIT.
+        const handle = {};
+        const ownerA = { table: "table_a" };
+        const ownerB = { table: "table_b" };
+        const order: string[] = [];
 
-      releaseTx();
-      await txPromise;
-    });
+        let releaseTx: () => void = () => {};
+        const txCanFinish = new Promise<void>((resolve) => {
+          releaseTx = resolve;
+        });
+        let signalTxStarted: () => void = () => {};
+        const txStarted = new Promise<void>((resolve) => {
+          signalTxStarted = resolve;
+        });
+
+        const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
+          order.push("BEGIN");
+          signalTxStarted();
+          await txCanFinish;
+          order.push("COMMIT");
+        });
+        await txStarted;
+
+        // Captured rather than awaited here: a pre-fix refusal must surface as
+        // a failed expectation, not as an unhandled rejection.
+        let unrelatedError: unknown;
+        const unrelated = runOnConnection(handle, ownerB, async () => {
+          order.push("UNRELATED-WRITE");
+          return "ok";
+        }).catch((err: unknown) => {
+          unrelatedError = err;
+          return "refused";
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        // Waiting, not refused and not slipped inside the open BEGIN.
+        expect(unrelatedError).toBeUndefined();
+        expect(order).toEqual(["BEGIN"]);
+
+        releaseTx();
+        await txPromise;
+        expect(await unrelated).toBe("ok");
+        expect(unrelatedError).toBeUndefined();
+        expect(order).toEqual(["BEGIN", "COMMIT", "UNRELATED-WRITE"]);
+      }
+    );
 
     it("runInTransactionOnConnection throws ConnectionReentryError when a different owner tries a nested transaction", async () => {
       const handle = {};
@@ -175,23 +233,21 @@ describe("ConnectionMutex F1: cross-instance re-entry is ALS-independent", () =>
       const handle = {};
       const ownerA = { table: "table_a" };
       const ownerB = { table: "table_b" };
-      let signalTxStarted: () => void = () => {};
-      const txStarted = new Promise<void>((resolve) => {
-        signalTxStarted = resolve;
-      });
 
       let step = "before-tx";
-      const txDone = runInTransactionOnConnection(handle, ownerA, async () => {
-        signalTxStarted();
+      let siblingError: unknown;
+      await runInTransactionOnConnection(handle, ownerA, async () => {
         step = "in-tx";
+        // Issued from inside the body, so it is an async descendant on both
+        // runtimes — the caller whose write would escape the BEGIN, and the
+        // one that is still refused.
+        await runOnConnection(handle, ownerB, async () => "unreachable").catch((err: unknown) => {
+          siblingError = err;
+        });
       });
-      await txStarted;
 
-      await expect(
-        runOnConnection(handle, ownerB, async () => "unreachable")
-      ).rejects.toBeInstanceOf(ConnectionReentryError);
-
-      await txDone;
+      expect(siblingError).toBeInstanceOf(ConnectionReentryError);
+      expect((siblingError as ConnectionReentryError).mode).toBe("sibling-op");
       expect(step).toBe("in-tx");
 
       // The chain slot must be released — a subsequent A op runs cleanly.
@@ -358,27 +414,19 @@ describe("ConnectionMutex F2: ConnectionReentryError message and mode", () => {
     const handle = {};
     const ownerA = { table: "issuer" };
     const ownerB = { table: "filing" };
-    let releaseTx: () => void = () => {};
-    const txCanFinish = new Promise<void>((resolve) => {
-      releaseTx = resolve;
-    });
-    let signalTxStarted: () => void = () => {};
-    const txStarted = new Promise<void>((resolve) => {
-      signalTxStarted = resolve;
-    });
-
-    const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
-      signalTxStarted();
-      await txCanFinish;
-    });
-    await txStarted;
 
     let err: unknown;
-    try {
-      await runOnConnection(handle, ownerB, async () => "unreachable");
-    } catch (e) {
-      err = e;
-    }
+    // A descendant of the transaction body: the reach-through this error is
+    // named for. An unrelated concurrent caller queues instead of erroring, so
+    // it has no message to assert on.
+    await runInTransactionOnConnection(handle, ownerA, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      try {
+        await runOnConnection(handle, ownerB, async () => "unreachable");
+      } catch (e) {
+        err = e;
+      }
+    });
     const casted = err as ConnectionReentryError;
     expect(casted).toBeInstanceOf(ConnectionReentryError);
     expect(casted.mode).toBe("sibling-op");
@@ -390,9 +438,6 @@ describe("ConnectionMutex F2: ConnectionReentryError message and mode", () => {
     expect(casted.message).toContain("'tx' proxy");
     expect(casted.message).toContain("SAVEPOINT");
     expect(casted.message).toContain("single storage instance");
-
-    releaseTx();
-    await txPromise;
   });
 
   it("carries mode='nested-transaction' for a nested withTransaction reach-through", async () => {
@@ -434,35 +479,21 @@ describe("ConnectionMutex F2: ConnectionReentryError message and mode", () => {
     const handle = {};
     const ownerA = {}; // no table property
     const ownerB = {};
-    let releaseTx: () => void = () => {};
-    const txCanFinish = new Promise<void>((resolve) => {
-      releaseTx = resolve;
-    });
-    let signalTxStarted: () => void = () => {};
-    const txStarted = new Promise<void>((resolve) => {
-      signalTxStarted = resolve;
-    });
-
-    const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
-      signalTxStarted();
-      await txCanFinish;
-    });
-    await txStarted;
 
     let err: unknown;
-    try {
-      await runOnConnection(handle, ownerB, async () => "unreachable");
-    } catch (e) {
-      err = e;
-    }
+    await runInTransactionOnConnection(handle, ownerA, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      try {
+        await runOnConnection(handle, ownerB, async () => "unreachable");
+      } catch (e) {
+        err = e;
+      }
+    });
     const casted = err as ConnectionReentryError;
     expect(casted).toBeInstanceOf(ConnectionReentryError);
     expect(casted.activeTable).toBeUndefined();
     expect(casted.blockedTable).toBeUndefined();
     expect(casted.message).toContain("another storage instance");
     expect(casted.message).toContain("an unlabeled storage instance");
-
-    releaseTx();
-    await txPromise;
   });
 });

--- a/packages/storage/src/tabular/__tests__/ConnectionMutex.test.ts
+++ b/packages/storage/src/tabular/__tests__/ConnectionMutex.test.ts
@@ -25,42 +25,36 @@ describe("ConnectionMutex F1: re-entry is classified from the async context", ()
       __resetAlsForTesting(useShim);
     });
 
-    it("refuses a participant set whose lead is enlisted but whose sibling is not", async () => {
+    it("refuses a DESCENDANT whose lead is enlisted but whose sibling is not", async () => {
       // The set {a, c} shares its lead with the open transaction's {a, b} but
       // is a DIFFERENT transaction. Judged by its lead alone it classified as
       // an enlisted descendant and ran inline — a nested BEGIN whose COMMIT
       // commits the outer transaction's work, with `c` never checked at all.
+      //
+      // Issued from INSIDE the body, after an `await`: that is what makes it a
+      // descendant on the real ALS, and the shim's fallback answers the same
+      // way. An unrelated concurrent caller with this same set queues instead —
+      // see the PARTIALLY OVERLAPPING test below.
       const handle = {};
       const ownerA = { table: "table_a" };
       const ownerB = { table: "table_b" };
       const ownerC = { table: "table_c" };
 
-      let releaseTx: () => void = () => {};
-      const txCanFinish = new Promise<void>((resolve) => {
-        releaseTx = resolve;
-      });
-      let signalTxStarted: () => void = () => {};
-      const txStarted = new Promise<void>((resolve) => {
-        signalTxStarted = resolve;
-      });
-
       let innerRan = false;
-      const txPromise = runInTransactionOnConnection(handle, [ownerA, ownerB], async () => {
-        signalTxStarted();
-        await txCanFinish;
-      });
-      await txStarted;
-
-      const start = Date.now();
       let error: unknown;
-      try {
-        await runInTransactionOnConnection(handle, [ownerA, ownerC], async () => {
-          innerRan = true;
-        });
-      } catch (err) {
-        error = err;
-      }
-      const elapsed = Date.now() - start;
+      let elapsed = 0;
+      await runInTransactionOnConnection(handle, [ownerA, ownerB], async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        const start = Date.now();
+        try {
+          await runInTransactionOnConnection(handle, [ownerA, ownerC], async () => {
+            innerRan = true;
+          });
+        } catch (err) {
+          error = err;
+        }
+        elapsed = Date.now() - start;
+      });
 
       expect(innerRan).toBe(false);
       expect(error).toBeInstanceOf(ConnectionReentryError);
@@ -69,10 +63,205 @@ describe("ConnectionMutex F1: re-entry is classified from the async context", ()
       expect((error as ConnectionReentryError).message).toContain("table_c");
       // Fails fast rather than queueing on a slot the outer transaction holds.
       expect(elapsed).toBeLessThan(500);
-
-      releaseTx();
-      await txPromise;
     });
+
+    it.skipIf(useShim)(
+      "an unrelated concurrent transaction with a DISJOINT participant set waits instead of being refused",
+      async () => {
+        // Only one BEGIN can be open on a single-session backend, so waiting is
+        // the whole point of the chain. Refusing here makes the primitive
+        // unusable from any concurrent caller.
+        const handle = {};
+        const ownerA = { table: "table_a" };
+        const ownerB = { table: "table_b" };
+        const ownerC = { table: "table_c" };
+        const ownerD = { table: "table_d" };
+        const order: string[] = [];
+
+        let releaseTx: () => void = () => {};
+        const txCanFinish = new Promise<void>((resolve) => {
+          releaseTx = resolve;
+        });
+        let signalTxStarted: () => void = () => {};
+        const txStarted = new Promise<void>((resolve) => {
+          signalTxStarted = resolve;
+        });
+
+        const txPromise = runInTransactionOnConnection(handle, [ownerA, ownerB], async () => {
+          order.push("BEGIN-1");
+          signalTxStarted();
+          await txCanFinish;
+          order.push("COMMIT-1");
+        });
+        await txStarted;
+
+        let secondError: unknown;
+        const second = runInTransactionOnConnection(handle, [ownerC, ownerD], async () => {
+          order.push("BEGIN-2");
+          return "ok";
+        }).catch((err: unknown) => {
+          secondError = err;
+          return "refused";
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(secondError).toBeUndefined();
+        expect(order).toEqual(["BEGIN-1"]);
+
+        releaseTx();
+        await txPromise;
+        expect(await second).toBe("ok");
+        expect(secondError).toBeUndefined();
+        expect(order).toEqual(["BEGIN-1", "COMMIT-1", "BEGIN-2"]);
+      }
+    );
+
+    it.skipIf(useShim)(
+      "an unrelated concurrent transaction with a PARTIALLY OVERLAPPING participant set waits instead of being refused",
+      async () => {
+        // The shape a consumer actually runs: one transaction over the person
+        // participants and another over the company participants, sharing the
+        // provenance table. Two units of work ten wide on one handle overlap in
+        // time constantly, and neither is inside the other.
+        const handle = {};
+        const provenance = { table: "observation_provenance" };
+        const personLink = { table: "person_identity_link" };
+        const personObs = { table: "person_observations" };
+        const companyLink = { table: "company_identity_link" };
+        const companyObs = { table: "company_observations" };
+        const order: string[] = [];
+
+        let releaseTx: () => void = () => {};
+        const txCanFinish = new Promise<void>((resolve) => {
+          releaseTx = resolve;
+        });
+        let signalTxStarted: () => void = () => {};
+        const txStarted = new Promise<void>((resolve) => {
+          signalTxStarted = resolve;
+        });
+
+        const personTx = runInTransactionOnConnection(
+          handle,
+          [personLink, provenance, personObs],
+          async () => {
+            order.push("BEGIN-person");
+            signalTxStarted();
+            await txCanFinish;
+            order.push("COMMIT-person");
+          }
+        );
+        await txStarted;
+
+        let companyError: unknown;
+        const companyTx = runInTransactionOnConnection(
+          handle,
+          [companyLink, provenance, companyObs],
+          async () => {
+            order.push("BEGIN-company");
+            return "ok";
+          }
+        ).catch((err: unknown) => {
+          companyError = err;
+          return "refused";
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(companyError).toBeUndefined();
+        expect(order).toEqual(["BEGIN-person"]);
+
+        releaseTx();
+        await personTx;
+        expect(await companyTx).toBe("ok");
+        expect(companyError).toBeUndefined();
+        expect(order).toEqual(["BEGIN-person", "COMMIT-person", "BEGIN-company"]);
+      }
+    );
+
+    it.skipIf(useShim)(
+      "an unrelated concurrent transaction with IDENTICAL participants waits, like any other",
+      async () => {
+        // Repeated reaps take this path. It reached the chain before only as a
+        // side effect of being wholly enlisted; now it chains for the same
+        // reason every unrelated caller does — no store, so not a descendant.
+        const handle = {};
+        const ownerA = { table: "table_a" };
+        const ownerB = { table: "table_b" };
+        const order: string[] = [];
+
+        let releaseTx: () => void = () => {};
+        const txCanFinish = new Promise<void>((resolve) => {
+          releaseTx = resolve;
+        });
+        let signalTxStarted: () => void = () => {};
+        const txStarted = new Promise<void>((resolve) => {
+          signalTxStarted = resolve;
+        });
+
+        const first = runInTransactionOnConnection(handle, [ownerA, ownerB], async () => {
+          order.push("BEGIN-1");
+          signalTxStarted();
+          await txCanFinish;
+          order.push("COMMIT-1");
+        });
+        await txStarted;
+
+        const second = runInTransactionOnConnection(handle, [ownerA, ownerB], async () => {
+          order.push("BEGIN-2");
+          return "ok";
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(order).toEqual(["BEGIN-1"]);
+
+        releaseTx();
+        await first;
+        expect(await second).toBe("ok");
+        expect(order).toEqual(["BEGIN-1", "COMMIT-1", "BEGIN-2"]);
+      }
+    );
+
+    it.skipIf(!useShim)(
+      "the shim still refuses an unrelated concurrent transaction whose participants differ",
+      async () => {
+        // No async context, so a descendant opening a partly-enlisted nested
+        // transaction is indistinguishable from this. Refusing is the
+        // conservative side: a nested BEGIN would commit the outer's work.
+        const handle = {};
+        const ownerA = { table: "table_a" };
+        const ownerB = { table: "table_b" };
+        const ownerC = { table: "table_c" };
+
+        let releaseTx: () => void = () => {};
+        const txCanFinish = new Promise<void>((resolve) => {
+          releaseTx = resolve;
+        });
+        let signalTxStarted: () => void = () => {};
+        const txStarted = new Promise<void>((resolve) => {
+          signalTxStarted = resolve;
+        });
+
+        const txPromise = runInTransactionOnConnection(handle, [ownerA, ownerB], async () => {
+          signalTxStarted();
+          await txCanFinish;
+        });
+        await txStarted;
+
+        const start = Date.now();
+        let error: unknown;
+        try {
+          await runInTransactionOnConnection(handle, [ownerA, ownerC], async () => "unreachable");
+        } catch (err) {
+          error = err;
+        }
+        expect(error).toBeInstanceOf(ConnectionReentryError);
+        expect((error as ConnectionReentryError).mode).toBe("nested-transaction");
+        expect((error as ConnectionReentryError).message).toContain("table_c");
+        expect(Date.now() - start).toBeLessThan(200);
+
+        releaseTx();
+        await txPromise;
+      }
+    );
 
     it("still inlines a participant set that is wholly enlisted", async () => {
       const handle = {};
@@ -192,41 +381,28 @@ describe("ConnectionMutex F1: re-entry is classified from the async context", ()
       }
     );
 
-    it("runInTransactionOnConnection throws ConnectionReentryError when a different owner tries a nested transaction", async () => {
+    it("throws ConnectionReentryError when a DESCENDANT with a different owner opens a nested transaction", async () => {
       const handle = {};
       const ownerA = { table: "table_a" };
       const ownerB = { table: "table_b" };
 
-      let releaseTx: () => void = () => {};
-      const txCanFinish = new Promise<void>((resolve) => {
-        releaseTx = resolve;
-      });
-      let signalTxStarted: () => void = () => {};
-      const txStarted = new Promise<void>((resolve) => {
-        signalTxStarted = resolve;
-      });
-
-      const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
-        signalTxStarted();
-        await txCanFinish;
-      });
-      await txStarted;
-
-      const start = Date.now();
       let error: unknown;
-      try {
-        await runInTransactionOnConnection(handle, ownerB, async () => "unreachable");
-      } catch (err) {
-        error = err;
-      }
-      const elapsed = Date.now() - start;
+      let elapsed = 0;
+      await runInTransactionOnConnection(handle, ownerA, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        const start = Date.now();
+        try {
+          await runInTransactionOnConnection(handle, ownerB, async () => "unreachable");
+        } catch (err) {
+          error = err;
+        }
+        elapsed = Date.now() - start;
+      });
 
       expect(error).toBeInstanceOf(ConnectionReentryError);
       expect((error as ConnectionReentryError).mode).toBe("nested-transaction");
+      // Fails fast rather than queueing on a slot its own transaction holds.
       expect(elapsed).toBeLessThan(200);
-
-      releaseTx();
-      await txPromise;
     });
 
     it("cross-instance sibling throw does not corrupt the outer transaction's chain", async () => {
@@ -444,35 +620,26 @@ describe("ConnectionMutex F2: ConnectionReentryError message and mode", () => {
     const handle = {};
     const ownerA = { table: "issuer" };
     const ownerB = { table: "filing" };
-    let releaseTx: () => void = () => {};
-    const txCanFinish = new Promise<void>((resolve) => {
-      releaseTx = resolve;
-    });
-    let signalTxStarted: () => void = () => {};
-    const txStarted = new Promise<void>((resolve) => {
-      signalTxStarted = resolve;
-    });
 
-    const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
-      signalTxStarted();
-      await txCanFinish;
-    });
-    await txStarted;
-
+    // A descendant of the body, which is what "nested" names. An unrelated
+    // concurrent transaction queues instead of erroring, so it has no message
+    // to assert on.
     let err: unknown;
-    try {
-      await runInTransactionOnConnection(handle, ownerB, async () => "unreachable");
-    } catch (e) {
-      err = e;
-    }
+    await runInTransactionOnConnection(handle, ownerA, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      try {
+        await runInTransactionOnConnection(handle, ownerB, async () => "unreachable");
+      } catch (e) {
+        err = e;
+      }
+    });
     const casted = err as ConnectionReentryError;
     expect(casted).toBeInstanceOf(ConnectionReentryError);
     expect(casted.mode).toBe("nested-transaction");
+    expect(casted.activeTable).toBe("issuer");
+    expect(casted.blockedTable).toBe("filing");
     expect(casted.message).toContain("open its own transaction");
     expect(casted.message).toContain("SAVEPOINT");
-
-    releaseTx();
-    await txPromise;
   });
 
   it("falls back to generic labels when the owner has no `table` property", async () => {

--- a/packages/storage/src/tabular/__tests__/runNativeConnectionTransaction.test.ts
+++ b/packages/storage/src/tabular/__tests__/runNativeConnectionTransaction.test.ts
@@ -8,7 +8,9 @@ import {
   activeConnectionTxGroupHandle,
   assertSharedConnectionHandle,
   connectionTxQuery,
+  discardAllDeferredPuts,
   enqueueDeferredPut,
+  flushDeferredPuts,
   isEnlistedInConnectionTx,
   NestedConnectionTransactionError,
   runNativeConnectionTransaction,
@@ -18,7 +20,7 @@ import {
   type ConnectionTransactionHost,
 } from "@workglow/storage";
 import { __resetAlsForTesting, isSynchronousAls } from "@workglow/storage/test";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 /**
  * A participant stands in for a storage instance: `runNativeConnectionTransaction`
@@ -36,6 +38,36 @@ function makeHost(handle: object, table: string): AnyTabularStorage & Connection
   } as unknown as AnyTabularStorage & ConnectionTransactionHost;
 }
 
+/**
+ * A participant that records what a `put` subscriber would observe.
+ *
+ * `emitPut` is what every SQL backend's own `emitPut` does — offer the entity
+ * to the deferral buffer, emit immediately when it is refused — so these tests
+ * fail for exactly the reason a browser app would show rows that never
+ * committed.
+ */
+interface RecordingParticipant extends ConnectionTransactionHost {
+  readonly observed: unknown[];
+  readonly emitPut: (entity: unknown) => void;
+  readonly emitCommittedPut: (entity: unknown) => void;
+}
+
+function makeParticipant(handle: object, table: string): AnyTabularStorage & RecordingParticipant {
+  const observed: unknown[] = [];
+  const participant = {
+    ...makeHost(handle, table),
+    observed,
+    emitPut(entity: unknown): void {
+      if (enqueueDeferredPut(participant, entity)) return;
+      observed.push(entity);
+    },
+    emitCommittedPut(entity: unknown): void {
+      observed.push(entity);
+    },
+  } as unknown as AnyTabularStorage & RecordingParticipant;
+  return participant;
+}
+
 interface RunOptions {
   readonly handle: object;
   readonly participants: readonly AnyTabularStorage[];
@@ -44,12 +76,14 @@ interface RunOptions {
   readonly afterCommit?: () => void;
   readonly afterRollback?: () => void;
   readonly begin?: () => void;
+  readonly ownsSession?: boolean;
 }
 
 function run(options: RunOptions): Promise<unknown> {
   return runNativeConnectionTransaction({
     handle: options.handle,
     participants: options.participants,
+    ownsSession: options.ownsSession ?? true,
     begin: options.begin ?? ((): void => {}),
     commit: (): void => {},
     rollback: (): void => {},
@@ -201,6 +235,7 @@ describe("runNativeConnectionTransaction: the store is deactivated at COMMIT", (
       runNativeConnectionTransaction({
         handle,
         participants: [owner],
+        ownsSession: true,
         begin: () => {
           throw new Error("begin failed");
         },
@@ -273,6 +308,126 @@ describe("assertSharedConnectionHandle: nesting guard", () => {
 
     await run({ handle, participants: [a], fn: async () => undefined });
     expect(assertSharedConnectionHandle(a, [a])).toBe(handle);
+  });
+});
+
+/**
+ * Deferral must not be keyed off the ALS store. The browser bundle installs
+ * {@link createShimAls}, which restores its store as soon as the synchronous
+ * portion of the callback returns — that is the first `await` inside
+ * `runNativeConnectionTransaction`, namely `await begin()`. Every participant
+ * `put` after that point runs with no store at all, so a store-keyed buffer
+ * would emit each one immediately and leave the flush/discard pass draining
+ * nothing. Both runtimes therefore run the same cases here; the shim one is
+ * what a browser app on SQLite-WASM or PGlite actually gets.
+ */
+const alsModes = [
+  { name: "real AsyncLocalStorage", useShim: false },
+  { name: "the browser's synchronous shim", useShim: true },
+] as const;
+
+describe.each(alsModes)("put deferral on $name", ({ useShim }) => {
+  beforeEach(() => {
+    __resetAlsForTesting(useShim);
+  });
+
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  it("holds a put until COMMIT, then emits it exactly once", async () => {
+    const handle = {};
+    const participant = makeParticipant(handle, "table_a");
+    let observedInBody: readonly unknown[] = ["unset"];
+
+    await run({
+      handle,
+      participants: [participant],
+      fn: async () => {
+        // Past the body's first await: the shim's store is already gone.
+        await Promise.resolve();
+        participant.emitPut("row-1");
+        observedInBody = [...participant.observed];
+      },
+      afterCommit: () => flushDeferredPuts([participant]),
+    });
+
+    expect(observedInBody).toEqual([]);
+    expect(participant.observed).toEqual(["row-1"]);
+  });
+
+  it("never lets a subscriber observe a put that rolls back", async () => {
+    const handle = {};
+    const participant = makeParticipant(handle, "table_a");
+
+    await expect(
+      run({
+        handle,
+        participants: [participant],
+        fn: async () => {
+          await Promise.resolve();
+          participant.emitPut("row-1");
+          throw new Error("boom");
+        },
+        afterRollback: () => discardAllDeferredPuts([participant]),
+      })
+    ).rejects.toThrow("boom");
+
+    expect(participant.observed).toEqual([]);
+  });
+});
+
+/**
+ * `ownsSession: false` is the real-`pg.Pool` arm, which never runs in a browser
+ * — so unlike the cases above it is exercised on the real `AsyncLocalStorage`
+ * only, and the reset here is explicit rather than inherited.
+ */
+describe("put deferral when the transaction does not own the session", () => {
+  beforeEach(() => {
+    __resetAlsForTesting();
+  });
+
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  /**
+   * A real `pg.Pool` transaction holds one checked-out client while unrelated
+   * callers keep writing through the pool and committing at once. Their rows
+   * survive this transaction's ROLLBACK, so their `put` events must fire
+   * straight away rather than joining a buffer that may be discarded.
+   */
+  it("emits a put from a caller that never entered the body", async () => {
+    const handle = {};
+    const participant = makeParticipant(handle, "table_a");
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let started!: () => void;
+    const bodyStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+
+    const tx = run({
+      handle,
+      participants: [participant],
+      ownsSession: false,
+      fn: async () => {
+        participant.emitPut("enlisted");
+        started();
+        await gate;
+      },
+      afterCommit: () => flushDeferredPuts([participant]),
+    });
+
+    await bodyStarted;
+    participant.emitPut("outsider");
+    expect(participant.observed).toEqual(["outsider"]);
+
+    release();
+    await tx;
+    expect(participant.observed).toEqual(["outsider", "enlisted"]);
   });
 });
 

--- a/packages/storage/src/tabular/connectionAls.shared.ts
+++ b/packages/storage/src/tabular/connectionAls.shared.ts
@@ -57,22 +57,6 @@ export interface AlsContext {
    */
   active: boolean;
   /**
-   * `true` only while a connection-scoped transaction (see
-   * `runNativeConnectionTransaction`) is deferring `put` events. A plain
-   * `withTransaction` installs a store too, but buffers its events on the `tx`
-   * proxy and never drains {@link deferredPuts} — so without this flag a `put`
-   * that reaches the base `emitPut` in that window is queued and silently
-   * lost. Set from INSIDE the ALS scope, and cleared at deactivation.
-   */
-  deferPuts: boolean;
-  /**
-   * `put` events deferred until COMMIT of a connection-scoped transaction.
-   * Callers drain this after COMMIT, once the store has been deactivated, so a
-   * listener that writes in response emits (and commits) normally instead of
-   * queueing onto a fresh buffer nothing drains.
-   */
-  readonly deferredPuts: WeakMap<object, unknown[]>;
-  /**
    * Dedicated query handle for a real `pg.Pool` transaction. Enlisted
    * Postgres storages route writes through this so every participant shares
    * one client. Written after the store is created, once the client is

--- a/packages/storage/src/tabular/defineConnectionMutex.ts
+++ b/packages/storage/src/tabular/defineConnectionMutex.ts
@@ -25,19 +25,31 @@ import type { Als, AlsContext } from "./connectionAls.shared";
  *
  * Re-entry is classified from the `AsyncLocalStorage` store, and the question
  * it asks is not "is this owner enlisted" but "is this call an async
- * DESCENDANT of the open transaction body". That is the only caller whose
- * write could escape the `BEGIN`, and the store is what proves it: a
- * descendant carries it across every `await`, an unrelated concurrent caller
- * never does. So a descendant that is wholly enlisted re-enters inline, a
- * descendant that is not is refused, and an unrelated concurrent call — on an
- * enlisted instance or on one the transaction never named — queues on the
- * chain and runs after COMMIT.
+ * DESCENDANT of the open transaction body". A descendant is the only caller
+ * whose write could escape the open `BEGIN`, or whose own `BEGIN` would nest
+ * inside it, and the store is what proves it: a descendant carries it across
+ * every `await`, an unrelated concurrent caller never does. So a descendant
+ * whose owners are wholly enlisted re-enters inline, a descendant whose owners
+ * are not is refused, and an unrelated concurrent call — on an enlisted
+ * instance, on one the transaction never named, or opening a transaction of
+ * its own over a different participant set — queues on the chain and runs
+ * after COMMIT.
  *
- * Refusing that last caller instead is what made this primitive unusable from
- * more than one task at a time. Ten concurrent units of work over one handle,
- * one of them holding a transaction whose body awaits: every other write in
- * that window was refused, in its OWN task, where the transaction's caller
- * cannot catch it.
+ * {@link ConnectionMutexApi.runOnConnection} and
+ * {@link ConnectionMutexApi.runInTransactionOnConnection} both go through
+ * {@link classifyReentry} for this, and differ only in the error a refusal
+ * raises (`sibling-op` vs `nested-transaction`). Answering it two ways is what
+ * let them disagree.
+ *
+ * Refusing that unrelated caller instead is what made this primitive unusable
+ * from more than one task at a time. Ten concurrent units of work over one
+ * handle, one of them holding a transaction whose body awaits: every other
+ * write in that window was refused, and so was every other transaction whose
+ * participants were not a subset of the open one's — in its OWN task, where
+ * the transaction's caller cannot catch it. Overlapping-but-unequal sets are
+ * the common case, not the exotic one: a caller that transacts over the person
+ * tables and a caller that transacts over the company tables share a
+ * provenance table and nothing else.
  *
  * The browser shim has no async context — its store is gone at the first
  * `await` inside the transaction body — so on that runtime only, the question
@@ -92,7 +104,7 @@ function ownerSet(owner: TransactionOwners): Set<object> {
   return new Set([owner as object]);
 }
 
-function leadOwner(owners: Set<object>): object {
+function leadOwner(owners: ReadonlySet<object>): object {
   return owners.values().next().value as object;
 }
 
@@ -109,6 +121,18 @@ export function connectionOwnerLabel(owner: object | undefined): string | undefi
 }
 
 type ReentryDecision = "throw" | "inline" | "chain";
+
+interface ReentryClassification {
+  readonly decision: ReentryDecision;
+  /**
+   * Participants of the open transaction the decision was judged against, or
+   * `undefined` when no open transaction was consulted — the decision is then
+   * always `"chain"`. A refusal names the first of the caller's owners missing
+   * from this set (the participant to hoist or remove) rather than its lead,
+   * which may well be enlisted already.
+   */
+  readonly enlisted: ReadonlySet<object> | undefined;
+}
 
 /**
  * Thrown when a storage instance tries to reach a shared connection while a
@@ -185,21 +209,18 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     return state;
   }
 
-  function activeLead(state: HandleState): object | undefined {
-    return state.txOwners !== null ? leadOwner(state.txOwners) : undefined;
-  }
-
   /**
    * First owner in `owners` that `enlisted` does not contain, or `undefined`
    * when every one of them is enlisted.
    *
    * EVERY owner is checked, not just the lead. A participant set that is only
-   * partly enlisted is not a descendant of the open transaction — it is a
-   * different transaction that happens to share a member. Judging it by its
-   * lead alone let `withConnectionTransaction([a, c])` run inline inside a
-   * transaction owning `{a, b}`, which issues a nested `BEGIN` whose `COMMIT`
-   * commits the outer transaction's work, and skipped `c`'s sibling-op check
-   * entirely.
+   * partly enlisted is not a MEMBER of the open transaction — it is a different
+   * transaction that happens to share one. Judging it by its lead alone let
+   * `withConnectionTransaction([a, c])` run inline inside a transaction owning
+   * `{a, b}`, which issues a nested `BEGIN` whose `COMMIT` commits the outer
+   * transaction's work, and skipped `c`'s sibling-op check entirely. Whether
+   * such a caller is refused or queued is a separate question, and only the
+   * async context answers it — see {@link classifyReentry}.
    */
   function firstUnenlisted(
     owners: ReadonlySet<object>,
@@ -227,7 +248,7 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     owners: ReadonlySet<object>,
     handle: object,
     store: Als
-  ): ReentryDecision {
+  ): ReentryClassification {
     // Walk the whole store chain, not just the innermost store: a transaction
     // on a different connection may nest inside ours, and it shadows our store
     // rather than replacing it. Reading only `getStore()` there would classify
@@ -238,10 +259,14 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     for (let ctx = store.getStore(); ctx !== undefined; ctx = ctx.parent) {
       if (ctx.active && ctx.handle === handle) {
         // A descendant of the body holding THIS connection. Wholly enlisted
-        // joins the open BEGIN; anything else would write outside it. At most
-        // one store in the chain can match — a second transaction on the same
-        // handle is refused before it installs one — so the first wins.
-        return firstUnenlisted(owners, ctx.owners) === undefined ? "inline" : "throw";
+        // joins the open BEGIN; anything else would write, or open its own
+        // BEGIN, outside it. At most one store in the chain can match — a
+        // second transaction on the same handle never installs one while this
+        // one is active — so the first wins.
+        return {
+          decision: firstUnenlisted(owners, ctx.owners) === undefined ? "inline" : "throw",
+          enlisted: ctx.owners,
+        };
       }
     }
     // Synchronous shim only: a descendant of our own transaction body loses the
@@ -255,9 +280,12 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     // (a non-null `txOwners` here implies an open transaction: `txOwners` and
     // `txId` are always written and cleared together.)
     if (store.synchronousOnly === true && state.txOwners !== null) {
-      return firstUnenlisted(owners, state.txOwners) === undefined ? "inline" : "throw";
+      return {
+        decision: firstUnenlisted(owners, state.txOwners) === undefined ? "inline" : "throw",
+        enlisted: state.txOwners,
+      };
     }
-    return "chain";
+    return { decision: "chain", enlisted: undefined };
   }
 
   /**
@@ -285,10 +313,10 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
   ): Promise<T> {
     const state = getState(handle);
     const store = als.ensureAls();
-    const decision = classifyReentry(state, new Set([owner]), handle, store);
+    const { decision, enlisted } = classifyReentry(state, new Set([owner]), handle, store);
     if (decision === "throw") {
       throw new ConnectionReentryError(
-        connectionOwnerLabel(activeLead(state) ?? owner),
+        connectionOwnerLabel(enlisted !== undefined ? leadOwner(enlisted) : owner),
         connectionOwnerLabel(owner),
         "sibling-op"
       );
@@ -317,13 +345,19 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
    *
    * `owner` is either a single storage instance (the one-participant
    * `withTransaction` case) or every participant of a connection-scoped
-   * transaction. Cross-instance re-entry from a non-enlisted descendant throws
-   * {@link ConnectionReentryError} with `mode === "nested-transaction"` at the
-   * transaction-opening call site. Unlike {@link runOnConnection}, that refusal
-   * is decided from handle state alone and so also catches an unrelated
-   * concurrent caller: a participant set that is only partly enlisted is a
-   * different transaction sharing a member, and there is no autonomous `BEGIN`
-   * to give a wholly separate one on this connection either way.
+   * transaction.
+   *
+   * It classifies exactly as {@link runOnConnection} does, and for the same
+   * reason. A DESCENDANT of the open body whose participants are not all
+   * enlisted is a different transaction sharing a member: running it would
+   * issue a nested `BEGIN` whose `COMMIT` commits the outer transaction's
+   * work, so it throws {@link ConnectionReentryError} with
+   * `mode === "nested-transaction"`, naming the participant to hoist. An
+   * UNRELATED concurrent transaction whose participants merely differ is not
+   * inside anything — on a single-session backend only one `BEGIN` can be open
+   * at a time, so it queues on the chain and opens its own once the first
+   * commits. Refusing it would make `withConnectionTransaction` unusable from
+   * more than one task, which is the same defect the sibling-op path had.
    *
    * `handle` keys the chain slot; `groupHandle` names the physical connection
    * the transaction owns and defaults to `handle`. They differ only where a
@@ -341,29 +375,18 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     const owners = ownerSet(owner);
     const lead = leadOwner(owners);
     const state = getState(handle);
-    // Every participant is checked, not just the lead: a set that is only
-    // partly enlisted is a DIFFERENT transaction sharing a member, and running
-    // it inline would issue a nested BEGIN whose COMMIT commits the open
-    // transaction's work. The error names the participant that is actually
-    // un-enlisted, which is the one the caller has to remove or hoist.
-    const intruder = state.txOwners !== null ? firstUnenlisted(owners, state.txOwners) : undefined;
-    if (intruder !== undefined) {
-      throw new ConnectionReentryError(
-        connectionOwnerLabel(activeLead(state)),
-        connectionOwnerLabel(intruder),
-        "nested-transaction"
-      );
-    }
     const store = als.ensureAls();
-    const decision = classifyReentry(state, owners, handle, store);
-    // Unreachable today: the guard above already refused every owner set the
-    // classifier could throw on. Kept deliberately — without it a "throw"
-    // classification would fall through to the chain and HANG instead of
-    // erroring, which is a far worse failure than a redundant branch.
+    const { decision, enlisted } = classifyReentry(state, owners, handle, store);
     if (decision === "throw") {
+      // Every participant was checked, not just the lead, and the error names
+      // the one that is actually un-enlisted — the participant the caller has
+      // to hoist into the outer call or remove. Its lead is no use here: it is
+      // routinely enlisted already, which is exactly how a partly-enlisted set
+      // used to pass for a member of the open transaction.
+      const intruder = enlisted !== undefined ? firstUnenlisted(owners, enlisted) : undefined;
       throw new ConnectionReentryError(
-        connectionOwnerLabel(activeLead(state) ?? lead),
-        connectionOwnerLabel(lead),
+        connectionOwnerLabel(enlisted !== undefined ? leadOwner(enlisted) : lead),
+        connectionOwnerLabel(intruder ?? lead),
         "nested-transaction"
       );
     }

--- a/packages/storage/src/tabular/defineConnectionMutex.ts
+++ b/packages/storage/src/tabular/defineConnectionMutex.ts
@@ -384,8 +384,6 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
       handle,
       groupHandle,
       active: true,
-      deferPuts: false,
-      deferredPuts: new WeakMap(),
       txQuery: undefined,
       // `store.run` shadows the enclosing store; keep a link to it so accessors
       // can still see a transaction open on another connection.
@@ -403,7 +401,6 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
         // reachable from any continuation that captured it, so mark it dead
         // here too.
         ctx.active = false;
-        ctx.deferPuts = false;
         ctx.txQuery = undefined;
       }
       release();

--- a/packages/storage/src/tabular/defineConnectionMutex.ts
+++ b/packages/storage/src/tabular/defineConnectionMutex.ts
@@ -21,24 +21,33 @@ import type { Als, AlsContext } from "./connectionAls.shared";
  *
  * This module keeps a module-level {@link WeakMap} keyed on the connection
  * handle so every instance that binds the same handle chains through the same
- * promise. Cross-instance re-entry detection lives on the handle state
- * itself (`txOwners`), so it is **ALS-independent**: the module works
- * identically on Node (real `AsyncLocalStorage`) and in the browser (the
- * synchronous shim), even when the caller `await`s between the outer
- * transaction opening and the sibling call.
+ * promise.
  *
- * Same-instance re-entry is classified from the `AsyncLocalStorage` store,
- * which is precise: only a genuine async descendant of the transaction body
- * carries it, so an unrelated concurrent call on the same instance still
- * queues on the chain instead of slipping inside the open transaction.
+ * Re-entry is classified from the `AsyncLocalStorage` store, and the question
+ * it asks is not "is this owner enlisted" but "is this call an async
+ * DESCENDANT of the open transaction body". That is the only caller whose
+ * write could escape the `BEGIN`, and the store is what proves it: a
+ * descendant carries it across every `await`, an unrelated concurrent caller
+ * never does. So a descendant that is wholly enlisted re-enters inline, a
+ * descendant that is not is refused, and an unrelated concurrent call — on an
+ * enlisted instance or on one the transaction never named — queues on the
+ * chain and runs after COMMIT.
+ *
+ * Refusing that last caller instead is what made this primitive unusable from
+ * more than one task at a time. Ten concurrent units of work over one handle,
+ * one of them holding a transaction whose body awaits: every other write in
+ * that window was refused, in its OWN task, where the transaction's caller
+ * cannot catch it.
  *
  * The browser shim has no async context — its store is gone at the first
- * `await` inside the transaction body — so on that runtime only, a descendant
- * is recognized from handle state (`state.txOwners.has(owner)`). Chain-waiting
- * there would deadlock: the chain slot is released by the outer transaction's
- * `finally`, which is itself awaiting the inner call. That fallback cannot
- * tell a descendant from an unrelated concurrent call, which is why it is
- * gated to the runtime that has no better option.
+ * `await` inside the transaction body — so on that runtime only, the question
+ * is answered from handle state (`state.txOwners`) instead. Chain-waiting a
+ * descendant there would deadlock: the chain slot is released by the outer
+ * transaction's `finally`, which is itself awaiting the inner call. That
+ * fallback cannot tell a descendant from an unrelated concurrent call, so it
+ * takes the conservative side and refuses both. It is the one behavioural
+ * difference between the runtimes, and it is gated to the runtime that has no
+ * better option.
  *
  * KNOWN LIMIT of the store-based classification: carrying the store proves a
  * descendant, but *lacking* it does not prove the opposite. A descendant whose
@@ -49,7 +58,10 @@ import type { Als, AlsContext } from "./connectionAls.shared";
  * also poisons the handle, since the waiter has already installed itself as
  * `state.chain`. Transaction bodies must therefore reach this connection
  * directly (or via the `tx` proxy), never by handing work to an outside
- * scheduler and awaiting it.
+ * scheduler and awaiting it. The limit covers un-enlisted owners as well as
+ * enlisted ones: refusing every un-enlisted owner outright would turn that
+ * deadlock into an error, but only by also refusing every legitimate
+ * concurrent writer, which is the far commoner call.
  *
  * Platform ALS is injected by {@link defineConnectionMutex} so the browser
  * entry can wire the shim via a relative import (never `node:async_hooks`)
@@ -200,11 +212,15 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
   }
 
   /**
-   * Classify the current call against the state of the shared handle. Order
-   * matters: an active owner set that does **not** contain every one of our
-   * owners is always a cross-instance re-entry — regardless of whether the ALS
-   * store is present. Only if the whole caller is enlisted (matching ALS
-   * store) do we inline; anything else queues through the chain.
+   * Classify the current call against the open transaction on this handle.
+   *
+   * The deciding question is whether the caller is an async DESCENDANT of the
+   * open transaction body, not merely whether its owners are enlisted. Only a
+   * descendant's write can escape the `BEGIN`, and only the ALS store can
+   * prove one: it rides every `await` out of the body and an unrelated
+   * concurrent caller never holds it. So a descendant inlines when every one
+   * of its owners is enlisted and is refused when any is not, while everyone
+   * else queues through the chain.
    */
   function classifyReentry(
     state: HandleState,
@@ -212,9 +228,6 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     handle: object,
     store: Als
   ): ReentryDecision {
-    if (state.txOwners !== null && firstUnenlisted(owners, state.txOwners) !== undefined) {
-      return "throw";
-    }
     // Walk the whole store chain, not just the innermost store: a transaction
     // on a different connection may nest inside ours, and it shadows our store
     // rather than replacing it. Reading only `getStore()` there would classify
@@ -223,28 +236,26 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     // store outlives COMMIT — `afterCommit` listeners are no longer inside the
     // transaction and must take the chain like any other caller.
     for (let ctx = store.getStore(); ctx !== undefined; ctx = ctx.parent) {
-      if (
-        ctx.active &&
-        ctx.handle === handle &&
-        firstUnenlisted(owners, ctx.owners) === undefined
-      ) {
-        return "inline";
+      if (ctx.active && ctx.handle === handle) {
+        // A descendant of the body holding THIS connection. Wholly enlisted
+        // joins the open BEGIN; anything else would write outside it. At most
+        // one store in the chain can match — a second transaction on the same
+        // handle is refused before it installs one — so the first wins.
+        return firstUnenlisted(owners, ctx.owners) === undefined ? "inline" : "throw";
       }
     }
     // Synchronous shim only: a descendant of our own transaction body loses the
     // store at the body's first `await` and lands here with none. Chain-waiting
     // would deadlock — the chain slot is released by the outer transaction's
     // `finally`, which is awaiting this call — so fall back to handle state.
-    // This cannot distinguish a descendant from an unrelated concurrent call on
-    // the same instance, so it stays off wherever a real ALS store exists.
-    // (a fully-enlisted `txOwners` here implies an open transaction: `txOwners`
-    // and `txId` are always written and cleared together.)
-    if (
-      store.synchronousOnly === true &&
-      state.txOwners !== null &&
-      firstUnenlisted(owners, state.txOwners) === undefined
-    ) {
-      return "inline";
+    // That fallback cannot tell a descendant from an unrelated concurrent call,
+    // so it answers as if every caller were a descendant: enlisted inlines,
+    // un-enlisted is refused. Erring the other way would deadlock, which is why
+    // this stays off wherever a real ALS store exists.
+    // (a non-null `txOwners` here implies an open transaction: `txOwners` and
+    // `txId` are always written and cleared together.)
+    if (store.synchronousOnly === true && state.txOwners !== null) {
+      return firstUnenlisted(owners, state.txOwners) === undefined ? "inline" : "throw";
     }
     return "chain";
   }
@@ -252,16 +263,20 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
   /**
    * Runs `fn` in a chain shared across every caller bound to `handle`.
    *
-   * The handle state (`txOwners`) is checked first: if another instance holds
-   * the transaction and this owner is not enlisted, this throws
-   * {@link ConnectionReentryError} synchronously — no `await ensureAls()`
-   * needed on the throw path, so browser shim and Node behave identically.
-   *
    * An enlisted descendant of an open transaction body runs `fn` inline —
-   * re-taking the chain would deadlock. It is recognized from the
-   * `AsyncLocalStorage` store on Node and from handle state on the browser
-   * shim (which has no async context). An unrelated concurrent call on an
-   * enlisted instance still queues on the chain under a real ALS.
+   * re-taking the chain would deadlock. An un-enlisted descendant is refused
+   * with {@link ConnectionReentryError}: its write is the one that would land
+   * outside the open `BEGIN`. Everyone else queues on the chain, including an
+   * unrelated concurrent caller on an instance the transaction never enlisted
+   * — it is not inside the transaction, so its write cannot escape it, and it
+   * simply runs once the transaction commits.
+   *
+   * The store answers both questions, so it is consulted before either. That
+   * costs nothing: `ensureAls()` is synchronous, and handle state alone cannot
+   * tell a descendant from an unrelated caller. The browser shim, whose store
+   * dies at the body's first `await`, falls back to handle state and refuses
+   * every un-enlisted owner while a transaction is open — the conservative
+   * side of a distinction it cannot make.
    */
   async function runOnConnection<T>(
     handle: object,
@@ -269,21 +284,8 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     fn: () => Promise<T>
   ): Promise<T> {
     const state = getState(handle);
-    // Fast, synchronous throw on cross-instance sibling ops — do NOT await
-    // ensureAls first, so the shim path (browser) still fails fast.
-    if (state.txOwners !== null && !state.txOwners.has(owner)) {
-      throw new ConnectionReentryError(
-        connectionOwnerLabel(activeLead(state)),
-        connectionOwnerLabel(owner),
-        "sibling-op"
-      );
-    }
     const store = als.ensureAls();
     const decision = classifyReentry(state, new Set([owner]), handle, store);
-    // Unreachable today — the guard above throws on the same condition — but
-    // kept deliberately: without it a "throw" classification would fall
-    // through to the chain and HANG instead of erroring, which is a far worse
-    // failure than a redundant branch.
     if (decision === "throw") {
       throw new ConnectionReentryError(
         connectionOwnerLabel(activeLead(state) ?? owner),
@@ -316,10 +318,12 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
    * `owner` is either a single storage instance (the one-participant
    * `withTransaction` case) or every participant of a connection-scoped
    * transaction. Cross-instance re-entry from a non-enlisted descendant throws
-   * {@link ConnectionReentryError} the same way {@link runOnConnection} does,
-   * with `mode === "nested-transaction"` at the transaction-opening call
-   * site. The synchronous throw path here is symmetric with `runOnConnection`
-   * — the handle state is checked before awaiting ALS.
+   * {@link ConnectionReentryError} with `mode === "nested-transaction"` at the
+   * transaction-opening call site. Unlike {@link runOnConnection}, that refusal
+   * is decided from handle state alone and so also catches an unrelated
+   * concurrent caller: a participant set that is only partly enlisted is a
+   * different transaction sharing a member, and there is no autonomous `BEGIN`
+   * to give a wholly separate one on this connection either way.
    *
    * `handle` keys the chain slot; `groupHandle` names the physical connection
    * the transaction owns and defaults to `handle`. They differ only where a
@@ -352,8 +356,10 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
     }
     const store = als.ensureAls();
     const decision = classifyReentry(state, owners, handle, store);
-    // Unreachable today, kept for the same reason as in `runOnConnection`: a
-    // "throw" that fell through would hang on the chain rather than error.
+    // Unreachable today: the guard above already refused every owner set the
+    // classifier could throw on. Kept deliberately — without it a "throw"
+    // classification would fall through to the chain and HANG instead of
+    // erroring, which is a far worse failure than a redundant branch.
     if (decision === "throw") {
       throw new ConnectionReentryError(
         connectionOwnerLabel(activeLead(state) ?? lead),

--- a/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
+++ b/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
@@ -39,8 +39,14 @@
  * the first `await` inside {@link runNativeConnectionTransaction} (`await
  * begin()`). A store-keyed buffer therefore stops answering for every
  * participant `put` the body makes, each one fires while the transaction can
- * still ROLLBACK, and the flush drains nothing. Cross-instance re-entry
- * (`HandleState.txOwners`) is handle-state based for the same reason.
+ * still ROLLBACK, and the flush drains nothing. The connection mutex meets the
+ * same wall and cannot dodge it: its question — is this caller an async
+ * DESCENDANT of the open body — is one only the store can answer, so under the
+ * shim it falls back to handle state (`HandleState.txOwners`) and gives up
+ * telling a descendant from an unrelated concurrent caller. Deferral asks a
+ * narrower question — which transaction is this participant enlisted in — and
+ * a per-participant buffer answers that one exactly on both runtimes, so it
+ * pays none of that price.
  *
  * The exception is a transaction that does NOT own its participants' session —
  * a real `pg.Pool`, which checks out one client while unrelated callers keep

--- a/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
+++ b/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
@@ -49,11 +49,16 @@
  *
  * ## Nesting detection
  *
- * {@link assertSharedConnectionHandle} refuses a second connection-scoped
- * transaction on a connection that already has a live one, via
+ * {@link assertSharedConnectionHandle} refuses a connection-scoped transaction
+ * opened from INSIDE a live one on the same connection, via
  * {@link isConnectionTxOpenOn}. Detection is ALS-store based, so it is precise
  * under a real `AsyncLocalStorage`: only a genuine async descendant of the open
- * body carries the store. It is ABSENT
+ * body carries the store, and a merely concurrent second transaction — which
+ * has its own `BEGIN` to open once the first commits, whatever its participant
+ * list — passes and takes the connection chain. That is the same distinction
+ * the connection mutex draws, and the two must agree: a guard that refused
+ * every second transaction would make the primitive unusable from more than
+ * one task. It is ABSENT
  * under {@link createShimAls}, whose store dies at the body's first `await` —
  * the guard's job there falls back to whatever the backend's own
  * `inTransaction` flag catches.

--- a/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
+++ b/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
@@ -474,7 +474,9 @@ export function defineNativeConnectionTransaction(
    * Detection is ALS-scoped rather than handle-state based, which is what keeps
    * the pool a pool: an unrelated concurrent caller carries no store and is
    * untouched, while a descendant of the transaction body — the only caller
-   * whose write can silently escape the transaction — is refused.
+   * whose write can silently escape the transaction — is refused. That is the
+   * same question the connection mutex asks, so a backend with a shared handle
+   * and one without refuse the same callers.
    */
   function assertNotForeignConnectionTx(owner: object, groupHandle: object): void {
     const ctx = findStore((c) => c.active && c.groupHandle === groupHandle);

--- a/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
+++ b/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
@@ -15,8 +15,8 @@
  * from every continuation of the body and from the `afterCommit` callbacks —
  * long after COMMIT ran. "Is the store present" is therefore NOT the same
  * question as "is a transaction open", and answering the second with the first
- * lets post-commit work believe it is still enlisted: writes route to a
- * released client, `put` events queue onto a buffer nothing drains.
+ * lets post-commit work believe it is still enlisted, routing its writes to a
+ * released client.
  *
  * {@link AlsContext.active} separates the two. It is cleared by
  * {@link deactivateConnectionTxStore} from INSIDE the ALS scope (a mutation
@@ -24,19 +24,30 @@
  * `store.run` returns into the caller's context), and the accessors below
  * split on it:
  *
- * | accessor                          | honors `active` | why                                     |
- * | --------------------------------- | --------------- | --------------------------------------- |
- * | {@link connectionTxQuery}         | yes             | the client is released at deactivation  |
- * | {@link isEnlistedInConnectionTx}  | yes             | nothing is open to enlist in            |
- * | {@link enqueueDeferredPut}        | yes             | post-commit emits must not be deferred  |
- * | {@link activeConnectionTxGroupHandle} | yes         | that is the question it answers         |
- * | {@link takeDeferredPuts}          | no              | it drains the queue in that very window |
- * | {@link discardDeferredPuts}       | no              | same, on the rollback path              |
+ * | accessor                          | honors `active` | why                                    |
+ * | --------------------------------- | --------------- | -------------------------------------- |
+ * | {@link connectionTxQuery}         | yes             | the client is released at deactivation |
+ * | {@link isEnlistedInConnectionTx}  | yes             | nothing is open to enlist in           |
+ * | {@link activeConnectionTxGroupHandle} | yes         | that is the question it answers        |
  *
- * {@link enqueueDeferredPut} additionally requires `AlsContext.deferPuts`,
- * which only this host sets: a plain `withTransaction` installs a store too but
- * buffers its events on the `tx` proxy and never drains the ALS queue, so a
- * `put` enqueued against that store would be silently dropped.
+ * ## `put` deferral does not live on the store
+ *
+ * {@link enqueueDeferredPut} and the flush/discard pass read a per-participant
+ * buffer this module registers for the life of the transaction, NOT the ALS
+ * store. Under {@link createShimAls} — the browser's ALS — the store is
+ * restored as soon as the synchronous portion of the callback returns, which is
+ * the first `await` inside {@link runNativeConnectionTransaction} (`await
+ * begin()`). A store-keyed buffer therefore stops answering for every
+ * participant `put` the body makes, each one fires while the transaction can
+ * still ROLLBACK, and the flush drains nothing. Cross-instance re-entry
+ * (`HandleState.txOwners`) is handle-state based for the same reason.
+ *
+ * The exception is a transaction that does NOT own its participants' session —
+ * a real `pg.Pool`, which checks out one client while unrelated callers keep
+ * writing through the pool and committing at once. Their rows survive this
+ * transaction's ROLLBACK, so `ownsSession: false` narrows deferral to writers
+ * that actually joined it, which is the same ALS-scoped question that arm's
+ * routing already asks.
  *
  * ## The innermost store is not the only store
  *
@@ -146,6 +157,19 @@ export interface RunNativeConnectionTransactionOptions<T> {
    */
   readonly chainHandle?: object;
   readonly participants: readonly AnyTabularStorage[];
+  /**
+   * `true` when this transaction owns the participants' only session, so every
+   * write they make necessarily joins it — SQLite, DuckDB, PGlite. Deferral is
+   * then unconditional for the duration, which is what carries it across an
+   * `await` on a runtime whose ALS store cannot.
+   *
+   * A real `pg.Pool` transaction passes `false`: it holds one checked-out
+   * client while unrelated callers keep writing through the pool and
+   * committing at once, and those rows survive this transaction's ROLLBACK.
+   * Deferral there follows the same ALS-scoped enlistment test the pool arm's
+   * own query routing uses.
+   */
+  readonly ownsSession: boolean;
   readonly begin: () => Promise<void> | void;
   readonly commit: () => Promise<void> | void;
   readonly rollback: () => Promise<void> | void;
@@ -176,6 +200,76 @@ export function defineNativeConnectionTransaction(
   mutex: Pick<ConnectionMutexApi, "getAlsStore" | "runInTransactionOnConnection">
 ): NativeConnectionTransactionApi {
   const { getAlsStore, runInTransactionOnConnection } = mutex;
+
+  /**
+   * One participant's deferred `put` events, held for the life of one
+   * transaction. Registered against the storage instance rather than the ALS
+   * store so it stays readable after an `await` on either runtime.
+   */
+  interface DeferralBuffer {
+    /**
+     * Cleared at deactivation, before the queue is drained: a listener that
+     * writes in response to a flushed `put` must emit, not queue onto a buffer
+     * nothing will drain again.
+     */
+    deferring: boolean;
+    readonly ownsSession: boolean;
+    readonly entities: unknown[];
+  }
+
+  /** The buffers registered for one transaction, by participant. */
+  interface DeferralScope {
+    readonly buffers: ReadonlyMap<object, DeferralBuffer>;
+  }
+
+  /**
+   * Innermost-first buffers per participant. A stack rather than a single slot
+   * because {@link runInTransactionOnConnection} runs an enlisted owner's
+   * nested transaction inline to surface a clearer downstream error, and the
+   * inner one's drain must not take the outer one's queue with it.
+   */
+  const deferralStacks = new WeakMap<object, DeferralBuffer[]>();
+
+  function currentDeferralBuffer(owner: object): DeferralBuffer | undefined {
+    const stack = deferralStacks.get(owner);
+    return stack === undefined ? undefined : stack[stack.length - 1];
+  }
+
+  function removeDeferralBuffer(owner: object, buffer: DeferralBuffer): void {
+    const stack = deferralStacks.get(owner);
+    if (stack === undefined) return;
+    const index = stack.lastIndexOf(buffer);
+    if (index !== -1) stack.splice(index, 1);
+    if (stack.length === 0) deferralStacks.delete(owner);
+  }
+
+  function armDeferredPuts(
+    participants: readonly AnyTabularStorage[],
+    ownsSession: boolean
+  ): DeferralScope {
+    const buffers = new Map<object, DeferralBuffer>();
+    for (const participant of participants) {
+      const buffer: DeferralBuffer = { deferring: true, ownsSession, entities: [] };
+      buffers.set(participant, buffer);
+      const stack = deferralStacks.get(participant);
+      if (stack === undefined) deferralStacks.set(participant, [buffer]);
+      else stack.push(buffer);
+    }
+    return { buffers };
+  }
+
+  /** Stops accepting puts while leaving the queue readable by the flush pass. */
+  function stopDeferringPuts(scope: DeferralScope): void {
+    for (const buffer of scope.buffers.values()) buffer.deferring = false;
+  }
+
+  /**
+   * Unregisters this transaction's buffers, including any the backend's
+   * `afterCommit`/`afterRollback` never drained.
+   */
+  function releaseDeferredPuts(scope: DeferralScope): void {
+    for (const [owner, buffer] of scope.buffers) removeDeferralBuffer(owner, buffer);
+  }
 
   /**
    * First store in the chain satisfying `match`.
@@ -255,44 +349,49 @@ export function defineNativeConnectionTransaction(
   async function runNativeConnectionTransaction<T>(
     options: RunNativeConnectionTransactionOptions<T>
   ): Promise<T> {
-    const deactivate = (): void => {
-      deactivateConnectionTxStore();
-      options.onDeactivate?.();
-    };
     return runInTransactionOnConnection(
       options.chainHandle ?? options.handle,
       options.participants,
       async () => {
-        // Inside the ALS scope: from here on the base `emitPut` may queue.
-        enableDeferredPuts();
+        // The transaction is open: from here on the base `emitPut` queues.
+        const scope = armDeferredPuts(options.participants, options.ownsSession);
+        const deactivate = (): void => {
+          deactivateConnectionTxStore();
+          stopDeferringPuts(scope);
+          options.onDeactivate?.();
+        };
         try {
-          await options.begin();
-        } catch (err) {
-          // BEGIN never took, so there is nothing to ROLLBACK.
-          deactivate();
-          throw err;
-        }
-        let result: T;
-        try {
-          result = await options.fn();
-          await options.commit();
-        } catch (err) {
           try {
-            await options.rollback();
-          } catch {
-            // prefer the original error if rollback fails
+            await options.begin();
+          } catch (err) {
+            // BEGIN never took, so there is nothing to ROLLBACK.
+            deactivate();
+            throw err;
           }
+          let result: T;
+          try {
+            result = await options.fn();
+            await options.commit();
+          } catch (err) {
+            try {
+              await options.rollback();
+            } catch {
+              // prefer the original error if rollback fails
+            }
+            deactivate();
+            options.afterRollback();
+            throw err;
+          }
+          // Deliberately outside the try: COMMIT has already taken, so a throw
+          // from teardown or from a `put`-flush listener must not issue a
+          // ROLLBACK against a connection with no open transaction and report
+          // the committed work as failed.
           deactivate();
-          options.afterRollback();
-          throw err;
+          options.afterCommit();
+          return result;
+        } finally {
+          releaseDeferredPuts(scope);
         }
-        // Deliberately outside the try: COMMIT has already taken, so a throw
-        // from teardown or from a `put`-flush listener must not issue a ROLLBACK
-        // against a connection with no open transaction and report the committed
-        // work as failed.
-        deactivate();
-        options.afterCommit();
-        return result;
       },
       options.handle
     );
@@ -309,20 +408,7 @@ export function defineNativeConnectionTransaction(
     const store = getAlsStore();
     if (store === undefined) return;
     store.active = false;
-    store.deferPuts = false;
     store.txQuery = undefined;
-  }
-
-  /**
-   * Opts this store into `put` deferral. MUST be called from inside the ALS
-   * scope. Only a connection-scoped transaction drains {@link takeDeferredPuts},
-   * so only it may enqueue: a plain `withTransaction` installs a store of its
-   * own and buffers events on the `tx` proxy, and a `put` queued against that
-   * store would never be flushed.
-   */
-  function enableDeferredPuts(): void {
-    const store = getAlsStore();
-    if (store !== undefined) store.deferPuts = true;
   }
 
   /**
@@ -345,29 +431,25 @@ export function defineNativeConnectionTransaction(
   }
 
   function enqueueDeferredPut(owner: object, entity: unknown): boolean {
-    const store = findStore((ctx) => ctx.active && ctx.deferPuts && ctx.owners.has(owner));
-    if (store === undefined) return false;
-    let queue = store.deferredPuts.get(owner);
-    if (queue === undefined) {
-      queue = [];
-      store.deferredPuts.set(owner, queue);
-    }
-    queue.push(entity);
+    const buffer = currentDeferralBuffer(owner);
+    if (buffer === undefined || !buffer.deferring) return false;
+    if (!buffer.ownsSession && !isEnlistedInConnectionTx(owner)) return false;
+    buffer.entities.push(entity);
     return true;
   }
 
-  /** Drains the post-commit queue; runs after deactivation, so it ignores `active`. */
+  /** Drains the post-commit queue; runs after deactivation, so it ignores `deferring`. */
   function takeDeferredPuts(owner: object): unknown[] {
-    const store = findStore((ctx) => ctx.deferredPuts.has(owner));
-    const queue = store?.deferredPuts.get(owner);
-    if (store === undefined || queue === undefined) return [];
-    store.deferredPuts.delete(owner);
-    return queue;
+    const buffer = currentDeferralBuffer(owner);
+    if (buffer === undefined) return [];
+    removeDeferralBuffer(owner, buffer);
+    return buffer.entities;
   }
 
-  /** Drops the queue after ROLLBACK; runs after deactivation, so it ignores `active`. */
+  /** Drops the queue after ROLLBACK; runs after deactivation, so it ignores `deferring`. */
   function discardDeferredPuts(owner: object): void {
-    findStore((ctx) => ctx.deferredPuts.has(owner))?.deferredPuts.delete(owner);
+    const buffer = currentDeferralBuffer(owner);
+    if (buffer !== undefined) removeDeferralBuffer(owner, buffer);
   }
 
   function isEnlistedInConnectionTx(owner: object): boolean {
@@ -394,8 +476,9 @@ export function defineNativeConnectionTransaction(
   /**
    * Emits every `put` a participant deferred, now that COMMIT has taken.
    *
-   * Goes through `emitCommittedPut` rather than the participant's own `emitPut`,
-   * which would see the store still installed and queue the event straight back.
+   * Goes through `emitCommittedPut` rather than the participant's own
+   * `emitPut`: these events have already cleared deferral and must reach
+   * subscribers whatever buffering `emitPut` is currently doing.
    */
   function flushDeferredPuts(participants: readonly AnyTabularStorage[]): void {
     for (const member of members(participants)) {
@@ -439,6 +522,7 @@ export function defineNativeConnectionTransaction(
     return runNativeConnectionTransaction({
       handle,
       participants: options.participants,
+      ownsSession: true,
       begin: async () => {
         setActive(true);
         await options.exec("BEGIN");

--- a/packages/storage/src/tabular/withConnectionTransaction.ts
+++ b/packages/storage/src/tabular/withConnectionTransaction.ts
@@ -63,7 +63,9 @@ function dedupeByIdentity(participants: readonly AnyTabularStorage[]): AnyTabula
  * could otherwise escape the transaction. An unrelated concurrent caller on
  * the same connection is a different matter and is not refused here: on a
  * pooled backend it simply runs on another client, and on a single-session
- * backend the connection chain makes it wait.
+ * backend the connection chain makes it wait. The one exception is the
+ * browser's synchronous ALS shim, whose store is gone at the body's first
+ * `await`: it cannot tell the two apart and refuses both.
  */
 export async function withConnectionTransaction<T>(
   participants: readonly AnyTabularStorage[],

--- a/packages/storage/src/tabular/withConnectionTransaction.ts
+++ b/packages/storage/src/tabular/withConnectionTransaction.ts
@@ -52,7 +52,10 @@ function dedupeByIdentity(participants: readonly AnyTabularStorage[]): AnyTabula
  * Calling this from inside an open connection-scoped transaction on the SAME
  * connection throws `NestedConnectionTransactionError` — SQLite and Postgres
  * have no autonomous `BEGIN`, so hoist the participants into the outer call or
- * use a `SAVEPOINT`.
+ * use a `SAVEPOINT`. "From inside" is literal: a call from another task that
+ * merely OVERLAPS an open transaction in time is not nesting and is not
+ * refused, whatever its participant list. On a single-session backend it waits
+ * for the open transaction to commit and then opens its own.
  *
  * Inside `fn`, call ordinary methods on the original storage instances — not a
  * `tx` proxy. Enlisted writes join the open `BEGIN`; a write from a storage

--- a/packages/test/src/contract/tabular-storage/assertions/withConnectionTransaction.ts
+++ b/packages/test/src/contract/tabular-storage/assertions/withConnectionTransaction.ts
@@ -126,6 +126,48 @@ export function withConnectionTransactionBlock(opts: TabularStorageContractOpts)
     );
 
     itImpl(
+      "does not refuse a concurrent transaction whose participant set merely differs",
+      async () => {
+        // Two units of work on one handle, neither inside the other, opening
+        // transactions over overlapping-but-unequal participant sets — the
+        // shape any concurrent sweep produces. On a single-session backend only
+        // one BEGIN can be open at a time, so the second waits; on a pool it
+        // takes another client. Either way it must not be refused.
+        let releaseFirst: () => void = () => {};
+        const firstCanFinish = new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        let signalStarted: () => void = () => {};
+        const firstStarted = new Promise<void>((resolve) => {
+          signalStarted = resolve;
+        });
+
+        const first = withConnectionTransaction([primary, sibling], async () => {
+          await primary.put({ name: "first", type: "x", option: "one", success: true });
+          signalStarted();
+          await firstCanFinish;
+        });
+        await firstStarted;
+
+        let secondError: unknown;
+        const second = withConnectionTransaction([sibling, outsider], async () => {
+          await outsider.put({ name: "second", type: "x", option: "two", success: true });
+        }).catch((err: unknown) => {
+          secondError = err;
+        });
+
+        releaseFirst();
+        await first;
+        await second;
+
+        expect(secondError).toBeUndefined();
+        expect(await primary.get({ name: "first", type: "x" })).toBeDefined();
+        expect(await outsider.get({ name: "second", type: "x" })).toBeDefined();
+      },
+      opts.timeout
+    );
+
+    itImpl(
       "throws sibling-op for a storage that was not enlisted",
       async () => {
         let error: unknown;

--- a/packages/test/src/contract/tabular-storage/assertions/withConnectionTransaction.ts
+++ b/packages/test/src/contract/tabular-storage/assertions/withConnectionTransaction.ts
@@ -83,6 +83,49 @@ export function withConnectionTransactionBlock(opts: TabularStorageContractOpts)
     );
 
     itImpl(
+      "does not refuse an unrelated concurrent caller",
+      async () => {
+        // Issued from outside the transaction body, so it is not an async
+        // descendant and its write cannot escape the BEGIN. Refusing it would
+        // land the error in a caller that did nothing wrong. Whether it waits
+        // for COMMIT (single-session backends chain) or runs at once (a pool
+        // hands it another client) is a backend detail — that it completes is
+        // not.
+        let releaseBody: () => void = () => {};
+        const bodyCanFinish = new Promise<void>((resolve) => {
+          releaseBody = resolve;
+        });
+        let signalStarted: () => void = () => {};
+        const bodyStarted = new Promise<void>((resolve) => {
+          signalStarted = resolve;
+        });
+
+        const txPromise = withConnectionTransaction([primary, sibling], async () => {
+          await primary.put({ name: "enlisted", type: "x", option: "ok", success: true });
+          signalStarted();
+          await bodyCanFinish;
+        });
+        await bodyStarted;
+
+        let outsiderError: unknown;
+        const concurrent = outsider
+          .put({ name: "concurrent", type: "x", option: "yes", success: true })
+          .catch((err: unknown) => {
+            outsiderError = err;
+          });
+
+        releaseBody();
+        await txPromise;
+        await concurrent;
+
+        expect(outsiderError).toBeUndefined();
+        expect(await outsider.get({ name: "concurrent", type: "x" })).toBeDefined();
+        expect(await primary.get({ name: "enlisted", type: "x" })).toBeDefined();
+      },
+      opts.timeout
+    );
+
+    itImpl(
       "throws sibling-op for a storage that was not enlisted",
       async () => {
         let error: unknown;

--- a/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
@@ -449,7 +449,7 @@ describe("PostgresTabularStorage", () => {
       return [a, b, pglite] as const;
     }
 
-    it("sibling single-op throws ConnectionReentryError during a transaction on the same handle", async () => {
+    it("unrelated concurrent sibling op waits for the transaction instead of being refused", async () => {
       const [a, b, pglite] = await makeSharedPair();
       try {
         let releaseInner: () => void = () => {};
@@ -461,23 +461,65 @@ describe("PostgresTabularStorage", () => {
           signalTxStarted = resolve;
         });
 
+        const order: string[] = [];
         const txPromise = a.withTransaction(async (tx) => {
           await tx.put({ name: "tx-row", type: "x", option: "tx", success: true });
           signalTxStarted();
           await innerCanFinish;
+          order.push("TX-BODY-END");
         });
 
         await txStarted;
 
-        // Sibling put from a different instance on the same handle: must
-        // fail fast with ConnectionReentryError(mode="sibling-op"), not
-        // silently block until the tx releases.
+        // Sibling put from a different instance on the same handle, issued from
+        // a task that is NOT an async descendant of the transaction body. It
+        // cannot escape the BEGIN, so it queues on the connection chain instead
+        // of being refused in a caller that did nothing wrong.
         let siblingErr: unknown;
-        await b
+        const sibling = b
           .put({ name: "sibling-row", type: "x", option: "sib", success: true })
-          .catch((err) => {
+          .then(() => {
+            order.push("SIBLING-WRITE");
+          })
+          .catch((err: unknown) => {
             siblingErr = err;
           });
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(siblingErr).toBeUndefined();
+        expect(order).toEqual([]);
+
+        releaseInner();
+        await txPromise;
+        await sibling;
+
+        expect(siblingErr).toBeUndefined();
+        expect(order).toEqual(["TX-BODY-END", "SIBLING-WRITE"]);
+        expect(await b.get({ name: "sibling-row", type: "x" })).toBeDefined();
+
+        expect(await a.get({ name: "tx-row", type: "x" })).toBeDefined();
+        // After the tx releases the connection, a further sibling put succeeds.
+        await b.put({ name: "post-tx-row", type: "x", option: "sib", success: true });
+        expect(await b.get({ name: "post-tx-row", type: "x" })).toBeDefined();
+      } finally {
+        await pglite.close();
+      }
+    });
+
+    it("sibling single-op from inside the transaction body still throws ConnectionReentryError", async () => {
+      const [a, b, pglite] = await makeSharedPair();
+      try {
+        // A descendant of the body is the caller whose write WOULD escape the
+        // BEGIN — it must still be refused, and its row must not exist.
+        let siblingErr: unknown;
+        await a.withTransaction(async (tx) => {
+          await tx.put({ name: "tx-row", type: "x", option: "tx", success: true });
+          await b
+            .put({ name: "sibling-row", type: "x", option: "sib", success: true })
+            .catch((err: unknown) => {
+              siblingErr = err;
+            });
+        });
 
         expect(siblingErr).toBeInstanceOf(ConnectionReentryError);
         const reentry = siblingErr as ConnectionReentryError;
@@ -487,13 +529,8 @@ describe("PostgresTabularStorage", () => {
         expect(reentry.message).toContain("SAVEPOINT");
         expect(reentry.message).toContain("single storage instance");
 
-        releaseInner();
-        await txPromise;
-
+        expect(await b.get({ name: "sibling-row", type: "x" })).toBeUndefined();
         expect(await a.get({ name: "tx-row", type: "x" })).toBeDefined();
-        // After the tx releases the connection, a sibling put succeeds.
-        await b.put({ name: "post-tx-row", type: "x", option: "sib", success: true });
-        expect(await b.get({ name: "post-tx-row", type: "x" })).toBeDefined();
       } finally {
         await pglite.close();
       }

--- a/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
@@ -627,6 +627,63 @@ describe("SqliteTabularStorage shared-connection safety", () => {
     expect(await b.get({ name: "from-b", type: "x" })).toMatchObject({ option: "vb" });
   });
 
+  it("two concurrent withConnectionTransaction calls with overlapping participant sets both commit", async () => {
+    const [a, b, db] = await makeSharedPair();
+    const c = new SqliteTabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>(
+      db,
+      `shared_c_${uuid4().replace(/-/g, "_")}`,
+      CompoundSchema,
+      CompoundPrimaryKeyNames
+    );
+    await c.setupDatabase();
+
+    // The shape a concurrent sweep produces: one unit of work opens a
+    // transaction over {a, b} and another, in a different task on the same
+    // handle, opens one over {b, c}. The sets overlap but are not equal, and
+    // neither call is an async descendant of the other. Only one BEGIN can be
+    // open on a single SQLite handle, so the second waits — refusing it would
+    // fail a unit of work that has nothing wrong with it.
+    const order: string[] = [];
+    let releaseFirst: () => void = () => {};
+    const firstCanFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let signalFirstStarted: () => void = () => {};
+    const firstStarted = new Promise<void>((resolve) => {
+      signalFirstStarted = resolve;
+    });
+
+    const first = withConnectionTransaction([a, b], async () => {
+      order.push("BEGIN-1");
+      await a.put({ name: "first", type: "x", option: "va", success: true });
+      signalFirstStarted();
+      await firstCanFinish;
+      order.push("END-1");
+    });
+    await firstStarted;
+
+    let secondError: unknown;
+    const second = withConnectionTransaction([b, c], async () => {
+      order.push("BEGIN-2");
+      await c.put({ name: "second", type: "x", option: "vc", success: true });
+    }).catch((err: unknown) => {
+      secondError = err;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(secondError).toBeUndefined();
+    expect(order).toEqual(["BEGIN-1"]);
+
+    releaseFirst();
+    await first;
+    await second;
+
+    expect(secondError).toBeUndefined();
+    expect(order).toEqual(["BEGIN-1", "END-1", "BEGIN-2"]);
+    expect(await a.get({ name: "first", type: "x" })).toMatchObject({ option: "va" });
+    expect(await c.get({ name: "second", type: "x" })).toMatchObject({ option: "vc" });
+  });
+
   it("withConnectionTransaction rolls back both tables when the callback throws", async () => {
     const [a, b] = await makeSharedPair();
     await a.put({ name: "kept", type: "x", option: "base", success: true });

--- a/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
@@ -490,7 +490,7 @@ describe("SqliteTabularStorage shared-connection safety", () => {
     return [a, b, db] as const;
   }
 
-  it("sibling single-op throws ConnectionReentryError during a transaction on the same handle", async () => {
+  it("unrelated concurrent sibling op waits for the transaction instead of being refused", async () => {
     const [a, b] = await makeSharedPair();
     let releaseInner: () => void = () => {};
     const innerCanFinish = new Promise<void>((resolve) => {
@@ -501,24 +501,69 @@ describe("SqliteTabularStorage shared-connection safety", () => {
       signalTxStarted = resolve;
     });
 
+    const order: string[] = [];
     const txPromise = a.withTransaction(async (tx) => {
       // After this awaited put returns, we are provably inside the tx body,
       // which means the shared ConnectionMutex has already set
-      // `state.txOwner = a`.
+      // `state.txOwners = {a}`.
       await tx.put({ name: "tx-row", type: "x", option: "tx", success: true });
       signalTxStarted();
       await innerCanFinish;
+      order.push("TX-BODY-END");
     });
 
     await txStarted;
 
-    // A sibling put from a *different* storage instance on the same handle
-    // must fail fast, not sneak into the tx BEGIN/COMMIT window and not
-    // block silently. The connection mutex throws ConnectionReentryError
-    // synchronously with mode="sibling-op".
+    // A sibling put from a *different* storage instance on the same handle,
+    // issued from a task that is NOT an async descendant of the transaction
+    // body. Its write cannot escape the BEGIN, so refusing it would only
+    // dead-letter a caller that did nothing wrong — in its own task, where the
+    // transaction's caller cannot catch it. It queues on the connection chain.
     let siblingErr: unknown;
-    await b.put({ name: "sibling-row", type: "x", option: "sib", success: true }).catch((err) => {
-      siblingErr = err;
+    const sibling = b
+      .put({ name: "sibling-row", type: "x", option: "sib", success: true })
+      .then(() => {
+        order.push("SIBLING-WRITE");
+      })
+      .catch((err: unknown) => {
+        siblingErr = err;
+      });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    // Neither refused nor slipped inside the open BEGIN: reads do not take the
+    // chain, so this observes the row's absence directly.
+    expect(siblingErr).toBeUndefined();
+    expect(order).toEqual([]);
+    expect(await b.get({ name: "sibling-row", type: "x" })).toBeUndefined();
+
+    releaseInner();
+    await txPromise;
+    await sibling;
+
+    expect(siblingErr).toBeUndefined();
+    expect(order).toEqual(["TX-BODY-END", "SIBLING-WRITE"]);
+    expect(await b.get({ name: "sibling-row", type: "x" })).toBeDefined();
+
+    // The outer tx still commits cleanly, and the shared connection is
+    // released so a further sibling put also succeeds.
+    expect(await a.get({ name: "tx-row", type: "x" })).toBeDefined();
+    await b.put({ name: "post-tx-row", type: "x", option: "sib", success: true });
+    expect(await b.get({ name: "post-tx-row", type: "x" })).toBeDefined();
+  });
+
+  it("sibling single-op from inside the transaction body still throws ConnectionReentryError", async () => {
+    const [a, b] = await makeSharedPair();
+
+    // A descendant of the body is the caller whose write WOULD escape the
+    // BEGIN — it must still be refused, and its row must not exist.
+    let siblingErr: unknown;
+    await a.withTransaction(async (tx) => {
+      await tx.put({ name: "tx-row", type: "x", option: "tx", success: true });
+      await b
+        .put({ name: "sibling-row", type: "x", option: "sib", success: true })
+        .catch((err: unknown) => {
+          siblingErr = err;
+        });
     });
 
     expect(siblingErr).toBeInstanceOf(ConnectionReentryError);
@@ -529,14 +574,8 @@ describe("SqliteTabularStorage shared-connection safety", () => {
     expect(reentry.message).toContain("SAVEPOINT");
     expect(reentry.message).toContain("single storage instance");
 
-    releaseInner();
-    await txPromise;
-
-    // The outer tx still commits cleanly, and the shared connection is
-    // released so a normal sibling put now succeeds.
+    expect(await b.get({ name: "sibling-row", type: "x" })).toBeUndefined();
     expect(await a.get({ name: "tx-row", type: "x" })).toBeDefined();
-    await b.put({ name: "post-tx-row", type: "x", option: "sib", success: true });
-    expect(await b.get({ name: "post-tx-row", type: "x" })).toBeDefined();
   });
 
   it("rejects cross-instance nested withTransaction within 500ms (no hang)", async () => {

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -944,6 +944,11 @@ export class PostgresTabularStorage<
           // connection for nesting detection.
           chainHandle: client,
           participants,
+          // The pool keeps serving unrelated callers on other clients while
+          // this transaction runs, and their rows survive its ROLLBACK — so
+          // deferral must follow enlistment rather than cover the participants
+          // wholesale.
+          ownsSession: false,
           begin: async () => {
             setConnectionTxQuery({ query: client.query.bind(client) });
             await client.query("BEGIN");

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -937,11 +937,13 @@ export class PostgresTabularStorage<
         return await runNativeConnectionTransaction({
           handle,
           // Each real-pool transaction owns its own checked-out client, so it
-          // must NOT chain on the pool: two concurrent
-          // `withConnectionTransaction` calls with different participants would
-          // otherwise see each other's owner set on the pool's chain slot and
-          // throw `ConnectionReentryError`. `handle` (the pool) still names the
-          // connection for nesting detection.
+          // must NOT chain on the pool: the pool's chain slot admits one holder
+          // at a time, so chaining there would make every pooled transaction
+          // wait for every other one and erase the pool. Concurrent callers are
+          // no longer REFUSED for sharing a slot — an unrelated one queues and
+          // opens its own `BEGIN` after the first commits — so what is at stake
+          // here is throughput, not an error. `handle` (the pool) still names
+          // the connection for nesting detection.
           chainHandle: client,
           participants,
           // The pool keeps serving unrelated callers on other clients while


### PR DESCRIPTION
## Summary

Fixes a critical regression in the connection mutex that refused unrelated concurrent callers instead of queuing them on the connection chain. This made the primitive unusable from more than one task at a time, as any concurrent write or transaction whose participants didn't match the open transaction's would be immediately rejected with `ConnectionReentryError`.

## Key Changes

- **Reclassified re-entry detection** to distinguish between three cases:
  - **Descendants** (async children of the open transaction body): inline if wholly enlisted, refuse if partially enlisted
  - **Unrelated concurrent callers**: queue on the connection chain instead of refusing
  - **Shim fallback** (browser runtime): conservatively refuses both descendants and unrelated callers since it cannot distinguish them after the first `await`

- **Moved `put` deferral off the ALS store** to a per-participant buffer registered for the transaction lifetime. The browser shim's store is restored at the first `await`, making store-keyed deferral ineffective. The new per-participant approach works identically on both runtimes.

- **Updated test suite** to reflect the corrected behavior:
  - Descendants with partially-enlisted participants are still refused (they would issue a nested `BEGIN` that commits outer work)
  - Unrelated concurrent callers with disjoint, overlapping, or identical participant sets now queue and run after `COMMIT`
  - Shim-specific tests verify the conservative fallback behavior
  - Integration tests confirm sibling operations from outside the transaction body no longer fail

- **Added `ownsSession` parameter** to `RunNativeConnectionTransactionOptions` to distinguish single-session backends (SQLite, DuckDB, PGlite) from connection pools (PostgreSQL via `pg.Pool`), allowing deferral to follow the same enlistment logic as query routing.

## Implementation Details

The core insight is that "is this caller an async descendant" is the only question that matters for safety. A descendant's write could escape the open `BEGIN`, or its own `BEGIN` would nest inside it—only the ALS store proves this across `await` boundaries. An unrelated concurrent caller has its own `BEGIN` to open once the first commits, whatever its participant list, so it queues on the chain.

The shim cannot answer this question after the first `await` (its store is gone), so it falls back to handle state and takes the conservative side: refusing both. This is the one behavioral difference between runtimes, and it's gated to the one that has no better option.

Deferral now uses a per-participant buffer stack, allowing nested transactions to maintain separate queues and the flush/discard pass to drain only the innermost one.

https://claude.ai/code/session_01MjALisNxwy6RpjwidMSLkn