### PR TITLE
Web-search fixes: credential routing, import side effects, and two over-declared ports

### DIFF
--- a/packages/web-search/README.md
+++ b/packages/web-search/README.md
@@ -11,6 +11,22 @@ Even where it could, the API key would be readable by any visitor.
 The browser build therefore registers the **task** (so a builder UI can render
 and validate the node) but **no providers**. Execution happens on a server.
 
+## Registering providers
+
+Importing this package registers the **task class** and nothing else. Which
+providers exist — and so which one `"auto"` may bill you for — is the host's
+decision, stated with a call:
+
+```ts
+import { registerBuiltInWebSearchProviders } from "@workglow/web-search";
+
+registerBuiltInWebSearchProviders(); // brave, tavily, and searxng when a base URL is set
+```
+
+Nothing registers itself on import, which is what lets a vendor adapter pull
+this package in for `registerWebSearchProvider` without quietly adding three
+providers ahead of the one the host asked for.
+
 ## Providers
 
 | provider     | auth                   | answer | content | domain filter            | date filter |
@@ -20,7 +36,7 @@ and validate the node) but **no providers**. Execution happens on a server.
 | `searxng`    | none (self-hosted)     | no     | no      | via `site:`              | no          |
 | `anthropic`  | vendor SDK             | yes    | no      | native, **one list**     | no          |
 | `openai`     | vendor SDK             | yes    | no      | native, **include only** | no          |
-| `openrouter` | vendor SDK             | yes    | yes     | native                   | no          |
+| `openrouter` | vendor SDK             | yes    | no      | native                   | no          |
 | `gemini`     | vendor SDK             | yes    | no      | **none**                 | **yes**     |
 
 The four grounded providers ship in their vendor packages and must be registered
@@ -45,7 +61,9 @@ with `format=json` enabled.
 ## Usage
 
 ```ts
-import { WebSearchTask } from "@workglow/web-search";
+import { registerBuiltInWebSearchProviders, WebSearchTask } from "@workglow/web-search";
+
+registerBuiltInWebSearchProviders();
 
 const out = await new WebSearchTask().run({
   query: "transformer architecture",
@@ -86,6 +104,14 @@ The key sent is the one named for the provider that actually runs, so a key
 issued for one vendor cannot reach another; routing prefers a provider a key is
 named for, and a provider none was named for is simply searched unauthenticated.
 
+A name in `credential_keys` that matches no registered provider is refused, not
+ignored — a typo or a missing `register…()` call otherwise surfaces as an
+authentication error from whichever provider ran instead. So is a name matching
+a grounded provider: those authenticate through their own vendor client, which
+never sees this key. Give them theirs at registration
+(`registerAnthropicWebSearchProvider({ apiKey })`) or in the vendor's own
+environment variable.
+
 ## Adding a provider
 
 Implement `IWebSearchProvider` and register it:
@@ -98,7 +124,14 @@ registerWebSearchProvider(myProvider);
 
 Declare capabilities honestly — `domainFilter: "query-operator"` means the task
 rewrites the query with `site:`, and `dateFilter: false` means a date-bounded
-request is refused rather than approximated by dropping results.
+request is refused rather than approximated by dropping results. Set
+`acceptsCredentialKey` to `true` only if `request.credentialKey` actually
+reaches the request; a provider holding its own client sets `false`, and a
+credential key named for it is then refused rather than dropped.
+
+`publishedDate` is an ISO-8601 string or absent. Run a provider's own value
+through `toIsoPublishedDate` — several engines report display text ("3 days
+ago") that a downstream date comparison turns into an Invalid Date.
 
 ## License
 

--- a/packages/web-search/src/IWebSearchProvider.ts
+++ b/packages/web-search/src/IWebSearchProvider.ts
@@ -117,5 +117,14 @@ export interface IWebSearchProvider {
    * URL this package controls.
    */
   readonly endpoint: string | undefined;
+  /**
+   * Whether {@link WebSearchRequest.credentialKey} reaches this provider's
+   * request. True for one whose fetch this package owns, where the owned
+   * `FetchUrlTask` resolves the key and attaches it. False for an adapter that
+   * authenticates through a vendor client, and for an unauthenticated instance
+   * — both ignore the field, so naming a key for one is refused rather than
+   * dropped in silence.
+   */
+  readonly acceptsCredentialKey: boolean;
   search(request: WebSearchRequest, context: IExecuteContext): Promise<WebSearchResponse>;
 }

--- a/packages/web-search/src/WebSearchProviderRegistry.ts
+++ b/packages/web-search/src/WebSearchProviderRegistry.ts
@@ -8,6 +8,15 @@ import { TaskConfigurationError } from "@workglow/task-graph";
 import { unhonorableOptions } from "./capabilityCheck";
 import type { IWebSearchProvider, WebSearchRequest } from "./IWebSearchProvider";
 
+/**
+ * What to do about an empty registry. Importing the package registers the task
+ * class but no provider, so the missing step is always a call rather than an
+ * import.
+ */
+const NOTHING_REGISTERED_HINT =
+  "Call registerBuiltInWebSearchProviders() for Brave/Tavily/SearXNG, or " +
+  "registerWebSearchProvider() with your own.";
+
 class Registry {
   private readonly providers = new Map<string, IWebSearchProvider>();
 
@@ -35,9 +44,39 @@ class Registry {
     throw new TaskConfigurationError(
       known.length === 0
         ? `WebSearchTask: provider ${JSON.stringify(name)} is not registered, and neither is any ` +
-            "other. Import @workglow/web-search from a server runtime to register the built-in providers."
+            `other. ${NOTHING_REGISTERED_HINT}`
         : `WebSearchTask: unknown provider ${JSON.stringify(name)}. Registered: ${known.join(", ")}.`
     );
+  }
+
+  /**
+   * Refuses a credential key named for a provider that cannot receive one.
+   *
+   * Two names are refused: one matching nothing registered, which would
+   * otherwise change nothing and be reported nowhere while the request goes out
+   * unauthenticated; and one matching an adapter that authenticates through its
+   * own vendor client, which moves that provider to the front of routing for a
+   * key it then ignores.
+   */
+  assertCredentialKeyUsable(name: string): void {
+    const provider = this.providers.get(name);
+    if (provider === undefined) {
+      const known = this.list().map((p) => p.name);
+      throw new TaskConfigurationError(
+        `WebSearchTask: credential_keys names ${JSON.stringify(name)}, which is not a ` +
+          (known.length === 0
+            ? `registered provider — none is registered. ${NOTHING_REGISTERED_HINT}`
+            : `registered provider. Registered: ${known.join(", ")}.`)
+      );
+    }
+    if (!provider.acceptsCredentialKey) {
+      throw new TaskConfigurationError(
+        `WebSearchTask: provider ${JSON.stringify(name)} never receives a credential-store ` +
+          "key — it authenticates through its own client, or not at all. Configure its key " +
+          "where the provider is registered, or in the vendor's own environment variable, and " +
+          "drop it from credential_keys."
+      );
+    }
   }
 
   /**
@@ -62,8 +101,7 @@ class Registry {
     const candidates = this.list();
     if (candidates.length === 0) {
       throw new TaskConfigurationError(
-        "WebSearchTask: No web-search providers are registered. Import @workglow/web-search " +
-          "from a server runtime, or register one with registerWebSearchProvider()."
+        `WebSearchTask: No web-search providers are registered. ${NOTHING_REGISTERED_HINT}`
       );
     }
     const ordered =

--- a/packages/web-search/src/WebSearchTask.ts
+++ b/packages/web-search/src/WebSearchTask.ts
@@ -91,7 +91,8 @@ const inputSchema = {
       description:
         "Credential-store keys by provider name. The key sent is the one named for the " +
         "provider that runs, so a key issued for one vendor never reaches another, and " +
-        "routing prefers a provider a key is named for.",
+        "routing prefers a provider a key is named for. A name matching no registered " +
+        "provider, or one that authenticates through its own vendor client, is refused.",
       "x-ui-hidden": true,
     },
   },
@@ -244,11 +245,19 @@ export class WebSearchTask extends Task<WebSearchTaskInput, WebSearchTaskOutput>
       includeContent: input.includeContent,
     };
 
+    // Before routing, so a key named for a provider that never receives one is
+    // reported as what it is rather than as the vendor error of whatever
+    // provider ran instead.
+    for (const named of Object.keys(input.credential_keys ?? {})) {
+      WebSearchProviderRegistry.assertCredentialKeyUsable(named);
+    }
+
     const provider = this.resolveProvider(input, baseRequest);
-    const request = this.adaptRequest(provider, {
-      ...baseRequest,
-      credentialKey: credentialKeyFor(provider.name, input),
-    });
+    const credentialKey = credentialKeyFor(provider.name, input);
+    if (credentialKey !== undefined) {
+      WebSearchProviderRegistry.assertCredentialKeyUsable(provider.name);
+    }
+    const request = this.adaptRequest(provider, { ...baseRequest, credentialKey });
 
     await context.updateProgress(undefined, `Searching via ${provider.name}`);
     const response = await provider.search(request, context);

--- a/packages/web-search/src/__tests__/BraveWebSearchProvider.test.ts
+++ b/packages/web-search/src/__tests__/BraveWebSearchProvider.test.ts
@@ -15,7 +15,9 @@ const BRAVE_PAYLOAD = {
         title: "Attention Is All You Need",
         url: "https://arxiv.org/abs/1706.03762",
         description: "The transformer paper.",
-        age: "2017-06-12T00:00:00Z",
+        // What Brave actually sends: `age` is display text, `page_age` the timestamp.
+        age: "8 years ago",
+        page_age: "2017-06-12T00:00:00Z",
         meta_url: { favicon: "https://arxiv.org/favicon.ico" },
       },
       { title: "No description", url: "https://example.com/b" },
@@ -53,12 +55,25 @@ describe("BraveWebSearchProvider", () => {
       title: "Attention Is All You Need",
       url: "https://arxiv.org/abs/1706.03762",
       snippet: "The transformer paper.",
-      publishedDate: "2017-06-12T00:00:00Z",
+      publishedDate: "2017-06-12T00:00:00.000Z",
       favicon: "https://arxiv.org/favicon.ico",
       content: undefined,
       score: undefined,
     });
     expect(out.results[1].snippet).toBeUndefined();
+  });
+
+  it("leaves publishedDate absent when Brave reports only a relative age", async () => {
+    const p = new BraveWebSearchProvider();
+    const out = await p.search(
+      { query: "transformers" },
+      contextWithResponse({
+        web: { results: [{ title: "T", url: "https://x.example/a", age: "3 days ago" }] },
+      })
+    );
+    // "3 days ago" through an ISO-8601 port becomes an Invalid Date in any
+    // recency filter downstream; absent is the honest answer.
+    expect(out.results[0].publishedDate).toBeUndefined();
   });
 
   it("sends the credential as the X-Subscription-Token header", async () => {

--- a/packages/web-search/src/__tests__/WebSearchCredential.test.ts
+++ b/packages/web-search/src/__tests__/WebSearchCredential.test.ts
@@ -16,6 +16,7 @@ import {
 } from "@workglow/util";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { BraveWebSearchProvider } from "../providers/BraveWebSearchProvider";
+import { SearxngWebSearchProvider } from "../providers/SearxngWebSearchProvider";
 import { TavilyWebSearchProvider } from "../providers/TavilyWebSearchProvider";
 import { WebSearchProviderRegistry } from "../WebSearchProviderRegistry";
 import { WebSearchTask } from "../WebSearchTask";
@@ -167,19 +168,52 @@ describe("WebSearchTask credential forwarding", () => {
     }
   });
 
-  it("sends no key at all when routing lands on a provider none was named for", async () => {
+  it("sends no key at all when the provider that runs is not the one named", async () => {
     WebSearchProviderRegistry.register(new BraveWebSearchProvider());
+    WebSearchProviderRegistry.register(new TavilyWebSearchProvider());
     const registry = await credentialRegistry();
 
     const out = await new WebSearchTask().run(
-      { query: "cats", provider: "auto", credential_keys: { tavily: STORE_KEY } },
+      { query: "cats", provider: "brave", credential_keys: { tavily: STORE_KEY } },
       { registry }
     );
 
     // An unauthenticated search that fails is recoverable; the Tavily secret
-    // arriving at Brave is not.
+    // arriving at Brave is not. Tavily is registered here because a key named
+    // for nothing at all is a separate, reported error.
     expect(out.provider).toBe("brave");
     expect(JSON.stringify(mockFetch.mock.calls.at(-1))).not.toContain(SECRET);
+  });
+
+  it("names the unregistered provider a credential key was issued for", async () => {
+    WebSearchProviderRegistry.register(new BraveWebSearchProvider());
+    WebSearchProviderRegistry.register(new TavilyWebSearchProvider());
+    const registry = await credentialRegistry();
+
+    // Capitalised, so it matches nothing: routing is unchanged, the search goes
+    // out unauthenticated, and the only signal an operator gets is a 401 naming
+    // a provider they never configured a key for.
+    await expect(
+      new WebSearchTask().run(
+        { query: "cats", provider: "auto", credential_keys: { Tavily: STORE_KEY } },
+        { registry }
+      )
+    ).rejects.toThrow(/"Tavily"/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("refuses a key named for SearXNG, which forwards no credential", async () => {
+    WebSearchProviderRegistry.register(new BraveWebSearchProvider());
+    WebSearchProviderRegistry.register(new SearxngWebSearchProvider("https://searx.example"));
+    const registry = await credentialRegistry();
+
+    await expect(
+      new WebSearchTask().run(
+        { query: "cats", provider: "auto", credential_keys: { searxng: STORE_KEY } },
+        { registry }
+      )
+    ).rejects.toThrow(/never receives a credential-store key/);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("refuses a bare credential_key alongside provider 'auto'", async () => {

--- a/packages/web-search/src/__tests__/WebSearchProviderRegistry.test.ts
+++ b/packages/web-search/src/__tests__/WebSearchProviderRegistry.test.ts
@@ -8,10 +8,15 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { IWebSearchProvider, WebSearchCapabilities } from "../IWebSearchProvider";
 import { WebSearchProviderRegistry } from "../WebSearchProviderRegistry";
 
-function provider(name: string, caps: Partial<WebSearchCapabilities>): IWebSearchProvider {
+function provider(
+  name: string,
+  caps: Partial<WebSearchCapabilities>,
+  acceptsCredentialKey = true
+): IWebSearchProvider {
   return {
     name,
     endpoint: `https://${name}.example`,
+    acceptsCredentialKey,
     capabilities: {
       answer: false,
       content: false,
@@ -115,6 +120,27 @@ describe("WebSearchProviderRegistry", () => {
     WebSearchProviderRegistry.register(provider("brave", {}));
     expect(() => WebSearchProviderRegistry.require("nope")).toThrow(/nope/);
     expect(() => WebSearchProviderRegistry.require("nope")).toThrow(/brave/);
+  });
+
+  it("refuses a credential key named for nothing registered, listing what is", () => {
+    WebSearchProviderRegistry.register(provider("brave", {}));
+    WebSearchProviderRegistry.register(provider("tavily", {}));
+    expect(() => WebSearchProviderRegistry.assertCredentialKeyUsable("Tavily")).toThrow(/Tavily/);
+    expect(() => WebSearchProviderRegistry.assertCredentialKeyUsable("Tavily")).toThrow(
+      /Registered: brave, tavily/
+    );
+  });
+
+  it("refuses a credential key named for a provider that never receives one", () => {
+    WebSearchProviderRegistry.register(provider("anthropic", {}, false));
+    expect(() => WebSearchProviderRegistry.assertCredentialKeyUsable("anthropic")).toThrow(
+      /never receives a credential-store key/
+    );
+  });
+
+  it("accepts a credential key named for a provider that does receive one", () => {
+    WebSearchProviderRegistry.register(provider("tavily", {}));
+    expect(() => WebSearchProviderRegistry.assertCredentialKeyUsable("tavily")).not.toThrow();
   });
 
   it("replaces a same-named provider rather than shadowing it", () => {

--- a/packages/web-search/src/__tests__/WebSearchTask.test.ts
+++ b/packages/web-search/src/__tests__/WebSearchTask.test.ts
@@ -21,6 +21,7 @@ function fake(
   return {
     name,
     endpoint: `https://${name}.example`,
+    acceptsCredentialKey: true,
     capabilities: {
       answer: false,
       content: false,
@@ -174,13 +175,16 @@ describe("WebSearchTask", () => {
     expect(seen).toHaveBeenCalledWith(expect.objectContaining({ credentialKey: undefined }));
   });
 
-  it("sends no credential to a routed provider none was named for", async () => {
+  it("sends no credential to a provider none was named for", async () => {
     const seen = vi.fn();
     WebSearchProviderRegistry.register(fake("brave", {}, seen));
+    WebSearchProviderRegistry.register(fake("tavily", {}));
 
+    // A key issued for one vendor arriving at another is not recoverable by
+    // rotating anything but that key, so the map is the only thing consulted.
     await new WebSearchTask().run({
       query: "cats",
-      provider: "auto",
+      provider: "brave",
       credential_keys: { tavily: "tavily-key" },
     });
 
@@ -208,10 +212,64 @@ describe("WebSearchTask", () => {
     expect(seen).toHaveBeenCalledWith(expect.objectContaining({ credentialKey: "tavily-key" }));
   });
 
+  it("refuses a credential key named for a provider that is not registered", async () => {
+    WebSearchProviderRegistry.register(fake("brave", {}));
+    WebSearchProviderRegistry.register(fake("tavily", {}));
+
+    // The capitalisation is the whole bug: the entry matches nothing, routing
+    // is unchanged by it, and the run used to reach Brave unauthenticated and
+    // report Brave's own 401 — nothing pointing at the name that was wrong.
+    await expect(
+      new WebSearchTask().run({
+        query: "cats",
+        provider: "auto",
+        credential_keys: { Tavily: "tavily-key" },
+      })
+    ).rejects.toThrow(/"Tavily".*Registered: brave, tavily/s);
+  });
+
+  it("refuses a credential key named for a provider that never receives one", async () => {
+    const seen = vi.fn();
+    WebSearchProviderRegistry.register(fake("brave", {}, seen));
+    WebSearchProviderRegistry.register({
+      ...fake("anthropic", { answer: true }),
+      acceptsCredentialKey: false,
+    });
+
+    // Naming a key moves anthropic to the front of routing, and the adapter
+    // then authenticates from its own client — so the key is neither used nor
+    // reported, and the search is billed to whatever that client resolved.
+    await expect(
+      new WebSearchTask().run({
+        query: "cats",
+        provider: "auto",
+        includeAnswer: true,
+        credential_keys: { anthropic: "anthropic-prod" },
+      })
+    ).rejects.toThrow(/never receives a credential-store key/);
+    expect(seen).not.toHaveBeenCalled();
+  });
+
+  it("refuses a bare credential_key pinned to a provider that never receives one", async () => {
+    WebSearchProviderRegistry.register({
+      ...fake("anthropic", {}),
+      acceptsCredentialKey: false,
+    });
+
+    await expect(
+      new WebSearchTask().run({
+        query: "cats",
+        provider: "anthropic",
+        credential_key: "anthropic-prod",
+      })
+    ).rejects.toThrow(/never receives a credential-store key/);
+  });
+
   it("reports zero results as success, not failure", async () => {
     WebSearchProviderRegistry.register({
       name: "empty",
       endpoint: undefined,
+      acceptsCredentialKey: false,
       capabilities: {
         answer: false,
         content: false,

--- a/packages/web-search/src/__tests__/nodeEntry.test.ts
+++ b/packages/web-search/src/__tests__/nodeEntry.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+describe("the node entry", () => {
+  it("registers the task class and no provider", async () => {
+    // The four vendor adapters value-import this package to reach
+    // `registerWebSearchProvider`, so whatever the entry registers is
+    // registered by the act of importing `@workglow/anthropic/web-search`:
+    // brave lands in front of "auto" routing in an app that asked for
+    // anthropic, and a SearXNG instance is stood up from an environment
+    // variable nobody read.
+    //
+    // The module graph has to be fresh for the side effects to run again — the
+    // registry is a module singleton and the shared graph loaded this entry
+    // long before any test could clear it.
+    vi.resetModules();
+    process.env.WEB_SEARCH_SEARXNG_URL = "https://searx.uninvited.example";
+    try {
+      const { WebSearchProviderRegistry } = await import("../WebSearchProviderRegistry");
+      const { WebSearchTask } = await import("../WebSearchTask");
+      const { TaskRegistry } = await import("@workglow/task-graph");
+      await import("../node");
+
+      expect(WebSearchProviderRegistry.list()).toEqual([]);
+      expect(TaskRegistry.all.get(WebSearchTask.type)).toBe(WebSearchTask);
+    } finally {
+      delete process.env.WEB_SEARCH_SEARXNG_URL;
+      vi.resetModules();
+    }
+  });
+});

--- a/packages/web-search/src/__tests__/publishedDate.test.ts
+++ b/packages/web-search/src/__tests__/publishedDate.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { toIsoPublishedDate } from "../publishedDate";
+
+describe("toIsoPublishedDate", () => {
+  it("passes an ISO timestamp through as ISO", () => {
+    expect(toIsoPublishedDate("2017-06-12T00:00:00Z")).toBe("2017-06-12T00:00:00.000Z");
+  });
+
+  it("normalizes a date-only value", () => {
+    expect(toIsoPublishedDate("2024-11-15")).toBe("2024-11-15T00:00:00.000Z");
+  });
+
+  it("normalizes a human-written date rather than passing the display text on", () => {
+    // Anthropic's page_age reads like this. It is a real date, but a caller
+    // comparing `new Date(r.publishedDate)` deserves the same shape from every
+    // provider.
+    expect(toIsoPublishedDate("April 30, 2025")).toBe("2025-04-30T00:00:00.000Z");
+  });
+
+  it("drops a relative phrase rather than reporting it as a date", () => {
+    // Brave's `age`. Left as-is it becomes an Invalid Date downstream, which
+    // silently drops (or, inverted, silently keeps) every row from that
+    // provider — absent says "unknown", and that a caller can handle.
+    expect(toIsoPublishedDate("3 days ago")).toBeUndefined();
+    expect(toIsoPublishedDate("2 weeks ago")).toBeUndefined();
+  });
+
+  it("treats absent and blank alike", () => {
+    expect(toIsoPublishedDate(undefined)).toBeUndefined();
+    expect(toIsoPublishedDate("   ")).toBeUndefined();
+  });
+});

--- a/packages/web-search/src/common.ts
+++ b/packages/web-search/src/common.ts
@@ -21,6 +21,7 @@ export * from "./providers/BraveWebSearchProvider";
 export * from "./providers/httpSearch";
 export * from "./providers/SearxngWebSearchProvider";
 export * from "./providers/TavilyWebSearchProvider";
+export * from "./publishedDate";
 export * from "./queryOperators";
 export * from "./urlText";
 export * from "./WebSearchProviderRegistry";

--- a/packages/web-search/src/node.ts
+++ b/packages/web-search/src/node.ts
@@ -4,9 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { registerBuiltInWebSearchProviders, registerWebSearchTasks } from "./common";
+import { registerWebSearchTasks } from "./common";
 
 export * from "./common";
 
+/**
+ * The task class is registered so a host can build, render and validate a graph
+ * containing the node. Providers are not: every vendor adapter value-imports
+ * this package to reach `registerWebSearchProvider`, so anything registered
+ * here is registered by the mere act of importing
+ * `@workglow/anthropic/web-search` — putting Brave at the front of `"auto"`
+ * routing in an app that asked for Anthropic, and standing a SearXNG instance
+ * up from an environment variable nobody read.
+ *
+ * Which providers exist is the host's decision, and it states it by calling
+ * {@link registerBuiltInWebSearchProviders} or {@link registerWebSearchProvider}.
+ */
 registerWebSearchTasks();
-registerBuiltInWebSearchProviders();

--- a/packages/web-search/src/providers/BraveWebSearchProvider.ts
+++ b/packages/web-search/src/providers/BraveWebSearchProvider.ts
@@ -14,6 +14,7 @@ import type {
   WebSearchResponse,
 } from "../IWebSearchProvider";
 import { limitResults } from "../limitResults";
+import { toIsoPublishedDate } from "../publishedDate";
 import { fetchSearchJson } from "./httpSearch";
 
 const BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
@@ -22,7 +23,10 @@ interface BraveResult {
   readonly title?: string;
   readonly url?: string;
   readonly description?: string;
+  /** Display text — "3 days ago". Only a date when the page carried no timestamp. */
   readonly age?: string;
+  /** The timestamp, when Brave resolved one. */
+  readonly page_age?: string;
   readonly meta_url?: { readonly favicon?: string };
 }
 
@@ -50,6 +54,7 @@ function freshnessParam(range: WebSearchDateRange): string | undefined {
 export class BraveWebSearchProvider implements IWebSearchProvider {
   public readonly name = "brave";
   public readonly endpoint = BRAVE_ENDPOINT;
+  public readonly acceptsCredentialKey = true;
   public readonly capabilities: WebSearchCapabilities = {
     answer: false,
     content: false,
@@ -87,7 +92,9 @@ export class BraveWebSearchProvider implements IWebSearchProvider {
       url: r.url ?? "",
       snippet: r.description,
       content: undefined,
-      publishedDate: r.age,
+      // `page_age` first: `age` is the relative phrase Brave renders, and only
+      // sometimes a date. Either way the result has to parse as one.
+      publishedDate: toIsoPublishedDate(r.page_age ?? r.age),
       score: undefined,
       favicon: r.meta_url?.favicon,
     }));

--- a/packages/web-search/src/providers/SearxngWebSearchProvider.ts
+++ b/packages/web-search/src/providers/SearxngWebSearchProvider.ts
@@ -31,6 +31,8 @@ interface SearxngResult {
 export class SearxngWebSearchProvider implements IWebSearchProvider {
   public readonly name = "searxng";
   public readonly endpoint: string;
+  /** A self-hosted instance is unauthenticated; nothing here sends a key. */
+  public readonly acceptsCredentialKey = false;
   public readonly capabilities: WebSearchCapabilities = {
     answer: false,
     content: false,

--- a/packages/web-search/src/providers/TavilyWebSearchProvider.ts
+++ b/packages/web-search/src/providers/TavilyWebSearchProvider.ts
@@ -29,6 +29,7 @@ interface TavilyResult {
 export class TavilyWebSearchProvider implements IWebSearchProvider {
   public readonly name = "tavily";
   public readonly endpoint = TAVILY_ENDPOINT;
+  public readonly acceptsCredentialKey = true;
   public readonly capabilities: WebSearchCapabilities = {
     answer: true,
     content: true,

--- a/packages/web-search/src/publishedDate.ts
+++ b/packages/web-search/src/publishedDate.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Normalizes a provider's publish date onto the ISO-8601 string
+ * {@link SearchResult.publishedDate} promises, or `undefined` when it is not a
+ * date at all.
+ *
+ * Several engines report a display string next to (or instead of) a timestamp —
+ * "3 days ago", "April 30, 2025". A graph filtering on recency compares with
+ * `new Date(...)`, and a display string that does not parse silently becomes an
+ * Invalid Date, dropping or keeping every one of that provider's rows depending
+ * on which way the comparison runs. An absent date says "unknown" and can be
+ * handled; a string that means a date but is not one cannot.
+ */
+export function toIsoPublishedDate(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Date.parse(trimmed);
+  return Number.isNaN(parsed) ? undefined : new Date(parsed).toISOString();
+}

--- a/providers/anthropic/src/__tests__/AnthropicWebSearchProvider.test.ts
+++ b/providers/anthropic/src/__tests__/AnthropicWebSearchProvider.test.ts
@@ -62,7 +62,8 @@ describe("AnthropicWebSearchProvider", () => {
               type: "web_search_result",
               title: "Cats",
               url: "https://en.wikipedia.org/wiki/Cat",
-              page_age: "2026-01-02",
+              // What the tool actually reports: a date written for a reader.
+              page_age: "January 2, 2026",
             },
           ],
         },
@@ -79,13 +80,38 @@ describe("AnthropicWebSearchProvider", () => {
         url: "https://en.wikipedia.org/wiki/Cat",
         snippet: undefined,
         content: undefined,
-        publishedDate: "2026-01-02",
+        publishedDate: "2026-01-02T00:00:00.000Z",
         score: undefined,
         favicon: undefined,
       },
     ]);
     expect(out.answer).toBe("Cats are domestic animals.");
     expect(out.usage).toEqual({ inputTokens: 10, outputTokens: 20 });
+  });
+
+  it("leaves publishedDate absent when page_age is not a date", async () => {
+    const { client } = clientReturning(
+      messageWith([
+        {
+          type: "web_search_tool_result",
+          content: [
+            {
+              type: "web_search_result",
+              title: "Cats",
+              url: "https://en.wikipedia.org/wiki/Cat",
+              page_age: "3 days ago",
+            },
+          ],
+        },
+      ])
+    );
+    const out = await new AnthropicWebSearchProvider({ client: client as never }).search(
+      { query: "cats" },
+      context
+    );
+    // Through an ISO-8601 port this becomes an Invalid Date in any recency
+    // filter downstream, which drops or keeps every Anthropic row silently.
+    expect(out.results[0].publishedDate).toBeUndefined();
   });
 
   it("omits the answer when the caller did not ask for one", async () => {

--- a/providers/anthropic/src/web-search/AnthropicWebSearchProvider.ts
+++ b/providers/anthropic/src/web-search/AnthropicWebSearchProvider.ts
@@ -14,7 +14,7 @@ import type {
   WebSearchRequest,
   WebSearchResponse,
 } from "@workglow/web-search";
-import { limitResults } from "@workglow/web-search";
+import { limitResults, toIsoPublishedDate } from "@workglow/web-search";
 
 /**
  * Dynamic-filtering web search, available on Opus 5/4.8/4.7/4.6 and Sonnet 5/4.6.
@@ -27,6 +27,12 @@ const MAX_PAUSE_RESUMES = 4;
 
 export interface AnthropicWebSearchOptions {
   readonly client?: Anthropic | undefined;
+  /**
+   * Key handed to the SDK. Left unset it reads `ANTHROPIC_API_KEY`, which is
+   * the only other place this adapter looks — a credential-store key named for
+   * it in the task's `credential_keys` is refused rather than sent.
+   */
+  readonly apiKey?: string | undefined;
   readonly model?: string | undefined;
   readonly maxTokens?: number | undefined;
   /**
@@ -42,6 +48,7 @@ interface AnthropicSearchResultBlock {
   readonly type?: string;
   readonly title?: string;
   readonly url?: string;
+  /** Display text — "April 30, 2025", sometimes a relative phrase. */
   readonly page_age?: string;
 }
 
@@ -49,6 +56,8 @@ export class AnthropicWebSearchProvider implements IWebSearchProvider {
   public readonly name = "anthropic";
   /** No endpoint: this adapter reaches Anthropic through the vendor SDK. */
   public readonly endpoint = undefined;
+  /** The SDK carries the key; `credentialKey` never reaches this request. */
+  public readonly acceptsCredentialKey = false;
   public readonly capabilities: WebSearchCapabilities = {
     answer: true,
     content: false,
@@ -67,7 +76,9 @@ export class AnthropicWebSearchProvider implements IWebSearchProvider {
   private readonly maxUses: number | undefined;
 
   constructor(options: AnthropicWebSearchOptions = {}) {
-    this.client = options.client ?? new Anthropic();
+    this.client =
+      options.client ??
+      (options.apiKey === undefined ? new Anthropic() : new Anthropic({ apiKey: options.apiKey }));
     this.model = options.model ?? DEFAULT_MODEL;
     this.maxTokens = options.maxTokens ?? 16000;
     this.maxUses = options.maxUses;
@@ -182,7 +193,7 @@ export class AnthropicWebSearchProvider implements IWebSearchProvider {
           url: entry.url ?? "",
           snippet: undefined,
           content: undefined,
-          publishedDate: entry.page_age,
+          publishedDate: toIsoPublishedDate(entry.page_age),
           score: undefined,
           favicon: undefined,
         });

--- a/providers/google-gemini/src/web-search/GeminiWebSearchProvider.ts
+++ b/providers/google-gemini/src/web-search/GeminiWebSearchProvider.ts
@@ -59,6 +59,8 @@ export class GeminiWebSearchProvider implements IWebSearchProvider {
   public readonly name = "gemini";
   /** Reached through the vendor SDK, not a fetch this package owns. */
   public readonly endpoint = undefined;
+  /** The SDK carries the key; `credentialKey` never reaches this request. */
+  public readonly acceptsCredentialKey = false;
   public readonly capabilities: WebSearchCapabilities = {
     answer: true,
     content: false,

--- a/providers/openai/src/web-search/OpenAiWebSearchProvider.ts
+++ b/providers/openai/src/web-search/OpenAiWebSearchProvider.ts
@@ -37,6 +37,8 @@ export class OpenAiWebSearchProvider implements IWebSearchProvider {
   public readonly name = "openai";
   /** Reached through the vendor SDK, not a fetch this package owns. */
   public readonly endpoint = undefined;
+  /** The SDK carries the key; `credentialKey` never reaches this request. */
+  public readonly acceptsCredentialKey = false;
   public readonly capabilities: WebSearchCapabilities = {
     answer: true,
     content: false,

--- a/providers/openrouter/src/__tests__/OpenRouterWebSearchProvider.test.ts
+++ b/providers/openrouter/src/__tests__/OpenRouterWebSearchProvider.test.ts
@@ -46,12 +46,16 @@ function clientReturning(payload: unknown, spy?: (body: unknown) => void) {
 }
 
 describe("OpenRouterWebSearchProvider", () => {
-  it("declares native domain filtering, answers and content", () => {
+  it("declares native domain filtering and answers, but not content", () => {
     const c = new OpenRouterWebSearchProvider({ client: clientReturning(PAYLOAD).client })
       .capabilities;
     expect(c.domainFilter).toBe("native");
     expect(c.answer).toBe(true);
-    expect(c.content).toBe(true);
+    // A url_citation carries the excerpt the model was shown, not the page
+    // text `content` promises. Declared true, "auto" routing wins an
+    // includeContent request from a provider that returns the real thing and
+    // answers it with a ~200-character snippet, with nothing saying so.
+    expect(c.content).toBe(false);
     expect(c.dateFilter).toBe(false);
   });
 
@@ -91,7 +95,7 @@ describe("OpenRouterWebSearchProvider", () => {
     expect(out.usage).toEqual({ inputTokens: 11, outputTokens: 22 });
   });
 
-  it("gates answer and content on the caller asking", async () => {
+  it("gates the answer on the caller asking, and never reports the excerpt as content", async () => {
     const { client } = clientReturning(PAYLOAD);
     const bare = await new OpenRouterWebSearchProvider({ client }).search({ query: "t" }, context);
     expect(bare.answer).toBeUndefined();
@@ -103,7 +107,10 @@ describe("OpenRouterWebSearchProvider", () => {
       context
     );
     expect(full.answer).toBe("Transformers are a neural network architecture.");
-    expect(full.results[0].content).toBe("We propose a new simple network architecture...");
+    // The excerpt is reported as what it is — a snippet — on both ports it
+    // could occupy, so a caller cannot mistake it for full page text.
+    expect(full.results[0].snippet).toBe("We propose a new simple network architecture...");
+    expect(full.results[0].content).toBeUndefined();
   });
 
   it("passes a configured engine through", async () => {

--- a/providers/openrouter/src/web-search/OpenRouterWebSearchProvider.ts
+++ b/providers/openrouter/src/web-search/OpenRouterWebSearchProvider.ts
@@ -41,10 +41,14 @@ export class OpenRouterWebSearchProvider implements IWebSearchProvider {
   public readonly name = "openrouter";
   /** Reached through the OpenAI-compatible SDK, not a fetch this package owns. */
   public readonly endpoint = undefined;
+  /** The SDK carries the key; `credentialKey` never reaches this request. */
+  public readonly acceptsCredentialKey = false;
   public readonly capabilities: WebSearchCapabilities = {
     answer: true,
-    // Each url_citation carries the excerpt handed to the model.
-    content: true,
+    // A url_citation carries the short excerpt handed to the model, which is
+    // not the page text this port promises. Declaring it would win `"auto"`
+    // routing for an includeContent request and answer it with a snippet.
+    content: false,
     domainFilter: "native",
     dateFilter: false,
     maxResultsCap: undefined,
@@ -122,7 +126,7 @@ export class OpenRouterWebSearchProvider implements IWebSearchProvider {
         title: citation.title ?? citation.url,
         url: citation.url,
         snippet: citation.content,
-        content: request.includeContent === true ? citation.content : undefined,
+        content: undefined,
         publishedDate: undefined,
         score: undefined,
         favicon: undefined,


### PR DESCRIPTION
This stacks onto **#850 (feat(web-search): add WebSearchTask with pluggable search providers)** and targets `claude/websearch-task-providers-8aik77`, so it can be merged into that branch and land as part of the same PR.

Five review findings, each with a test that fails without the fix.

---

## 1. `credential_keys` preferred providers that never receive the key

`route()` moves a provider named in `credential_keys` to the front, and `credentialKeyFor()` puts the key on `request.credentialKey`. None of the four SDK adapters read that field — they resolve from `options.apiKey` or the environment — so naming a key for one of them selected it *because a key existed* and then threw the key away.

Concretely: `provider: "auto"` with `credential_keys: { anthropic: "anthropic-prod" }` preferred anthropic, the adapter discarded the key, and `new Anthropic()` read `ANTHROPIC_API_KEY`. Unset, every run 401s while a usable Tavily key sits behind it. Set to a different account's key, searches are billed there with nothing saying so. The task port and README both promise "the key sent is the one named for the provider that runs".

**Fix.** `IWebSearchProvider` gains `acceptsCredentialKey`: `true` where the owned `FetchUrlTask` attaches the key (brave, tavily), `false` for the four vendor-client adapters and for SearXNG, which deliberately forwards no credential. A key named for a provider that cannot receive one is **refused**, naming where to configure it instead, rather than dropped in silence — for `provider: "auto"` and for a bare `credential_key` pinned to such a provider alike. `AnthropicWebSearchOptions` gains `apiKey`, so the place the error points at exists for Anthropic too (the other three already had it).

## 2. A `credential_keys` name matching nothing was ignored

`route()` filtered registered candidates by name, so an entry matching nothing changed nothing and was reported nowhere — `{ Tavily: "tavily-prod" }` (capital T), or naming `openai` where `registerOpenAiWebSearchProvider()` was never called. The run fell through to brave, went out unauthenticated, and handed the operator a Brave 401 naming Brave, with nothing pointing at the typo or the missing registration.

**Fix.** Both checks live in one `WebSearchProviderRegistry.assertCredentialKeyUsable(name)`, called from the task before routing so the diagnosis arrives instead of the wrong provider's vendor error. An unknown name is refused listing what *is* registered.

The existing "sends no key at all" containment test is kept — it is right about secret containment — but restated so it does not depend on naming a key for an unregistered provider: both providers are registered and the run is pinned to the one no key was named for. A Tavily secret still never reaches Brave.

## 3. Importing any grounded-provider subpath registered Brave, Tavily and SearXNG

The README says the grounded providers "must be registered explicitly — importing the subpath registers nothing". Each adapter value-imports `@workglow/web-search` for `registerWebSearchProvider`/`limitResults`; that resolves to `dist/node.js`, whose module body called `registerBuiltInWebSearchProviders()`. So an app importing `@workglow/anthropic/web-search` and calling only `registerAnthropicWebSearchProvider()` ran `"auto"` straight into Brave (registered first) with no credential, and if `WEB_SEARCH_SEARXNG_URL` happened to be set, a `searxng` provider was registered too and could receive the user's query with nobody having asked.

**Fix.** `src/node.ts` registers the task class and nothing else; built-ins come from an explicit `registerBuiltInWebSearchProviders()`. The registry's "nothing is registered" messages now name that call rather than telling the reader to import the package, and the README's registration section and usage example are updated.

**On the alternative.** The review suggested a side-effect-free `@workglow/web-search/core` for the adapters to import. I did not take that route: with `--packages=external` a second entry is a **second bundle**, so `dist/core.js` and `dist/node.js` would each carry their own copy of the module-singleton `WebSearchProviderRegistry` — an adapter registering into one while the task reads the other. Avoiding that needs either a self-referencing `@workglow/web-search/core` import inside `src/node.ts` (so the root re-exports the core bundle at runtime rather than inlining it) or a globalThis-keyed registry; both are larger, riskier changes than the harm requires. Removing the side effect fixes the reported behaviour outright, and leaves the door open if a side-effect-free entry is wanted later for other reasons.

## 4. OpenRouter over-declared `content`

`SearchResult.content` is "Full page text, when the provider returns it and the caller asked", but the adapter assigned the same short `citation.content` excerpt to both `snippet` and `content` while declaring `content: true`. With `provider: "auto"`, `includeContent: true` and an openrouter key named, routing preferred openrouter, `unhonorableOptions()` found no gap, and the caller got ~200-character excerpts on `results[].content` instead of Tavily's `raw_content`, with no signal the text was truncated — the same shape as `excludeDomainFilter` for OpenAI and `exclusiveDomainDirections` for Anthropic.

**Fix.** `content: false`, and the excerpt is reported only as `snippet`. README table updated.

## 5. `publishedDate` carried display strings through an ISO-8601 port

Brave's `age` is "3 days ago" and Anthropic's `page_age` is "April 30, 2025"; both were assigned straight to `publishedDate`. Brave's actual ISO field, `page_age`, was not read. A graph filtering on recency with `new Date(r.publishedDate) >= cutoff` works for Tavily and SearXNG and silently drops — or, inverted, silently keeps — every Brave and Anthropic row, invisible because the port is heterogeneous by design.

**Fix.** New `toIsoPublishedDate` (exported from the package): normalizes a parseable value to ISO-8601 and returns `undefined` for anything else, so "April 30, 2025" becomes `2025-04-30T00:00:00.000Z` and "3 days ago" becomes absent. Absent means "unknown" and a caller can handle it; a string that means a date but is not one cannot. Brave reads `page_age` first and falls back to `age`, both through the normalizer. The Brave and Anthropic test fixtures now carry what those APIs actually send rather than pre-normalized ISO.

---

## Verification

Run in a worktree at this branch, on **Node 22** (the repo asks for Node 24; nothing here touches `node:sqlite` and nothing failed for environment reasons).

Passed, seen directly:

- `vitest run --project web-search --project anthropic --project openai --project openrouter --project google-gemini` — **174 passed, 19 files**. Baseline on the untouched base branch was 158 passed across 17 files.
- `bun run build:types` — 43/43 packages, clean (this is the typecheck).
- `bun scripts/typecheck-budget.ts --no-build` — `OK (40 packages within budget)`.
- `bunx oxlint --type-aware` over `packages/web-search/src` and the four provider `src` trees — clean.
- `oxfmt --check` over everything touched — clean.
- `vitest run scripts/testDiscovery.test.ts` — 11 passed, and `bun scripts/test.ts --check-sections` reports every test file reachable (the two new test files included).

Each new or rewritten test was run against the unmodified source to confirm it fails without the fix: 8 failures for the credential findings, 3 providers registered where the node-entry test expects none, 2 for OpenRouter's content, 4 for the two date ports.

One test-mechanics note worth knowing: the node-entry test calls `vi.resetModules()` and re-imports into a fresh module graph. Without that it cannot see the side effect at all — something else in the run has already loaded the entry, and the registry is a module singleton, so a plain dynamic import returns the cached module and a cleared registry looks identical to a fixed one. That marker also tags the file `vitest`-only in `testDiscovery`, which is why it is a file of its own rather than another case in `entries.test.ts`.

Not run: the full suite, and no live provider calls (all adapter tests use injected clients).

Not re-reported: per-provider credential delivery on the HTTP path, `maxResults` clamping, abort threading, Brave's open date bound, OpenRouter's key fallback, and SSRF — the earlier review confirmed those are genuinely fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa)_