### PR TITLE
Price model usage from the live rate table, at the instant the request ran

### DIFF
--- a/examples/cli/src/test/lookupModelPricing.test.ts
+++ b/examples/cli/src/test/lookupModelPricing.test.ts
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getGlobalModelRepository } from "@workglow/ai";
+import { estimateCost, getGlobalModelRepository } from "@workglow/ai";
 import { afterEach, describe, expect, it } from "vitest";
 import { clearModelPricingCache, lookupModelPricing } from "../ui/rows/lookupModelPricing";
 
 const TEST_MODEL_ID = "test-explicit-pricing-model";
 const TABLE_MODEL_ID = "claude-sonnet-5";
+// A Gemini Pro card carries the published over-200K rows, so this is the model
+// whose provider tiers can contradict a negotiated base rate.
+const TIERED_MODEL_ID = "gemini-3.1-pro-preview";
 
 describe("lookupModelPricing", () => {
   // The model repository is a process-wide singleton, so a record added here
@@ -17,7 +20,7 @@ describe("lookupModelPricing", () => {
   afterEach(async () => {
     clearModelPricingCache();
     // `removeModel` throws when the id is absent, which most cases here are.
-    for (const id of [TEST_MODEL_ID, TABLE_MODEL_ID]) {
+    for (const id of [TEST_MODEL_ID, TABLE_MODEL_ID, TIERED_MODEL_ID]) {
       await getGlobalModelRepository()
         .removeModel(id)
         .catch(() => {});
@@ -70,6 +73,67 @@ describe("lookupModelPricing", () => {
     const pricing = await lookupModelPricing(TABLE_MODEL_ID);
     expect(pricing?.input).toBe(2);
     expect(pricing?.output).toBe(10);
+  });
+
+  it("fills the rates a record leaves unset from the provider's card", async () => {
+    // Someone enters one negotiated input rate on a model the provider does
+    // price. Everything they did not type must keep its published rate rather
+    // than becoming an unpriced counter.
+    await getGlobalModelRepository().addModel({
+      model_id: TABLE_MODEL_ID,
+      title: TABLE_MODEL_ID,
+      description: "",
+      provider: "ANTHROPIC",
+      capabilities: [],
+      provider_config: { model_name: TABLE_MODEL_ID },
+      metadata: {},
+      pricing: { currency: "USD", input: 1.25 },
+    });
+
+    const pricing = await lookupModelPricing(TABLE_MODEL_ID);
+    expect(pricing?.input).toBe(1.25);
+    expect(pricing?.output).toBe(10);
+    expect(pricing?.cached).toBe(0.2);
+    expect(pricing?.cacheWrite).toEqual({ cacheWrite5m: 2.5, cacheWrite1h: 4 });
+    expect(pricing?.batch).toEqual({
+      input: 1,
+      output: 5,
+      cached: 0.1,
+      cacheWrite: { cacheWrite5m: 1.25, cacheWrite1h: 2 },
+    });
+  });
+
+  it("charges a record's own rate for a prompt the provider's tiers would reprice", async () => {
+    // The published card doubles `input` past 200K. Inherited whole, that tier
+    // would put the list rate back on exactly the long prompts a negotiated
+    // rate is entered for; only the rates the record is silent about carry over.
+    await getGlobalModelRepository().addModel({
+      model_id: TIERED_MODEL_ID,
+      title: TIERED_MODEL_ID,
+      description: "",
+      provider: "GOOGLE_GEMINI",
+      capabilities: [],
+      provider_config: { model_name: TIERED_MODEL_ID },
+      metadata: {},
+      pricing: { currency: "USD", input: 1 },
+    });
+
+    const pricing = await lookupModelPricing(TIERED_MODEL_ID);
+    const cost = estimateCost(
+      {
+        input: 250_000,
+        output: 1_000,
+        cached: undefined,
+        cacheWrite: undefined,
+        reasoning: undefined,
+        total: undefined,
+        extra: undefined,
+      },
+      pricing
+    );
+    // 250_000 × $1/M input, plus the tier's own $18/M output.
+    expect(cost?.amount).toBeCloseTo(0.25 + 0.018, 10);
+    expect(cost?.unpriced).toEqual([]);
   });
 
   it("falls back to provider list pricing when unconfigured in the repository", async () => {

--- a/examples/cli/src/test/lookupModelPricing.test.ts
+++ b/examples/cli/src/test/lookupModelPricing.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { clearModelPricingCache, lookupModelPricing } from "../ui/rows/lookupModelPricing";
 
 const TEST_MODEL_ID = "test-explicit-pricing-model";
+const TABLE_MODEL_ID = "claude-sonnet-5";
 
 describe("lookupModelPricing", () => {
   // The model repository is a process-wide singleton, so a record added here
@@ -16,9 +17,11 @@ describe("lookupModelPricing", () => {
   afterEach(async () => {
     clearModelPricingCache();
     // `removeModel` throws when the id is absent, which most cases here are.
-    await getGlobalModelRepository()
-      .removeModel(TEST_MODEL_ID)
-      .catch(() => {});
+    for (const id of [TEST_MODEL_ID, TABLE_MODEL_ID]) {
+      await getGlobalModelRepository()
+        .removeModel(id)
+        .catch(() => {});
+    }
   });
 
   it("returns undefined for empty or undefined modelId", async () => {
@@ -48,6 +51,25 @@ describe("lookupModelPricing", () => {
       input: 99,
       output: 199,
     });
+  });
+
+  it("prices a model added from a search result off the provider's current table", async () => {
+    // This is the record `model add` / `model find` write: what the search
+    // result carried, with no rate card of its own. Nothing persisted can then
+    // shadow the table, so a corrected rate reaches a model added months ago.
+    await getGlobalModelRepository().addModel({
+      model_id: TABLE_MODEL_ID,
+      title: TABLE_MODEL_ID,
+      description: "",
+      provider: "ANTHROPIC",
+      capabilities: [],
+      provider_config: { model_name: TABLE_MODEL_ID },
+      metadata: {},
+    });
+
+    const pricing = await lookupModelPricing(TABLE_MODEL_ID);
+    expect(pricing?.input).toBe(2);
+    expect(pricing?.output).toBe(10);
   });
 
   it("falls back to provider list pricing when unconfigured in the repository", async () => {

--- a/examples/cli/src/ui/rows/lookupModelPricing.ts
+++ b/examples/cli/src/ui/rows/lookupModelPricing.ts
@@ -5,7 +5,12 @@
  */
 
 import type { ModelPricing, ModelRecord } from "@workglow/ai";
-import { FREE_LOCAL_PRICING, getAiProviderRegistry, getGlobalModelRepository } from "@workglow/ai";
+import {
+  FREE_LOCAL_PRICING,
+  getAiProviderRegistry,
+  getGlobalModelRepository,
+  mergeModelPricing,
+} from "@workglow/ai";
 import { getAnthropicModelPricing } from "@workglow/anthropic/ai";
 import { getDeepSeekModelPricing } from "@workglow/deepseek/ai";
 import { getGeminiModelPricing } from "@workglow/google-gemini/ai";
@@ -16,7 +21,7 @@ const cache = new Map<string, ModelPricing | undefined>();
 const inflight = new Map<string, Promise<ModelPricing | undefined>>();
 
 /**
- * Rate card for a model the repository does not price.
+ * Published rate card for a model id, under whatever the record declares.
  *
  * A record names its provider, so that provider answers for it. A bare id does
  * NOT get offered to every registered provider in turn: a local provider
@@ -44,7 +49,8 @@ function resolveFallbackPricing(modelId: string, record?: ModelRecord): ModelPri
 }
 
 /**
- * Resolve a model's declared rate card from the global repository.
+ * Resolve a model's effective rate card: the one its repository record declares,
+ * merged field by field over the provider's published card.
  *
  * Memoized per model id for the process lifetime — rate cards do not change
  * mid-run, and the CLI re-reads usage on every snapshot, so an uncached lookup
@@ -61,7 +67,7 @@ export async function lookupModelPricing(
     pending = getGlobalModelRepository()
       .findByName(modelId)
       .then((record) => {
-        const pricing = record?.pricing ?? resolveFallbackPricing(modelId, record);
+        const pricing = mergeModelPricing(record?.pricing, resolveFallbackPricing(modelId, record));
         cache.set(modelId, pricing);
         inflight.delete(modelId);
         return pricing;

--- a/examples/cli/src/ui/rows/useTaskUsageLine.ts
+++ b/examples/cli/src/ui/rows/useTaskUsageLine.ts
@@ -91,7 +91,10 @@ export function useTaskUsageLine(task: ITask): string {
   const { usage, modelId } = useTaskUsage(task);
   const pricing = useModelPricing(modelId);
 
-  const usageText = formatUsageWithCost(usage, "directional", pricing);
+  // Priced at the execution's own instant, not the render clock: a row that
+  // re-renders four times a second must not restate what a finished request
+  // cost when a time-of-day rate changes underneath it.
+  const usageText = formatUsageWithCost(usage, "directional", pricing, { at: task.startedAt });
   const needsTick = usageLineNeedsTick(usageText, task);
   const nowMs = useSyncExternalStore(
     needsTick ? subscribeToClock : subscribeIdle,

--- a/examples/cli/src/ui/useGraphUsageLine.ts
+++ b/examples/cli/src/ui/useGraphUsageLine.ts
@@ -16,6 +16,22 @@ function usageIsSpend(usage: Usage): boolean {
 }
 
 /**
+ * When the run started, for rate cards with a time-of-day tier. The earliest
+ * execution on the graph, so the footer keeps stating what the run cost instead
+ * of re-pricing a finished total every time the clock crosses a discount
+ * boundary. `undefined` until something has started, which is the one case
+ * where "now" is the right instant.
+ */
+function runInstant(graph: TaskGraph): Date | undefined {
+  let earliest: Date | undefined;
+  for (const task of graph.getTasks()) {
+    const started = task.startedAt;
+    if (started && (earliest === undefined || started < earliest)) earliest = started;
+  }
+  return earliest;
+}
+
+/**
  * Run-total usage line for a graph footer. Costs are summed per model (a blend
  * across rate cards would mis-price), and a missing rate on any contributing
  * model marks the figure partial (`~`).
@@ -39,10 +55,11 @@ export function useGraphUsageLine(graph: TaskGraph): string {
 
       const estimates: CostEstimate[] = [];
       let missingModel = false;
+      const at = runInstant(graph);
       for (const [key, usage] of graph.usageAggregator.byModel()) {
         const modelId = typeof key === "string" ? key : undefined;
         const pricing = await lookupModelPricing(modelId);
-        const estimate = estimateCost(usage, pricing);
+        const estimate = estimateCost(usage, pricing, { at });
         if (estimate) estimates.push(estimate);
         else if (usageIsSpend(usage)) missingModel = true;
       }

--- a/examples/eval/src/evals/runner.ts
+++ b/examples/eval/src/evals/runner.ts
@@ -46,10 +46,15 @@ export interface SweepOptions {
  * An unreported counter is stored as `null`, never `0` — the database has to
  * keep the distinction the in-memory type protects, or a model that never
  * mentions caching becomes indistinguishable from one that cached nothing.
+ *
+ * `at` is when the request ran, which is what a time-of-day rate is charged
+ * against. A batch that straddles the boundary of one must not have its rows
+ * priced by whenever the sweep happened to reach the write.
  */
 export function usageColumns(
   usage: Usage | undefined,
-  pricing: ModelPricing | undefined
+  pricing: ModelPricing | undefined,
+  at: Date | undefined
 ): {
   input_tokens: number | null;
   output_tokens: number | null;
@@ -59,7 +64,7 @@ export function usageColumns(
   cost: number | null;
   currency: string | null;
 } {
-  const estimate = usage ? estimateCost(usage, pricing) : undefined;
+  const estimate = usage ? estimateCost(usage, pricing, { at }) : undefined;
   return {
     input_tokens: usage?.input ?? null,
     output_tokens: usage?.output ?? null,
@@ -139,6 +144,7 @@ export async function runSweep(
 
     for (const { record, row, parseError } of parsedRows) {
       const t0 = performance.now();
+      const requestedAt = new Date();
       let outcome: SweepOutcome;
       let outcomeUsage: Usage | undefined;
       if (!executor) {
@@ -173,7 +179,7 @@ export async function runSweep(
         model: modelId,
         row_index: record.row_index,
         latency_ms: Math.round(latency * 100) / 100,
-        ...usageColumns(outcomeUsage, modelPricing),
+        ...usageColumns(outcomeUsage, modelPricing, requestedAt),
         ...outcome,
       });
       done++;

--- a/examples/eval/src/report/liveTally.ts
+++ b/examples/eval/src/report/liveTally.ts
@@ -48,7 +48,11 @@ export class LiveTally {
         tally.usage?.output === undefined
           ? ""
           : ` ${Math.round(tally.usage.output / elapsedSec)} tok/s`;
-      const cost = tally.usage ? formatCost(estimateCost(tally.usage, this.pricing(model))) : "";
+      // Priced at the sweep's start, so a redraw does not restate the same
+      // rows at a different rate once a time-of-day discount window opens.
+      const cost = tally.usage
+        ? formatCost(estimateCost(tally.usage, this.pricing(model), { at: this.startedAt }))
+        : "";
       lines.push(
         `  ${model}  ${tally.ok}/${tally.rows} ok  ` +
           `${formatUsage(tally.usage, "detailed")}${tps}${cost ? `  ${cost}` : ""}`

--- a/examples/eval/src/test/usageColumns.test.ts
+++ b/examples/eval/src/test/usageColumns.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { ModelPricing } from "@workglow/ai";
+import type { Usage } from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
 import { usageColumns } from "../evals/runner";
 import { EvalResultSchema } from "../storage";
@@ -35,6 +37,7 @@ describe("eval usage columns", () => {
         total: undefined,
         extra: undefined,
       },
+      undefined,
       undefined
     );
     expect(columns.input_tokens).toBe(10);
@@ -43,8 +46,60 @@ describe("eval usage columns", () => {
   });
 
   it("stores all-null columns when the model reported nothing", () => {
-    const columns = usageColumns(undefined, undefined);
+    const columns = usageColumns(undefined, undefined, undefined);
     expect(columns.input_tokens).toBe(null);
     expect(columns.output_tokens).toBe(null);
+  });
+
+  // A sweep row is priced once and stored, and DeepSeek's off-peak window is a
+  // 2x swing — so a batch that ran before the window must not be written at the
+  // discount because the write happened after it opened. The window below is
+  // derived from the current time so the test cannot pass by accident whichever
+  // hour it runs in: the request's instant is inside it, "now" is an hour past.
+  describe("time-of-day rates", () => {
+    const HOUR_MS = 3_600_000;
+    const now = Date.now();
+
+    const utcClock = (ms: number): string => {
+      const at = new Date(ms);
+      const hh = String(at.getUTCHours()).padStart(2, "0");
+      const mm = String(at.getUTCMinutes()).padStart(2, "0");
+      return `${hh}:${mm}`;
+    };
+
+    const pricing: ModelPricing = {
+      currency: "USD",
+      input: 3,
+      output: 15,
+      cached: undefined,
+      cacheWrite: undefined,
+      cacheStoragePerHour: undefined,
+      timingTiers: [
+        {
+          start: utcClock(now - 3 * HOUR_MS),
+          end: utcClock(now - HOUR_MS),
+          pricing: { input: 1.5, output: 7.5 },
+        },
+      ],
+    };
+
+    const spend: Usage = {
+      input: 1_000_000,
+      output: 1_000_000,
+      cached: undefined,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: undefined,
+      extra: undefined,
+    };
+
+    it("prices a row at the instant its request ran", () => {
+      const columns = usageColumns(spend, pricing, new Date(now - 2 * HOUR_MS));
+      expect(columns.cost).toBeCloseTo(9, 10);
+    });
+
+    it("prices at the current clock only when the instant is unknown", () => {
+      expect(usageColumns(spend, pricing, undefined).cost).toBeCloseTo(18, 10);
+    });
   });
 });

--- a/packages/ai/src/capability/CostEstimate.ts
+++ b/packages/ai/src/capability/CostEstimate.ts
@@ -43,9 +43,12 @@ export interface EstimateCostOptions {
   /**
    * When the request ran, for a rate card with a time-of-day tier. Defaults to
    * now — right for a live run, wrong for one replayed from a log, so pass the
-   * request's own instant when pricing after the fact.
+   * request's own instant when pricing after the fact. A figure rendered
+   * repeatedly (a footer, a report) must pass one: priced against the render
+   * clock, the same usage costs a different amount once the clock crosses a
+   * discount boundary.
    */
-  readonly at?: Date | number;
+  readonly at?: Date | number | undefined;
 }
 
 /**

--- a/packages/ai/src/capability/__tests__/formatUsage.test.ts
+++ b/packages/ai/src/capability/__tests__/formatUsage.test.ts
@@ -170,4 +170,53 @@ describe("formatUsageWithCost", () => {
       )
     ).toBe("~↑100 ↓20");
   });
+
+  // A row on screen is re-rendered constantly, so pricing it against the render
+  // clock means a finished request's cost changes as the clock crosses a
+  // discount window — the same tokens, two different totals. The window here is
+  // built from the current time so the test cannot pass by accident whichever
+  // hour it runs in: `at` is inside it and "now" is an hour past its end.
+  describe("time-of-day rates", () => {
+    const HOUR_MS = 3_600_000;
+    const now = Date.now();
+    const requestedAt = new Date(now - 2 * HOUR_MS);
+
+    const utcClock = (ms: number): string => {
+      const at = new Date(ms);
+      const hh = String(at.getUTCHours()).padStart(2, "0");
+      const mm = String(at.getUTCMinutes()).padStart(2, "0");
+      return `${hh}:${mm}`;
+    };
+
+    const discounted: ModelPricing = {
+      ...pricing,
+      timingTiers: [
+        {
+          start: utcClock(now - 3 * HOUR_MS),
+          end: utcClock(now - HOUR_MS),
+          pricing: { input: 1.5, output: 7.5 },
+        },
+      ],
+    };
+
+    const spend = usage({ input: 1_000_000, output: 1_000_000 });
+
+    it("prices at the instant the request ran when one is given", () => {
+      expect(formatUsageWithCost(spend, "cumulative", discounted, { at: requestedAt })).toBe(
+        "↑1,000,000 ↓1,000,000 $9.0000"
+      );
+    });
+
+    it("accepts the instant as epoch milliseconds", () => {
+      expect(
+        formatUsageWithCost(spend, "cumulative", discounted, { at: requestedAt.getTime() })
+      ).toBe("↑1,000,000 ↓1,000,000 $9.0000");
+    });
+
+    it("falls back to the current clock when no instant is given", () => {
+      expect(formatUsageWithCost(spend, "cumulative", discounted)).toBe(
+        "↑1,000,000 ↓1,000,000 $18.0000"
+      );
+    });
+  });
 });

--- a/packages/ai/src/capability/formatUsage.ts
+++ b/packages/ai/src/capability/formatUsage.ts
@@ -6,7 +6,7 @@
 
 import type { Usage } from "@workglow/task-graph";
 import type { ModelPricing } from "../model/ModelSchema";
-import type { CostEstimate } from "./CostEstimate";
+import type { CostEstimate, EstimateCostOptions } from "./CostEstimate";
 import { estimateCost } from "./CostEstimate";
 
 /**
@@ -103,15 +103,22 @@ function formatCostAmount(amount: number): string {
  *
  * Heuristic counters get a `~` and no cost figure: they are worth showing as
  * live feedback, but a reader must not mistake them for what was billed.
+ *
+ * `options.at` is the instant the request ran, forwarded to
+ * {@link estimateCost}. A caller that re-renders — every live UI — should pass
+ * it: without one, a card with a time-of-day tier prices against the render
+ * clock, so a finished run's cost changes on screen as the clock crosses the
+ * discount boundary.
  */
 export function formatUsageWithCost(
   usage: Usage | undefined,
   detail: UsageDetail,
-  pricing: ModelPricing | undefined
+  pricing: ModelPricing | undefined,
+  options: EstimateCostOptions = {}
 ): string {
   const tokens = formatUsage(usage, detail);
   if (!tokens || tokens === "cached") return tokens;
   if (usage?.estimated) return `~${tokens}`;
-  const cost = formatCost(estimateCost(usage!, pricing));
+  const cost = formatCost(estimateCost(usage!, pricing, options));
   return cost ? `${tokens} ${cost}` : tokens;
 }

--- a/packages/ai/src/model/ModelPricing.ts
+++ b/packages/ai/src/model/ModelPricing.ts
@@ -14,6 +14,10 @@ import type { DataPortSchemaObject } from "@workglow/util/worker";
  *
  * `cacheStoragePerHour` prices a provider-side cache billed by token-hours
  * (e.g. Gemini CachedContent) rather than by a one-off write.
+ *
+ * Every rate is optional and an unset one means "not declared here", never
+ * zero: it is what a merge fills in from a wider card, and what leaves a spent
+ * counter reported as unpriced when nothing declares it.
  */
 export interface ModelPricingBase {
   input?: number;
@@ -60,6 +64,15 @@ export interface ModelTimingTier {
   pricing: ModelPricingBase;
 }
 
+/**
+ * One model's rate card.
+ *
+ * A card stored on a model record is a **per-field** override of the provider's
+ * published card, not a replacement for it: {@link mergeModelPricing} fills
+ * every rate the record leaves unset from the provider's, so entering a single
+ * negotiated `input` rate does not leave `output` and the cache rates reading as
+ * unpriced. The two exceptions are stated with that function.
+ */
 export interface ModelPricing extends ModelPricingBase {
   currency: string;
   batch?: ModelPricingBase;
@@ -132,6 +145,111 @@ export function resolveModelPricingFromTable(
     best = key;
   }
   return best === undefined ? undefined : table[best];
+}
+
+/** The rates a base card, a `batch` card and a tier card all carry. */
+const RATE_FIELDS = ["input", "output", "cached", "cacheWrite", "cacheStoragePerHour"] as const;
+
+/** Currencies name the same unit however they are spelled or padded. */
+function isSameCurrency(a: string, b: string): boolean {
+  return a.trim().toUpperCase() === b.trim().toUpperCase();
+}
+
+/** Every rate `declared` states, with the rest taken from `inherited`. */
+function mergeRates(declared: ModelPricingBase, inherited: ModelPricingBase): ModelPricingBase {
+  return {
+    input: declared.input ?? inherited.input,
+    output: declared.output ?? inherited.output,
+    cached: declared.cached ?? inherited.cached,
+    cacheWrite: declared.cacheWrite ?? inherited.cacheWrite,
+    cacheStoragePerHour: declared.cacheStoragePerHour ?? inherited.cacheStoragePerHour,
+  };
+}
+
+function mergeOptionalRates(
+  declared: ModelPricingBase | undefined,
+  inherited: ModelPricingBase | undefined
+): ModelPricingBase | undefined {
+  if (!declared) return inherited;
+  if (!inherited) return declared;
+  return mergeRates(declared, inherited);
+}
+
+/**
+ * `tier` with every rate `declared` states removed, or `undefined` when that
+ * leaves nothing.
+ *
+ * A tier is a replacement card for a prompt range or a clock window, so an
+ * inherited tier restating a rate the declarer set would override it exactly
+ * where a long prompt or an off-peak hour selects the tier — silently undoing
+ * the declaration in the cases it was likely entered for.
+ */
+function tierRatesNotDeclared(
+  tier: ModelPricingBase,
+  declared: ModelPricingBase
+): ModelPricingBase | undefined {
+  const kept: ModelPricingBase = {
+    input: declared.input === undefined ? tier.input : undefined,
+    output: declared.output === undefined ? tier.output : undefined,
+    cached: declared.cached === undefined ? tier.cached : undefined,
+    cacheWrite: declared.cacheWrite === undefined ? tier.cacheWrite : undefined,
+    cacheStoragePerHour:
+      declared.cacheStoragePerHour === undefined ? tier.cacheStoragePerHour : undefined,
+  };
+  return RATE_FIELDS.some((field) => kept[field] !== undefined) ? kept : undefined;
+}
+
+/** Inherited tiers, stripped of what `declared` states and dropped when empty. */
+function inheritTiers<T extends { pricing: ModelPricingBase }>(
+  tiers: readonly T[] | undefined,
+  declared: ModelPricingBase
+): T[] | undefined {
+  if (!tiers) return undefined;
+  const kept: T[] = [];
+  for (const tier of tiers) {
+    const pricing = tierRatesNotDeclared(tier.pricing, declared);
+    if (pricing) kept.push({ ...tier, pricing });
+  }
+  return kept.length > 0 ? kept : undefined;
+}
+
+/**
+ * A model's effective rate card: the card someone declared for it, merged over
+ * the provider's published one field by field.
+ *
+ * Every rate `declared` omits is filled from `inherited` — including inside
+ * `batch` — so a single negotiated `input` rate does not turn the rest of the
+ * card into unpriced counters. Two rules keep the result from contradicting
+ * what was declared:
+ *
+ * - **A declared rate wins everywhere.** Inherited tiers drop any rate declared
+ *   at the base level, and a tier left with none is dropped whole; otherwise a
+ *   provider's over-200K row would re-price a long prompt at the list rate the
+ *   declaration replaced. Tiers the declarer supplied are used as given and
+ *   none are inherited — they already state what the ranges cost.
+ * - **Currencies are never mixed.** A declared card in another currency
+ *   inherits nothing, because merging the two would read as one card whose
+ *   rates are quietly in two units.
+ *
+ * Either side may be absent: with no declared card the provider's stands, with
+ * no provider card the declared one does, and with neither the result is
+ * `undefined` so a missing rate keeps reading as unpriced rather than free.
+ */
+export function mergeModelPricing(
+  declared: ModelPricing | undefined,
+  inherited: ModelPricing | undefined
+): ModelPricing | undefined {
+  if (!declared) return inherited;
+  if (!inherited) return declared;
+  if (!isSameCurrency(declared.currency, inherited.currency)) return declared;
+
+  return {
+    ...mergeRates(declared, inherited),
+    currency: declared.currency,
+    batch: mergeOptionalRates(declared.batch, inherited.batch),
+    usageTiers: declared.usageTiers ?? inheritTiers(inherited.usageTiers, declared),
+    timingTiers: declared.timingTiers ?? inheritTiers(inherited.timingTiers, declared),
+  };
 }
 
 const MINUTES_PER_HOUR = 60;
@@ -309,11 +427,12 @@ const CLOCK_TIME_PATTERN = "^([01][0-9]|2[0-3]):[0-5][0-9]$";
 /**
  * JSON schema for per-million-token model pricing rates.
  *
- * A model record carries a card only as a deliberate override — a negotiated
- * rate, or a model no provider table names. Absent is the ordinary case, and
- * the provider's own table answers instead: a rate correction there then
- * reaches every model already added, rather than being shadowed by whatever
- * the published rates were on the day the model was added.
+ * Every field is optional past the currency, because a card on a model record
+ * states only what someone declared — a negotiated `input` rate, or the whole
+ * card for a model no provider table names. Whatever it leaves out the
+ * provider's own table answers for ({@link mergeModelPricing}), so a rate
+ * correction there reaches every model already added instead of being shadowed
+ * by the published rates of the day it was added.
  */
 export const ModelPricingSchema = {
   type: "object",

--- a/packages/ai/src/model/ModelPricing.ts
+++ b/packages/ai/src/model/ModelPricing.ts
@@ -308,6 +308,12 @@ const CLOCK_TIME_PATTERN = "^([01][0-9]|2[0-3]):[0-5][0-9]$";
 
 /**
  * JSON schema for per-million-token model pricing rates.
+ *
+ * A model record carries a card only as a deliberate override — a negotiated
+ * rate, or a model no provider table names. Absent is the ordinary case, and
+ * the provider's own table answers instead: a rate correction there then
+ * reaches every model already added, rather than being shadowed by whatever
+ * the published rates were on the day the model was added.
  */
 export const ModelPricingSchema = {
   type: "object",

--- a/packages/ai/src/model/__tests__/ModelPricing.test.ts
+++ b/packages/ai/src/model/__tests__/ModelPricing.test.ts
@@ -4,10 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { Usage } from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
+import { estimateCost } from "../../capability/CostEstimate";
+import { formatCost } from "../../capability/formatUsage";
 import type { ModelPricing } from "../ModelPricing";
 import {
   FREE_LOCAL_PRICING,
+  mergeModelPricing,
   ModelPricingSchema,
   resolveEffectiveRates,
   resolveModelPricingFromTable,
@@ -227,5 +231,147 @@ describe("resolveEffectiveRates", () => {
       cacheWrite: undefined,
       cacheStoragePerHour: undefined,
     });
+  });
+});
+
+describe("mergeModelPricing", () => {
+  // A stand-in for a provider's published card: every rate filled in, plus the
+  // long-context rows and a batch card, so a partial declaration has something
+  // of each kind to inherit.
+  const provider: ModelPricing = {
+    currency: "USD",
+    input: 3,
+    output: 15,
+    cached: 0.3,
+    cacheWrite: 3.75,
+    cacheStoragePerHour: 1,
+    batch: { input: 1.5, output: 7.5 },
+    usageTiers: [
+      { maxInputTokens: 200_000, pricing: { input: 3, output: 15 } },
+      { minInputTokens: 200_000, pricing: { input: 6, output: 22.5 } },
+    ],
+  };
+
+  it("fills every rate the declared card leaves unset", () => {
+    // The case that motivates the merge: someone enters one negotiated rate.
+    // The rest must stay priced instead of reading as unpriced counters.
+    const merged = mergeModelPricing({ currency: "USD", input: 1 }, provider);
+    expect(merged?.input).toBe(1);
+    expect(merged?.output).toBe(15);
+    expect(merged?.cached).toBe(0.3);
+    expect(merged?.cacheWrite).toBe(3.75);
+    expect(merged?.cacheStoragePerHour).toBe(1);
+  });
+
+  it("keeps a declared rate of zero rather than treating it as unset", () => {
+    // A free-tier or comped rate is a declaration, and `0` must not fall
+    // through to the provider's list rate the way `undefined` does.
+    expect(mergeModelPricing({ currency: "USD", input: 0 }, provider)?.input).toBe(0);
+  });
+
+  it("keeps a declared rate over an inherited tier that would re-price it", () => {
+    // The tier is a replacement card for prompts over 200K. Inherited whole it
+    // would put the provider's `input: 6` back on exactly the long prompts the
+    // negotiated rate was entered for, so the tier keeps only `output`.
+    const merged = mergeModelPricing({ currency: "USD", input: 1 }, provider);
+    const rates = resolveEffectiveRates(merged!, { inputTokens: 300_000 });
+    expect(rates.input).toBe(1);
+    expect(rates.output).toBe(22.5);
+  });
+
+  it("drops an inherited tier that restates nothing else", () => {
+    // Both of the provider's tiers name only `input` and `output`; declaring
+    // both leaves each tier empty, and an empty tier is not worth carrying.
+    const merged = mergeModelPricing({ currency: "USD", input: 1, output: 2 }, provider);
+    expect(merged?.usageTiers).toBeUndefined();
+    expect(resolveEffectiveRates(merged!, { inputTokens: 300_000 }).input).toBe(1);
+  });
+
+  it("uses the declarer's own tiers as given and inherits none", () => {
+    // Tiers someone supplied already say what each range costs; splicing the
+    // provider's rows in beside them would price ranges nobody declared.
+    const merged = mergeModelPricing(
+      {
+        currency: "USD",
+        input: 1,
+        usageTiers: [{ minInputTokens: 500_000, pricing: { input: 2 } }],
+      },
+      provider
+    );
+    expect(merged?.usageTiers).toEqual([{ minInputTokens: 500_000, pricing: { input: 2 } }]);
+    // 300K falls in the provider's over-200K row and in none of the declared
+    // ones, so it is priced at the declared base rate.
+    expect(resolveEffectiveRates(merged!, { inputTokens: 300_000 }).input).toBe(1);
+    expect(resolveEffectiveRates(merged!, { inputTokens: 600_000 }).input).toBe(2);
+  });
+
+  it("inherits timing tiers under the same rule", () => {
+    const offPeak: ModelPricing = {
+      currency: "USD",
+      input: 3,
+      output: 15,
+      timingTiers: [{ start: "00:00", end: "12:00", pricing: { input: 1.5, output: 7.5 } }],
+    };
+    const merged = mergeModelPricing({ currency: "USD", input: 1 }, offPeak);
+    const rates = resolveEffectiveRates(merged!, { at: new Date("2026-09-04T06:00:00Z") });
+    expect(rates.input).toBe(1);
+    expect(rates.output).toBe(7.5);
+  });
+
+  it("inherits nothing from a card in another currency", () => {
+    // Two currencies merged field by field would read as one card whose rates
+    // are silently in different units, which no downstream sum can detect.
+    const merged = mergeModelPricing({ currency: "EUR", input: 1 }, provider);
+    expect(merged).toEqual({ currency: "EUR", input: 1 });
+  });
+
+  it("still inherits when the same currency is spelled differently", () => {
+    expect(mergeModelPricing({ currency: "usd", input: 1 }, provider)?.output).toBe(15);
+  });
+
+  it("merges the batch card field by field too", () => {
+    const merged = mergeModelPricing({ currency: "USD", batch: { input: 0.5 } }, provider);
+    expect(merged?.batch).toEqual({ input: 0.5, output: 7.5 });
+  });
+
+  it("keeps the provider's batch card when the declared one says nothing", () => {
+    expect(mergeModelPricing({ currency: "USD", input: 1 }, provider)?.batch).toEqual({
+      input: 1.5,
+      output: 7.5,
+    });
+  });
+
+  it("returns the provider's card unchanged when nothing is declared", () => {
+    expect(mergeModelPricing(undefined, provider)).toBe(provider);
+  });
+
+  it("returns the declared card when the provider prices nothing", () => {
+    const declared: ModelPricing = { currency: "USD", input: 1 };
+    expect(mergeModelPricing(declared, undefined)).toBe(declared);
+  });
+
+  it("stays undefined when neither side prices the model, and reads as unpriced", () => {
+    // `undefined` must never collapse to a zero card: an unpriced model has to
+    // keep printing the partial marker rather than a confident free run.
+    expect(mergeModelPricing(undefined, undefined)).toBeUndefined();
+
+    const usage: Usage = {
+      input: 1_000,
+      output: 500,
+      cached: undefined,
+      cacheWrite: undefined,
+      reasoning: undefined,
+      total: undefined,
+      extra: undefined,
+    };
+    expect(estimateCost(usage, mergeModelPricing(undefined, undefined))).toBeUndefined();
+
+    // And a merged card that prices only part of what was spent still marks
+    // the figure partial with `~`.
+    const partial = mergeModelPricing({ currency: "USD", input: 1 }, undefined);
+    const estimate = estimateCost(usage, partial);
+    expect(estimate?.unpriced).toEqual(["output"]);
+    expect(formatCost(estimate)).toBe("~$0.0010");
+    expect(formatCost(undefined)).toBe("");
   });
 });

--- a/packages/ai/src/provider/AiProvider.ts
+++ b/packages/ai/src/provider/AiProvider.ts
@@ -174,8 +174,12 @@ export abstract class AiProvider<TModelConfig extends ModelConfig = ModelConfig>
   }
 
   /**
-   * Default rate card for `model` when not overridden in the model's own record.
-   * `undefined` means this provider publishes no list pricing for the model.
+   * Published list rate card for `model`.
+   *
+   * A card on the model's own record overrides this **field by field**, not
+   * wholesale: every rate the record leaves unset is taken from here. See
+   * `mergeModelPricing`. `undefined` means this provider publishes no list
+   * pricing for the model.
    */
   modelPricing(_model: ModelConfig): ModelPricing | undefined {
     return undefined;

--- a/packages/test/src/test/ai-provider-api/LongContextPricing.test.ts
+++ b/packages/test/src/test/ai-provider-api/LongContextPricing.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ModelPricing } from "@workglow/ai";
+import { estimateCost } from "@workglow/ai";
+import { ANTHROPIC_PRICING } from "@workglow/anthropic/ai";
+import { getGeminiModelPricing } from "@workglow/google-gemini/ai";
+import type { Usage } from "@workglow/task-graph";
+import { describe, expect, it } from "vitest";
+
+const MILLION = 1_000_000;
+
+const usage = (input: number, output: number): Usage => ({
+  input,
+  output,
+  cached: undefined,
+  cacheWrite: undefined,
+  reasoning: undefined,
+  total: undefined,
+  extra: undefined,
+});
+
+const cost = (pricing: ModelPricing | undefined, input: number, output: number): number =>
+  estimateCost(usage(input, output), pricing)!.amount;
+
+/** USD per million input tokens actually charged for a prompt of this size. */
+const inputRate = (pricing: ModelPricing | undefined, prompt: number): number =>
+  (cost(pricing, prompt, 0) / prompt) * MILLION;
+
+/**
+ * Google publishes two rows for its Pro models: one for a prompt up to 200K
+ * tokens and a higher one above it. A card carrying only the first prices a
+ * 250K-token prompt at roughly half — and, because every counter it was handed
+ * did have a rate, the figure prints without the `~` that marks a partial
+ * estimate. The tiers are what keep the estimate on the published table.
+ */
+describe("Gemini long-context pricing", () => {
+  it("charges gemini-2.5-pro's over-200K rates above the threshold", () => {
+    const pricing = getGeminiModelPricing("gemini-2.5-pro");
+    expect(inputRate(pricing, 199_000)).toBeCloseTo(1.25, 10);
+    expect(inputRate(pricing, 250_000)).toBeCloseTo(2.5, 10);
+    expect(cost(pricing, 250_000, MILLION)).toBeCloseTo((250_000 * 2.5) / MILLION + 15, 10);
+  });
+
+  it("puts a prompt of exactly 200K on the lower row", () => {
+    expect(inputRate(getGeminiModelPricing("gemini-2.5-pro"), 200_000)).toBeCloseTo(1.25, 10);
+  });
+
+  it("charges gemini-3.1-pro-preview's over-200K rates above the threshold", () => {
+    const pricing = getGeminiModelPricing("gemini-3.1-pro-preview");
+    expect(inputRate(pricing, 199_000)).toBeCloseTo(2, 10);
+    expect(inputRate(pricing, 250_000)).toBeCloseTo(4, 10);
+    expect(cost(pricing, 250_000, MILLION)).toBeCloseTo((250_000 * 4) / MILLION + 18, 10);
+  });
+
+  it("leaves Flash cards flat, because Google publishes one row for them", () => {
+    const pricing = getGeminiModelPricing("gemini-2.5-flash");
+    expect(pricing?.usageTiers).toBeUndefined();
+    expect(inputRate(pricing, 250_000)).toBeCloseTo(inputRate(pricing, 1_000), 10);
+  });
+});
+
+/**
+ * Anthropic bills a long prompt at the card's standard rates: the 1M-context
+ * models carry no long-context premium, and every other model in the table has
+ * a 200K window, so no prompt could select a tier. The absence is deliberate —
+ * this fails if one is added without published rates behind it.
+ */
+describe("Anthropic long-context pricing", () => {
+  it("declares no usage tier on any card", () => {
+    for (const [id, card] of Object.entries(ANTHROPIC_PRICING)) {
+      expect(card.usageTiers, `${id} declares a usage tier`).toBeUndefined();
+    }
+  });
+
+  it("prices a 250K-token prompt at the same per-token rate as a small one", () => {
+    const pricing = ANTHROPIC_PRICING["claude-sonnet-4-5"];
+    expect(inputRate(pricing, 250_000)).toBeCloseTo(inputRate(pricing, 10_000), 10);
+  });
+});

--- a/packages/test/src/test/ai-provider-api/ModelSearchPricing.test.ts
+++ b/packages/test/src/test/ai-provider-api/ModelSearchPricing.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Anthropic_ModelSearch_Stream, getAnthropicModelPricing } from "@workglow/anthropic/ai";
+import { DeepSeek_ModelSearch_Stream, getDeepSeekModelPricing } from "@workglow/deepseek/ai";
+import { Gemini_ModelSearch_Stream, getGeminiModelPricing } from "@workglow/google-gemini/ai";
+import { OpenAI_ModelSearch_Stream, getOpenAiModelPricing } from "@workglow/openai/ai";
+import { Xai_ModelSearch_Stream, getXaiModelPricing } from "@workglow/xai/ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => vi.restoreAllMocks());
+
+/**
+ * `model add` / `model find` persist the record a search result carries, and a
+ * persisted rate card is never revisited. A card copied out of the provider's
+ * table at search time therefore freezes those rates into the repository: the
+ * table is the maintained source and correcting a rate there would no longer
+ * reach the model, with nothing on screen to say the figure is old.
+ *
+ * So a search result describes the model and leaves `pricing` unset. The rate
+ * is resolved from the provider's table when a cost is estimated, and a card
+ * that IS on a record means someone declared it deliberately.
+ */
+async function searchRecords(
+  fn: (input: any, model: any, signal: any, emit: any) => Promise<void>
+): Promise<any[]> {
+  const events: any[] = [];
+  await fn({ query: "" } as any, undefined as any, undefined as any, (e: any) => events.push(e));
+  const results = events.at(-1)!.data.results as any[];
+  expect(results.length).toBeGreaterThan(0);
+  return results;
+}
+
+describe("cloud model search results", () => {
+  it("leaves pricing unset on Anthropic records while the table still prices them", async () => {
+    const results = await searchRecords(Anthropic_ModelSearch_Stream);
+    for (const result of results) {
+      expect(result.record.pricing).toBeUndefined();
+      expect(getAnthropicModelPricing(result.id)).toBeDefined();
+    }
+  });
+
+  it("leaves pricing unset on OpenAI records while the table still prices them", async () => {
+    const results = await searchRecords(OpenAI_ModelSearch_Stream);
+    for (const result of results) {
+      expect(result.record.pricing).toBeUndefined();
+    }
+    expect(results.some((result) => getOpenAiModelPricing(result.id) !== undefined)).toBe(true);
+  });
+
+  it("leaves pricing unset on DeepSeek records while the table still prices them", async () => {
+    const results = await searchRecords(DeepSeek_ModelSearch_Stream);
+    for (const result of results) {
+      expect(result.record.pricing).toBeUndefined();
+    }
+    expect(results.some((result) => getDeepSeekModelPricing(result.id) !== undefined)).toBe(true);
+  });
+
+  it("leaves pricing unset on xAI records while the table still prices them", async () => {
+    const results = await searchRecords(Xai_ModelSearch_Stream);
+    for (const result of results) {
+      expect(result.record.pricing).toBeUndefined();
+    }
+    expect(results.some((result) => getXaiModelPricing(result.id) !== undefined)).toBe(true);
+  });
+
+  // Gemini maps the live /models listing through a different function than its
+  // credential-free fallback list, and only the live one ever carried a card —
+  // so the listing is what this has to exercise.
+  it("leaves pricing unset on Gemini records from the live listing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          models: [{ name: "models/gemini-2.5-pro", displayName: "Gemini 2.5 Pro" }],
+        }),
+        { status: 200 }
+      )
+    );
+    const events: any[] = [];
+    await Gemini_ModelSearch_Stream(
+      { query: "", credential_key: "test-key" } as any,
+      undefined as any,
+      undefined as any,
+      (e: any) => events.push(e)
+    );
+    const results = events.at(-1)!.data.results as any[];
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe("gemini-2.5-pro");
+    expect(results[0].record.pricing).toBeUndefined();
+    expect(getGeminiModelPricing("gemini-2.5-pro")).toBeDefined();
+  });
+});

--- a/providers/anthropic/src/ai/common/Anthropic_ModelSearch.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_ModelSearch.ts
@@ -15,7 +15,6 @@ import { stampEffortOptions } from "@workglow/ai/worker";
 import { getClient } from "./Anthropic_Client";
 import { ANTHROPIC } from "./Anthropic_Constants";
 import { anthropicEffortPolicy } from "./Anthropic_EffortPolicy";
-import { getAnthropicModelPricing } from "./Anthropic_Pricing";
 
 interface AnthropicModelListItem {
   readonly label: string;
@@ -67,7 +66,6 @@ function mapModelList(models: AnthropicModelListItem[]): ModelSearchResultItem[]
         capabilities: [],
         provider_config: { model_name: m.value },
         metadata: {},
-        pricing: getAnthropicModelPricing(m.value),
       },
       anthropicEffortPolicy({
         provider: ANTHROPIC,

--- a/providers/anthropic/src/ai/common/Anthropic_Pricing.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Pricing.ts
@@ -9,6 +9,10 @@ import { resolveModelPricingFromTable } from "@workglow/ai";
 
 /**
  * Public list pricing for Anthropic Claude models (USD per 1M tokens).
+ *
+ * No card carries a long-context tier, and that is not an omission: the
+ * 1M-context models bill a long prompt at these same rates, and every other
+ * model here has a 200K window, so no prompt size could select one.
  */
 export const ANTHROPIC_PRICING: Record<string, ModelPricing> = {
   "claude-fable-5-1": {

--- a/providers/deepseek/src/ai/common/DeepSeek_ModelSearch.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_ModelSearch.ts
@@ -15,7 +15,6 @@ import { stampEffortOptions } from "@workglow/ai/worker";
 import { getClient } from "./DeepSeek_Client";
 import { DEEPSEEK } from "./DeepSeek_Constants";
 import { deepseekEffortPolicy } from "./DeepSeek_EffortPolicy";
-import { getDeepSeekModelPricing } from "./DeepSeek_Pricing";
 
 interface DeepSeekModelListItem {
   readonly label: string;
@@ -56,7 +55,6 @@ function mapModelList(models: DeepSeekModelListItem[]): ModelSearchResultItem[] 
         capabilities: [],
         provider_config: { model_name: m.value },
         metadata: {},
-        pricing: getDeepSeekModelPricing(m.value),
       },
       deepseekEffortPolicy({
         provider: DEEPSEEK,

--- a/providers/google-gemini/src/ai/common/Gemini_ModelSearch.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ModelSearch.ts
@@ -14,7 +14,6 @@ import { normalizedModelSearchQuery } from "@workglow/ai/provider-utils";
 import { stampEffortOptions } from "@workglow/ai/worker";
 import { GOOGLE_GEMINI } from "./Gemini_Constants";
 import { geminiEffortPolicy } from "./Gemini_EffortPolicy";
-import { getGeminiModelPricing } from "./Gemini_Pricing";
 
 interface GeminiModelEntry {
   readonly label: string;
@@ -84,7 +83,6 @@ function mapGeminiModel(model: GeminiApiModel): ModelSearchResultItem {
         capabilities: capabilitiesForGeminiApiModel(model, id),
         provider_config: { model_name: id },
         metadata: {},
-        pricing: getGeminiModelPricing(id),
       },
       geminiEffortPolicy({
         provider: GOOGLE_GEMINI,

--- a/providers/google-gemini/src/ai/common/Gemini_Pricing.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Pricing.ts
@@ -9,6 +9,12 @@ import { resolveModelPricingFromTable } from "@workglow/ai";
 
 /**
  * Public list pricing for Google Gemini models (USD per 1M tokens).
+ *
+ * Pro models bill a prompt over 200K tokens at a higher rate, so their cards
+ * carry both published rows as usage tiers. The `≤200K` tier restates the base
+ * rates rather than being left implicit, which is what puts a prompt of exactly
+ * 200K on the lower row: tiers resolve in declared order. Tiers restate `input`
+ * and `output` only, so the card's own cache rates keep applying.
  */
 export const GEMINI_PRICING: Record<string, ModelPricing> = {
   "gemini-3.8-flash-lite": {
@@ -59,6 +65,10 @@ export const GEMINI_PRICING: Record<string, ModelPricing> = {
     output: 12,
     cached: 0.5,
     cacheStoragePerHour: 4.5,
+    usageTiers: [
+      { maxInputTokens: 200_000, pricing: { input: 2, output: 12 } },
+      { minInputTokens: 200_000, pricing: { input: 4, output: 18 } },
+    ],
   },
   "gemini-3.1-pro": {
     currency: "USD",
@@ -94,6 +104,10 @@ export const GEMINI_PRICING: Record<string, ModelPricing> = {
     output: 10,
     cached: 0.3125,
     cacheStoragePerHour: 4.5,
+    usageTiers: [
+      { maxInputTokens: 200_000, pricing: { input: 1.25, output: 10 } },
+      { minInputTokens: 200_000, pricing: { input: 2.5, output: 15 } },
+    ],
   },
   "gemini-embedding-2": { currency: "USD", input: 0.04, output: 0 },
   "text-embedding-004": { currency: "USD", input: 0.025, output: 0 },

--- a/providers/openai/src/ai/common/OpenAI_ModelSearch.ts
+++ b/providers/openai/src/ai/common/OpenAI_ModelSearch.ts
@@ -15,7 +15,6 @@ import { stampEffortOptions } from "@workglow/ai/worker";
 import { getClient } from "./OpenAI_Client";
 import { OPENAI } from "./OpenAI_Constants";
 import { openaiEffortPolicy } from "./OpenAI_EffortPolicy";
-import { getOpenAiModelPricing } from "./OpenAI_Pricing";
 
 interface OpenAiModelListItem {
   readonly label: string;
@@ -82,7 +81,6 @@ function mapModelList(models: OpenAiModelListItem[]): ModelSearchResultItem[] {
           capabilities: imageEntry?.capabilities ?? [],
           provider_config: { model_name: m.value },
           metadata: {},
-          pricing: getOpenAiModelPricing(m.value),
         },
         openaiEffortPolicy({ provider: OPENAI, provider_config: { model_name: m.value } })
       ),

--- a/providers/xai/src/ai/common/Xai_ModelSearch.ts
+++ b/providers/xai/src/ai/common/Xai_ModelSearch.ts
@@ -15,7 +15,6 @@ import { stampEffortOptions } from "@workglow/ai/worker";
 import { getClient } from "./Xai_Client";
 import { XAI } from "./Xai_Constants";
 import { xaiEffortPolicy } from "./Xai_EffortPolicy";
-import { getXaiModelPricing } from "./Xai_Pricing";
 
 interface XaiModelListItem {
   readonly label: string;
@@ -70,7 +69,6 @@ function mapModelList(models: XaiModelListItem[]): ModelSearchResultItem[] {
           capabilities: imageEntry?.capabilities ?? [],
           provider_config: { model_name: m.value },
           metadata: {},
-          pricing: getXaiModelPricing(m.value),
         },
         xaiEffortPolicy({ provider: XAI, provider_config: { model_name: m.value } })
       ),


### PR DESCRIPTION
Three ways a cost figure could be confidently wrong, with nothing on screen saying so.

## A persisted model froze its rates at the moment it was added

`model add` and `model find` persist the record a search result carries, and every cloud model search stamped the provider's rate card into that record. `lookupModelPricing` resolves `record.pricing` first, so a model added today kept those numbers for the life of the repository: correcting a rate in the provider's table — which is how a rate is meant to be corrected — no longer reached it, and the estimate printed with no `~` to mark it stale.

Search results now describe the model and leave `pricing` unset (Anthropic, OpenAI, Gemini, DeepSeek, xAI). A card on a record is again what it claims to be: something someone declared — a negotiated rate, or the whole card for a model no table names. Everything else resolves from the table on every estimate.

**Note for existing installs:** a model added before this change keeps the card that was stamped into it. `model edit` clears it; nothing migrates records automatically, because a card on a record is indistinguishable from one a user typed.

## A record's card is a per-field override, not a replacement

Resolving the record's card *or* the provider's, whole, was all-or-nothing: a record carrying any card discarded the provider's entirely. Someone who entered only a negotiated `input` rate silently lost `output`, `cached`, `cacheWrite`, `cacheStoragePerHour` and every long-context tier, and those read downstream as "unpriced" rather than as rates nobody changed.

`mergeModelPricing` (`packages/ai/src/model/ModelPricing.ts`) is now the single definition of the resolution, and `lookupModelPricing` — the one call site with this shape in the repo — routes through it. In plain terms:

- **Enters the whole card** — every rate they typed is what is charged. Nothing is inherited that they stated.
- **Enters part of it** — what they typed wins; every rate they left blank comes from the provider's published card, including inside `batch`.
- **Enters none** — the provider's card stands unchanged, so a rate correction there reaches models added months ago.
- **Neither exists** — the result stays `undefined`, never a zero card, so `formatCost` keeps printing its partial/unknown marker instead of a confident `$0.0000`.

Two rules keep an inherited rate from contradicting a declared one:

- **A declared rate wins everywhere, tiers included.** A tier is a replacement card for a prompt range or a clock window, so an inherited tier restating a rate declared at the base level would override that declaration exactly on long prompts or off-peak hours — the cases a negotiated rate is usually entered for. Inherited tiers therefore drop any rate declared at the base level, and a tier left with nothing is dropped whole. If the record supplies its own `usageTiers`/`timingTiers`, those are used as given and none are inherited.
- **Currencies are never mixed.** A record card declaring a different currency from the provider's inherits nothing — the numbers are not comparable, and merging them would produce one card silently denominated in two units.

## A prompt over 200K tokens was priced at the under-200K rate

Google publishes two rows for its Pro models. The cards carried only the first, so a 250K-token prompt to `gemini-2.5-pro` was priced at roughly half — and because every counter it was handed did have a rate, `formatCost` printed that figure without the `~` that marks a partial estimate.

Rates verified against https://ai.google.dev/gemini-api/docs/pricing:

| Model | ≤200K in/out | >200K in/out |
| --- | --- | --- |
| `gemini-2.5-pro` | $1.25 / $10 | $2.50 / $15 |
| `gemini-3.1-pro-preview` | $2 / $12 | $4 / $18 |

The tiers restate `input` and `output` only, so each card's own cache rates keep applying. The `≤200K` tier restates the base rates rather than being left implicit, which is what puts a prompt of exactly 200K on the lower row.

Deliberately **not** changed, and said plainly because both are places a future reader may expect a tier:

- **Anthropic — no tier anywhere, confirmed.** The published pricing page states that Claude 4.6 and later include the full 1M context window at standard pricing, and every other model in the table has a 200K window, so no prompt size could select a tier. The absence is now documented on the table and pinned by a test.
- **`gemini-3.1-pro` (the non-preview id) — left alone.** Google's pricing page carries a `gemini-3.1-pro-preview` row and no separate stable row, so there is no published >200K rate to transcribe for it. It still prices a long prompt at the base rate. Adding the preview's tiers to it would be a guess, and a wrong rate is worse than a missing tier.
- Flash cards are flat on the published table and stay flat; a test pins that too.

## Time-of-day rates were resolved against the render clock

`selectTimingTier` defaults to `new Date()`, and no caller passed anything else — `formatUsageWithCost` could not even accept one. DeepSeek's off-peak window (16:30–00:30 UTC) is a 2× swing on `deepseek-v4-pro` input, so a batch that ran from 15:50 to 16:20 UTC and was rendered at 16:35 priced every request off-peak; the same report rendered before 16:30 gave a different total for identical usage, and in the CLI footer a completed run's cost visibly dropped as the clock crossed the boundary.

`formatUsageWithCost` now takes the same options bag `estimateCost` does, and every caller passes the instant it knows:

- task usage row → that execution's `startedAt`
- graph footer → the run's earliest execution start, so a finished total stops moving
- eval sweep row → a timestamp captured when the request was issued, stored with the row
- eval live tally → the sweep's start

## Tests

Each fix is covered by a test that fails on the code before it (verified by reverting each in turn):

- `ModelSearchPricing.test.ts` — no search result carries a rate card, and the provider table still prices those same ids.
- `ModelPricing.test.ts` — the merge: a partial card inheriting the rest, a declared rate surviving a 300K prompt the provider's tiers would reprice, a tier left empty being dropped, a record's own tiers inheriting none, a mismatched currency inheriting nothing, `batch` merged per field, and neither card present staying `undefined` and still rendering `~`.
- `lookupModelPricing.test.ts` — the same semantics through the real call site, against the live Anthropic and Gemini tables.
- `LongContextPricing.test.ts` — a 250K-token prompt selects the published over-200K rates through `estimateCost`, exactly 200K stays on the lower row, and no Anthropic card declares a tier.
- `formatUsage.test.ts` / `usageColumns.test.ts` — the same usage priced at a given instant versus at the current clock. The discount window is derived from the current time so the assertion cannot pass by accident depending on the hour the suite runs.

## Verification

For the original three fixes: `bun run format`, `bun run lint`, and `bunx vitest run packages/ai/src examples/eval/src/test examples/cli/src/test packages/test/src/test/ai-provider-api` — 112 files, 1107 tests passing against the same slice on untouched `main` as the baseline.

Re-run for the merge change, all clean:

- `bun run format-check`, `bun run lint` (includes `build:types` across all 42 packages).
- `bunx vitest run --project ai --project cli` — 74 files, 655 passed / 1 skipped.
- `bunx vitest run --project eval` — 12 files, 87 passed.
- `bunx vitest run packages/test/src/test/ai-provider-api` — 48 files, 541 passed.
- `bun test ./packages/ai/src/model/__tests__/ModelPricing.test.ts ./examples/cli/src/test/lookupModelPricing.test.ts` — 41 passed, so the new tests hold on both engines.
- The merge tests were mutation-checked three ways — reverting to `declared ?? inherited`, inheriting tiers whole, and dropping the currency guard each turned exactly the tests that pin those rules red.
- Full suite not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa)_