### PR TITLE
Join fixes: per-call executor, central right-side unwrap, bounded fallback read

### DIFF
--- a/packages/storage/src/tabular/BaseSqlTabularStorage.ts
+++ b/packages/storage/src/tabular/BaseSqlTabularStorage.ts
@@ -36,6 +36,7 @@ import type {
   SimplifyPrimaryKey,
   ValueOptionType,
 } from "./ITabularStorage";
+import { resolveJoinDelegate } from "./joinDelegate";
 import { pkFingerprint } from "./pkFingerprint";
 
 /**
@@ -84,10 +85,10 @@ export interface SqlJoinDialect {
   ) => Promise<Record<string, unknown>[]>;
 }
 
-/** The two storages and dialect a pushed-down join runs against. */
+/** The right-hand storage and SQL dialect a pushed-down join runs against. */
 interface SqlJoinPlan {
   readonly right: BaseSqlTabularStorage<any, any, any, any, any, any>;
-  readonly dialect: SqlJoinDialect;
+  readonly dialect: ISqlDialect;
 }
 
 /**
@@ -629,24 +630,21 @@ export abstract class BaseSqlTabularStorage<
     return null;
   }
 
-  /** Memoized {@link sqlJoinDialect}: the bag is per-instance and immutable. */
-  private _joinDialectCache: SqlJoinDialect | null | undefined;
-  private cachedSqlJoinDialect(): SqlJoinDialect | null {
-    if (this._joinDialectCache === undefined) {
-      this._joinDialectCache = this.sqlJoinDialect();
-    }
-    return this._joinDialectCache;
-  }
-
   /**
    * Decides whether `right` can be joined in one statement: it must be a SQL
    * storage speaking the same dialect on the same connection. The dialect is
    * compared by identity, not name — DuckDB's reports itself as Postgres.
+   *
+   * Only the SQL dialect is carried into the plan. The executor is resolved
+   * again at execution time from whatever receiver runs the join, because a
+   * backend's `executeRaw` closes over the connection its `this` names — and
+   * inside `withTransaction` that receiver is the transaction proxy, whose
+   * connection is the transaction's, not the instance's.
    */
   private planSqlJoin(right: unknown): SqlJoinPlan | null {
     if (!(right instanceof BaseSqlTabularStorage)) return null;
-    const mine = this.cachedSqlJoinDialect();
-    const theirs = right.cachedSqlJoinDialect();
+    const mine = this.sqlJoinDialect();
+    const theirs = right.sqlJoinDialect();
     if (mine === null || theirs === null || mine.dialect !== theirs.dialect) return null;
     const handle = this.sharedConnectionHandle();
     if (handle === null || handle !== right.sharedConnectionHandle()) return null;
@@ -660,7 +658,7 @@ export abstract class BaseSqlTabularStorage<
     // case to it. `this.inTransaction` means the join is already inside that
     // transaction, where reading its own uncommitted rows is correct.
     if (right.inTransaction && !this.inTransaction) return null;
-    return { right, dialect: mine };
+    return { right, dialect: mine.dialect };
   }
 
   /**
@@ -678,8 +676,9 @@ export abstract class BaseSqlTabularStorage<
     spec: JoinSpec<Entity, R, T>,
     right: ITabularStorage<any, any, R, any, any>
   ): Promise<JoinedRow<Entity, R, T>[]> {
-    const plan = this.planSqlJoin(right);
-    if (plan === null) return super.join(spec, right);
+    const target = resolveJoinDelegate(right) as ITabularStorage<any, any, R, any, any>;
+    const plan = this.planSqlJoin(target);
+    if (plan === null) return super.join(spec, target);
     return this.mutex(() => this.runSqlJoin(spec, plan.right, plan.dialect));
   }
 
@@ -695,24 +694,37 @@ export abstract class BaseSqlTabularStorage<
     spec: JoinSpec<Entity, R, T>,
     right: ITabularStorage<any, any, R, any, any>
   ): Promise<JoinedRow<Entity, R, T>[]> {
-    const plan = this.planSqlJoin(right);
-    if (plan === null) return super.join(spec, right);
+    const target = resolveJoinDelegate(right) as ITabularStorage<any, any, R, any, any>;
+    const plan = this.planSqlJoin(target);
+    if (plan === null) return super.join(spec, target);
     return this.runSqlJoin(spec, plan.right, plan.dialect);
   }
 
-  /** Builds, executes and hydrates a pushed-down join. */
+  /**
+   * Builds, executes and hydrates a pushed-down join.
+   *
+   * The executor comes from `this.sqlJoinDialect()` here rather than from the
+   * plan: a backend binds `executeRaw` to the connection its `this` names, so
+   * resolving it anywhere but the receiver that runs the statement can send it
+   * down a connection that has since been released, or past an open
+   * transaction whose uncommitted rows the join is supposed to see.
+   */
   protected async runSqlJoin<R, T extends JoinType>(
     spec: JoinSpec<Entity, R, T>,
     right: BaseSqlTabularStorage<any, any, any, any, any, any>,
-    dialect: SqlJoinDialect
+    dialect: ISqlDialect
   ): Promise<JoinedRow<Entity, R, T>[]> {
+    const executor = this.sqlJoinDialect();
+    if (executor === null) {
+      throw new Error(`${this.constructor.name} cannot execute a pushed-down join.`);
+    }
     // The right schema is always in hand here, so every column named by the
     // spec is checked before anything is quoted into SQL.
     this.validateJoinSpec(spec, right);
     const leftSide = this.sqlJoinSide(JOIN_LEFT_ALIAS);
     const rightSide = right.sqlJoinSide(JOIN_RIGHT_ALIAS);
-    const { sql, params } = buildJoinSelect(dialect.dialect, spec, leftSide, rightSide);
-    const rows = await dialect.executeRaw(sql, params);
+    const { sql, params } = buildJoinSelect(dialect, spec, leftSide, rightSide);
+    const rows = await executor.executeRaw(sql, params);
 
     // Built once for the whole result rather than per cell: the alias depends
     // only on the side and the column's position.

--- a/packages/storage/src/tabular/BaseTabularStorage.ts
+++ b/packages/storage/src/tabular/BaseTabularStorage.ts
@@ -46,6 +46,7 @@ import type {
 } from "./ITabularStorage";
 import { runHashJoin } from "./hashJoin";
 import { isSearchCondition, isSearchInCondition, isSearchNotInCondition } from "./ITabularStorage";
+import { resolveJoinDelegate } from "./joinDelegate";
 import type { KeysetPageDeps } from "./keysetPage";
 import {
   applyKeysetFilter,
@@ -315,17 +316,24 @@ export abstract class BaseTabularStorage<
    * backends override it with a single `JOIN` statement when both tables sit
    * on one connection. The callbacks are bound to `this`, so a subclass's own
    * `query` / `getAll` (mutex, transaction routing) still runs underneath.
+   *
+   * The right side is unwrapped through any chain of delegating wrappers
+   * ({@link resolveJoinDelegate}) before anything reads it, so a join whose
+   * left side is a plain storage and whose right side is wrapped still reads
+   * both halves from the same place. A wrapper that must stay in the path —
+   * one that scopes what the join may see — does not delegate, and survives.
    */
   async join<R, T extends JoinType>(
     spec: JoinSpec<Entity, R, T>,
     right: ITabularStorage<any, any, R, any, any>
   ): Promise<JoinedRow<Entity, R, T>[]> {
-    this.validateJoinSpec(spec, right);
+    const target = resolveJoinDelegate(right) as ITabularStorage<any, any, R, any, any>;
+    this.validateJoinSpec(spec, target);
     return runHashJoin<Entity, R, T>(
       {
         leftQuery: (criteria, options) => this.query(criteria, options),
         leftGetAll: (options) => this.getAll(options),
-        rightQuery: (criteria) => right.query(criteria),
+        rightQuery: (criteria) => target.query(criteria),
         leftColumnIsNullable: (column) => this.columnIsNullable(column),
       },
       spec

--- a/packages/storage/src/tabular/ITabularStorage.ts
+++ b/packages/storage/src/tabular/ITabularStorage.ts
@@ -779,6 +779,19 @@ export interface ITabularStorage<
    * unmatched left row carries `right: undefined`. A `null` join key never
    * matches. Returns `[]` (never `undefined`) when nothing matches. Emits no
    * event of its own.
+   *
+   * **What the fallback reads.** The single-statement path is bounded by the
+   * database. The hash join is not, by default: `limit` and `offset` are
+   * applied to the joined rows, so a bounded join can still be a whole-table
+   * read. It bounds the left read — and stops early — only when the joined
+   * rows come back in their final order, meaning `orderBy` is absent or names
+   * only left columns the left query can order by. An `orderBy` touching the
+   * right side, or a left column that may be null, is sorted in memory
+   * instead, and that sort needs every joined row: such a join reads the whole
+   * left table and every right row matching it, however small its `limit`.
+   * Over a remote backend (HTTP proxy, Supabase) that is the whole table on
+   * the wire, so prefer a `where.left` that narrows it, or an `orderBy` the
+   * left side can serve.
    */
   join<R, T extends JoinType>(
     spec: JoinSpec<Entity, R, T>,

--- a/packages/storage/src/tabular/__tests__/hashJoin.test.ts
+++ b/packages/storage/src/tabular/__tests__/hashJoin.test.ts
@@ -311,7 +311,7 @@ describe("runHashJoin", () => {
     expect(ids(rows)).toEqual(["p6:a1", "p3:a2"]);
   });
 
-  it("does not bound the left read for an inner join, which drops unmatched rows", async () => {
+  it("bounds the left read for an inner join whose first prefix already fills the limit", async () => {
     const { deps } = await fixtures();
     const leftGetAll = vi.fn(deps.leftGetAll);
     const rows = await runHashJoin(
@@ -323,12 +323,60 @@ describe("runHashJoin", () => {
         limit: 3,
       }
     );
-    // p4 and p5 have no author; bounding the left read to 3 would have
-    // returned only 2 joined rows.
-    expect(leftGetAll).toHaveBeenCalledWith({
-      orderBy: [{ column: "views", direction: "DESC" }],
-    });
+    // p1, p6 and p3 are the three highest-viewed posts and all three match, so
+    // three left rows are all this join ever has to read.
+    expect(leftGetAll.mock.calls).toEqual([
+      [{ orderBy: [{ column: "views", direction: "DESC" }], limit: 3 }],
+    ]);
     expect(ids(rows)).toEqual(["p1:a1", "p6:a1", "p3:a2"]);
+  });
+
+  it("widens the left read for an inner join until the limit is filled", async () => {
+    const { deps } = await fixtures();
+    const leftGetAll = vi.fn(deps.leftGetAll);
+    const rows = await runHashJoin(
+      { ...deps, leftGetAll },
+      {
+        type: "inner",
+        on,
+        // Ascending by views puts the two unmatched posts (p4 views 1 with a
+        // dangling author, p5 views 3 with a null key) first, so a read bounded
+        // at the limit yields only one joined row and has to widen.
+        orderBy: [{ side: "left", column: "views", direction: "ASC" }],
+        limit: 3,
+      }
+    );
+    expect(leftGetAll.mock.calls).toEqual([
+      [{ orderBy: [{ column: "views", direction: "ASC" }], limit: 3 }],
+      [{ orderBy: [{ column: "views", direction: "ASC" }], limit: 12 }],
+    ]);
+    expect(ids(rows)).toEqual(["p2:a1", "p3:a2", "p6:a1"]);
+  });
+
+  it("reads the whole left side when the order can only be applied in memory", async () => {
+    const { deps } = await fixtures();
+    const leftGetAll = vi.fn(deps.leftGetAll);
+    const rows = await runHashJoin(
+      { ...deps, leftGetAll },
+      {
+        type: "inner",
+        on,
+        // A right-side order is decided after the pairing, so no prefix of the
+        // left side can be known to hold the first `limit` rows.
+        orderBy: [{ side: "right", column: "name", direction: "ASC" }],
+        limit: 2,
+      }
+    );
+    expect(leftGetAll.mock.calls).toEqual([[undefined]]);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("bounds an unordered join, whose result order is unspecified either way", async () => {
+    const { deps } = await fixtures();
+    const leftGetAll = vi.fn(deps.leftGetAll);
+    const rows = await runHashJoin({ ...deps, leftGetAll }, { type: "left", on, limit: 2 });
+    expect(leftGetAll.mock.calls).toEqual([[{ limit: 2 }]]);
+    expect(rows).toHaveLength(2);
   });
 
   it("emits one row per matching right row when the right side is one-to-many", async () => {

--- a/packages/storage/src/tabular/hashJoin.ts
+++ b/packages/storage/src/tabular/hashJoin.ts
@@ -113,6 +113,14 @@ export function sortJoinedRows<L, R, T extends JoinType>(
 }
 
 /**
+ * How much wider each successive left-side read is than the one before, when a
+ * bounded join has not yet produced enough rows. Growing geometrically keeps
+ * the number of round trips logarithmic in how selective the join turns out to
+ * be, while a join that matches everything still reads only what it returns.
+ */
+const LEFT_READ_GROWTH = 4;
+
+/**
  * Application-side hash join: read the left rows, fetch the right rows whose
  * key is among them in one `in` query per chunk, and pair them up in memory.
  * This is the join every backend gets for free; SQL backends replace it with
@@ -123,6 +131,14 @@ export function sortJoinedRows<L, R, T extends JoinType>(
  * rows: pushing them to the left query would under-produce under an inner
  * join (unmatched left rows drop out) and over-produce against a one-to-many
  * right side.
+ *
+ * A bounded join reads the left side in **growing prefixes** of that same
+ * ordering and stops as soon as `offset + limit` joined rows exist, so a
+ * `limit: 20` join does not have to materialise a million-row table first. It
+ * can only do that when the joined rows are already in their final order — the
+ * left query served the order, or none was asked for. An `orderBy` naming the
+ * right side, or one the left query could not serve, is sorted here instead,
+ * and that sort needs every row: such a join reads the whole left table.
  */
 export async function runHashJoin<L, R, T extends JoinType>(
   deps: HashJoinDeps<L, R>,
@@ -142,27 +158,73 @@ export async function runHashJoin<L, R, T extends JoinType>(
     ? { orderBy: orderBy.map((o) => ({ column: o.column as keyof L, direction: o.direction })) }
     : undefined;
 
-  // A left join emits at least one row per left row, in left order, so the
-  // first `offset + limit` joined rows can only come from the first
-  // `offset + limit` left rows — the read can stop there. This is exact only
-  // for a left join whose order is fully pushed down: an inner join drops
-  // unmatched left rows, so bounding its left read would under-produce.
-  // (Over-production against a one-to-many right side is harmless; the slice
-  // at the end trims it.)
-  const boundedLeft =
-    pushLeftOrder && spec.type === "left" && spec.limit !== undefined
-      ? { ...leftOptions, limit: (spec.offset ?? 0) + spec.limit }
-      : leftOptions;
+  const offset = spec.offset ?? 0;
+  const needed = spec.limit === undefined ? undefined : offset + spec.limit;
+  // The joined rows are already in their final order — so the first `needed`
+  // of them are the answer, and the read can stop once it has them — exactly
+  // when nothing is sorted here afterwards.
+  const boundLeftRead = needed !== undefined && (pushLeftOrder || orderBy.length === 0);
 
   const leftWhere = spec.where?.left;
-  const leftRows =
-    (leftWhere !== undefined && Object.keys(leftWhere).length > 0
-      ? await deps.leftQuery(leftWhere, boundedLeft)
-      : await deps.leftGetAll(boundedLeft)) ?? [];
+  const hasLeftWhere = leftWhere !== undefined && Object.keys(leftWhere).length > 0;
+  const readLeft = async (options: QueryOptions<L> | undefined): Promise<L[]> =>
+    (hasLeftWhere
+      ? await deps.leftQuery(leftWhere as SearchCriteria<L>, options)
+      : await deps.leftGetAll(options)) ?? [];
 
   const leftColumns = spec.on.map((o) => o.left as string);
   const rightColumns = spec.on.map((o) => o.right as string);
+  const joined: JoinedRow<L, R, T>[] = [];
 
+  if (!boundLeftRead) {
+    const leftRows = await readLeft(leftOptions);
+    await appendJoinedRows(deps, spec, leftRows, leftColumns, rightColumns, joined);
+  } else {
+    const target = needed as number;
+    // Each pass joins one left read whole, so what it produces is exactly what
+    // the same unbounded join would have produced from that prefix — a widened
+    // pass replaces the narrower one rather than extending it, which is what
+    // keeps the result independent of how the backend broke ties in the
+    // narrower read. A left join emits at least one row per left row, so its
+    // first pass always suffices; an inner join drops unmatched left rows and
+    // may have to widen.
+    let batchLimit = target;
+    let previousRead = -1;
+    while (true) {
+      const rows = await readLeft({ ...leftOptions, limit: batchLimit });
+      joined.length = 0;
+      await appendJoinedRows(deps, spec, rows, leftColumns, rightColumns, joined);
+      // `rows.length <= previousRead` also covers a backend that ignores
+      // `limit`: widening then reads no more than the pass before it did.
+      if (joined.length >= target || rows.length < batchLimit || rows.length <= previousRead) {
+        break;
+      }
+      previousRead = rows.length;
+      batchLimit *= LEFT_READ_GROWTH;
+    }
+  }
+
+  if (!pushLeftOrder && orderBy.length > 0) {
+    sortJoinedRows(joined, orderBy);
+  }
+
+  if (offset === 0 && spec.limit === undefined) return joined;
+  return joined.slice(offset, spec.limit === undefined ? undefined : offset + spec.limit);
+}
+
+/**
+ * Fetches the right rows matching `leftRows` and appends the pairs to
+ * `joined`, in left order. Under a `left` join an unmatched left row is
+ * appended NULL-extended.
+ */
+async function appendJoinedRows<L, R, T extends JoinType>(
+  deps: HashJoinDeps<L, R>,
+  spec: JoinSpec<L, R, T>,
+  leftRows: readonly L[],
+  leftColumns: readonly string[],
+  rightColumns: readonly string[],
+  joined: JoinedRow<L, R, T>[]
+): Promise<void> {
   // Distinct key tuples, in first-seen order, and each left row's fingerprint.
   const tuples = new Map<string, unknown[]>();
   const leftKeys = leftRows.map((row) => {
@@ -226,7 +288,6 @@ export async function runHashJoin<L, R, T extends JoinType>(
     }
   }
 
-  const joined: JoinedRow<L, R, T>[] = [];
   leftRows.forEach((left, i) => {
     const fp = leftKeys[i];
     const matches = fp === undefined ? undefined : rightByKey.get(fp);
@@ -238,12 +299,4 @@ export async function runHashJoin<L, R, T extends JoinType>(
       joined.push({ left, right: undefined } as JoinedRow<L, R, T>);
     }
   });
-
-  if (!pushLeftOrder && orderBy.length > 0) {
-    sortJoinedRows(joined, orderBy);
-  }
-
-  const offset = spec.offset ?? 0;
-  if (offset === 0 && spec.limit === undefined) return joined;
-  return joined.slice(offset, spec.limit === undefined ? undefined : offset + spec.limit);
 }

--- a/packages/test/src/test/storage-tabular/CachedTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/CachedTabularStorage.integration.test.ts
@@ -811,4 +811,42 @@ describe("CachedTabularStorage join", () => {
     expect(rows.map((r) => r.left.id).sort()).toEqual(["p1", "p2"]);
     expect(durableJoin).toHaveBeenCalledWith(expect.anything(), durableAuthors);
   });
+  it("unwraps a cached right side even when the left side is a plain storage", async () => {
+    // The left side here delegates nothing, so nothing in the call chain is a
+    // wrapper that could unwrap the right one on its own behalf.
+    const posts = new InMemoryTabularStorage<typeof PostSchema, typeof PostPrimaryKeyNames>(
+      PostSchema,
+      PostPrimaryKeyNames
+    );
+    const durableAuthors = new InMemoryTabularStorage<
+      typeof AuthorSchema,
+      typeof AuthorPrimaryKeyNames
+    >(AuthorSchema, AuthorPrimaryKeyNames);
+    const authors = new CachedTabularStorage<typeof AuthorSchema, typeof AuthorPrimaryKeyNames>(
+      durableAuthors,
+      undefined,
+      AuthorSchema,
+      AuthorPrimaryKeyNames
+    );
+    await authors.put({ id: "a1", tenant: "t", name: "Ann", country: null });
+    // Warm the cache, then add an author behind its back: `authors.query` no
+    // longer reports a9, but the durable side does.
+    expect(await authors.getAll()).toHaveLength(1);
+    await durableAuthors.put({ id: "a9", tenant: "t", name: "Nine", country: null });
+    expect((await authors.query({ id: "a9" })) ?? []).toEqual([]);
+
+    await posts.putBulk([
+      { id: "p1", tenant: "t", author_id: "a1", title: "one", views: 1 },
+      { id: "p9", tenant: "t", author_id: "a9", title: "nine", views: 2 },
+    ]);
+
+    // A join served by the cache would drop p9 — one half reading the cache
+    // while the other reads durable is exactly the disagreement that costs
+    // rows under an inner join.
+    const rows = await posts.join(
+      { type: "inner", on: [{ left: "author_id", right: "id" }] },
+      authors
+    );
+    expect(rows.map((r) => `${r.left.id}:${r.right.id}`).sort()).toEqual(["p1:a1", "p9:a9"]);
+  });
 });

--- a/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
@@ -962,3 +962,97 @@ describe("PostgresTabularStorage join", () => {
     { expectSqlPushdown: false }
   );
 });
+
+describe("PostgresTabularStorage join and the connection it runs on", () => {
+  // A real `pg.Pool` hands `withTransaction` a dedicated client and releases it
+  // when the transaction ends; PGlite, being one session with no `connect()`,
+  // never takes that path. This double gives PGlite the shape of a pool: its
+  // `connect()` returns a client that refuses to work once released, and every
+  // JOIN statement records which of the two it was issued on.
+  function poolOver(pg: PGlite): { pool: Pool; joins: string[] } {
+    const joins: string[] = [];
+    const run = async (via: string, sql: string, params?: unknown[]): Promise<unknown> => {
+      if (sql.includes("JOIN")) joins.push(via);
+      return await pg.query(sql, params as unknown[]);
+    };
+    const pool = {
+      query: (sql: string, params?: unknown[]) => run("pool", sql, params),
+      connect: async () => {
+        let released = false;
+        return {
+          query: (sql: string, params?: unknown[]) => {
+            if (released) throw new Error("Cannot use a pooled client after release");
+            return run("client", sql, params);
+          },
+          release: () => {
+            released = true;
+          },
+        };
+      },
+    };
+    return { pool: pool as unknown as Pool, joins };
+  }
+
+  const spec = { type: "inner", on: [{ left: "author_id", right: "id" }] } as const;
+  const pair = (r: { left: { id: string }; right?: { id: string } }): string =>
+    `${r.left.id}:${r.right?.id ?? "-"}`;
+
+  async function fixture() {
+    const pg = new PGlite();
+    const { pool, joins } = poolOver(pg);
+    const posts = new PostgresTabularStorage<typeof PostSchema, typeof PostPrimaryKeyNames>(
+      pool,
+      `pooled_posts_${uuid4().replace(/-/g, "_")}`,
+      PostSchema,
+      PostPrimaryKeyNames
+    );
+    const authors = new PostgresTabularStorage<typeof AuthorSchema, typeof AuthorPrimaryKeyNames>(
+      pool,
+      `pooled_authors_${uuid4().replace(/-/g, "_")}`,
+      AuthorSchema,
+      AuthorPrimaryKeyNames
+    );
+    await posts.setupDatabase();
+    await authors.setupDatabase();
+    await authors.put({ id: "a1", tenant: "t1", name: "Ann", country: null });
+    await posts.put({ id: "p1", tenant: "t1", author_id: "a1", title: "one", views: 1 });
+    return { pg, joins, posts, authors };
+  }
+
+  it("goes back to the pool for a join issued after one ran inside a transaction", async () => {
+    const { pg, joins, posts, authors } = await fixture();
+    try {
+      const inside = await posts.withTransaction(async (tx) => await tx.join(spec, authors));
+      expect(inside.map(pair)).toEqual(["p1:a1"]);
+
+      // The transaction's client has been released by now. Anything still
+      // holding it either throws or, once the pool re-hands it out, runs this
+      // SELECT on somebody else's connection.
+      const outside = await posts.join(spec, authors);
+      expect(outside.map(pair)).toEqual(["p1:a1"]);
+      expect(joins).toEqual(["client", "pool"]);
+    } finally {
+      await pg.close();
+    }
+  });
+
+  it("uses the transaction's client for a join issued after one ran on the pool", async () => {
+    const { pg, joins, posts, authors } = await fixture();
+    try {
+      expect((await posts.join(spec, authors)).map(pair)).toEqual(["p1:a1"]);
+
+      const inside = await posts.withTransaction(async (tx) => {
+        await tx.put({ id: "p2", tenant: "t1", author_id: "a1", title: "two", views: 2 });
+        return await tx.join(spec, authors);
+      });
+
+      // A join that ran on the pool here would be looking at a different
+      // client from the one holding the open transaction, and could neither
+      // see p2 nor be sure of not blocking on the locks it holds.
+      expect(inside.map(pair).sort()).toEqual(["p1:a1", "p2:a1"]);
+      expect(joins).toEqual(["pool", "client"]);
+    } finally {
+      await pg.close();
+    }
+  });
+});

--- a/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
@@ -10,6 +10,7 @@ import {
   InMemoryTabularStorage,
   NestedConnectionTransactionError,
   StorageValidationError,
+  TelemetryTabularStorage,
   withConnectionTransaction,
 } from "@workglow/storage";
 import { setLogger, uuid4 } from "@workglow/util";
@@ -1062,4 +1063,42 @@ describe("SqliteTabularStorage join", () => {
       ),
     { expectSqlPushdown: false }
   );
+});
+
+describe("SqliteTabularStorage join with a wrapped right side", () => {
+  it("still runs one statement when the right side arrives behind a wrapper", async () => {
+    await Sqlite.init();
+    const db = new Sqlite.Database(":memory:");
+    const posts = new SqliteTabularStorage<typeof PostSchema, typeof PostPrimaryKeyNames>(
+      db,
+      `wrapped_posts_${uuid4().replace(/-/g, "_")}`,
+      PostSchema,
+      PostPrimaryKeyNames
+    );
+    const authorsInner = new SqliteTabularStorage<
+      typeof AuthorSchema,
+      typeof AuthorPrimaryKeyNames
+    >(db, `wrapped_authors_${uuid4().replace(/-/g, "_")}`, AuthorSchema, AuthorPrimaryKeyNames);
+    await posts.setupDatabase();
+    await authorsInner.setupDatabase();
+    await authorsInner.put({ id: "a1", tenant: "t", name: "Ann", country: null });
+    await posts.put({ id: "p1", tenant: "t", author_id: "a1", title: "one", views: 1 });
+
+    // The left side is a plain storage: it is the join itself, not a wrapper
+    // in the call chain, that has to see past the telemetry layer.
+    const authors = new TelemetryTabularStorage("wrapped-authors", authorsInner);
+    const rightQuery = vi.spyOn(authorsInner, "query");
+
+    const rows = await posts.join(
+      { type: "inner", on: [{ left: "author_id", right: "id" }] },
+      authors
+    );
+
+    expect(rows.map((r) => `${r.left.id}:${r.right.id}`)).toEqual(["p1:a1"]);
+    // One statement over both tables reads the right side through the join,
+    // never through its own `query`.
+    expect(rightQuery).not.toHaveBeenCalled();
+    posts.destroy?.();
+    authorsInner.destroy?.();
+  });
 });

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -1635,7 +1635,10 @@ export class PostgresTabularStorage<
   protected override sqlJoinDialect(): SqlJoinDialect {
     return {
       dialect: PostgresDialect,
-      // `db` resolves to the transaction-bound client inside `withTransaction`.
+      // `db` is read through whatever receiver this was called on: the pool for
+      // the instance, and the transaction-bound client when the call arrived
+      // through the `withTransaction` proxy. Holding onto the returned bag past
+      // the call that made it would pin whichever of the two came first.
       executeRaw: async (sql, params) =>
         ((await this.db.query(sql, params as unknown[])).rows ?? []) as Record<string, unknown>[],
     };


### PR DESCRIPTION
This stacks onto **#893 (Add join support to tabular storage with SQL pushdown)** and targets `claude/storage-layer-joins-v7mrh9`, so it can be merged into that branch and land as part of the same PR.

Three review findings on that branch, each with a test that fails without the fix.

---

## 1. The memoized join dialect pinned one connection (critical)

`BaseSqlTabularStorage.cachedSqlJoinDialect()` memoized the whole dialect bag — including `executeRaw` — onto the instance. Postgres builds `executeRaw` as an arrow closing over `this.db`, and `createTxView` is a Proxy that answers `db` with the transaction-bound client while writes still land on the real target. So the first join an instance ever ran decided which connection *every later* join would use.

Observable behaviour, both directions:

- **Transaction first.** A join inside `withTransaction` memoized the executor bound to the dedicated pool client. After `withTransaction`'s `finally` released that client, the next join on the same instance threw `Cannot use a pooled client after release` — or, once the pool re-handed that client out, issued its `SELECT` on somebody else's connection.
- **Pool first.** A join outside a transaction memoized the pool. A later `tx.join(...)` then ran on a different client from the one holding the open transaction: it could not see that transaction's uncommitted rows, and could block on locks it held.

SQLite and DuckDB were unaffected only because their transaction proxies do not intercept `db`.

**Fix.** The plan now carries only the SQL dialect; `runSqlJoin` resolves `executeRaw` from `this.sqlJoinDialect()` at the moment it executes, so the receiver that runs the statement decides the connection. The memo is gone, and the now-false comment on `PostgresTabularStorage.sqlJoinDialect` ("`db` resolves to the transaction-bound client inside `withTransaction`") is corrected.

**Tests.** `PostgresTabularStorage.integration.test.ts` gains a pool double over PGlite whose `connect()` returns a client that refuses to work after `release()` and which records, per JOIN statement, whether it went through the pool or a client. Both orderings are pinned. Without the fix they fail with `Cannot use a pooled client after release` and `expected ['pool','pool'] to deeply equal ['pool','client']` respectively.

## 2. Wrapper unwrapping only happened when the wrapper was on the LEFT

`resolveJoinDelegate` was called from `CachedTabularStorage.join` and `TelemetryTabularStorage.join` only. Neither `BaseTabularStorage.join` nor `planSqlJoin` unwrapped the right side, so with a plain left storage nothing in the chain looked past a wrapper on the right:

- `posts.join({type:"inner"}, cachedAuthors)` served the right half from the cache while the left half read durable, and silently dropped every row the two disagreed about — the exact bug the PR describes fixing, still reachable from the other side.
- `sqliteA.join(spec, telemetryWrapped(sqliteB))` on one connection fell back to a whole-table hash join instead of one statement.

**Fix.** `resolveJoinDelegate(right)` now runs once, centrally, at the top of `BaseTabularStorage.join` and before `planSqlJoin` in both `BaseSqlTabularStorage.join` and `_joinInternal`. The wrappers' own calls are left in place; they are idempotent and cover a durable storage that does not extend `BaseTabularStorage`.

**Tests.** A cached right side with a plain left side (row drop) and a telemetry-wrapped right side on one SQLite connection (lost pushdown). Without the fix: `expected ['p1:a1'] to deeply equal ['p1:a1','p9:a9']` and `expected "query" to not be called at all`.

## 3. `limit` never bounded the hash join's reads

`limit`/`offset` were applied as a slice over the fully materialised join. The only read bound required `pushLeftOrder && type === "left" && limit !== undefined`, so an inner join — or any join without a pushed-down left order — read the entire left table and then every matching right row in 900-parameter chunks before returning 20 rows. Over `HttpTabularProxyStorage`, IndexedDB or Supabase that is the whole table on the wire.

**Fix.** When the joined rows are already in their final order — the left query served the `orderBy`, or none was asked for — the left side is read in **growing prefixes** and the loop stops as soon as `offset + limit` joined rows exist. Each pass joins one left read whole and replaces the previous pass's output rather than extending it, so the result never depends on how the backend broke ties in a narrower read; a pass that reads no more than the one before it ends the loop, which also covers a backend that ignores `limit`. A left join still settles in one pass, as before, and this now also covers unordered joins, which previously read everything.

What still cannot be bounded — an `orderBy` naming the right side, or a left column that may be null, both of which are sorted in memory after the pairing — is now documented on `ITabularStorage.join` along with the advice to narrow with `where.left` instead.

**Tests.** Four cases in `hashJoin.test.ts`: an inner join whose first prefix suffices (one read), one that must widen (`limit: 3` → reads of 3 then 12, same rows as the unbounded join), an in-memory-sorted join that still reads everything, and a bounded unordered join. The existing test pinning "does not bound the left read for an inner join" is replaced by these.

---

## Verification

Run in a worktree at this branch, on **Node 22** (the repo asks for Node 24; `node:sqlite` still worked here, and nothing failed for environment reasons).

Passed, seen directly:

- `bun run build:types` — 42/42 packages, clean (this is the typecheck).
- `bun scripts/typecheck-budget.ts` — `OK (39 packages within budget)`.
- `bunx oxlint --type-aware packages/storage/src providers/postgres/src packages/test/src/test/storage-tabular` — clean.
- `oxfmt --check` — clean on everything touched. (Two pre-existing markdown files, `packages/storage/src/vector/README.md` and `packages/test/src/test/rag/history_of_the_united_states.md`, report format issues on the untouched base branch too.)
- `vitest run --project storage packages/storage/src/tabular/__tests__/hashJoin.test.ts` — 27 passed.
- `vitest run --project test packages/test/src/test/storage-tabular/` (unit tier) — 507 passed, 34 skipped, 10 files.
- `WORKGLOW_TEST_TIER=all vitest run` over `SqliteTabularStorage.integration.test.ts` + `CachedTabularStorage.integration.test.ts` — 442 passed, 12 skipped.
- `WORKGLOW_TEST_TIER=all vitest run` over `PostgresTabularStorage.integration.test.ts` + `ScopedTabularStorageSqlite.integration.test.ts` + `IndexedDbTabularStorage.integration.test.ts` — 430 passed, 11 skipped.

Each new test was also run against the unmodified source to confirm it fails without the fix.

Not run: the full suite, `DuckDbTabularStorage.integration.test.ts`, `SupabaseTabularStorage.integration.test.ts` and `FsFolderTabularStorage.integration.test.ts` (a broad run of every storage-tabular file did not terminate in the time available, so it was narrowed rather than reported). Those backends reach the join through the same shared `runHashJoin` and `runGenericTabularJoinTests` that the SQLite and IndexedDB runs above exercise on both the pushdown and hash-join paths.

Not re-audited: SQL injection on the join builder — the earlier review checked it and found none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa)_