### PR TITLE
Handle Retry-After: 0 and negative values correctly

### DIFF
--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -448,9 +448,20 @@ async function buildHttpError(url: string, response: Response): Promise<Error> {
     const retryAfterStr = response.headers.get("Retry-After");
     if (retryAfterStr) {
       const seconds = Number(retryAfterStr);
-      if (Number.isFinite(seconds) && seconds > 0) {
+      // `>= 0`, not `> 0`: zero is a valid delta-seconds meaning "retry now",
+      // and it is the whole of what the server said. Excluding it dropped the
+      // header entirely — the date branch below reads "0" as the year 2000,
+      // which is in the past and so sets nothing — leaving the caller unable to
+      // tell `Retry-After: 0` from a response carrying no header at all. A
+      // caller that backs off on its own then applies its no-guidance default
+      // to a response that asked for no wait.
+      if (Number.isFinite(seconds) && seconds >= 0) {
         retryDate = new Date(Date.now() + seconds * 1000);
       } else {
+        // A negative or non-numeric value falls through to the HTTP-date form.
+        // The `> new Date()` guard is what rejects garbage that still parses as
+        // a date, so a past date is treated as no guidance rather than as
+        // "retry now" — only the numeric form can say that.
         const parsedDate = new Date(retryAfterStr);
         if (!isNaN(parsedDate.getTime()) && parsedDate > new Date()) retryDate = parsedDate;
       }

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -490,6 +490,7 @@ describe("FetchUrlTask", () => {
 
     expect(error).toBeInstanceOf(JobTaskFailedError);
     expect(error.code).toBe(FetchUrlErrorCode.HTTP_RATE_LIMITED);
+    expect(error.jobError).toBeInstanceOf(RetryableJobError);
     // The value a caller reads to decide how long to wait. Left unset, a zero
     // is indistinguishable from a response carrying no Retry-After at all, and
     // a caller with its own backoff applies its no-guidance default to a
@@ -516,8 +517,15 @@ describe("FetchUrlTask", () => {
       response_type: "stream",
     }).catch((e) => e);
 
+    // The kind of error matters as much as the missing date: an absent
+    // `retryDate` alone would also hold for a PermanentJobError, which never
+    // carries one, so on its own it cannot tell "still a retryable rate limit,
+    // just with no usable guidance" from "stopped being retryable at all".
     expect(error).toBeInstanceOf(JobTaskFailedError);
+    expect(error.code).toBe(FetchUrlErrorCode.HTTP_RATE_LIMITED);
+    expect(error.jobError).toBeInstanceOf(RetryableJobError);
     expect(error.jobError.retryDate).toBeUndefined();
+    expect(mockFetch.mock.calls.length).toBe(1);
   });
 
   test("handles service unavailable with default retry time", async () => {

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -471,6 +471,55 @@ describe("FetchUrlTask", () => {
     expect(mockFetch.mock.calls.length).toBe(1);
   });
 
+  test("keeps a Retry-After of 0, which means retry now rather than no guidance", async () => {
+    const beforeTest = Date.now();
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response("Too Many Requests", {
+          status: 429,
+          statusText: "Too Many Requests",
+          headers: { "Retry-After": "0" },
+        })
+      )
+    );
+
+    const error = await fetchUrl({
+      url: "https://api.example.com/retry-now",
+      response_type: "stream",
+    }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(JobTaskFailedError);
+    expect(error.code).toBe(FetchUrlErrorCode.HTTP_RATE_LIMITED);
+    // The value a caller reads to decide how long to wait. Left unset, a zero
+    // is indistinguishable from a response carrying no Retry-After at all, and
+    // a caller with its own backoff applies its no-guidance default to a
+    // response that asked for none.
+    expect(error.jobError.retryDate).toBeInstanceOf(Date);
+    const waitMs = error.jobError.retryDate.getTime() - beforeTest;
+    expect(waitMs).toBeGreaterThanOrEqual(0);
+    expect(waitMs).toBeLessThan(1000);
+  });
+
+  test("ignores a negative Retry-After, which delta-seconds cannot express", async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response("Too Many Requests", {
+          status: 429,
+          statusText: "Too Many Requests",
+          headers: { "Retry-After": "-5" },
+        })
+      )
+    );
+
+    const error = await fetchUrl({
+      url: "https://api.example.com/negative-retry-after",
+      response_type: "stream",
+    }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(JobTaskFailedError);
+    expect(error.jobError.retryDate).toBeUndefined();
+  });
+
   test("handles service unavailable with default retry time", async () => {
     mockFetch.mockImplementation(() =>
       Promise.resolve(


### PR DESCRIPTION
## Summary

`Retry-After: 0` was being dropped, leaving callers unable to tell "the server said retry now" from "the server said nothing".

## The bug

`buildHttpError` in `packages/tasks/src/task/FetchUrlTask.ts` accepted the delta-seconds form only when `seconds > 0`. A zero therefore fell through to the HTTP-date branch, where `new Date("0")` parses as the year 2000 — in the past, and so rejected by the `> new Date()` guard that exists to throw out garbage which still parses as a date. No `retryDate` was set.

Nothing downstream could recover the value: the `RetryableJobError` exposes `retryDate` and carries no headers, so a zero header became indistinguishable from a response with no `Retry-After` at all. A caller with its own backoff then applied its no-guidance default to a response that had asked for no wait — and a caller walking a cooldown ladder climbed a rung on it.

## The change

`packages/tasks/src/task/FetchUrlTask.ts` — accept `seconds >= 0`. `retryDate` then lands at "now", which `rescheduleJob` already turns into an immediate `visibleAt`. Comments record why zero must survive, and why the date branch's past-date guard stays as it is.

**Negative values are unchanged.** `-5` failed `> 0` before and fails `>= 0` now, so it took and still takes the date branch, where it parses as nothing and is ignored. The new test pins that behaviour rather than altering it.

## Tests

`packages/test/src/test/task/FetchTask.test.ts` — the fetch suite lives in the `@workglow/test` package, not beside the source:

- `keeps a Retry-After of 0, which means retry now rather than no guidance` — `retryDate` is a Date within a second of now, instead of `undefined`.
- `ignores a negative Retry-After, which delta-seconds cannot express` — `Retry-After: -5` leaves `retryDate` undefined.

Confirmed the first test actually catches the bug: reverting `>= 0` back to `> 0` fails it with "expected undefined to be an instance of Date". All 268 tests across the ten fetch-related files pass, and lint and format are clean.

## How it was found

Auditing the `embarc-data` test suite. Its `secFetchThrottle` is written to honour `Retry-After: 0` as "retry now" and documents at length why a zero must not climb its cooldown ladder — but it never got the chance, because the header never survived this far. Tracked on the consumer side at sroussey/embarc-data#88, which has to flip its pinned expectation once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156JBfRnaEMKETRiZKpuTRa