### PR TITLE
fix(sqlite): similaritySearch decoded an already-decoded vector

### DIFF
--- a/packages/test/src/test/vector/SqliteVectorStorage.search.test.ts
+++ b/packages/test/src/test/vector/SqliteVectorStorage.search.test.ts
@@ -103,8 +103,17 @@ describe("SqliteVectorStorage similarity search", async () => {
 
   it("emits the similaritySearch event with the results", async () => {
     let seen: readonly { id: string }[] | undefined;
-    storage.on("similaritySearch", (_query, results) => {
-      seen = results as unknown as readonly { id: string }[];
+    // The event belongs to the vector extension of the event surface; the
+    // inherited `on` is typed to the tabular names, so cast at the call site.
+    (
+      storage as unknown as {
+        on: (
+          name: string,
+          fn: (query: unknown, results: readonly { id: string }[]) => void
+        ) => void;
+      }
+    ).on("similaritySearch", (_query, results) => {
+      seen = results;
     });
     await storage.similaritySearch(EAST, { topK: 1 });
     expect(seen?.map((hit) => hit.id)).toEqual(["east"]);

--- a/packages/test/src/test/vector/SqliteVectorStorage.search.test.ts
+++ b/packages/test/src/test/vector/SqliteVectorStorage.search.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Sqlite, SqliteVectorStorage } from "@workglow/sqlite/storage";
+import type { DataPortSchemaObject } from "@workglow/util/schema";
+import { TypedArraySchema } from "@workglow/util/schema";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const VecSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    vector: TypedArraySchema(),
+    metadata: { type: "object", format: "metadata", additionalProperties: true },
+  },
+  required: ["id", "vector", "metadata"],
+  additionalProperties: false,
+} as const satisfies DataPortSchemaObject;
+
+const VecPK = ["id"] as const;
+const DIM = 4;
+
+/** Unit vectors, so a cosine score is exactly the coordinate it points along. */
+const EAST = new Float32Array([1, 0, 0, 0]);
+const NORTH = new Float32Array([0, 1, 0, 0]);
+const NORTHEAST = new Float32Array([Math.SQRT1_2, Math.SQRT1_2, 0, 0]);
+
+/**
+ * `similaritySearch` end to end on a real SQLite database.
+ *
+ * The sibling validation suite only ever wrote and read back, which is why this
+ * shipped broken: `similaritySearch` re-decoded a vector column the inherited
+ * tabular read had already turned into a `Float32Array`, so `JSON.parse` threw
+ * on the first row of every search. A store that accepts writes and fails every
+ * query looks healthy from anywhere except a query.
+ */
+describe("SqliteVectorStorage similarity search", async () => {
+  await Sqlite.init();
+
+  let db: InstanceType<typeof Sqlite.Database>;
+  let storage: SqliteVectorStorage<typeof VecSchema, typeof VecPK>;
+
+  beforeEach(async () => {
+    db = new Sqlite.Database(":memory:");
+    storage = new SqliteVectorStorage(db, "vec_search", VecSchema, VecPK, [], DIM);
+    await storage.setupDatabase();
+    await storage.putBulk([
+      { id: "east", vector: EAST, metadata: { region: "e" } },
+      { id: "north", vector: NORTH, metadata: { region: "n" } },
+      { id: "northeast", vector: NORTHEAST, metadata: { region: "ne" } },
+    ] as never);
+  });
+
+  afterEach(async () => {
+    await storage.deleteAll();
+    db.close();
+  });
+
+  it("returns the stored rows, ranked by cosine similarity", async () => {
+    const hits = await storage.similaritySearch(EAST);
+    expect(hits.map((hit) => hit.id)).toEqual(["east", "northeast", "north"]);
+    expect(hits[0]!.score).toBeCloseTo(1, 5);
+    expect(hits[1]!.score).toBeCloseTo(Math.SQRT1_2, 5);
+    expect(hits[2]!.score).toBeCloseTo(0, 5);
+  });
+
+  it("hands back the vector as a TypedArray, not the stored JSON", async () => {
+    const [hit] = await storage.similaritySearch(EAST, { topK: 1 });
+    expect(hit!.vector).toBeInstanceOf(Float32Array);
+    expect([...(hit!.vector as Float32Array)]).toEqual([...EAST]);
+  });
+
+  it("honours topK", async () => {
+    expect(await storage.similaritySearch(EAST, { topK: 2 })).toHaveLength(2);
+  });
+
+  it("honours scoreThreshold", async () => {
+    const hits = await storage.similaritySearch(EAST, { scoreThreshold: 0.9 });
+    expect(hits.map((hit) => hit.id)).toEqual(["east"]);
+  });
+
+  it("honours a metadata filter", async () => {
+    const hits = await storage.similaritySearch(EAST, { filter: { region: "n" } });
+    expect(hits.map((hit) => hit.id)).toEqual(["north"]);
+  });
+
+  it("searches rows written as raw JSON by an older release", async () => {
+    // The column's stored form. A row that never round-tripped through this
+    // class's writer must still be searchable, which is the other half of why
+    // the decode accepts both shapes.
+    db.prepare(`INSERT INTO vec_search (id, vector, metadata) VALUES (?, ?, ?)`).run(
+      "legacy",
+      JSON.stringify([...NORTH]),
+      JSON.stringify({ region: "legacy" })
+    );
+
+    const hits = await storage.similaritySearch(NORTH, { topK: 2 });
+    expect(hits.map((hit) => hit.id)).toContain("legacy");
+  });
+
+  it("emits the similaritySearch event with the results", async () => {
+    let seen: readonly { id: string }[] | undefined;
+    storage.on("similaritySearch", (_query, results) => {
+      seen = results as unknown as readonly { id: string }[];
+    });
+    await storage.similaritySearch(EAST, { topK: 1 });
+    expect(seen?.map((hit) => hit.id)).toEqual(["east"]);
+  });
+});

--- a/providers/sqlite/src/storage/SqliteVectorStorage.ts
+++ b/providers/sqlite/src/storage/SqliteVectorStorage.ts
@@ -95,13 +95,23 @@ export class SqliteVectorStorage<
   }
 
   /**
-   * Deserialize vector from JSON string
-   * Defaults to Float32Array for compatibility with typical embedding vectors
+   * The stored vector as a TypedArray, from whichever form the read produced.
+   *
+   * SQLite holds it as a JSON string, but the tabular read this class inherits
+   * already decodes a `TypedArraySchema` column back to a TypedArray — so by
+   * the time a row reaches `similaritySearch` the column is usually decoded
+   * and occasionally not (a row written by an older release, a caller handing
+   * back a raw row). Accepting both is what makes this correct in either case
+   * rather than in whichever one the read layer happens to do today.
    */
-  private deserializeVector(vectorJson: string): TypedArray {
-    const array = JSON.parse(vectorJson);
-    // Default to Float32Array for typical use case (embeddings)
-    return new this.vectorCtor(array);
+  private toVector(stored: unknown): TypedArray {
+    if (typeof stored === "string") {
+      return new this.vectorCtor(JSON.parse(stored) as number[]);
+    }
+    if (Array.isArray(stored)) {
+      return new this.vectorCtor(stored);
+    }
+    return stored as TypedArray;
   }
 
   /**
@@ -135,9 +145,7 @@ export class SqliteVectorStorage<
     const allEntities = (await this.getAll()) || [];
 
     for (const entity of allEntities) {
-      // SQLite stores vectors as JSON strings, need to deserialize
-      const vectorRaw = entity[this.vectorPropertyName] as unknown as string;
-      const vector = this.deserializeVector(vectorRaw);
+      const vector = this.toVector(entity[this.vectorPropertyName]);
       const metadata = this.metadataPropertyName
         ? (entity[this.metadataPropertyName] as Metadata)
         : ({} as Metadata);


### PR DESCRIPTION
## The bug

`SqliteVectorStorage.similaritySearch` reads rows through the inherited `getAll()` and then runs its own `deserializeVector` over the vector column. But the tabular read already decodes a `TypedArraySchema` column back to a `Float32Array` — so `JSON.parse` receives a TypedArray and throws on the first row:

```
SyntaxError: Unexpected non-whitespace character after JSON at position 1
    at SqliteVectorStorage.deserializeVector (SqliteVectorStorage.ts:102)
    at SqliteVectorStorage.similaritySearch (SqliteVectorStorage.ts:140)
```

**Every query fails.** Writes, dimension validation, `getAll` and the rest of the class are correct, which is what let this survive: a store that accepts writes and fails every query looks healthy from anywhere except a query.

Reproduced in four lines — put one vector, search for it.

## The fix

`toVector` accepts whichever form the read produced: the decoded TypedArray, a plain array, or the raw JSON string a row written by an older release still carries. Correct whichever way the read layer behaves, rather than correct for whichever way it behaves today.

```ts
private toVector(stored: unknown): TypedArray {
  if (typeof stored === "string") return new this.vectorCtor(JSON.parse(stored) as number[]);
  if (Array.isArray(stored)) return new this.vectorCtor(stored);
  return stored as TypedArray;
}
```

## Why it shipped

There was no search coverage at all. The sibling suite is `SqliteVectorStorage.validation.test.ts`, which only ever writes and reads back — so it exercises exactly the paths that work.

This adds `SqliteVectorStorage.search.test.ts`: seven cases over a real in-memory database covering ranking, the returned vector's type, `topK`, `scoreThreshold`, a metadata filter, a row inserted as raw JSON the way an older release wrote it, and the `similaritySearch` event. **All seven fail on the previous implementation** (verified by stashing the fix) and pass with it.

Named `.search.test.ts`, not `.integration.test.ts` — `vitest.config.ts` excludes that suffix from the default run for suites that need something external, and a test excluded from CI would not have caught this either.

## Verification

```
bunx vitest run packages/test/src/test/vector packages/test/src/test/rag
  Test Files  26 passed (26)
       Tests  249 passed (249)
```

`oxlint` and `oxfmt` clean on both files.

## How it was found

Building `sec ask` in [workglow-dev/sec#…](https://github.com/workglow-dev/sec) — a knowledge base backed by `SqliteVectorStorage` — where every retrieval failed. That repo currently carries a local instance-level patch with a docblock saying to delete it once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWKzhH398se57h3tKJfvuf

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWKzhH398se57h3tKJfvuf)_