### PR TITLE
Share one status-rail read so its cleanups cannot run under another read

### DIFF
--- a/examples/cli/src/web/extensions.test.ts
+++ b/examples/cli/src/web/extensions.test.ts
@@ -180,4 +180,78 @@ describe("status widgets", () => {
     await readWebStatusWidgets();
     expect(closed).toBe(1);
   });
+
+  // Two open browser tabs poll `/api/status-widgets` on their own intervals and
+  // the server answers both at once. The cleanups tear down state the widgets
+  // share, so a second read running under the first sees its connection closed
+  // mid-query: its widgets throw, get dropped as unanswerable, and rows vanish
+  // from that tab's rail with nothing logged anywhere.
+  describe("concurrent reads", () => {
+    function deferred(): { readonly promise: Promise<void>; resolve: () => void } {
+      let resolve = (): void => {};
+      const promise = new Promise<void>((r) => {
+        resolve = r;
+      });
+      return { promise, resolve };
+    }
+
+    it("does not tear down a shared connection under an overlapping read", async () => {
+      // The connection the widget needs, closed by the cleanup that follows
+      // whichever read finishes first.
+      const connection = { open: true };
+      const overlapping = deferred();
+      const firstFinished = deferred();
+      let reads = 0;
+
+      registerWebStatusReadCleanup(async () => {
+        connection.open = false;
+      });
+      registerWebStatusWidget({
+        id: "db",
+        title: "Database",
+        source: "test",
+        read: async () => {
+          // The first query waits for a second read to be under way; a second
+          // query (which only happens without a shared pass) is still in flight
+          // when the first read's cleanup lands.
+          reads += 1;
+          await (reads === 1 ? overlapping.promise : firstFinished.promise);
+          if (!connection.open) throw new Error("connection closed");
+          return [{ kind: "text" as const, label: "backend", value: "postgres" }];
+        },
+      });
+
+      const first = readWebStatusWidgets();
+      const second = readWebStatusWidgets();
+      overlapping.resolve();
+      const a = await first;
+      firstFinished.resolve();
+      const b = await second;
+
+      expect(reads).toBe(1);
+      expect(a.map((w) => w.id)).toEqual(["db"]);
+      expect(b.map((w) => w.id)).toEqual(["db"]);
+    });
+
+    it("runs the cleanups once for a shared pass, and again for the next one", async () => {
+      let closed = 0;
+      registerWebStatusReadCleanup(async () => {
+        closed += 1;
+      });
+      registerWebStatusWidget({
+        id: "db",
+        title: "Database",
+        source: "test",
+        read: async () => [{ kind: "text", label: "backend", value: "postgres" }],
+      });
+
+      await Promise.all([readWebStatusWidgets(), readWebStatusWidgets()]);
+      expect(closed).toBe(1);
+
+      // A read that starts after the pass settled is a pass of its own: the
+      // cleanups have already run, so nothing is torn down underneath it.
+      await readWebStatusWidgets();
+      expect(closed).toBe(2);
+    });
+  });
 });

--- a/examples/cli/src/web/extensions.ts
+++ b/examples/cli/src/web/extensions.ts
@@ -236,15 +236,38 @@ export function listWebStatusWidgets(): readonly WebStatusWidget[] {
   return [...statusWidgets];
 }
 
-/** Reads every status widget, dropping any that cannot answer right now. */
-export async function readWebStatusWidgets(): Promise<
-  readonly {
-    readonly id: string;
-    readonly title: string;
-    readonly source: string;
-    readonly items: readonly WebStatusItem[];
-  }[]
-> {
+export interface WebStatusWidgetReading {
+  readonly id: string;
+  readonly title: string;
+  readonly source: string;
+  readonly items: readonly WebStatusItem[];
+}
+
+let statusReadInFlight: Promise<readonly WebStatusWidgetReading[]> | undefined;
+
+/**
+ * Reads every status widget, dropping any that cannot answer right now.
+ *
+ * Callers overlapping in time share one pass. The rail is polled on a bare
+ * interval by every open tab and served concurrently, so two reads can be in
+ * progress at once — and the cleanups below close resources the widgets share
+ * (a database connection, typically). Run under each other, the first read's
+ * teardown closes the connection the second is still querying: that read's
+ * widgets throw, get dropped as unanswerable, and the rows vanish from the rail
+ * with nothing logged. Sharing the pass also means the cleanups run once per
+ * pass rather than once per caller.
+ *
+ * The in-flight promise is only cleared after the cleanups have finished, so a
+ * read that starts later never overlaps an earlier one's teardown either.
+ */
+export function readWebStatusWidgets(): Promise<readonly WebStatusWidgetReading[]> {
+  statusReadInFlight ??= readStatusWidgetsOnce().finally(() => {
+    statusReadInFlight = undefined;
+  });
+  return statusReadInFlight;
+}
+
+async function readStatusWidgetsOnce(): Promise<readonly WebStatusWidgetReading[]> {
   try {
     const results = await Promise.all(
       statusWidgets.map(async (widget) => {


### PR DESCRIPTION
## The problem

`readWebStatusWidgets()` runs every registered cleanup in a `finally`, on every call. Those cleanups close what the widgets share — closing a database connection is the contract `registerWebStatusReadCleanup` is documented for.

Nothing serialized them. `/api/status-widgets` is served concurrently, and each open console tab polls it on its own bare `setInterval` with no overlap guard, so two reads are in progress at once whenever a poll takes longer than the gap between them (or simply whenever two tabs are open and out of phase). Tab A's `finally` then closes the connection while tab B is still awaiting a query on it. B's `widget.read()` throws, the `catch { return undefined }` drops that widget as unanswerable, and the row silently disappears from B's status rail — no error to the client, nothing logged, and the row is back on the next poll, so it reads as a flicker rather than a fault.

## The fix

Overlapping callers share one pass. The cleanups therefore run once per pass instead of once per caller, and never while another read is still using what they tear down. The in-flight promise is cleared inside the same chain, *after* the cleanups have finished, so a read that starts later is a pass of its own and cannot overlap an earlier one's teardown either.

Two callers 200ms apart now see the same snapshot rather than two reads a fifth of a second apart — for a rail polled every 15 seconds, that is the intended trade.

**Scope, stated plainly:** this fixes overlapping *status reads*, which is the case the cleanups are triggered by. A cleanup can still land under an unrelated in-flight request (`/api/fields`, a widget search) that happens to share the same connection — closing process-global state on a timer is inherently that way, and narrowing it further belongs to whichever package registers the cleanup, not to the rail.

The client's polling loop is unchanged: with the read shared server-side, an overlapping poll is harmless.

## Tests

Both new tests fail on the code before this change (verified by reverting the fix):

- Two reads overlap; the first read's cleanup closes the shared connection while the second read's query is still in flight. Before: the second read comes back with the widget dropped. After: one query serves both, and both callers get the row.
- The cleanups run once for a shared pass, and again for a read that starts after that pass has settled.

## Verification

- `bun run format`, `bun run lint` (includes `build:types` across all 42 packages) — clean.
- `bunx vitest run examples/cli/src/web examples/cli/src/test` — 30 files, 223 tests passing (1 skipped, as on `main`).
- `bun test ./examples/cli/src/web/extensions.test.ts` — 11 passing under the Bun runner too.
- Full suite not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa)_