### PR TITLE
Assert the billing unit in the contract suite, off the same fixtures

### DIFF
--- a/packages/test/src/contract/ai-provider/assertions/pricingMatchesModality.ts
+++ b/packages/test/src/contract/ai-provider/assertions/pricingMatchesModality.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ModelPricing } from "@workglow/ai";
+import { expect } from "vitest";
+
+/** One fixture model, its inferred capabilities, and the card its provider returns. */
+export interface PricedModel {
+  readonly id: string;
+  readonly capabilities: readonly string[];
+  readonly pricing: ModelPricing | undefined;
+}
+
+/**
+ * Capabilities billed by something other than a token.
+ *
+ * An image is billed per image, speech per character or per second. A card
+ * carrying `input`/`output` per-1M-token rates for one of these is not an
+ * approximation of the real price — it is a different unit, and arithmetic on
+ * it produces a number with no meaning that renders beside real costs.
+ */
+const NOT_TOKEN_BILLED: ReadonlySet<string> = new Set([
+  "image.generation",
+  "audio.speech",
+  "audio.transcription",
+]);
+
+/** Whether a card quotes a per-token rate at all. */
+function quotesTokenRate(pricing: ModelPricing | undefined): boolean {
+  if (pricing === undefined) return false;
+  return (
+    typeof pricing.input === "number" ||
+    typeof pricing.output === "number" ||
+    typeof pricing.cached === "number"
+  );
+}
+
+/**
+ * A provider must not quote a per-token rate for a model its own inference says
+ * is not billed per token.
+ *
+ * This is the direction that catches a real fabricated number, and it is a hard
+ * assertion because there is no legitimate case for it: `grok-2-image-1212`
+ * resolved `grok-2`'s per-1M-token card through the pricing table's substring
+ * walk, and `gemini-2.5-flash-image-preview` took `gemini-2.5-flash`'s the same
+ * way. Both are image models by the provider's own catalogue.
+ *
+ * A free card is exempt: `input: 0` on a local model says "this costs nothing",
+ * which is true whatever the billing unit, and is how every local provider
+ * answers.
+ */
+export function assertPricingMatchesModality(
+  name: string,
+  models: readonly PricedModel[],
+  namedByTable: readonly string[] = []
+): void {
+  const named = new Set(namedByTable);
+  const fabricated: string[] = [];
+  for (const { id, capabilities, pricing } of models) {
+    if (!capabilities.some((capability) => NOT_TOKEN_BILLED.has(capability))) continue;
+    if (!quotesTokenRate(pricing)) continue;
+    // A card the provider's table names outright is a deliberate rate, not a
+    // borrowed one. Recorded per provider rather than inferred, so adding an
+    // image model to a table is a decision someone writes down.
+    if (named.has(id)) continue;
+    const free = (pricing?.input ?? 0) === 0 && (pricing?.output ?? 0) === 0;
+    if (free) continue;
+    const billed = capabilities.filter((capability) => NOT_TOKEN_BILLED.has(capability));
+    fabricated.push(
+      `${id}: ${billed.join(", ")} but priced ` +
+        `input=${String(pricing?.input)} output=${String(pricing?.output)} per 1M tokens`
+    );
+  }
+
+  expect(fabricated, `${name} borrows a per-token rate for a model not billed per token`).toEqual(
+    []
+  );
+
+  // The recorded set must stay honest too: an id that stopped being priced, or
+  // stopped being an image model, should leave it rather than sit there
+  // exempting nothing.
+  const stale = namedByTable.filter(
+    (id) =>
+      !models.some(
+        ({ id: modelId, capabilities, pricing }) =>
+          modelId === id &&
+          capabilities.some((capability) => NOT_TOKEN_BILLED.has(capability)) &&
+          quotesTokenRate(pricing)
+      )
+  );
+  expect(
+    stale,
+    `${name}: recorded as deliberately priced but no longer is: ${stale.join(", ")}`
+  ).toEqual([]);
+}
+
+/**
+ * The weaker direction: a token-billed model SHOULD carry a card.
+ *
+ * A ratchet rather than an assertion, deliberately. Real gaps exist today —
+ * `gemini-embedding-001` among them — and a hard assert would redden the build
+ * on a known one and get disabled, which costs more than the gap. Recording the
+ * set means it cannot grow while it shrinks deliberately.
+ */
+export function assertPricedGapDoesNotGrow(
+  name: string,
+  models: readonly PricedModel[],
+  knownUnpriced: readonly string[]
+): void {
+  const unpriced = models
+    .filter(
+      ({ capabilities, pricing }) =>
+        capabilities.length > 0 &&
+        !capabilities.some((capability) => NOT_TOKEN_BILLED.has(capability)) &&
+        pricing === undefined
+    )
+    .map(({ id }) => id)
+    .sort();
+
+  const known = new Set(knownUnpriced);
+  expect(
+    unpriced.filter((id) => !known.has(id)),
+    `${name} has a token-billed model with no rate card that was not recorded`
+  ).toEqual([]);
+
+  // Not a failure — a prompt to shrink the recorded set once a gap is closed.
+  const closed = knownUnpriced.filter((id) => !unpriced.includes(id));
+  expect(closed, `${name}: now priced — drop from the recorded set: ${closed.join(", ")}`).toEqual(
+    []
+  );
+}

--- a/packages/test/src/test/ai-provider/inferAdvertisesRegistered.test.ts
+++ b/packages/test/src/test/ai-provider/inferAdvertisesRegistered.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Capability, ModelRecord } from "@workglow/ai";
+import type { Capability, ModelPricing, ModelRecord } from "@workglow/ai";
 import { _testOnly as anthropic } from "@workglow/anthropic/ai";
 import { _testOnly as cactus } from "@workglow/cactus/ai";
 import { _testOnly as chromeAi } from "@workglow/chrome-ai/ai";
@@ -20,11 +20,16 @@ import { _testOnly as openrouter } from "@workglow/openrouter/ai";
 import { _testOnly as sdCpp } from "@workglow/stable-diffusion-server/ai";
 import { _testOnly as tfmp } from "@workglow/tf-mediapipe/ai";
 import { _testOnly as xai } from "@workglow/xai/ai";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { assertInferAdvertisesRegistered } from "../../contract/ai-provider/assertions/inferAdvertisesRegistered";
 import type { InferredForModel } from "../../contract/ai-provider/assertions/inferServesInferred";
 import { assertInferServesInferred } from "../../contract/ai-provider/assertions/inferServesInferred";
+import type { PricedModel } from "../../contract/ai-provider/assertions/pricingMatchesModality";
+import {
+  assertPricedGapDoesNotGrow,
+  assertPricingMatchesModality,
+} from "../../contract/ai-provider/assertions/pricingMatchesModality";
 
 function model(
   provider: string,
@@ -58,6 +63,33 @@ function inferEach(
   infer: (id: string) => readonly Capability[]
 ): readonly InferredForModel[] {
   return ids.map((id) => ({ id, capabilities: infer(id) }));
+}
+
+/**
+ * Pairs each fixture id with both what the provider infers for it and what the
+ * provider charges for it, from one construction of the provider.
+ */
+function pricedEach(
+  provider: string,
+  ids: readonly string[],
+  // Each provider narrows these to its own config type, whose `provider` is a
+  // string literal — so `ModelRecord` does not satisfy them structurally. `never`
+  // accepts every one of those by contravariance, and the cast lands here once
+  // rather than at each of the five call sites.
+  make: () => {
+    inferCapabilities: (record: never) => readonly Capability[];
+    modelPricing: (record: never) => ModelPricing | undefined;
+  }
+): readonly PricedModel[] {
+  const instance = make();
+  return ids.map((id) => {
+    const record = model(provider, id) as never;
+    return {
+      id,
+      capabilities: instance.inferCapabilities(record) as readonly string[],
+      pricing: instance.modelPricing(record),
+    };
+  });
 }
 
 const PROVIDER_CASES: readonly {
@@ -256,6 +288,117 @@ const PROVIDER_CASES: readonly {
     ),
   },
 ];
+
+/**
+ * The pricing half of the same fixtures.
+ *
+ * Driven off the ids `PROVIDER_CASES` already lists rather than a second list,
+ * so a model added for a capability check is priced-checked on the same commit.
+ * Only the providers that quote a rate at all appear: the local ones answer
+ * `FREE_LOCAL_PRICING` for everything, which says nothing about modality.
+ */
+const PRICED_CASES: readonly {
+  readonly name: string;
+  readonly models: readonly PricedModel[];
+  /**
+   * Non-token-billed ids the provider's own table names outright. Recorded, so
+   * that adding an image model to a pricing table is a decision someone writes
+   * down rather than something the guard silently tolerates.
+   *
+   * Gemini's flash and pro image models genuinely bill by token — text tokens
+   * in, image tokens out. `imagen-4.0-generate-001` is the doubtful one: $0.03
+   * is Imagen's per-IMAGE list price sitting in a per-1M-token field, which is
+   * the unit confusion this assertion exists to surface. Left recorded rather
+   * than changed here, because correcting it means either a per-image field on
+   * `ModelPricing` or dropping a real rate, and neither is a test's call.
+   */
+  readonly namedByTable: readonly string[];
+}[] = [
+  {
+    name: "anthropic",
+    models: pricedEach(
+      "ANTHROPIC",
+      ["claude-sonnet-5"],
+      () => new anthropic.AnthropicQueuedProvider(anthropic.ANTHROPIC_RUN_FNS)
+    ),
+    namedByTable: [],
+  },
+  {
+    name: "openai",
+    models: pricedEach(
+      "OPENAI",
+      ["gpt-4o", "text-embedding-3-small", "dall-e-3", "gpt-image-1"],
+      () => new openai.OpenAiQueuedProvider(openai.OPENAI_RUN_FNS)
+    ),
+    namedByTable: [],
+  },
+  {
+    name: "google-gemini",
+    models: pricedEach(
+      "GOOGLE_GEMINI",
+      [
+        "gemini-2.5-pro",
+        "gemini-embedding-001",
+        "imagen-4.0-generate-001",
+        "gemini-3.1-flash-image",
+      ],
+      () => new gemini.GoogleGeminiQueuedProvider(gemini.GEMINI_RUN_FNS)
+    ),
+    namedByTable: ["imagen-4.0-generate-001", "gemini-3.1-flash-image"],
+  },
+  {
+    name: "xai",
+    models: pricedEach(
+      "XAI",
+      ["grok-4", "grok-2-image-1212"],
+      () => new xai.XaiQueuedProvider(xai.XAI_RUN_FNS)
+    ),
+    namedByTable: [],
+  },
+  {
+    name: "deepseek",
+    models: pricedEach(
+      "DEEPSEEK",
+      ["deepseek-v4-flash"],
+      () => new deepseek.DeepSeekQueuedProvider(deepseek.DEEPSEEK_RUN_FNS)
+    ),
+    namedByTable: [],
+  },
+];
+
+/**
+ * Token-billed models with no rate card today.
+ *
+ * A ratchet, not a target — see `assertPricedGapDoesNotGrow`. A hard assert
+ * would redden the build on a gap everyone already knows about.
+ */
+const KNOWN_UNPRICED: Readonly<Record<string, readonly string[]>> = {
+  anthropic: [],
+  openai: [],
+  "google-gemini": ["gemini-embedding-001"],
+  xai: [],
+  deepseek: [],
+};
+
+describe("a rate card matches the model's billing unit", () => {
+  it.each(PRICED_CASES)(
+    "$name does not borrow a per-token rate",
+    ({ name, models, namedByTable }) => {
+      assertPricingMatchesModality(name, models, namedByTable);
+    }
+  );
+
+  it.each(PRICED_CASES)("$name prices no fewer models than recorded", ({ name, models }) => {
+    assertPricedGapDoesNotGrow(name, models, KNOWN_UNPRICED[name] ?? []);
+  });
+
+  it("is not vacuous: the fixtures include a non-token-billed model", () => {
+    const imageModels = PRICED_CASES.flatMap(({ models }) =>
+      models.filter((m) => m.capabilities.includes("image.generation")).map((m) => m.id)
+    );
+    expect(imageModels.length).toBeGreaterThan(2);
+  });
+});
 
 describe("inferCapabilities and registered run-fns agree", () => {
   it.each(PROVIDER_CASES)(


### PR DESCRIPTION
Closes #909.

## What was missing after #915

The pricing work added a modality check, but it went into `packages/test/src/test/ai-provider-api/` — the section that needs live API keys and network. So the one assertion that catches a fabricated rate **only ran where a key was present**, and it re-derived its own list of models.

`assertPricingMatchesModality` now lives in `contract/ai-provider/assertions/` beside the capability assertions, driven off the ids `PROVIDER_CASES` already carries. A model added for a capability check is priced-checked on the same commit, and the whole thing runs with no key.

## Two directions, deliberately different in strength

**Hard:** a provider must not quote a per-token rate for a model its own `inferCapabilities` calls image generation or speech.

**Ratchet:** a token-billed model *should* carry a card — but `gemini-embedding-001` is unpriced today, and asserting that away would redden the build on a known gap and get disabled. The set is recorded, growth fails, and a gap that closes is reported so the record shrinks rather than going stale.

This is the change the issue asks for in its "second, weaker direction", and the reason it is a ratchet rather than an assert.

## `namedByTable`, and a question it surfaces

#915 decided that a table naming an id outranks any matcher, so `namedByTable` records the non-token-billed ids each provider prices deliberately. Probing the fixtures:

| model | card | verdict |
| --- | --- | --- |
| `dall-e-3`, `gpt-image-1` | unpriced | correct |
| `grok-2-image-1212` | unpriced | correct (fixed by #915) |
| `gemini-3.1-flash-image` | 0.15 / 0.6 | genuinely token-billed — text in, image tokens out |
| `imagen-4.0-generate-001` | 0.03 / 0.03 | **doubtful** |

`$0.03` is Imagen's per-**image** list price sitting in a per-1M-token field. I left it recorded rather than changed: correcting it means either adding a per-image field to `ModelPricing` or dropping a real rate, and neither is a test's call. The record is where that question is now visible instead of invisible.

## Verified by breaking things

Each guard was checked by making the regression it exists to catch:

- **Reverting the xAI guard** (`false && XAI_IMAGE_MODEL.test(id)`) → `xai borrows a per-token rate for a model not billed per token: expected [ 'grok-2-image-1212' ] to deeply equal []`. The original #908 defect, caught by the new assertion.
- **Clearing the recorded gap** → `google-gemini has a token-billed model with no rate card that was not recorded: [ 'gemini-embedding-001' ]`.
- **A stale `namedByTable` entry** → `recorded as deliberately priced but no longer is: gemini-2.5-pro`.

Plus an anti-vacuity test: the fixtures must contain more than two image-generation models, or the whole suite could pass by finding nothing.

## One note for reviewers

`pricedEach` takes `never`-typed callbacks. Each provider narrows `modelPricing` to its own config type whose `provider` is a string literal, which `ModelRecord` does not satisfy structurally; `never` accepts all of them by contravariance and the cast lands once in the helper rather than at five call sites.

Worth knowing: `bun run lint` builds types and is what catches that — **`typecheck:tests` passed on the broken version**.

## Verification

`format-check`, `lint` (exit 0), `typecheck:tests`, and `--check-sections` all clean. `bun scripts/test.ts vitest unit provider` — 43 files / 539 passed, 1 skipped. The contract file itself is 41/41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWp6Z6wvAPDaDCjAFcTSj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWp6Z6wvAPDaDCjAFcTSj6)_