### PR TITLE
Fix deferral buffer selection for concurrent pooled transactions

### DIFF
--- a/packages/storage/src/tabular/__tests__/runNativeConnectionTransaction.test.ts
+++ b/packages/storage/src/tabular/__tests__/runNativeConnectionTransaction.test.ts
@@ -68,8 +68,21 @@ function makeParticipant(handle: object, table: string): AnyTabularStorage & Rec
   return participant;
 }
 
+/**
+ * A latch two transaction bodies use to interleave. `open()` is idempotent, so
+ * both sides may call it to mean "I have arrived".
+ */
+function gate(): { readonly reached: Promise<void>; readonly open: () => void } {
+  let open!: () => void;
+  const reached = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { reached, open };
+}
+
 interface RunOptions {
   readonly handle: object;
+  readonly chainHandle?: object;
   readonly participants: readonly AnyTabularStorage[];
   readonly fn: () => Promise<unknown>;
   readonly onDeactivate?: () => void;
@@ -82,6 +95,7 @@ interface RunOptions {
 function run(options: RunOptions): Promise<unknown> {
   return runNativeConnectionTransaction({
     handle: options.handle,
+    chainHandle: options.chainHandle,
     participants: options.participants,
     ownsSession: options.ownsSession ?? true,
     begin: options.begin ?? ((): void => {}),
@@ -428,6 +442,100 @@ describe("put deferral when the transaction does not own the session", () => {
     release();
     await tx;
     expect(participant.observed).toEqual(["outsider", "enlisted"]);
+  });
+});
+
+/**
+ * A real `pg.Pool` transaction chains on its own checked-out client, not on the
+ * pool, so two transactions over the SAME participant are open at once by
+ * design — `withConnectionTransaction` documents that a merely overlapping
+ * caller is not refused. Deferral must therefore keep each one's queue to
+ * itself: picking the most recently armed buffer instead sends an enlisted
+ * `put` into a stranger's transaction, where its COMMIT publishes a row that
+ * may still roll back and its ROLLBACK drops a row that committed.
+ */
+describe("put deferral across concurrent transactions that share a participant", () => {
+  beforeEach(() => {
+    __resetAlsForTesting();
+  });
+
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  /** Two pooled transactions over one participant, each on its own client. */
+  function poolTransaction(
+    pool: object,
+    participant: AnyTabularStorage,
+    fn: () => Promise<void>
+  ): Promise<unknown> {
+    return run({
+      handle: pool,
+      // A fresh checkout per transaction, exactly as `pool.connect()` hands out.
+      chainHandle: {},
+      participants: [participant],
+      ownsSession: false,
+      fn,
+      afterCommit: () => flushDeferredPuts([participant]),
+      afterRollback: () => discardAllDeferredPuts([participant]),
+    });
+  }
+
+  it("does not let a concurrent ROLLBACK swallow a committed put", async () => {
+    const pool = {};
+    const participant = makeParticipant(pool, "table_a");
+    const bothOpen = gate();
+    const written = gate();
+    const otherDone = gate();
+
+    const committing = poolTransaction(pool, participant, async () => {
+      bothOpen.open();
+      await bothOpen.reached;
+      participant.emitPut("row-1");
+      written.open();
+      await otherDone.reached;
+    });
+
+    const rollingBack = poolTransaction(pool, participant, async () => {
+      bothOpen.open();
+      await written.reached;
+      throw new Error("boom");
+    });
+
+    await expect(rollingBack).rejects.toThrow("boom");
+    otherDone.open();
+    await committing;
+
+    expect(participant.observed).toEqual(["row-1"]);
+  });
+
+  it("does not let a concurrent COMMIT publish a put that then rolls back", async () => {
+    const pool = {};
+    const participant = makeParticipant(pool, "table_a");
+    const bothOpen = gate();
+    const written = gate();
+    const otherDone = gate();
+
+    const rollingBack = poolTransaction(pool, participant, async () => {
+      bothOpen.open();
+      await bothOpen.reached;
+      participant.emitPut("row-1");
+      written.open();
+      await otherDone.reached;
+      throw new Error("boom");
+    });
+
+    await poolTransaction(pool, participant, async () => {
+      bothOpen.open();
+      await written.reached;
+    });
+
+    const afterOtherCommitted = [...participant.observed];
+    otherDone.open();
+    await expect(rollingBack).rejects.toThrow("boom");
+
+    expect(afterOtherCommitted).toEqual([]);
+    expect(participant.observed).toEqual([]);
   });
 });
 

--- a/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
+++ b/packages/storage/src/tabular/defineNativeConnectionTransaction.ts
@@ -53,7 +53,10 @@
  * writing through the pool and committing at once. Their rows survive this
  * transaction's ROLLBACK, so `ownsSession: false` narrows deferral to writers
  * that actually joined it, which is the same ALS-scoped question that arm's
- * routing already asks.
+ * routing already asks. That arm also chains on its own client rather than on
+ * the pool, so two transactions over one participant are legitimately open at
+ * once and the store is what tells their buffers apart — see
+ * {@link deferralBufferFor}. It never runs in a browser, so it always has one.
  *
  * ## The innermost store is not the only store
  *
@@ -225,6 +228,13 @@ export function defineNativeConnectionTransaction(
      */
     deferring: boolean;
     readonly ownsSession: boolean;
+    /**
+     * The store this buffer was armed under, or `undefined` when there was
+     * none. Only the `ownsSession: false` arm reads it, and only to tell its
+     * own buffer from a concurrent transaction's — see
+     * {@link deferralBufferFor}.
+     */
+    readonly ctx: AlsContext | undefined;
     readonly entities: unknown[];
   }
 
@@ -234,16 +244,48 @@ export function defineNativeConnectionTransaction(
   }
 
   /**
-   * Innermost-first buffers per participant. A stack rather than a single slot
+   * Buffers per participant, innermost last. A stack rather than a single slot
    * because {@link runInTransactionOnConnection} runs an enlisted owner's
    * nested transaction inline to surface a clearer downstream error, and the
-   * inner one's drain must not take the outer one's queue with it.
+   * inner one's drain must not take the outer one's queue with it — and
+   * because a pooled backend opens several concurrent transactions over one
+   * participant by design. {@link deferralBufferFor} decides which entry a
+   * given caller is in.
    */
   const deferralStacks = new WeakMap<object, DeferralBuffer[]>();
 
-  function currentDeferralBuffer(owner: object): DeferralBuffer | undefined {
+  /**
+   * The buffer a `put` on `owner` belongs in, or `undefined` when this caller
+   * is in no transaction over it.
+   *
+   * On a single-session backend the connection chain admits one transaction
+   * over a participant at a time, so the innermost buffer IS this caller's and
+   * no store has to be consulted — which is what keeps deferral working under
+   * the browser shim, whose store is gone by the body's first `await`.
+   *
+   * A real `pg.Pool` transaction takes its own checked-out client and chains
+   * on THAT, so several transactions over one participant are open at once by
+   * design. Innermost-wins would then hand a participant's `put` to whichever
+   * of them armed last: a concurrent transaction's ROLLBACK would discard a
+   * committed row's event, and its COMMIT would publish a row still free to
+   * roll back. That arm therefore picks the buffer whose store this caller is
+   * actually inside, the same question its query routing asks. `active` is not
+   * consulted — the flush pass runs after deactivation, on this very store.
+   */
+  function deferralBufferFor(owner: object): DeferralBuffer | undefined {
     const stack = deferralStacks.get(owner);
-    return stack === undefined ? undefined : stack[stack.length - 1];
+    if (stack === undefined) return undefined;
+    const innermost = stack[stack.length - 1];
+    if (innermost === undefined || innermost.ownsSession) return innermost;
+    for (let i = stack.length - 1; i >= 0; i--) {
+      const buffer = stack[i];
+      if (buffer === undefined) continue;
+      const armedUnder = buffer.ctx;
+      if (armedUnder !== undefined && findStore((ctx) => ctx === armedUnder) !== undefined) {
+        return buffer;
+      }
+    }
+    return undefined;
   }
 
   function removeDeferralBuffer(owner: object, buffer: DeferralBuffer): void {
@@ -260,7 +302,14 @@ export function defineNativeConnectionTransaction(
   ): DeferralScope {
     const buffers = new Map<object, DeferralBuffer>();
     for (const participant of participants) {
-      const buffer: DeferralBuffer = { deferring: true, ownsSession, entities: [] };
+      const buffer: DeferralBuffer = {
+        deferring: true,
+        ownsSession,
+        // Armed from inside the ALS scope, so this is this transaction's own
+        // store on any runtime that has one.
+        ctx: getAlsStore(),
+        entities: [],
+      };
       buffers.set(participant, buffer);
       const stack = deferralStacks.get(participant);
       if (stack === undefined) deferralStacks.set(participant, [buffer]);
@@ -442,7 +491,7 @@ export function defineNativeConnectionTransaction(
   }
 
   function enqueueDeferredPut(owner: object, entity: unknown): boolean {
-    const buffer = currentDeferralBuffer(owner);
+    const buffer = deferralBufferFor(owner);
     if (buffer === undefined || !buffer.deferring) return false;
     if (!buffer.ownsSession && !isEnlistedInConnectionTx(owner)) return false;
     buffer.entities.push(entity);
@@ -451,7 +500,7 @@ export function defineNativeConnectionTransaction(
 
   /** Drains the post-commit queue; runs after deactivation, so it ignores `deferring`. */
   function takeDeferredPuts(owner: object): unknown[] {
-    const buffer = currentDeferralBuffer(owner);
+    const buffer = deferralBufferFor(owner);
     if (buffer === undefined) return [];
     removeDeferralBuffer(owner, buffer);
     return buffer.entities;
@@ -459,7 +508,7 @@ export function defineNativeConnectionTransaction(
 
   /** Drops the queue after ROLLBACK; runs after deactivation, so it ignores `deferring`. */
   function discardDeferredPuts(owner: object): void {
-    const buffer = currentDeferralBuffer(owner);
+    const buffer = deferralBufferFor(owner);
     if (buffer !== undefined) removeDeferralBuffer(owner, buffer);
   }
 


### PR DESCRIPTION
## Summary

Fix a critical bug in deferral buffer selection that caused concurrent transactions over the same participant (as in a real `pg.Pool`) to interfere with each other's deferred puts. The innermost-buffer-wins strategy broke when multiple transactions were legitimately open at once over a single participant, causing committed rows to be discarded on rollback and uncommitted rows to be published on commit.

## Changes

- **Renamed `currentDeferralBuffer` to `deferralBufferFor`** with new logic to select the correct buffer for a given caller:
  - On single-session backends (ownsSession: true), returns the innermost buffer as before
  - On pooled backends (ownsSession: false), searches the stack for the buffer whose store matches the current ALS context, ensuring each transaction's puts stay in its own queue

- **Added `ctx` field to `DeferralBuffer`** to track which ALS store a buffer was armed under, enabling the pooled backend to distinguish concurrent transactions over the same participant

- **Updated `armDeferralBuffers`** to capture the current ALS store (`getAlsStore()`) when arming a buffer, providing the context needed for later buffer selection

- **Added `chainHandle` parameter to test infrastructure** to simulate how `pg.Pool` transactions chain on their own checked-out client rather than the pool itself

- **Added comprehensive test suite** with two test cases demonstrating the bug:
  - Verifies a concurrent ROLLBACK doesn't swallow a committed put
  - Verifies a concurrent COMMIT doesn't publish a put that then rolls back

- **Updated documentation** in `defineNativeConnectionTransaction.ts` to explain the pooled transaction scenario and how deferral buffer selection now handles it

## Implementation Details

The fix leverages the fact that each transaction runs in its own ALS (Async Local Storage) context. When a buffer is armed, we capture its store. Later, when a `put` arrives, we search the stack for the buffer whose store matches the current context—the same question the query routing already asks. This ensures puts are enqueued in the correct transaction's buffer, preventing cross-transaction interference while maintaining backward compatibility with single-session backends that have no store.

https://claude.ai/code/session_01AQM9fuGdtrFVFU3WReaW48