### PR TITLE
fix(storage): stop connection transactions hanging and leaking uncommitted rows

### DIFF
--- a/packages/storage/src/browser.ts
+++ b/packages/storage/src/browser.ts
@@ -8,11 +8,13 @@
 
 export * from "./common";
 
-// Connection-mutex seam. Everything below except `ConnectionReentryError` is a
+// Connection-mutex seam. Everything below except the error classes
+// (`ConnectionReentryError`, `ConnectionDeadlockError`) is a
 // provider-package internal, versioned in lockstep with this package rather
 // than covered by semver. Application code should use
 // `withConnectionTransaction` instead.
 export {
+  ConnectionDeadlockError,
   ConnectionReentryError,
   /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   getAlsStore,
@@ -20,6 +22,8 @@ export {
   runInTransactionOnConnection,
   /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   runOnConnection,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
+  runReadOnConnection,
 } from "./tabular/ConnectionMutex.browser";
 
 export { _internal } from "./tabular/connectionMutexTestSeam.browser";

--- a/packages/storage/src/common-server.ts
+++ b/packages/storage/src/common-server.ts
@@ -8,13 +8,15 @@
 
 export * from "./common";
 
-// Connection-mutex seam. Everything below except `ConnectionReentryError` and
-// `NestedConnectionTransactionError` is a provider-package internal: the
+// Connection-mutex seam. Everything below except the error classes
+// (`ConnectionReentryError`, `ConnectionDeadlockError`,
+// `NestedConnectionTransactionError`) is a provider-package internal: the
 // vendor storages (`@workglow/sqlite`, `@workglow/postgres`,
 // `@workglow/duckdb`) build their `withConnectionTransaction` support on it
 // and are versioned in lockstep with this package. Application code should use
 // `withConnectionTransaction` instead; these names are not covered by semver.
 export {
+  ConnectionDeadlockError,
   ConnectionReentryError,
   /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   getAlsStore,
@@ -22,6 +24,8 @@ export {
   runInTransactionOnConnection,
   /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
   runOnConnection,
+  /** @internal — provider-package seam for withConnectionTransaction; not covered by semver. */
+  runReadOnConnection,
 } from "./tabular/ConnectionMutex.server";
 
 export { _internal } from "./tabular/connectionMutexTestSeam.server";

--- a/packages/storage/src/tabular/ConnectionMutex.browser.ts
+++ b/packages/storage/src/tabular/ConnectionMutex.browser.ts
@@ -7,10 +7,11 @@
 import { ensureAls, __resetAlsForTesting as resetAlsForTesting } from "./connectionAls.browser";
 import { defineConnectionMutex } from "./defineConnectionMutex";
 
-export { ConnectionReentryError } from "./defineConnectionMutex";
+export { ConnectionDeadlockError, ConnectionReentryError } from "./defineConnectionMutex";
 
 export const {
   runOnConnection,
+  runReadOnConnection,
   runInTransactionOnConnection,
   getAlsStore,
   isSynchronousAls,

--- a/packages/storage/src/tabular/ConnectionMutex.server.ts
+++ b/packages/storage/src/tabular/ConnectionMutex.server.ts
@@ -7,10 +7,11 @@
 import { ensureAls, __resetAlsForTesting as resetAlsForTesting } from "./connectionAls.server";
 import { defineConnectionMutex } from "./defineConnectionMutex";
 
-export { ConnectionReentryError } from "./defineConnectionMutex";
+export { ConnectionDeadlockError, ConnectionReentryError } from "./defineConnectionMutex";
 
 export const {
   runOnConnection,
+  runReadOnConnection,
   runInTransactionOnConnection,
   getAlsStore,
   isSynchronousAls,

--- a/packages/storage/src/tabular/__tests__/ConnectionMutex.test.ts
+++ b/packages/storage/src/tabular/__tests__/ConnectionMutex.test.ts
@@ -5,12 +5,23 @@
  */
 
 import {
+  ConnectionDeadlockError,
   ConnectionReentryError,
   runInTransactionOnConnection,
   runOnConnection,
+  runReadOnConnection,
 } from "@workglow/storage";
 import { __resetAlsForTesting } from "@workglow/storage/test";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/** A promise plus the function that resolves it, for ordering assertions. */
+function latch(): readonly [Promise<void>, () => void] {
+  let open: () => void = () => {};
+  const gate = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return [gate, open] as const;
+}
 
 describe("ConnectionMutex F1: re-entry is classified from the async context", () => {
   afterEach(() => {
@@ -662,5 +673,209 @@ describe("ConnectionMutex F2: ConnectionReentryError message and mode", () => {
     expect(casted.blockedTable).toBeUndefined();
     expect(casted.message).toContain("another storage instance");
     expect(casted.message).toContain("an unlabeled storage instance");
+  });
+});
+
+describe("ConnectionMutex F3: cross-connection wait cycles fail loudly", () => {
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  it("still allows a transaction on a DIFFERENT connection to nest inside an open one", async () => {
+    // The legal case the deadlock check must not break: two connections, one
+    // task, acquired one after the other. Nothing else holds either slot, so
+    // there is no cycle to find and the inner call simply runs.
+    const h1 = {};
+    const h2 = {};
+    const a = { table: "table_a" };
+    const b = { table: "table_b" };
+
+    const order: string[] = [];
+    await runInTransactionOnConnection(h1, a, async () => {
+      order.push("outer");
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      await runInTransactionOnConnection(h2, b, async () => {
+        order.push("inner");
+      });
+      order.push("outer-end");
+    });
+
+    expect(order).toEqual(["outer", "inner", "outer-end"]);
+  });
+
+  it("refuses the second of two tasks that nest two connections in opposite orders", async () => {
+    // Task 1 holds h1 and asks for h2; task 2 holds h2 and asks for h1. Each
+    // classifies the other's connection as "chain" — neither is an async
+    // descendant of the other — so both would wait forever, with no timeout
+    // and no error. Worse, a waiter installs itself as the handle's chain slot
+    // BEFORE awaiting, so both connections would stay poisoned for every later
+    // caller as well.
+    //
+    // One of the two must therefore be refused. Which one is a race the test
+    // does not pin: it asserts exactly one deadlock error, and that whichever
+    // side survived committed.
+    const h1 = {};
+    const h2 = {};
+    const a = { table: "table_a" };
+    const b = { table: "table_b" };
+
+    const [t1Ready, t1Started] = latch();
+    const [t2Ready, t2Started] = latch();
+    const done: string[] = [];
+
+    const t1 = runInTransactionOnConnection(h1, a, async () => {
+      t1Started();
+      await t2Ready;
+      await runInTransactionOnConnection(h2, b, async () => {
+        done.push("t1-inner");
+      });
+    });
+    const t2 = runInTransactionOnConnection(h2, b, async () => {
+      t2Started();
+      await t1Ready;
+      await runInTransactionOnConnection(h1, a, async () => {
+        done.push("t2-inner");
+      });
+    });
+
+    const settled = await Promise.race([
+      Promise.allSettled([t1, t2]),
+      new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 2000)),
+    ]);
+    expect(settled).not.toBe("hung");
+
+    const results = settled as PromiseSettledResult<void>[];
+    const rejections = results.filter((r) => r.status === "rejected");
+    expect(rejections).toHaveLength(1);
+    expect((rejections[0] as PromiseRejectedResult).reason).toBeInstanceOf(ConnectionDeadlockError);
+    // The winner really ran its inner body rather than being unwound too.
+    expect(done).toHaveLength(1);
+  });
+
+  it("leaves both connections usable after refusing the cycle", async () => {
+    // The refusal happens BEFORE the chain slot is replaced, so the loser
+    // poisons nothing. Both handles must still serve an ordinary transaction
+    // afterwards — the property the silent hang destroyed permanently.
+    const h1 = {};
+    const h2 = {};
+    const a = { table: "table_a" };
+    const b = { table: "table_b" };
+
+    const [t1Ready, t1Started] = latch();
+    const [t2Ready, t2Started] = latch();
+
+    await Promise.allSettled([
+      runInTransactionOnConnection(h1, a, async () => {
+        t1Started();
+        await t2Ready;
+        await runInTransactionOnConnection(h2, b, async () => undefined);
+      }),
+      runInTransactionOnConnection(h2, b, async () => {
+        t2Started();
+        await t1Ready;
+        await runInTransactionOnConnection(h1, a, async () => undefined);
+      }),
+    ]);
+
+    await expect(runInTransactionOnConnection(h1, a, async () => "h1-ok")).resolves.toBe("h1-ok");
+    await expect(runInTransactionOnConnection(h2, b, async () => "h2-ok")).resolves.toBe("h2-ok");
+  });
+
+  it("does not refuse a wait on a busy connection that is not waiting back", async () => {
+    // The check is a wait-for CYCLE, not "never wait while holding". Task 1
+    // holds h1 and wants h2; h2 is busy with a task that wants nothing from
+    // h1, so the wait terminates on its own and must be allowed.
+    const h1 = {};
+    const h2 = {};
+    const a = { table: "table_a" };
+    const b = { table: "table_b" };
+
+    const [h2Busy, h2Started] = latch();
+    const [releaseH2, openH2] = latch();
+    const order: string[] = [];
+
+    const holder = runInTransactionOnConnection(h2, b, async () => {
+      h2Started();
+      await releaseH2;
+      order.push("holder-end");
+    });
+    await h2Busy;
+
+    const nesting = runInTransactionOnConnection(h1, a, async () => {
+      await runInTransactionOnConnection(h2, b, async () => {
+        order.push("nested");
+      });
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(order).toEqual([]);
+    openH2();
+    await holder;
+    await nesting;
+
+    expect(order).toEqual(["holder-end", "nested"]);
+  });
+});
+
+describe("ConnectionMutex F4: reads take the chain but are never refused as siblings", () => {
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  it("runs an un-enlisted DESCENDANT read inline where a write would be refused", async () => {
+    // A read commits nothing, so there is no write to strand outside the open
+    // BEGIN — the hazard the sibling-op refusal exists for. Refusing reads
+    // would break every transaction body that reads from a storage its
+    // participant list happens not to name.
+    const handle = {};
+    const enlisted = { table: "enlisted" };
+    const outsider = { table: "outsider" };
+
+    let readResult: string | undefined;
+    let writeError: unknown;
+    await runInTransactionOnConnection(handle, enlisted, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      readResult = await runReadOnConnection(handle, outsider, async () => "read-ran");
+      try {
+        await runOnConnection(handle, outsider, async () => "unreachable");
+      } catch (err) {
+        writeError = err;
+      }
+    });
+
+    expect(readResult).toBe("read-ran");
+    expect(writeError).toBeInstanceOf(ConnectionReentryError);
+  });
+
+  it("queues an UNRELATED concurrent read behind the open transaction", async () => {
+    // The single-session hazard: without the chain this read runs on the very
+    // session the BEGIN is open on and reports rows a ROLLBACK is about to
+    // erase.
+    const handle = {};
+    const owner = { table: "table_a" };
+    const reader = { table: "table_b" };
+
+    const [bodyRunning, bodyStarted] = latch();
+    const [bodyCanFinish, releaseBody] = latch();
+    const order: string[] = [];
+
+    const tx = runInTransactionOnConnection(handle, owner, async () => {
+      bodyStarted();
+      await bodyCanFinish;
+      order.push("commit");
+    });
+    await bodyRunning;
+
+    const read = runReadOnConnection(handle, reader, async () => {
+      order.push("read");
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(order).toEqual([]);
+
+    releaseBody();
+    await tx;
+    await read;
+    expect(order).toEqual(["commit", "read"]);
   });
 });

--- a/packages/storage/src/tabular/defineConnectionMutex.ts
+++ b/packages/storage/src/tabular/defineConnectionMutex.ts
@@ -61,6 +61,13 @@ import type { Als, AlsContext } from "./connectionAls.shared";
  * difference between the runtimes, and it is gated to the runtime that has no
  * better option.
  *
+ * Because an unrelated caller queues rather than being refused, two tasks that
+ * nest two connections in opposite orders can deadlock, and nothing times a
+ * chain slot out. Every queueing caller therefore walks the wait-for graph
+ * recorded in {@link HandleState.waitingOn} first, and a wait that would close
+ * a cycle is refused with {@link ConnectionDeadlockError} before any slot is
+ * replaced.
+ *
  * KNOWN LIMIT of the store-based classification: carrying the store proves a
  * descendant, but *lacking* it does not prove the opposite. A descendant whose
  * continuation is resumed by a scheduler created outside the transaction (a
@@ -90,6 +97,11 @@ interface HandleState {
   chain: Promise<void>;
   txOwners: Set<object> | null;
   txId: symbol | null;
+  /**
+   * The handle this slot's holder is itself blocked acquiring, or `null` while
+   * it runs. One edge of the wait-for graph {@link assertNoWaitCycle} walks.
+   */
+  waitingOn: object | null;
 }
 
 export type TransactionOwners = object | readonly object[];
@@ -180,8 +192,49 @@ export class ConnectionReentryError extends Error {
   }
 }
 
+/**
+ * Thrown when taking a connection's chain slot would close a wait-for cycle,
+ * which nothing would ever break: the chain has no timeout. Refused before the
+ * slot is taken, so both connections stay usable and the winner proceeds.
+ *
+ * Nesting a transaction on a different connection stays legal; only two tasks
+ * doing it in opposite orders at once is refused, and only while the cycle is
+ * real. The message carries the supported refactors.
+ */
+export class ConnectionDeadlockError extends Error {
+  constructor(readonly blockedTable: string | undefined) {
+    const blocked = blockedTable ?? "a storage instance";
+    super(
+      [
+        "Deadlock acquiring a shared database connection.",
+        `${blocked} waited for a connection held by a task that is itself waiting for a connection this one already holds.`,
+        "",
+        "Supported refactors:",
+        "  (a) Acquire the connections in the SAME order in every task that spans two databases.",
+        "  (b) Complete the outer transaction before opening one on the other connection — two databases cannot commit atomically together anyway.",
+        "  (c) Put the participants on one connection so a single withConnectionTransaction covers them.",
+      ].join("\n")
+    );
+    this.name = "ConnectionDeadlockError";
+  }
+}
+
 export interface ConnectionMutexApi {
   readonly runOnConnection: <T>(handle: object, owner: object, fn: () => Promise<T>) => Promise<T>;
+  /**
+   * {@link ConnectionMutexApi.runOnConnection} for a read.
+   *
+   * Differs in one case: an un-enlisted descendant of an open transaction runs
+   * inline rather than being refused, since a read has no write to strand
+   * outside the `BEGIN` and refusing it would break any body reading from a
+   * storage its participant list does not name. Unrelated readers still queue
+   * — otherwise they read uncommitted rows off the shared session.
+   */
+  readonly runReadOnConnection: <T>(
+    handle: object,
+    owner: object,
+    fn: () => Promise<T>
+  ) => Promise<T>;
   readonly runInTransactionOnConnection: <T>(
     handle: object,
     owner: TransactionOwners,
@@ -203,7 +256,7 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
   function getState(handle: object): HandleState {
     let state = handleStates.get(handle);
     if (state === undefined) {
-      state = { chain: Promise.resolve(), txOwners: null, txId: null };
+      state = { chain: Promise.resolve(), txOwners: null, txId: null, waitingOn: null };
       handleStates.set(handle, state);
     }
     return state;
@@ -289,6 +342,85 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
   }
 
   /**
+   * The handles whose chain slot this async context already holds.
+   *
+   * Only a transaction holds a slot across user code, and it installs a store,
+   * so the store chain is the whole answer. Empty under the synchronous shim
+   * once the body has awaited — hence detection is Node/Bun only, and the shim
+   * keeps its existing conservative refusals.
+   */
+  function heldHandles(store: Als): Set<object> {
+    const held = new Set<object>();
+    for (let ctx = store.getStore(); ctx !== undefined; ctx = ctx.parent) {
+      if (ctx.active) held.add(ctx.handle);
+    }
+    return held;
+  }
+
+  /**
+   * Refuses to wait on `target` when doing so would close a wait-for cycle.
+   *
+   * Follows {@link HandleState.waitingOn} from `target`; reaching a handle in
+   * `held` means the far end is transitively waiting on us. This check and the
+   * {@link markWaiting} after it are synchronous, so of two tasks forming a
+   * cycle the second always sees the first's marker: exactly one is refused.
+   */
+  function assertNoWaitCycle(target: object, held: ReadonlySet<object>, owner: object): void {
+    if (held.size === 0) return;
+    const seen = new Set<object>();
+    let next: object | undefined = target;
+    while (next !== undefined) {
+      if (held.has(next)) throw new ConnectionDeadlockError(connectionOwnerLabel(owner));
+      // A cycle that does not run through us belongs to the tasks in it; they
+      // have already refused each other, and following it further would spin.
+      if (seen.has(next)) return;
+      seen.add(next);
+      next = handleStates.get(next)?.waitingOn ?? undefined;
+    }
+  }
+
+  /**
+   * Records (or clears) what the holder of each `held` slot is waiting for.
+   *
+   * Last writer wins, so a context waiting on two connections at once records
+   * only the later wait and a cycle through the other goes unseen. That costs
+   * a missed detection, never a false one.
+   */
+  function markWaiting(held: ReadonlySet<object>, target: object | null): void {
+    for (const handle of held) {
+      const state = handleStates.get(handle);
+      if (state !== undefined) state.waitingOn = target;
+    }
+  }
+
+  /**
+   * Takes `handle`'s chain slot, returning the release callback. Every queueing
+   * caller goes through here so the cycle check cannot be applied to one entry
+   * point and forgotten on the other.
+   */
+  async function acquireChainSlot(
+    state: HandleState,
+    handle: object,
+    owner: object,
+    store: Als
+  ): Promise<() => void> {
+    const held = heldHandles(store);
+    assertNoWaitCycle(handle, held, owner);
+    markWaiting(held, handle);
+    const prev = state.chain;
+    let release!: () => void;
+    state.chain = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    try {
+      await prev;
+    } finally {
+      markWaiting(held, null);
+    }
+    return release;
+  }
+
+  /**
    * Runs `fn` in a chain shared across every caller bound to `handle`.
    *
    * An enlisted descendant of an open transaction body runs `fn` inline —
@@ -305,36 +437,38 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
    * dies at the body's first `await`, falls back to handle state and refuses
    * every un-enlisted owner while a transaction is open — the conservative
    * side of a distinction it cannot make.
+   *
+   * Only {@link runReadOnConnection} passes `refuseUnenlistedDescendant: false`.
    */
   async function runOnConnection<T>(
     handle: object,
     owner: object,
-    fn: () => Promise<T>
+    fn: () => Promise<T>,
+    refuseUnenlistedDescendant: boolean = true
   ): Promise<T> {
     const state = getState(handle);
     const store = als.ensureAls();
     const { decision, enlisted } = classifyReentry(state, new Set([owner]), handle, store);
-    if (decision === "throw") {
+    if (decision === "throw" && refuseUnenlistedDescendant) {
       throw new ConnectionReentryError(
         connectionOwnerLabel(enlisted !== undefined ? leadOwner(enlisted) : owner),
         connectionOwnerLabel(owner),
         "sibling-op"
       );
     }
-    if (decision === "inline") {
+    if (decision !== "chain") {
       return fn();
     }
-    const prev = state.chain;
-    let release!: () => void;
-    state.chain = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    await prev;
+    const release = await acquireChainSlot(state, handle, owner, store);
     try {
       return await fn();
     } finally {
       release();
     }
+  }
+
+  function runReadOnConnection<T>(handle: object, owner: object, fn: () => Promise<T>): Promise<T> {
+    return runOnConnection(handle, owner, fn, false);
   }
 
   /**
@@ -397,12 +531,7 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
       // downstream error instead of deadlocking here.
       return fn();
     }
-    const prev = state.chain;
-    let release!: () => void;
-    state.chain = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    await prev;
+    const release = await acquireChainSlot(state, handle, lead, store);
     const txId = Symbol("connection-tx");
     state.txId = txId;
     state.txOwners = owners;
@@ -437,7 +566,8 @@ export function defineConnectionMutex(als: ConnectionAlsApi): ConnectionMutexApi
   }
 
   return {
-    runOnConnection,
+    runOnConnection: (handle, owner, fn) => runOnConnection(handle, owner, fn),
+    runReadOnConnection,
     runInTransactionOnConnection,
     getAlsStore: () => als.ensureAls().getStore(),
     isSynchronousAls: () => als.ensureAls().synchronousOnly === true,

--- a/packages/test/src/contract/tabular-storage/assertions/withConnectionTransaction.ts
+++ b/packages/test/src/contract/tabular-storage/assertions/withConnectionTransaction.ts
@@ -168,6 +168,59 @@ export function withConnectionTransactionBlock(opts: TabularStorageContractOpts)
     );
 
     itImpl(
+      "does not show uncommitted rows to a concurrent reader",
+      async () => {
+        // A connection transaction takes the CONNECTION's chain slot and flags
+        // its participants; reads used to take only the per-instance mutex,
+        // which the transaction never holds. The two locks never intersected,
+        // so on a single-session backend a concurrent read ran on the very
+        // session sitting inside the open BEGIN and returned rows the ROLLBACK
+        // below erases — a caller could act on a ban, a balance or a lock that
+        // never existed.
+        //
+        // How a backend keeps the reader honest is its business: the
+        // single-session ones queue the read behind COMMIT, a real pool hands
+        // it another client and answers at once. Both must report the
+        // committed value, which is the pre-transaction one here.
+        await primary.put({ name: "iso", type: "x", option: "before", success: true });
+
+        let releaseBody: () => void = () => {};
+        const bodyCanFinish = new Promise<void>((resolve) => {
+          releaseBody = resolve;
+        });
+        let signalStarted: () => void = () => {};
+        const bodyStarted = new Promise<void>((resolve) => {
+          signalStarted = resolve;
+        });
+
+        let rollbackError: unknown;
+        const txPromise = withConnectionTransaction([primary, sibling], async () => {
+          await primary.put({ name: "iso", type: "x", option: "dirty", success: true });
+          signalStarted();
+          await bodyCanFinish;
+          throw new Error("forced rollback");
+        }).catch((err: unknown) => {
+          rollbackError = err;
+        });
+        await bodyStarted;
+
+        // Issued from the test's own task, so it is not an async descendant of
+        // the body — the caller the transaction is supposed to be invisible to.
+        const readPromise = primary.get({ name: "iso", type: "x" });
+        // Long enough that a read which is NOT held back has finished.
+        await new Promise((resolve) => setTimeout(resolve, 25));
+
+        releaseBody();
+        await txPromise;
+        expect((rollbackError as Error | undefined)?.message).toBe("forced rollback");
+
+        expect(await readPromise).toMatchObject({ option: "before" });
+        expect(await primary.get({ name: "iso", type: "x" })).toMatchObject({ option: "before" });
+      },
+      opts.timeout
+    );
+
+    itImpl(
       "throws sibling-op for a storage that was not enlisted",
       async () => {
         let error: unknown;

--- a/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
@@ -529,16 +529,28 @@ describe("SqliteTabularStorage shared-connection safety", () => {
         siblingErr = err;
       });
 
+    // An unrelated concurrent READ on the same connection, also queued rather
+    // than run: it would otherwise execute on the same session inside the open
+    // BEGIN and report whatever the transaction has written so far.
+    let readSettled = false;
+    const concurrentRead = b.get({ name: "sibling-row", type: "x" }).then((row) => {
+      readSettled = true;
+      return row;
+    });
+
     await new Promise((resolve) => setTimeout(resolve, 20));
-    // Neither refused nor slipped inside the open BEGIN: reads do not take the
-    // chain, so this observes the row's absence directly.
+    // Neither refused nor slipped inside the open BEGIN. The sibling write has
+    // not landed, and the sibling read has not answered.
     expect(siblingErr).toBeUndefined();
     expect(order).toEqual([]);
-    expect(await b.get({ name: "sibling-row", type: "x" })).toBeUndefined();
+    expect(readSettled).toBe(false);
 
     releaseInner();
     await txPromise;
     await sibling;
+    // The read ran after COMMIT released the connection, so it sees the
+    // sibling write that was queued ahead of it.
+    expect(await concurrentRead).toBeDefined();
 
     expect(siblingErr).toBeUndefined();
     expect(order).toEqual(["TX-BODY-END", "SIBLING-WRITE"]);

--- a/providers/duckdb/src/storage/DuckDbTabularStorage.ts
+++ b/providers/duckdb/src/storage/DuckDbTabularStorage.ts
@@ -36,6 +36,7 @@ import {
   pickCoveringIndex,
   runInTransactionOnConnection,
   runOnConnection,
+  runReadOnConnection,
   runSingleSessionConnectionTransaction,
   safeEmit,
   SqlTabularMigrationApplier,
@@ -191,6 +192,15 @@ export class DuckDbTabularStorage<
    */
   private guardedWrite<T>(fn: () => Promise<T>): Promise<T> {
     return runOnConnection(this.connectionHandle(), this, () => this.mutex(fn));
+  }
+
+  /**
+   * Chain first, then this instance's mutex — the order {@link guardedWrite}
+   * uses. A connection transaction holds the chain, not the mutex, so a read
+   * taking only the mutex read uncommitted rows off the shared session.
+   */
+  private guardedRead<T>(fn: () => Promise<T>): Promise<T> {
+    return runReadOnConnection(this.connectionHandle(), this, () => this.mutex(fn));
   }
 
   /**
@@ -884,7 +894,7 @@ export class DuckDbTabularStorage<
    * @emits "get" event with the key when successful
    */
   async get(key: PrimaryKey): Promise<Entity | undefined> {
-    return this.mutex(() => this._getInternal(key));
+    return this.guardedRead(() => this._getInternal(key));
   }
 
   private async _getInternal(key: PrimaryKey): Promise<Entity | undefined> {
@@ -922,12 +932,12 @@ export class DuckDbTabularStorage<
     const chunkSize = Math.max(1, Math.floor(30000 / pkColCount));
     let rows: Entity[];
     if (keys.length <= chunkSize) {
-      rows = await this.mutex(() => this._getBulkInternal(keys));
+      rows = await this.guardedRead(() => this._getBulkInternal(keys));
     } else {
       rows = [];
       for (let i = 0; i < keys.length; i += chunkSize) {
         const chunk = keys.slice(i, i + chunkSize);
-        const chunkRows = await this.mutex(() => this._getBulkInternal(chunk));
+        const chunkRows = await this.guardedRead(() => this._getBulkInternal(chunk));
         rows.push(...chunkRows);
       }
     }
@@ -999,7 +1009,7 @@ export class DuckDbTabularStorage<
    * @returns Promise resolving to an array of entries or undefined if not found
    */
   async getAll(options?: QueryOptions<Entity>): Promise<Entity[] | undefined> {
-    return this.mutex(() => this._getAllInternal(options));
+    return this.guardedRead(() => this._getAllInternal(options));
   }
 
   /**
@@ -1060,7 +1070,7 @@ export class DuckDbTabularStorage<
    * Returns the total number of rows in the database.
    */
   async size(): Promise<number> {
-    return this.mutex(() => this._sizeInternal());
+    return this.guardedRead(() => this._sizeInternal());
   }
 
   private async _sizeInternal(): Promise<number> {
@@ -1075,7 +1085,7 @@ export class DuckDbTabularStorage<
    * Counts rows matching the specified search criteria.
    */
   override async count(criteria?: SearchCriteria<Entity>): Promise<number> {
-    return this.mutex(() => this._countInternal(criteria));
+    return this.guardedRead(() => this._countInternal(criteria));
   }
 
   private async _countInternal(criteria?: SearchCriteria<Entity>): Promise<number> {
@@ -1100,7 +1110,7 @@ export class DuckDbTabularStorage<
    * @returns Array of entities or undefined if no records found
    */
   async getOffsetPage(offset: number, limit: number): Promise<Entity[] | undefined> {
-    return this.mutex(() => this._getOffsetPageInternal(offset, limit));
+    return this.guardedRead(() => this._getOffsetPageInternal(offset, limit));
   }
 
   private async _getOffsetPageInternal(
@@ -1166,12 +1176,12 @@ export class DuckDbTabularStorage<
   /**
    * Cursor-paginated read with keyset predicates pushed into SQL.
    *
-   * Goes through the per-instance mutex so a `getPage` call issued while a
-   * `withTransaction` is in flight queues behind the transaction instead of
-   * running between its `BEGIN` and `COMMIT` on the shared connection.
+   * Goes through {@link guardedRead} so a `getPage` call issued while a
+   * transaction is in flight queues behind it instead of running between that
+   * transaction's `BEGIN` and `COMMIT` on the shared connection.
    */
   override async getPage(request: PageRequest<Entity> = {}): Promise<Page<Entity>> {
-    return this.mutex(() => this._getPageInternal(request));
+    return this.guardedRead(() => this._getPageInternal(request));
   }
 
   private async _getPageInternal(request: PageRequest<Entity> = {}): Promise<Page<Entity>> {
@@ -1182,7 +1192,7 @@ export class DuckDbTabularStorage<
     criteria: SearchCriteria<Entity>,
     request: PageRequest<Entity> = {}
   ): Promise<Page<Entity>> {
-    return this.mutex(() => this._queryPageInternal(criteria, request));
+    return this.guardedRead(() => this._queryPageInternal(criteria, request));
   }
 
   private async _queryPageInternal(
@@ -1295,7 +1305,7 @@ export class DuckDbTabularStorage<
     criteria: SearchCriteria<Entity>,
     options?: QueryOptions<Entity>
   ): Promise<Entity[] | undefined> {
-    return this.mutex(() => this._queryInternal(criteria, options));
+    return this.guardedRead(() => this._queryInternal(criteria, options));
   }
 
   private async _queryInternal(
@@ -1347,7 +1357,7 @@ export class DuckDbTabularStorage<
     criteria: SearchCriteria<Entity>,
     options: CoveringIndexQueryOptions<Entity, K>
   ): Promise<Pick<Entity, K>[]> {
-    return this.mutex(() => this._queryIndexInternal(criteria, options));
+    return this.guardedRead(() => this._queryIndexInternal(criteria, options));
   }
 
   private async _queryIndexInternal<K extends keyof Entity & string>(

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -42,6 +42,7 @@ import {
   runInTransactionOnConnection,
   runNativeConnectionTransaction,
   runOnConnection,
+  runReadOnConnection,
   runSingleSessionConnectionTransaction,
   safeEmit,
   setConnectionTxQuery,
@@ -922,6 +923,23 @@ export class PostgresTabularStorage<
     return this.mutex(fn);
   }
 
+  /**
+   * Chain first, then this instance's mutex — the order {@link guardedWrite}
+   * uses. A connection transaction holds the chain, not the mutex, so a read
+   * taking only the mutex read uncommitted rows off the shared session.
+   *
+   * A real `pg.Pool` has no shared handle and needs none: each read checks out
+   * its own client and sees only committed rows, which is also why this skips
+   * the `assertNotForeignConnectionTx` guard `guardedWrite` needs.
+   */
+  protected guardedRead<T>(fn: () => Promise<T>): Promise<T> {
+    const handle = this.connectionHandle();
+    if (handle !== null) {
+      return runReadOnConnection(handle, this, () => this.mutex(fn));
+    }
+    return this.mutex(fn);
+  }
+
   async runConnectionTransaction<T>(
     participants: readonly AnyTabularStorage[],
     fn: () => Promise<T>
@@ -1278,7 +1296,7 @@ export class PostgresTabularStorage<
    * @emits "get" event with the key when successful
    */
   async get(key: PrimaryKey): Promise<Entity | undefined> {
-    return this.mutex(() => this._getInternal(key));
+    return this.guardedRead(() => this._getInternal(key));
   }
 
   private async _getInternal(key: PrimaryKey): Promise<Entity | undefined> {
@@ -1335,12 +1353,12 @@ export class PostgresTabularStorage<
         : Math.max(1, Math.min(COMPOUND_IN_TUPLE_LIMIT, Math.floor(30000 / pkColCount)));
     let rows: Entity[];
     if (keys.length <= chunkSize) {
-      rows = await this.mutex(() => this._getBulkInternal(keys));
+      rows = await this.guardedRead(() => this._getBulkInternal(keys));
     } else {
       rows = [];
       for (let i = 0; i < keys.length; i += chunkSize) {
         const chunk = keys.slice(i, i + chunkSize);
-        const chunkRows = await this.mutex(() => this._getBulkInternal(chunk));
+        const chunkRows = await this.guardedRead(() => this._getBulkInternal(chunk));
         rows.push(...chunkRows);
       }
     }
@@ -1417,7 +1435,7 @@ export class PostgresTabularStorage<
    * @returns Promise resolving to an array of entries or undefined if not found
    */
   async getAll(options?: QueryOptions<Entity>): Promise<Entity[] | undefined> {
-    return this.mutex(() => this._getAllInternal(options));
+    return this.guardedRead(() => this._getAllInternal(options));
   }
 
   private async _getAllInternal(options?: QueryOptions<Entity>): Promise<Entity[] | undefined> {
@@ -1480,7 +1498,7 @@ export class PostgresTabularStorage<
    * @returns Promise resolving to the count of stored items
    */
   async size(): Promise<number> {
-    return this.mutex(() => this._sizeInternal());
+    return this.guardedRead(() => this._sizeInternal());
   }
 
   private async _sizeInternal(): Promise<number> {
@@ -1493,7 +1511,7 @@ export class PostgresTabularStorage<
    * Counts rows matching the specified search criteria.
    */
   override async count(criteria?: SearchCriteria<Entity>): Promise<number> {
-    return this.mutex(() => this._countInternal(criteria));
+    return this.guardedRead(() => this._countInternal(criteria));
   }
 
   private async _countInternal(criteria?: SearchCriteria<Entity>): Promise<number> {
@@ -1518,7 +1536,7 @@ export class PostgresTabularStorage<
    * @returns Array of entities or undefined if no records found
    */
   async getOffsetPage(offset: number, limit: number): Promise<Entity[] | undefined> {
-    return this.mutex(() => this._getOffsetPageInternal(offset, limit));
+    return this.guardedRead(() => this._getOffsetPageInternal(offset, limit));
   }
 
   private async _getOffsetPageInternal(
@@ -1585,7 +1603,7 @@ export class PostgresTabularStorage<
    * and run on the transaction-bound `db`.
    */
   override async getPage(request: PageRequest<Entity> = {}): Promise<Page<Entity>> {
-    return this.mutex(() => this._getPageInternal(request));
+    return this.guardedRead(() => this._getPageInternal(request));
   }
 
   private async _getPageInternal(request: PageRequest<Entity>): Promise<Page<Entity>> {
@@ -1596,7 +1614,7 @@ export class PostgresTabularStorage<
     criteria: SearchCriteria<Entity>,
     request: PageRequest<Entity> = {}
   ): Promise<Page<Entity>> {
-    return this.mutex(() => this._queryPageInternal(criteria, request));
+    return this.guardedRead(() => this._queryPageInternal(criteria, request));
   }
 
   private async _queryPageInternal(
@@ -1769,7 +1787,7 @@ export class PostgresTabularStorage<
     criteria: SearchCriteria<Entity>,
     options?: QueryOptions<Entity>
   ): Promise<Entity[] | undefined> {
-    return this.mutex(() => this._queryInternal(criteria, options));
+    return this.guardedRead(() => this._queryInternal(criteria, options));
   }
 
   private async _queryInternal(
@@ -1827,7 +1845,7 @@ export class PostgresTabularStorage<
     criteria: SearchCriteria<Entity>,
     options: CoveringIndexQueryOptions<Entity, K>
   ): Promise<Pick<Entity, K>[]> {
-    return this.mutex(() => this._queryIndexInternal(criteria, options));
+    return this.guardedRead(() => this._queryIndexInternal(criteria, options));
   }
 
   private async _queryIndexInternal<K extends keyof Entity & string>(

--- a/providers/sqlite/src/storage/SqliteTabularStorage.ts
+++ b/providers/sqlite/src/storage/SqliteTabularStorage.ts
@@ -34,6 +34,7 @@ import {
   pickCoveringIndex,
   runInTransactionOnConnection,
   runOnConnection,
+  runReadOnConnection,
   runSingleSessionConnectionTransaction,
   safeEmit,
   SqliteDialect,
@@ -102,6 +103,19 @@ export class SqliteTabularStorage<
     const handle = this.connectionHandle();
     if (handle !== null) {
       return runOnConnection(handle, this, () => this.mutex(fn));
+    }
+    return this.mutex(fn);
+  }
+
+  /**
+   * Chain first, then this instance's mutex — the order {@link guardedWrite}
+   * uses. A connection transaction holds the chain, not the mutex, so a read
+   * taking only the mutex read uncommitted rows off the shared session.
+   */
+  protected guardedRead<T>(fn: () => Promise<T>): Promise<T> {
+    const handle = this.connectionHandle();
+    if (handle !== null) {
+      return runReadOnConnection(handle, this, () => this.mutex(fn));
     }
     return this.mutex(fn);
   }
@@ -963,7 +977,7 @@ export class SqliteTabularStorage<
    * @emits 'get' event when successful
    */
   async get(key: PrimaryKey): Promise<Entity | undefined> {
-    return this.mutex(() => this._getInternal(key));
+    return this.guardedRead(() => this._getInternal(key));
   }
 
   private async _getInternal(key: PrimaryKey): Promise<Entity | undefined> {
@@ -1008,12 +1022,12 @@ export class SqliteTabularStorage<
     const chunkSize = Math.max(1, Math.floor(900 / pkColCount));
     let rows: Entity[];
     if (keys.length <= chunkSize) {
-      rows = await this.mutex(() => this._getBulkInternal(keys));
+      rows = await this.guardedRead(() => this._getBulkInternal(keys));
     } else {
       rows = [];
       for (let i = 0; i < keys.length; i += chunkSize) {
         const chunk = keys.slice(i, i + chunkSize);
-        const chunkRows = await this.mutex(() => this._getBulkInternal(chunk));
+        const chunkRows = await this.guardedRead(() => this._getBulkInternal(chunk));
         rows.push(...chunkRows);
       }
     }
@@ -1084,7 +1098,7 @@ export class SqliteTabularStorage<
    * @returns Promise resolving to an array of entries or undefined if not found
    */
   async getAll(options?: QueryOptions<Entity>): Promise<Entity[] | undefined> {
-    return this.mutex(() => this._getAllInternal(options));
+    return this.guardedRead(() => this._getAllInternal(options));
   }
 
   private async _getAllInternal(options?: QueryOptions<Entity>): Promise<Entity[] | undefined> {
@@ -1147,7 +1161,7 @@ export class SqliteTabularStorage<
    * @returns The count of entries
    */
   async size(): Promise<number> {
-    return this.mutex(() => this._sizeInternal());
+    return this.guardedRead(() => this._sizeInternal());
   }
 
   private async _sizeInternal(): Promise<number> {
@@ -1162,7 +1176,7 @@ export class SqliteTabularStorage<
    * Counts rows matching the specified search criteria.
    */
   override async count(criteria?: SearchCriteria<Entity>): Promise<number> {
-    return this.mutex(() => this._countInternal(criteria));
+    return this.guardedRead(() => this._countInternal(criteria));
   }
 
   private async _countInternal(criteria?: SearchCriteria<Entity>): Promise<number> {
@@ -1186,7 +1200,7 @@ export class SqliteTabularStorage<
    * @returns Array of entities or undefined if no records found
    */
   async getOffsetPage(offset: number, limit: number): Promise<Entity[] | undefined> {
-    return this.mutex(() => this._getOffsetPageInternal(offset, limit));
+    return this.guardedRead(() => this._getOffsetPageInternal(offset, limit));
   }
 
   private async _getOffsetPageInternal(
@@ -1222,16 +1236,16 @@ export class SqliteTabularStorage<
    * `LIMIT N` plus a row-value-style WHERE so the database returns at most
    * one page worth of rows regardless of table size.
    *
-   * Goes through the per-instance mutex so a `getPage` call issued while a
-   * `withTransaction` is in flight queues behind the transaction instead of
-   * firing a `prepare`/`stmt.all` against the shared connection between the
+   * Goes through {@link guardedRead} so a `getPage` call issued while a
+   * transaction is in flight queues behind it instead of firing a
+   * `prepare`/`stmt.all` against the shared connection between that
    * transaction's `BEGIN` and `COMMIT`. The proxy returned by
    * {@link createTxView} routes back to {@link _getPageInternal} directly,
-   * so calls made *through* the `tx` handle bypass the mutex (which the
-   * transaction already holds) and run on the same connection.
+   * so calls made *through* the `tx` handle bypass both locks and run on the
+   * same connection.
    */
   override async getPage(request: PageRequest<Entity> = {}): Promise<Page<Entity>> {
-    return this.mutex(() => this._getPageInternal(request));
+    return this.guardedRead(() => this._getPageInternal(request));
   }
 
   private async _getPageInternal(request: PageRequest<Entity>): Promise<Page<Entity>> {
@@ -1242,7 +1256,7 @@ export class SqliteTabularStorage<
     criteria: SearchCriteria<Entity>,
     request: PageRequest<Entity> = {}
   ): Promise<Page<Entity>> {
-    return this.mutex(() => this._queryPageInternal(criteria, request));
+    return this.guardedRead(() => this._queryPageInternal(criteria, request));
   }
 
   private async _queryPageInternal(
@@ -1422,7 +1436,7 @@ export class SqliteTabularStorage<
     criteria: SearchCriteria<Entity>,
     options?: QueryOptions<Entity>
   ): Promise<Entity[] | undefined> {
-    return this.mutex(() => this._queryInternal(criteria, options));
+    return this.guardedRead(() => this._queryInternal(criteria, options));
   }
 
   private async _queryInternal(
@@ -1484,7 +1498,7 @@ export class SqliteTabularStorage<
     criteria: SearchCriteria<Entity>,
     options: CoveringIndexQueryOptions<Entity, K>
   ): Promise<Pick<Entity, K>[]> {
-    return this.mutex(() => this._queryIndexInternal(criteria, options));
+    return this.guardedRead(() => this._queryIndexInternal(criteria, options));
   }
 
   private async _queryIndexInternal<K extends keyof Entity & string>(


### PR DESCRIPTION
Two defects in `withConnectionTransaction` on the single-session backends (SQLite,
Postgres/PGlite, DuckDB). Both were reproduced against `main` before the fix.

## Problem 1 — a cross-connection lock cycle hung forever, permanently

Nesting a transaction on a *different* connection inside an open one is supported, and
an unrelated concurrent caller queues on the chain rather than being refused. Together
those make a classic lock-order cycle expressible:

```ts
// task 1
await withConnectionTransaction([a], async () => {          // holds H1
  await withConnectionTransaction([b], async () => { … });   // wants H2
});
// task 2, concurrently
await withConnectionTransaction([b], async () => {          // holds H2
  await withConnectionTransaction([a], async () => { … });   // wants H1
});
```

Neither inner call is an async descendant of the other, so both classify as `"chain"`
and wait. Nothing times a chain slot out, and a waiter installs itself as
`state.chain` **before** awaiting — so the pair hangs with no error, and both
connections stay poisoned for every later read-modify-write on either database.
Reproduced on `main` with two SQLite handles: the pair never settles.

## Fix 1 — wait-for cycle detection

`HandleState.waitingOn` records what the holder of each slot is itself blocked
acquiring. Every caller about to queue walks that wait-for graph from the handle it
wants; a wait that would close a cycle back onto a connection this async context
already holds is refused with a new `ConnectionDeadlockError`.

- The check and the marker write are synchronous, so of two tasks forming a cycle the
  second to arrive always observes the first's marker — exactly one is refused, never
  both and never neither.
- The refusal happens **before** the chain slot is replaced, so nothing is poisoned:
  the loser unwinds, releases the slot it does hold, and the winner proceeds and
  commits.
- It is a cycle check, not "never wait while holding": waiting on a busy connection
  whose holder is not waiting back is still allowed and still queues.
- Under the browser ALS shim the store is gone after the body's first `await`, so
  nothing is detected there — same behaviour as today, and noted in the module docs.

## Problem 2 — concurrent readers saw uncommitted rows

A connection transaction takes the *connection's* chain slot and flags its
participants. Reads (`get`, `getBulk`, `getAll`, `getPage`, `queryPage`, `query`,
`queryIndex`, `count`, `size`) took *only* the per-instance mutex, which the
transaction never holds. The two locks never intersected, so on a single-session
backend a read from another task ran on the very session inside the open `BEGIN`:

```ts
withConnectionTransaction([users, audit], async () => {
  await users.put({ id: 1, banned: true });
  throw new Error("…");             // → ROLLBACK
});
await users.get({ id: 1 });         // returned the banned row that never existed
```

The instance-level `withTransaction` never had this gap — it holds the instance mutex
for the whole body, which is why `getPage`'s own comment claimed reads queue behind a
transaction.

## Fix 2 — reads take the connection chain

The three SQL backends gain `guardedRead`: connection chain first, then instance mutex
— the same order `guardedWrite` already uses, so a read and a write can never take the
two locks in opposite orders. Every read entry point routes through it.

Reads use a new `runReadOnConnection`, which differs from `runOnConnection` in exactly
one case: a **descendant** of an open transaction body whose owner the transaction
never enlisted runs *inline* instead of being refused with `sibling-op`. The refusal
exists because such a caller's *write* would land inside a `BEGIN` it can neither
commit nor roll back; a read commits nothing, and refusing it would newly break every
transaction body that reads from a storage its participant list happens not to name.
An unrelated concurrent reader still queues, which is the fix.

A real `pg.Pool` is unaffected: `connectionHandle()` is null there, each read checks
out its own client and already sees only committed rows.

### Behaviour change worth calling out

An unrelated concurrent read on a shared connection now **waits** for an open
transaction instead of running immediately. One existing SQLite test asserted the old
behaviour explicitly ("reads do not take the chain, so this observes the row's absence
directly"); it is updated to assert the read queues and then answers with the
committed state.

## Verification

Ran on Node 22 (this environment); the repo targets Node 24, so `node:sqlite` runs
behind its experimental flag here. SQLite- and PGlite-backed suites nonetheless ran
clean.

- Both defects reproduced on unmodified `main`: the cross-connection pair never settled
  (1.5 s race guard fired), and the concurrent read returned `"dirty"`.
- The new contract assertion was confirmed **red before the fix** on SQLite and DuckDB
  and green after; Postgres/PGlite green after.
- `--project storage --project test packages/storage packages/test/src/test/storage-tabular/`
  (integration tier on): **2055 passed, 98 skipped, 0 failed**.
- Also clean after the change: `storage-kv`, `storage-migrations`, `storage-text`,
  `storage-util`, `storage-vector`, `vector` (275 passed); `job-queue`,
  `task-graph-output-cache`, `task-graph-job-queue` (512 passed);
  `tabular-migrations`, `task-graph-cache`, `task-graph-storage`, `ai-model`,
  `resource`, `trigger` (346 passed).
- `bunx oxlint` across the repo: exit 0. `oxfmt --check` on the touched trees: the only
  reported files are pre-existing unformatted READMEs and a test fixture, none of them
  touched here. Full `bun run lint` (which builds types first) and the full test suite
  were not run.
- Not exercised here: the browser ALS shim path (deadlock detection is inert there by
  design) and a real multi-client `pg.Pool` (no server available in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzfrDJo5BQKYksybxeQBsa)_