### PR TITLE
Price non-token-billed models as undefined, not borrowed

### DIFF
--- a/examples/cli/src/test/lookupModelPricing.test.ts
+++ b/examples/cli/src/test/lookupModelPricing.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { estimateCost, getGlobalModelRepository } from "@workglow/ai";
+import { estimateCost, getAiProviderRegistry, getGlobalModelRepository } from "@workglow/ai";
 import { afterEach, describe, expect, it } from "vitest";
 import { clearModelPricingCache, lookupModelPricing } from "../ui/rows/lookupModelPricing";
 
@@ -16,14 +16,22 @@ const TIERED_MODEL_ID = "gemini-3.1-pro-preview";
 // An OpenRouter route whose id is exactly what OpenAI's table strips a prefix
 // from, which is what made the fall-through report a wrong number as a cost.
 const ROUTED_MODEL_ID = "openai/gpt-4o";
+const QUOTED_MODEL_ID = "anthropic/claude-sonnet-5";
 
 describe("lookupModelPricing", () => {
   // The model repository is a process-wide singleton, so a record added here
   // outlives the file unless it is removed again.
   afterEach(async () => {
     clearModelPricingCache();
+    getAiProviderRegistry().unregisterProvider("OPENROUTER");
     // `removeModel` throws when the id is absent, which most cases here are.
-    for (const id of [TEST_MODEL_ID, TABLE_MODEL_ID, TIERED_MODEL_ID, ROUTED_MODEL_ID]) {
+    for (const id of [
+      TEST_MODEL_ID,
+      TABLE_MODEL_ID,
+      TIERED_MODEL_ID,
+      ROUTED_MODEL_ID,
+      QUOTED_MODEL_ID,
+    ]) {
       await getGlobalModelRepository()
         .removeModel(id)
         .catch(() => {});
@@ -160,6 +168,49 @@ describe("lookupModelPricing", () => {
     // whose per-token rate the package's own comment says a caller cannot
     // reconstruct locally. A provider that declines is asserting "no card", not
     // referring the question on.
+    await getGlobalModelRepository().addModel({
+      model_id: ROUTED_MODEL_ID,
+      title: "gpt-4o via OpenRouter",
+      description: "routed",
+      provider: "OPENROUTER",
+      capabilities: ["text.generation"],
+      provider_config: { model_name: ROUTED_MODEL_ID },
+      metadata: {},
+    });
+
+    expect(await lookupModelPricing(ROUTED_MODEL_ID)).toBeUndefined();
+  });
+
+  it("returns a registered provider's own card for a record naming it", async () => {
+    // The other half of the rule: a provider that ANSWERS is answered from,
+    // rather than the id's shape. Exercises the registered path, which the
+    // unregistered case below reaches `undefined` through a different branch.
+    getAiProviderRegistry().registerProvider({
+      name: "OPENROUTER",
+      modelPricing: () => ({ currency: "USD", input: 2.5, output: 10 }),
+    } as never);
+    await getGlobalModelRepository().addModel({
+      model_id: QUOTED_MODEL_ID,
+      title: "quoted route",
+      description: "routed",
+      provider: "OPENROUTER",
+      capabilities: ["text.generation"],
+      provider_config: { model_name: QUOTED_MODEL_ID },
+      metadata: {},
+    });
+
+    expect(await lookupModelPricing(QUOTED_MODEL_ID)).toMatchObject({ input: 2.5, output: 10 });
+  });
+
+  it("does not fall through to a vendor table when a registered provider declines", async () => {
+    // The assertion the fix is actually about: `openai/gpt-4o` is exactly the
+    // shape OpenAI's table strips a prefix from, so before the fix a declining
+    // OpenRouter provider handed the question on and got OpenAI's list rates
+    // back — reported as a cost for a route billed by someone else.
+    getAiProviderRegistry().registerProvider({
+      name: "OPENROUTER",
+      modelPricing: () => undefined,
+    } as never);
     await getGlobalModelRepository().addModel({
       model_id: ROUTED_MODEL_ID,
       title: "gpt-4o via OpenRouter",

--- a/examples/cli/src/test/lookupModelPricing.test.ts
+++ b/examples/cli/src/test/lookupModelPricing.test.ts
@@ -13,6 +13,9 @@ const TABLE_MODEL_ID = "claude-sonnet-5";
 // A Gemini Pro card carries the published over-200K rows, so this is the model
 // whose provider tiers can contradict a negotiated base rate.
 const TIERED_MODEL_ID = "gemini-3.1-pro-preview";
+// An OpenRouter route whose id is exactly what OpenAI's table strips a prefix
+// from, which is what made the fall-through report a wrong number as a cost.
+const ROUTED_MODEL_ID = "openai/gpt-4o";
 
 describe("lookupModelPricing", () => {
   // The model repository is a process-wide singleton, so a record added here
@@ -20,7 +23,7 @@ describe("lookupModelPricing", () => {
   afterEach(async () => {
     clearModelPricingCache();
     // `removeModel` throws when the id is absent, which most cases here are.
-    for (const id of [TEST_MODEL_ID, TABLE_MODEL_ID, TIERED_MODEL_ID]) {
+    for (const id of [TEST_MODEL_ID, TABLE_MODEL_ID, TIERED_MODEL_ID, ROUTED_MODEL_ID]) {
       await getGlobalModelRepository()
         .removeModel(id)
         .catch(() => {});
@@ -148,5 +151,25 @@ describe("lookupModelPricing", () => {
     expect(gpt?.currency).toBe("USD");
     expect(gpt?.input).toBe(5);
     expect(gpt?.output).toBe(30);
+  });
+
+  it("does not price an OpenRouter route from the direct vendor's card", async () => {
+    // The failure this closes: OpenRouter ids are exactly the shape the vendor
+    // tables strip a prefix from, so `openai/gpt-4o` resolved OpenAI's own list
+    // rates — for a route OpenRouter bills at whichever upstream it picked, and
+    // whose per-token rate the package's own comment says a caller cannot
+    // reconstruct locally. A provider that declines is asserting "no card", not
+    // referring the question on.
+    await getGlobalModelRepository().addModel({
+      model_id: ROUTED_MODEL_ID,
+      title: "gpt-4o via OpenRouter",
+      description: "routed",
+      provider: "OPENROUTER",
+      capabilities: ["text.generation"],
+      provider_config: { model_name: ROUTED_MODEL_ID },
+      metadata: {},
+    });
+
+    expect(await lookupModelPricing(ROUTED_MODEL_ID)).toBeUndefined();
   });
 });

--- a/examples/cli/src/ui/rows/lookupModelPricing.ts
+++ b/examples/cli/src/ui/rows/lookupModelPricing.ts
@@ -17,27 +17,58 @@ import { getGeminiModelPricing } from "@workglow/google-gemini/ai";
 import { getOpenAiModelPricing } from "@workglow/openai/ai";
 import { getXaiModelPricing } from "@workglow/xai/ai";
 
+/**
+ * Providers whose own list table is one of the five consulted below.
+ *
+ * The chain reads an id's SHAPE, which only means something for a record that
+ * belongs to one of these vendors — or for a bare id, where the shape is all
+ * there is. An aggregator carries vendor-shaped ids it is not billed at, so a
+ * record naming anything else must not reach the chain.
+ */
+const VENDOR_TABLE_PROVIDERS: ReadonlySet<string> = new Set([
+  "ANTHROPIC",
+  "OPENAI",
+  "GOOGLE_GEMINI",
+  "XAI",
+  "DEEPSEEK",
+]);
+
 const cache = new Map<string, ModelPricing | undefined>();
 const inflight = new Map<string, Promise<ModelPricing | undefined>>();
 
 /**
  * Published rate card for a model id, under whatever the record declares.
  *
- * A record names its provider, so that provider answers for it. A bare id does
- * NOT get offered to every registered provider in turn: a local provider
- * answers `FREE_LOCAL_PRICING` for anything it is asked about, so the first one
- * registered (the CLI always registers HuggingFace Transformers at startup)
- * would price every cloud model at zero. Without a record the id's own shape is
- * the only honest signal — local prefixes, then each cloud vendor's list table.
+ * A record names its provider, so that provider answers for it — including when
+ * the answer is "I have no card". Declining is an assertion, not a referral: the
+ * vendor chain below strips exactly the prefixes an OpenRouter id carries, so
+ * `openai/gpt-4o` would resolve OpenAI's own list rates for a route billed by
+ * OpenRouter at whichever upstream it chose. A number that is wrong reads as a
+ * cost; `undefined` reads as unpriced, which is true.
+ *
+ * A bare id does NOT get offered to every registered provider in turn: a local
+ * provider answers `FREE_LOCAL_PRICING` for anything it is asked about, so the
+ * first one registered (the CLI always registers HuggingFace Transformers at
+ * startup) would price every cloud model at zero. Without a record the id's own
+ * shape is the only honest signal — local prefixes, then each cloud vendor's
+ * list table.
  */
 function resolveFallbackPricing(modelId: string, record?: ModelRecord): ModelPricing | undefined {
   if (record?.provider) {
+    // The named provider answers, and its silence is an answer: declining is
+    // "I have no card", not "ask someone else".
     const provider = getAiProviderRegistry().getProvider(record.provider);
-    const pricing = provider?.modelPricing(record);
-    if (pricing) return pricing;
+    if (provider) return provider.modelPricing(record);
   }
   if (modelId.startsWith("gguf:") || modelId.startsWith("onnx:") || modelId.endsWith(".gguf")) {
     return FREE_LOCAL_PRICING;
+  }
+  // Reached when the record names no provider, or names one whose class is not
+  // registered here. Either way the chain may only answer for a vendor the
+  // record could plausibly be billed by — `openai/gpt-4o` on an OPENROUTER
+  // record is OpenAI's id, at rates OpenRouter never charged.
+  if (record?.provider !== undefined && !VENDOR_TABLE_PROVIDERS.has(record.provider)) {
+    return undefined;
   }
   return (
     getAnthropicModelPricing(modelId) ??

--- a/packages/ai/src/model/ModelPricing.ts
+++ b/packages/ai/src/model/ModelPricing.ts
@@ -114,11 +114,22 @@ const KEY_SUFFIX_BOUNDARY = new Set(["-", "_", ":", "/", "@"]);
  * `vendorPrefixes` are stripped (lower-cased, longest first is the caller's
  * responsibility) before matching, so `anthropic/claude-sonnet-5` resolves the
  * same as the bare id.
+ *
+ * `notTokenBilled` is how a provider says an id is not billed per token at all.
+ * The substring walk cannot know that: a dash is a legal suffix boundary — it
+ * marks a dated or sized variant of the same model — so `grok-2-image-1212`
+ * matches `grok-2` and would resolve its per-1M-token card. For a model billed
+ * per image or per second of audio that is not an approximation, it is a
+ * fabricated unit, and `undefined` is the honest answer. It is consulted only
+ * after the exact lookups, so a table that deliberately prices an image model
+ * still wins. Providers should pass the SAME matcher their effort policy uses
+ * rather than a second copy of it.
  */
 export function resolveModelPricingFromTable(
   table: Readonly<Record<string, ModelPricing>>,
   modelId: string | undefined,
-  vendorPrefixes: readonly string[] = []
+  vendorPrefixes: readonly string[] = [],
+  notTokenBilled?: (modelId: string) => boolean
 ): ModelPricing | undefined {
   if (!modelId) return undefined;
   let id = modelId.trim().toLowerCase();
@@ -133,6 +144,12 @@ export function resolveModelPricingFromTable(
   // `Object.prototype.constructor` for a model literally named "constructor".
   if (Object.hasOwn(table, modelId)) return table[modelId];
   if (Object.hasOwn(table, id)) return table[id];
+
+  // After the exact lookups, before the substring walk. A table that names an
+  // id has deliberately priced it — Gemini prices several image models — and
+  // that is a stronger statement than any matcher. What the guard blocks is the
+  // walk BORROWING a sibling's card for an id the table never named.
+  if (notTokenBilled?.(modelId) === true) return undefined;
 
   let best: string | undefined;
   for (const key of Object.keys(table)) {

--- a/packages/ai/src/model/__tests__/ModelPricing.test.ts
+++ b/packages/ai/src/model/__tests__/ModelPricing.test.ts
@@ -89,6 +89,40 @@ describe("resolveModelPricingFromTable", () => {
     expect(resolveModelPricingFromTable(table, "constructor")).toBeUndefined();
     expect(resolveModelPricingFromTable(table, "toString")).toBeUndefined();
   });
+
+  describe("notTokenBilled", () => {
+    // A dash is a legal suffix boundary — that is what resolves a dated variant
+    // to its family — so an id like `gpt-4o-image` reaches `gpt-4o`'s card. For
+    // a model billed per image that is a fabricated unit rather than an
+    // approximation, and a provider says so by passing its own matcher.
+    const isImage = (id: string): boolean => /(?:^|-)image(?:-|$)/i.test(id);
+
+    it("blocks the substring walk from borrowing a sibling's card", () => {
+      expect(resolveModelPricingFromTable(table, "gpt-4o-image")).toBe(table["gpt-4o"]);
+      expect(resolveModelPricingFromTable(table, "gpt-4o-image", [], isImage)).toBeUndefined();
+    });
+
+    it("does not override an id the table names outright", () => {
+      // Consulted AFTER the exact lookups: a table that prices an image model
+      // has declared a rate deliberately, which is a stronger statement than any
+      // matcher. Only the borrowing is blocked.
+      const withImage: Record<string, ModelPricing> = {
+        ...table,
+        "gpt-image-1": { currency: "USD", input: 5, output: 40 },
+      };
+      expect(resolveModelPricingFromTable(withImage, "gpt-image-1", [], isImage)).toBe(
+        withImage["gpt-image-1"]
+      );
+    });
+
+    it("leaves a text id alone, and is optional", () => {
+      expect(resolveModelPricingFromTable(table, "gpt-4o", [], isImage)).toBe(table["gpt-4o"]);
+      expect(resolveModelPricingFromTable(table, "gpt-4o-2024-08-06", [], isImage)).toBe(
+        table["gpt-4o"]
+      );
+      expect(resolveModelPricingFromTable(table, "gpt-4o", [], () => false)).toBe(table["gpt-4o"]);
+    });
+  });
 });
 
 describe("resolveEffectiveRates", () => {

--- a/packages/test/src/test/ai-provider-api/ModelSearchPricing.test.ts
+++ b/packages/test/src/test/ai-provider-api/ModelSearchPricing.test.ts
@@ -93,3 +93,65 @@ describe("cloud model search results", () => {
     expect(getGeminiModelPricing("gemini-2.5-pro")).toBeDefined();
   });
 });
+
+/**
+ * Capabilities whose models are not billed per token.
+ *
+ * A card of per-1M-token rates on one of these is not an approximation, it is a
+ * fabricated unit: image generation bills per image. `undefined` is the correct
+ * answer for a model a token table cannot price — a sibling's card is not.
+ */
+const NOT_TOKEN_BILLED = new Set(["image.generation", "audio.speech", "audio.transcription"]);
+
+const PRICED_PROVIDERS = [
+  { name: "Anthropic", search: Anthropic_ModelSearch_Stream, resolve: getAnthropicModelPricing },
+  { name: "OpenAI", search: OpenAI_ModelSearch_Stream, resolve: getOpenAiModelPricing },
+  { name: "DeepSeek", search: DeepSeek_ModelSearch_Stream, resolve: getDeepSeekModelPricing },
+  { name: "xAI", search: Xai_ModelSearch_Stream, resolve: getXaiModelPricing },
+] as const;
+
+/**
+ * The honesty axis the pricing primitive shipped without.
+ *
+ * Refusal, cache checkpoints and effort each needed a conformance assertion and
+ * each got one only after a defect. This one is driven off the provider's own
+ * catalogue, so the fixture cannot drift from what the provider reports.
+ */
+describe("a rate card must match the model's billing unit", () => {
+  it.each(PRICED_PROVIDERS)(
+    "$name prices no model its own catalogue calls non-token-billed",
+    async ({ search, resolve }) => {
+      const results = await searchRecords(search);
+      const offenders = results
+        .filter((result) =>
+          ((result.record?.capabilities ?? []) as string[]).some((c) => NOT_TOKEN_BILLED.has(c))
+        )
+        .filter((result) => resolve(result.id) !== undefined)
+        .map((result) => `${result.id} (${(result.record.capabilities as string[]).join(", ")})`);
+      expect(offenders).toEqual([]);
+    }
+  );
+
+  it("is not vacuous: some catalogue really does report a non-token-billed model", async () => {
+    // Without this the loop above passes just as well over four catalogues that
+    // contain nothing it could ever flag.
+    const seen: string[] = [];
+    for (const { search } of PRICED_PROVIDERS) {
+      for (const result of await searchRecords(search)) {
+        const capabilities = (result.record?.capabilities ?? []) as string[];
+        if (capabilities.some((c) => NOT_TOKEN_BILLED.has(c))) seen.push(result.id);
+      }
+    }
+    expect(seen).toContain("grok-2-image-1212");
+  });
+
+  it("Gemini prices the image models it names and refuses the ones it does not", () => {
+    // Gemini's table carries explicit image entries, so the guard must not
+    // override them — only stop an unnamed image id taking a text sibling's card.
+    expect(getGeminiModelPricing("gemini-3-pro-image")).toBeDefined();
+    expect(getGeminiModelPricing("gemini-3.1-flash-image")).toBeDefined();
+    expect(getGeminiModelPricing("imagen-4.0-generate-001")).toBeDefined();
+    expect(getGeminiModelPricing("gemini-2.5-flash-image-preview")).toBeUndefined();
+    expect(getGeminiModelPricing("gemini-2.5-flash")).toBeDefined();
+  });
+});

--- a/packages/test/src/test/ai-provider-api/OpenRouterPricing.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouterPricing.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { _testOnly } from "@workglow/openrouter/ai";
+import { describe, expect, it } from "vitest";
+
+const provider = new _testOnly.OpenRouterQueuedProvider();
+
+function priceOf(pricing: unknown): unknown {
+  return provider.modelPricing({
+    model_id: "openai/gpt-4o",
+    provider: "OPENROUTER",
+    provider_config: { model_name: "openai/gpt-4o" },
+    metadata: pricing === undefined ? {} : { pricing },
+  } as never);
+}
+
+/**
+ * OpenRouter routes to whichever upstream is cheapest or available, so a
+ * per-token rate is not something a caller can reconstruct locally. It quotes
+ * one per model, and the search already stored it — this reads that rather than
+ * leaving the model unpriced for a vendor table to guess at.
+ */
+describe("OpenRouter prices from the rate it quoted", () => {
+  it("converts the API's per-token strings to the per-1M convention", () => {
+    expect(
+      priceOf({ prompt: "0.0000025", completion: "0.00001", input_cache_read: "0.00000125" })
+    ).toEqual({ currency: "USD", input: 2.5, output: 10, cached: 1.25 });
+  });
+
+  it("treats a free model as free, not as unpriced", () => {
+    // `"0"` is a real quote and it is falsy, so the check has to be on the
+    // parse rather than on the value.
+    expect(priceOf({ prompt: "0", completion: "0" })).toEqual({
+      currency: "USD",
+      input: 0,
+      output: 0,
+      cached: undefined,
+    });
+  });
+
+  it("reports no card when the rate varies by upstream", () => {
+    // OpenRouter writes `-1` for "varies", which is finite and would otherwise
+    // become a negative rate.
+    expect(priceOf({ prompt: "-1", completion: "-1" })).toBeUndefined();
+  });
+
+  it("reports no card when the record carries no quote at all", () => {
+    expect(priceOf(undefined)).toBeUndefined();
+    expect(priceOf(null)).toBeUndefined();
+    expect(priceOf("nonsense")).toBeUndefined();
+    expect(priceOf({ completion: "0.00001" })).toBeUndefined();
+  });
+
+  it("declines a record belonging to another provider", () => {
+    expect(
+      provider.modelPricing({
+        model_id: "claude-sonnet-5",
+        provider: "ANTHROPIC",
+        provider_config: { model_name: "claude-sonnet-5" },
+        metadata: {},
+      } as never)
+    ).toBeUndefined();
+  });
+});

--- a/providers/chrome-ai/src/ai/WebBrowserProvider.ts
+++ b/providers/chrome-ai/src/ai/WebBrowserProvider.ts
@@ -8,9 +8,11 @@ import type {
   AiProviderPreviewRunFn,
   AiProviderRunFnRegistration,
   Capability,
+  ModelConfig,
+  ModelPricing,
   ModelRecord,
 } from "@workglow/ai/worker";
-import { AiProvider } from "@workglow/ai/worker";
+import { AiProvider, FREE_LOCAL_PRICING } from "@workglow/ai/worker";
 import {
   CONSERVATIVE_PROBED_CAPABILITIES,
   inferWebBrowserCapabilities,
@@ -75,6 +77,17 @@ export class WebBrowserProvider extends AiProvider<WebBrowserModelConfig> {
 
   override inferCapabilities(model: ModelRecord): readonly Capability[] {
     return inferWebBrowserCapabilities(model, this.probedCaps);
+  }
+
+  /**
+   * Chrome's built-in models run on the user's own machine, so they cost
+   * nothing. Said explicitly: without an answer here the cost path reads a
+   * local model as UNKNOWN rather than free, which is the same silence a
+   * metered provider with no rate card produces.
+   */
+  override modelPricing(model?: ModelConfig): ModelPricing | undefined {
+    if (model && model.provider !== this.name) return undefined;
+    return FREE_LOCAL_PRICING;
   }
 
   protected override workerRunFnSpecs(): readonly { serves: readonly Capability[] }[] {

--- a/providers/google-gemini/src/ai/common/Gemini_EffortPolicy.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_EffortPolicy.ts
@@ -15,6 +15,17 @@ import {
 const TEXT = { supported: MODEL_EFFORTS, default: "none" } as const satisfies ModelEffortPolicy;
 
 /**
+ * Ids Gemini serves as image generation rather than text.
+ *
+ * Exported because pricing needs the same answer and must not keep a second
+ * copy of it: these bill per image, so a per-1M-token card borrowed from a
+ * text sibling is a fabricated unit. The table names several of them
+ * explicitly, and an explicit entry still wins — this only stops the substring
+ * walk reaching for a neighbour's card.
+ */
+export const GEMINI_IMAGE_MODELS: readonly RegExp[] = [/^imagen-/i, /^gemini-.*-image(?:-|$)/i];
+
+/**
  * Gemini rejects `thinkingConfig` on the models that do not think, so an id
  * outside the `gemini-` text families keeps the plain path — including the
  * embedding and image ids denied above, which share that prefix.
@@ -22,13 +33,7 @@ const TEXT = { supported: MODEL_EFFORTS, default: "none" } as const satisfies Mo
 export const geminiEffortPolicy: ModelEffortPolicyFn = makeEffortPolicy({
   rules: [
     {
-      when: [
-        /^gemini-embedding/i,
-        /^text-embedding/i,
-        /^embedding-/i,
-        /^imagen-/i,
-        /^gemini-.*-image(?:-|$)/i,
-      ],
+      when: [/^gemini-embedding/i, /^text-embedding/i, /^embedding-/i, ...GEMINI_IMAGE_MODELS],
       policy: EFFORT_POLICY_NONE,
     },
     { when: /^gemini-/i, policy: TEXT },

--- a/providers/google-gemini/src/ai/common/Gemini_Pricing.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Pricing.ts
@@ -7,6 +7,8 @@
 import type { ModelPricing } from "@workglow/ai";
 import { resolveModelPricingFromTable } from "@workglow/ai";
 
+import { GEMINI_IMAGE_MODELS } from "./Gemini_EffortPolicy";
+
 /**
  * Public list pricing for Google Gemini models (USD per 1M tokens).
  *
@@ -118,11 +120,17 @@ export const GEMINI_PRICING: Record<string, ModelPricing> = {
 
 /**
  * Resolve list pricing for a Google Gemini model id.
+ *
+ * The table prices several image models outright and those still resolve; what
+ * the matcher stops is an image id the table does NOT name taking a text
+ * sibling's per-token card — `gemini-2.5-flash-image-preview` was resolving
+ * `gemini-2.5-flash`'s.
  */
 export function getGeminiModelPricing(modelId: string | undefined): ModelPricing | undefined {
-  return resolveModelPricingFromTable(GEMINI_PRICING, modelId, [
-    "google-gemini/",
-    "google/",
-    "models/",
-  ]);
+  return resolveModelPricingFromTable(
+    GEMINI_PRICING,
+    modelId,
+    ["google-gemini/", "google/", "models/"],
+    (id) => GEMINI_IMAGE_MODELS.some((pattern) => pattern.test(id))
+  );
 }

--- a/providers/mlx/src/ai/MlxProvider.ts
+++ b/providers/mlx/src/ai/MlxProvider.ts
@@ -10,11 +10,12 @@ import type {
   AiProviderRunFnRegistration,
   Capability,
   ModelConfig,
+  ModelPricing,
   ModelRecord,
   TextGenerationTaskInput,
   TextGenerationTaskOutput,
 } from "@workglow/ai";
-import { AiProvider } from "@workglow/ai";
+import { AiProvider, FREE_LOCAL_PRICING } from "@workglow/ai";
 import { LOCAL_MLX } from "./common/Mlx_Constants";
 
 /**
@@ -67,6 +68,16 @@ export class MlxProvider extends AiProvider {
    * the provider (and its models) out of any UI that offers a choice, rather
    * than surfacing an option whose every call throws.
    */
+  /**
+   * MLX runs on the user's own Apple silicon, so a run costs nothing. Said
+   * explicitly: an unanswered `modelPricing` reads as UNKNOWN rather than free,
+   * which is the same silence a metered provider with no rate card produces.
+   */
+  override modelPricing(model?: ModelConfig): ModelPricing | undefined {
+    if (model && model.provider !== this.name) return undefined;
+    return FREE_LOCAL_PRICING;
+  }
+
   override async isAvailable(): Promise<boolean> {
     return false;
   }

--- a/providers/openrouter/src/ai/OpenRouterQueuedProvider.ts
+++ b/providers/openrouter/src/ai/OpenRouterQueuedProvider.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Capability, ModelEffortPolicy, ModelRecord } from "@workglow/ai";
+import type {
+  Capability,
+  ModelConfig,
+  ModelEffortPolicy,
+  ModelPricing,
+  ModelRecord,
+} from "@workglow/ai";
 import { AiProvider } from "@workglow/ai";
 import { createCloudProviderClass } from "@workglow/ai/provider-utils";
 import {
@@ -26,6 +32,41 @@ export class OpenRouterQueuedProvider extends createCloudProviderClass<OpenRoute
 
   override effortPolicy(model: OpenRouterModelConfig): ModelEffortPolicy | undefined {
     return openrouterEffortPolicy(model);
+  }
+
+  /**
+   * The rate OpenRouter itself quoted for this model, from the record the
+   * search already populated.
+   *
+   * More honest than a table could be: OpenRouter routes to whichever upstream
+   * is cheapest or available, so per-token pricing is not something a caller can
+   * reconstruct locally — and without an answer here the resolver falls through
+   * to the direct-vendor tables, where `openai/gpt-4o` matches OpenAI's own card
+   * and reports a rate this route was never billed at.
+   *
+   * The API quotes USD per token as strings. `"0"` is a real answer (free
+   * models) and falsy, so the check is on the parse, not the value; `"-1"` means
+   * the rate varies by upstream, which is unpriced rather than negative.
+   */
+  override modelPricing(model?: ModelConfig): ModelPricing | undefined {
+    if (model && model.provider !== this.name) return undefined;
+    const raw = (model as { metadata?: { pricing?: unknown } } | undefined)?.metadata?.pricing;
+    if (raw === null || typeof raw !== "object") return undefined;
+    const quoted = raw as Record<string, unknown>;
+    const perMillion = (value: unknown): number | undefined => {
+      if (typeof value !== "string" && typeof value !== "number") return undefined;
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed) || parsed < 0) return undefined;
+      return parsed * 1e6;
+    };
+    const input = perMillion(quoted.prompt);
+    if (input === undefined) return undefined;
+    return {
+      currency: "USD",
+      input,
+      output: perMillion(quoted.completion) ?? 0,
+      cached: perMillion(quoted.input_cache_read),
+    };
   }
 
   protected override workerRunFnSpecs(): readonly { serves: readonly Capability[] }[] {

--- a/providers/xai/src/ai/common/Xai_EffortPolicy.ts
+++ b/providers/xai/src/ai/common/Xai_EffortPolicy.ts
@@ -18,12 +18,23 @@ const REASONING = {
 } as const satisfies ModelEffortPolicy;
 
 /**
+ * Ids xAI serves as image generation rather than text.
+ *
+ * Exported because pricing needs the same answer and must not keep a second
+ * copy of it: these models bill per image, so the per-1M-token card the
+ * pricing table would otherwise hand them (a dash is a legal suffix boundary,
+ * so `grok-2-image-1212` matches `grok-2`) is a fabricated unit. One matcher,
+ * so the two cannot drift.
+ */
+export const XAI_IMAGE_MODEL = /(?:^|-)image(?:-|$)/i;
+
+/**
  * xAI serves reasoning only on the Grok text ids, and rejects
  * `reasoning_effort` elsewhere, so an id outside them keeps the plain path.
  */
 export const xaiEffortPolicy: ModelEffortPolicyFn = makeEffortPolicy({
   rules: [
-    { when: [/(?:^|-)image(?:-|$)/i, /non-reasoning/i], policy: EFFORT_POLICY_NONE },
+    { when: [XAI_IMAGE_MODEL, /non-reasoning/i], policy: EFFORT_POLICY_NONE },
     { when: /^grok/i, policy: REASONING },
   ],
   fallback: EFFORT_POLICY_NONE,

--- a/providers/xai/src/ai/common/Xai_Pricing.ts
+++ b/providers/xai/src/ai/common/Xai_Pricing.ts
@@ -7,6 +7,8 @@
 import type { ModelPricing } from "@workglow/ai";
 import { resolveModelPricingFromTable } from "@workglow/ai";
 
+import { XAI_IMAGE_MODEL } from "./Xai_EffortPolicy";
+
 /**
  * Public list pricing for xAI Grok models (USD per 1M tokens).
  */
@@ -22,7 +24,14 @@ export const XAI_PRICING: Record<string, ModelPricing> = {
 
 /**
  * Resolve list pricing for an xAI Grok model id.
+ *
+ * Image models resolve to nothing: they bill per image, and the table names
+ * only the text ids, so without the guard `grok-2-image-1212` would take
+ * `grok-2`'s per-1M-token card. The matcher is the effort policy's, not a
+ * second copy.
  */
 export function getXaiModelPricing(modelId: string | undefined): ModelPricing | undefined {
-  return resolveModelPricingFromTable(XAI_PRICING, modelId, ["xai/"]);
+  return resolveModelPricingFromTable(XAI_PRICING, modelId, ["xai/"], (id) =>
+    XAI_IMAGE_MODEL.test(id)
+  );
 }


### PR DESCRIPTION
## Summary

Fixes pricing resolution to correctly handle models that are not billed per token (image generation, audio transcription, etc.). Previously, the pricing resolver would borrow a per-1M-token rate from a sibling model, producing a fabricated unit. Now it returns `undefined` for such models unless the pricing table explicitly names them.

## Key Changes

- **`resolveModelPricingFromTable`**: Added `notTokenBilled` parameter to guard against substring-walk borrowing. After exact lookups but before the substring walk, if a model matches the guard predicate, pricing returns `undefined` rather than falling through to a sibling's card.

- **Gemini pricing**: Extracted `GEMINI_IMAGE_MODELS` matcher from effort policy and passed it to the pricing resolver. Prevents `gemini-2.5-flash-image-preview` (not in the table) from borrowing `gemini-2.5-flash`'s card, while allowing explicitly-priced image models like `gemini-3-pro-image` to resolve.

- **xAI pricing**: Extracted `XAI_IMAGE_MODEL` matcher from effort policy and passed it to the pricing resolver. Prevents `grok-2-image-1212` from borrowing `grok-2`'s per-token card.

- **OpenRouter provider**: Implemented `modelPricing()` override to return the rate OpenRouter itself quoted (from metadata), converting API per-token strings to per-1M convention. Returns `undefined` for free models (`"0"`) correctly and for variable-rate models (`"-1"`). This prevents the fallback chain from incorrectly resolving `openai/gpt-4o` via OpenAI's direct table when routed through OpenRouter.

- **Chrome AI and MLX providers**: Implemented `modelPricing()` overrides to explicitly return `FREE_LOCAL_PRICING`, making local models correctly report as free rather than unpriced.

- **Fallback pricing logic**: Updated `resolveFallbackPricing` to treat a provider's decline as a final answer ("no card") rather than a referral. Added guard to prevent vendor-table chain from pricing records belonging to non-token-billed providers.

## Testing

- New test file `OpenRouterPricing.test.ts` validates OpenRouter's pricing conversion and edge cases.
- Extended `ModelSearchPricing.test.ts` with conformance tests ensuring no provider prices a model its own catalogue marks as non-token-billed.
- Extended `lookupModelPricing.test.ts` to verify OpenRouter routes are not priced from direct vendor tables.

https://claude.ai/code/session_01LWp6Z6wvAPDaDCjAFcTSj6