### PR TITLE
fix(storage): guard updateWhere's primary key on the transaction path

### DIFF
--- a/packages/test/src/test/storage-tabular/genericTabularStorageTests.ts
+++ b/packages/test/src/test/storage-tabular/genericTabularStorageTests.ts
@@ -1239,6 +1239,36 @@ export function runGenericTabularStorageTests(
         expect(await repository.get({ id: "pk2" } as never)).toBeUndefined();
       });
 
+      it("rejects a primary-key patch made through the transaction handle", async () => {
+        // The `tx` handle a backend hands its `withTransaction` callback is a
+        // Proxy that routes each method straight to its unlocked internal
+        // implementation, so a guard sitting only on the public method is
+        // skipped by every call made through `tx`. On the SQL backends that
+        // built an `UPDATE ... SET id = ?` and rewrote the row's identity —
+        // silently, or as a mid-transaction UNIQUE violation — while the same
+        // call outside a transaction threw. The guard belongs on the path both
+        // spellings share.
+        const ts = new Date().toISOString();
+        await repository.put({
+          id: "txpk1",
+          category: "a",
+          subcategory: "s",
+          value: 1,
+          createdAt: ts,
+          updatedAt: ts,
+        } as never);
+
+        await expect(
+          repository.withTransaction(async (tx) => {
+            await tx.updateWhere({ id: "txpk1" } as never, { id: "txpk2" } as never);
+          })
+        ).rejects.toThrow(/primary-key column/);
+
+        // Identity untouched: neither renamed in place nor duplicated.
+        expect(await repository.get({ id: "txpk1" } as never)).toBeDefined();
+        expect(await repository.get({ id: "txpk2" } as never)).toBeUndefined();
+      });
+
       it("is CAS under a raced update on the same match", async () => {
         // Two updateWhere calls with the same before-value predicate race for a
         // single row. A genuine CAS implementation must let exactly one win —

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -1725,6 +1725,14 @@ export class PostgresTabularStorage<
     match: SearchCriteria<Entity>,
     patch: Partial<Entity>
   ): Promise<Entity | undefined> {
+    // Repeated rather than redundant, exactly as `deleteSearch` is:
+    // {@link createTxView}'s Proxy routes `tx.updateWhere` straight here by the
+    // `_*Internal` naming convention, so a guard living only on the public
+    // method is skipped by every call made through a transaction handle.
+    // Unguarded, `tx.updateWhere({ id: "a" }, { id: "b" })` rewrites the row's
+    // identity in place — or aborts the transaction on a UNIQUE violation —
+    // instead of raising StorageValidationError.
+    this.assertPatchKeepsPrimaryKey(patch);
     const patchKeys = Object.keys(patch) as Array<keyof Entity>;
     if (patchKeys.length === 0) return undefined;
     return this.runUpdateWhereOnHandle(match, patch, patchKeys);

--- a/providers/sqlite/src/storage/SqliteTabularStorage.ts
+++ b/providers/sqlite/src/storage/SqliteTabularStorage.ts
@@ -1378,6 +1378,13 @@ export class SqliteTabularStorage<
     match: SearchCriteria<Entity>,
     patch: Partial<Entity>
   ): Promise<Entity | undefined> {
+    // Repeated rather than redundant, exactly as `deleteSearch` is:
+    // {@link createTxView}'s Proxy routes `tx.updateWhere` straight here by the
+    // `_*Internal` naming convention, so a guard living only on the public
+    // method is skipped by every call made through a transaction handle.
+    // Unguarded, `tx.updateWhere({ id: "a" }, { id: "b" })` rewrites the row's
+    // identity in place instead of raising StorageValidationError.
+    this.assertPatchKeepsPrimaryKey(patch);
     const patchKeys = Object.keys(patch) as Array<keyof Entity>;
     if (patchKeys.length === 0) return undefined;
     return this.runUpdateWhereOnHandle(match, patch, patchKeys);


### PR DESCRIPTION
## Problem

`withTransaction(async (tx) => …)` hands its callback a Proxy that routes every method
straight to the backend's unlocked `_*Internal` implementation. On SQLite and Postgres the
primary-key immutability guard (`assertPatchKeepsPrimaryKey`) sat only on the *public*
`updateWhere`, so it never ran for a call made through `tx`:

```ts
await repo.updateWhere({ id: "a" }, { id: "b" });                       // throws StorageValidationError
await repo.withTransaction(async (tx) => {
  await tx.updateWhere({ id: "a" }, { id: "b" });                       // silently rewrote the row's identity
});
```

Inside a transaction the SQLite backend built ``UPDATE `t` SET `id` = ? WHERE rowid IN (…)``
and moved the row to a new primary key with no error at all; Postgres did the same, or
aborted the transaction with a UNIQUE violation when the target key already existed.
DuckDB already carried the assertion on its internal method, so the three SQL backends
disagreed about the same call.

This is the same hole that was previously closed for `deleteSearch` and not closed for its
sibling.

## Fix

- `assertPatchKeepsPrimaryKey` moves onto `_updateWhereInternal` in
  `SqliteTabularStorage` and `PostgresTabularStorage`, and stays on the public method too —
  the shape `deleteSearch` already uses, and the shape DuckDB already had.
- The contract is pinned from the **shared generic tabular suite**
  (`genericTabularStorageTests.ts`), so every backend that runs it is checked rather than
  one: InMemory, HTTP proxy, Cached, IndexedDB, DuckDB, SQLite and Postgres. The new test
  also asserts the row is neither renamed in place nor duplicated.

Observable behaviour after the change: `tx.updateWhere` rejects with
`StorageValidationError` on every backend, exactly as the non-transactional call does.

## Verification

Ran on Node 22 (this environment) — the repo targets Node 24, so `node:sqlite` runs behind
its experimental flag here; SQLite-backed suites nonetheless ran clean.

- `npx vitest run --project test packages/test/src/test/storage-tabular/ …/SqliteAiVectorStorage.integration.test.ts`
  (integration tier enabled): **1617 passed, 85 skipped**. Two Postgres/PGlite files
  (`PostgresTabularDateTime.test.ts`, `ScopedTabularStoragePostgres.integration.test.ts`)
  hit the 15 s hook/test timeout when the whole directory runs in parallel; re-run on their
  own they pass (**7 passed**), and they failed the same way on unmodified `main` under load.
  Neither touches `updateWhere`.
- The new generic test was confirmed **red before the fix** on SQLite and Postgres and green
  on every other backend, then green everywhere after.
- `bunx oxfmt --check` on the changed files: clean. `bunx oxlint` across the repo: exit 0.
  Full `bun run lint` (which builds types first) was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa)_