### PR TITLE
Move `runPreview`'s return out of the `finally` block

### DIFF
--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -874,11 +874,17 @@ export class TaskRunner<
       await this.handleErrorPreview();
     } finally {
       ctx.dispose();
-      // Deliberate: runPreview always yields whatever preview output the task
-      // holds, including after the catch ran.
-      // oxlint-disable-next-line no-unsafe-finally
-      return this.task.runOutputData as Output;
     }
+    // Deliberate: runPreview yields whatever preview output the task holds,
+    // including after the catch ran — a task's own preview failing is
+    // best-effort, and the editor keeps showing the last good output.
+    //
+    // Outside the `finally`, though. Returning from inside one discards any
+    // pending completion, which here meant a rejection from
+    // `handleErrorPreview()` was swallowed and the caller was told the preview
+    // succeeded. Failing to clean up after a failed preview is a different
+    // event from the preview failing, and only the first should surface.
+    return this.task.runOutputData as Output;
   }
 
   /**

--- a/packages/task-graph/src/task/__tests__/preview-error-propagation.test.ts
+++ b/packages/task-graph/src/task/__tests__/preview-error-propagation.test.ts
@@ -24,7 +24,13 @@ class ThrowingPreviewTask extends Task<{ a?: string }, { a?: string }, TaskConfi
   public static override outputSchema(): DataPortSchema {
     return schema;
   }
-  override async executePreview(_input: { a?: string }, _ctx: IExecutePreviewContext) {
+  // The return type is annotated rather than inferred: a body that only throws
+  // infers `Promise<void>`, which does not satisfy the base class's
+  // `Promise<Output | undefined>`.
+  override async executePreview(
+    _input: { a?: string },
+    _ctx: IExecutePreviewContext
+  ): Promise<{ a?: string } | undefined> {
     throw new Error("preview blew up");
   }
 }

--- a/packages/task-graph/src/task/__tests__/preview-error-propagation.test.ts
+++ b/packages/task-graph/src/task/__tests__/preview-error-propagation.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IExecutePreviewContext, TaskConfig } from "@workglow/task-graph";
+import { Task } from "@workglow/task-graph";
+import { TaskRunner } from "../TaskRunner";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+
+const schema = {
+  type: "object",
+  properties: { a: { type: "string" } },
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+class ThrowingPreviewTask extends Task<{ a?: string }, { a?: string }, TaskConfig> {
+  public static override readonly type = "ThrowingPreviewTask";
+  public static override inputSchema(): DataPortSchema {
+    return schema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return schema;
+  }
+  override async executePreview(_input: { a?: string }, _ctx: IExecutePreviewContext) {
+    throw new Error("preview blew up");
+  }
+}
+
+/** A runner whose error handler fails — the case the `finally` used to hide. */
+class FailingHandlerRunner extends TaskRunner<{ a?: string }, { a?: string }> {
+  protected override async handleErrorPreview(): Promise<void> {
+    throw new Error("handleErrorPreview failed");
+  }
+}
+
+/**
+ * `runPreview` ended with `return` inside a `finally`, which discards whatever
+ * completion was pending. A `runPreview` that always resolves is the intent for
+ * a task's own preview failing — the preview is best-effort and the last good
+ * output is what the editor should keep showing — but the `return` swallowed
+ * one thing beyond that: a rejection from the error handler itself.
+ *
+ * Only that one. A throwing `ctx.dispose()` propagates either way, because in a
+ * `finally` an abrupt completion from an earlier statement means the `return`
+ * is never reached.
+ */
+describe("runPreview error propagation", () => {
+  it("still resolves with the held output when the task's own preview throws", async () => {
+    // Unchanged, and deliberately so: this is the case the comment on the
+    // `finally` was describing.
+    const task = new ThrowingPreviewTask();
+    await expect(task.runPreview({ a: "held" })).resolves.toBeDefined();
+  });
+
+  it("rejects when the error handler itself fails, instead of reporting success", async () => {
+    const task = new ThrowingPreviewTask();
+    // Swap in a runner whose handler fails. Previously the `finally` return
+    // discarded this rejection and `runPreview` resolved, so a failure to
+    // clean up after a failed preview was invisible to every caller.
+    (task as unknown as { _runner: TaskRunner<{ a?: string }, { a?: string }> })._runner =
+      new FailingHandlerRunner(task as never);
+
+    await expect(task.runPreview({ a: "held" })).rejects.toThrow("handleErrorPreview failed");
+  });
+});


### PR DESCRIPTION
Closes #905.

Returning from inside a `finally` discards whatever completion was pending.

The intent it was written for is right and **unchanged**: a task's own preview failing is best-effort, and `runPreview` still resolves with the held output so the editor keeps showing the last good one. But the same `return` also swallowed a rejection from `handleErrorPreview()` — so a failure to clean up *after* a failed preview was reported to the caller as success. Those are different events, and only the first should be absorbed.

## Exactly one path changes

Established by running both shapes rather than reasoning about them:

| | return inside `finally` | return below it |
| --- | --- | --- |
| task's own preview throws | resolves | resolves *(unchanged)* |
| `handleErrorPreview()` rejects | **resolves** | **rejects** |
| `ctx.dispose()` throws | rejects | rejects *(unchanged)* |

So the `dispose` half of the concern in the review doc was never real — in a `finally`, an abrupt completion from an earlier statement means the `return` is never reached, and a throwing disposer already propagated. **That is a correction to the plan's stated caution**, which said this fix makes `runPreview` able to reject "from those two sources".

## The call-site audit, and why it is cheap insurance

**No caller is affected today.** Both `handleErrorPreview` implementations are pure assignments and cannot throw:

- `TaskRunner` — `this.previewRunning = false;`
- `TaskGraphRunner` — `this.restorePreviewRegistry(); this.previewRunning = false;` (and `restorePreviewRegistry` is two assignments behind an `undefined` check)

So this is latent correctness for a subclass that overrides it with something that can fail. The internal callers were checked regardless: `runPreviewStream` already wraps its call in `try/catch` and logs, and `TaskGraphRunner`'s two calls sit inside its own preview `try/catch`.

## Verification

Both tests written first. The "still resolves" one passed against the old code and the "rejects when the handler fails" one failed with `promise resolved "{}" instead of rejecting` — the defect, reproduced.

The `oxlint-disable-next-line no-unsafe-finally` goes with the fix; `--report-unused-disable-directives` would flag it if it had been left behind, and `bun run lint` exits 0.

146 files / 1435 tests green across the `graph` and `task-graph` sections; `format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWp6Z6wvAPDaDCjAFcTSj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWp6Z6wvAPDaDCjAFcTSj6)_