### PR TITLE
Assert guard parity across the transaction proxy, over a derived method set

### DIFF
--- a/packages/test/src/contract/tabular-storage/assertions/guardParity.ts
+++ b/packages/test/src/contract/tabular-storage/assertions/guardParity.ts
@@ -1,0 +1,260 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ITabularStorage } from "@workglow/storage";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  CompoundPrimaryKeyNames,
+  CompoundSchema,
+} from "../../../test/storage-tabular/genericTabularStorageTests";
+import { itExpectFail } from "../../itExpectFail";
+import type { TabularStorageContractOpts } from "../types";
+
+type Storage = ITabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>;
+
+/**
+ * What one call did, reduced to what can be compared across the two paths.
+ *
+ * Only the error's class and message, not the instance: the two calls throw
+ * from the same guard but not the same throw site, and identity would make the
+ * comparison vacuous.
+ */
+type Outcome =
+  | { readonly kind: "returned" }
+  | { readonly kind: "threw"; readonly name: string; readonly message: string };
+
+async function outcomeOf(call: () => Promise<unknown>): Promise<Outcome> {
+  try {
+    await call();
+    return { kind: "returned" };
+  } catch (error) {
+    return {
+      kind: "threw",
+      name: error instanceof Error ? error.constructor.name : typeof error,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+interface GuardParityCase {
+  /** The public method, which is also the name the `tx` handle is called by. */
+  readonly method: string;
+  /** What makes the input bad, phrased as the test name reads it. */
+  readonly label: string;
+  readonly run: (target: Storage) => Promise<unknown>;
+}
+
+/**
+ * The inputs a guard is supposed to reject, one per guard rather than one per
+ * method: `queryIndex` has two ways to fail `validateSelect` and both are here,
+ * because a fix that reinstates one and not the other is the same bug again.
+ */
+const CASES: readonly GuardParityCase[] = [
+  {
+    method: "getAll",
+    label: "a limit of zero",
+    run: (t) => t.getAll({ limit: 0 }),
+  },
+  {
+    method: "getAll",
+    label: "a negative offset",
+    run: (t) => t.getAll({ offset: -1 }),
+  },
+  {
+    method: "getPage",
+    label: "a limit of zero",
+    run: (t) => t.getPage({ limit: 0 }),
+  },
+  {
+    method: "count",
+    label: "empty criteria",
+    run: (t) => t.count({}),
+  },
+  {
+    method: "query",
+    label: "an operator outside the allow-list",
+    run: (t) => t.query({ name: { operator: "regex", value: "a" } } as never),
+  },
+  {
+    method: "query",
+    label: "a column that is not in the schema",
+    run: (t) => t.query({ nope: "a" } as never),
+  },
+  {
+    method: "query",
+    label: "a list operator whose value is not an array",
+    run: (t) => t.query({ name: { operator: "in", value: "a" } } as never),
+  },
+  {
+    method: "queryPage",
+    label: "empty criteria",
+    run: (t) => t.queryPage({}, { limit: 5 }),
+  },
+  {
+    method: "queryIndex",
+    label: "an empty select",
+    run: (t) => t.queryIndex({ name: "a" }, { select: [] } as never),
+  },
+  {
+    method: "queryIndex",
+    label: "a select column that is not in the schema",
+    run: (t) => t.queryIndex({ name: "a" }, { select: ["nope"] } as never),
+  },
+  {
+    method: "deleteSearch",
+    label: "empty criteria",
+    run: (t) => t.deleteSearch({}),
+  },
+  {
+    method: "deleteSearch",
+    label: "criteria that exclude nothing",
+    run: (t) => t.deleteSearch({ option: { operator: "not-in", value: [] } } as never),
+  },
+  {
+    method: "updateWhere",
+    label: "a patch that rewrites a primary-key column",
+    run: (t) => t.updateWhere({ name: "guard", type: "parity" }, { name: "moved" } as never),
+  },
+];
+
+/**
+ * Methods the `tx` handle routes that no guard rejects an input to, and why.
+ *
+ * Not an exemption list — a name here is a claim that the method was read and
+ * has nothing to check, and the coverage assertion below is what forces the
+ * claim to be made rather than skipped.
+ */
+const UNGUARDED: Readonly<Record<string, string>> = {
+  put: "an entity is coerced against the schema, not rejected by a guard",
+  putBulk: "as `put`",
+  get: "a primary key, and a malformed one reads as a miss on every backend",
+  getBulk: "as `get`",
+  delete: "as `get`",
+  deleteAll: "takes no arguments",
+  size: "takes no arguments",
+  getOffsetPage: "takes two numbers and the SQL backends validate neither",
+};
+
+/** The public name the transaction proxy reaches `_fooInternal` by. */
+function publicNameOf(internal: string): string | undefined {
+  const match = /^_(.+)Internal$/.exec(internal);
+  return match?.[1];
+}
+
+/**
+ * Every method the transaction proxy routes, read off the instance rather than
+ * listed here.
+ *
+ * The proxy resolves `tx.foo` by looking for a `_fooInternal` property, so this
+ * is the same question it asks, asked of the same object — which is what makes
+ * a method added later show up without anyone remembering to add it.
+ */
+function routedMethods(storage: Storage): string[] {
+  const found = new Set<string>();
+  for (
+    let proto: object | null = Object.getPrototypeOf(storage);
+    proto !== null && proto !== Object.prototype;
+    proto = Object.getPrototypeOf(proto)
+  ) {
+    for (const key of Object.getOwnPropertyNames(proto)) {
+      const name = publicNameOf(key);
+      if (name !== undefined && typeof (storage as never)[key] === "function") found.add(name);
+    }
+  }
+  return [...found].sort();
+}
+
+/**
+ * A guard on a public method is not a guard on the transaction path.
+ *
+ * `withTransaction` hands its callback a Proxy that resolves `tx.foo(...)` to
+ * `_fooInternal(...)` by name, so a check written on `foo` is silently absent
+ * from `tx.foo`. That has happened twice: a `deleteSearch` guard moved to the
+ * public method turned `tx.deleteSearch({})` from a no-op into a `DELETE FROM t
+ * WHERE` syntax error, and criteria excluding nothing into a truncated table;
+ * and a primary-key guard on the public `updateWhere` alone let
+ * `tx.updateWhere` rewrite a row's identity where the same call outside a
+ * transaction threw. Both were found by reading the diff.
+ *
+ * So the property is stated once, for both paths at once, and the set of
+ * methods it covers is derived from the object rather than written down —
+ * a method added with a guard on one path and not the other fails here without
+ * anyone remembering this file exists.
+ */
+export function guardParityBlock(opts: TabularStorageContractOpts): void {
+  const expectFails = new Set(opts.expectedFailures ?? []);
+  const itImpl = expectFails.has("guardParity") ? itExpectFail : it;
+
+  describe.skipIf(!opts.capabilities.supportsTransactions || !opts.capabilities.supportsQuery)(
+    "guardParity",
+    () => {
+      let storage: Storage;
+
+      beforeEach(async () => {
+        storage = await opts.createStorage();
+        await storage.setupDatabase?.();
+        await storage.put({ name: "guard", type: "parity", option: "base", success: true });
+      });
+
+      afterEach(async () => {
+        await storage.deleteAll();
+        storage.destroy?.();
+        await opts.releaseStorage?.(storage);
+      });
+
+      for (const testCase of CASES) {
+        itImpl(
+          `${testCase.method} rejects ${testCase.label} the same way inside a transaction`,
+          async () => {
+            const direct = await outcomeOf(() => testCase.run(storage));
+
+            let inside: Outcome | undefined;
+            await storage.withTransaction(async (tx) => {
+              // Captured rather than rethrown: a guard firing is the expected
+              // result here, and letting it out would roll the transaction back
+              // and hide which of the two paths differed.
+              inside = await outcomeOf(() => testCase.run(tx as unknown as Storage));
+            });
+
+            expect(inside).toEqual(direct);
+          },
+          opts.timeout
+        );
+      }
+
+      itImpl(
+        "deleteSearch with empty criteria deletes nothing on either path",
+        async () => {
+          // The one case whose parity is a non-event: both paths return, and
+          // the guard is only observable in the rows that are still there.
+          await storage.deleteSearch({});
+          await storage.withTransaction(async (tx) => {
+            await tx.deleteSearch({});
+          });
+
+          expect(await storage.get({ name: "guard", type: "parity" })).toBeDefined();
+        },
+        opts.timeout
+      );
+
+      itImpl(
+        "states, for every method the transaction proxy routes, what its guard is",
+        async () => {
+          // The ratchet. A `_fooInternal` added later is routed by the proxy the
+          // moment it exists, so it arrives on the transaction path whether or
+          // not anyone thought about its guard — and this is where that is
+          // noticed, rather than in the diff of the commit that drops one.
+          const covered = new Set(CASES.map((testCase) => testCase.method));
+          const unstated = routedMethods(storage).filter(
+            (method) => !covered.has(method) && UNGUARDED[method] === undefined
+          );
+          expect(unstated).toEqual([]);
+        },
+        opts.timeout
+      );
+    }
+  );
+}

--- a/packages/test/src/contract/tabular-storage/runTabularStorageContract.ts
+++ b/packages/test/src/contract/tabular-storage/runTabularStorageContract.ts
@@ -6,6 +6,7 @@
 
 import { describe } from "vitest";
 import { countMatchesQueryBlock } from "./assertions/countMatchesQuery";
+import { guardParityBlock } from "./assertions/guardParity";
 import { inListCriterionBlock } from "./assertions/inListCriterion";
 import { notInListCriterionBlock } from "./assertions/notInListCriterion";
 import { subscribeToChangesBlock } from "./assertions/subscribeToChanges";
@@ -23,6 +24,7 @@ export function runTabularStorageContract(opts: TabularStorageContractOpts): voi
     countMatchesQueryBlock(opts);
     inListCriterionBlock(opts);
     notInListCriterionBlock(opts);
+    guardParityBlock(opts);
   });
 }
 

--- a/packages/test/src/contract/tabular-storage/types.ts
+++ b/packages/test/src/contract/tabular-storage/types.ts
@@ -34,7 +34,8 @@ export type TabularStorageContractAssertion =
   | "withConnectionTransaction"
   | "countMatchesQuery"
   | "inListCriterion"
-  | "notInListCriterion";
+  | "notInListCriterion"
+  | "guardParity";
 
 interface TabularStorageContractBaseOpts {
   readonly name: string;


### PR DESCRIPTION
Closes #907.

`withTransaction` hands its callback a Proxy that resolves `tx.foo(...)` to `_fooInternal(...)` **by name**, and the convention is documented as a feature — *"any public method with a matching `_fooInternal` is enough; no map to keep in step."* The cost of no map is that a guard written on the public method is silently absent from the transaction path, and that has cost twice:

- `19a458c` — `tx.deleteSearch({})` built ``DELETE FROM `t` WHERE `` (a syntax error where it had been a no-op), and criteria that were nothing but empty `not-in` lists built `WHERE 1 = 1` and **emptied the table**.
- `4386d22` — `tx.updateWhere({ id: "a" }, { id: "b" })` rewrote the row's identity, where the identical call outside a transaction threw `StorageValidationError`.

Both fixes added the contract case for *their own* method. Nothing stated the general property, so the third instance would have cost the same reading.

## The block

`guardParityBlock` runs each bad input twice — against the storage directly and through the `tx` handle — and asserts the two **outcomes are equal**: the error's class and message, or the absence of one.

```ts
const direct = await outcomeOf(() => testCase.run(storage));
let inside: Outcome | undefined;
await storage.withTransaction(async (tx) => {
  inside = await outcomeOf(() => testCase.run(tx as unknown as Storage));
});
expect(inside).toEqual(direct);
```

Captured rather than rethrown: a guard firing is the expected result, and letting it out would roll the transaction back and hide which path differed.

Twelve inputs across eight methods — `getAll` (limit, offset), `getPage`, `count`, `query` (operator, column, non-array list value), `queryPage`, `queryIndex` (empty select, unknown column), `deleteSearch` (empty, excludes-nothing), `updateWhere`. Two of those existed before, each written for the bug that produced it.

## The set of methods is derived, not written down

This is the part that matters, and it is where the issue's proposal is taken further. A hand-written seven-row table is a second map to keep in step — the thing the convention exists to avoid, reintroduced in the test.

Instead the block walks the instance's prototype chain for `_fooInternal` properties — the same question the proxy asks, of the same object — and fails naming any routed method that has neither a parity case nor an entry in `UNGUARDED`:

```ts
const UNGUARDED: Readonly<Record<string, string>> = {
  put: "an entity is coerced against the schema, not rejected by a guard",
  get: "a primary key, and a malformed one reads as a miss on every backend",
  deleteAll: "takes no arguments",
  getOffsetPage: "takes two numbers and the SQL backends validate neither",
  …
};
```

That is not an exemption list — a name there is a claim the method was read and has nothing to check, and the coverage assertion is what forces the claim to be *made* rather than skipped. A `_fooInternal` added later is routed by the proxy the moment it exists, so it reaches the transaction path whether or not anyone thought about its guard; this is where that gets noticed.

Skipped where there is no transaction path to diverge from, which leaves it running on the three SQL backends that route through `createTxView`.

## Verified by reproducing both bugs

| change | result |
| --- | --- |
| remove `shouldRunDeleteSearch` from `_deleteSearchInternal` | 3 cases red, including "deletes nothing on either path" |
| remove `assertPatchKeepsPrimaryKey` from `_updateWhereInternal` | `updateWhere` case red |
| add a `_pruneInternal` with no case | coverage assertion red: `expected [ 'prune' ] to deeply equal []` |

Green as it stands: 15 cases each on SQLite, DuckDB and Postgres; the full `storage-tabular` slice is 1647 passed / 195 skipped. `format-check`, `lint` (type-aware), `typecheck:tests` and `--check-sections` all clean.

## Not done here

The issue's alternative — routing `createTxView` to a public-method wrapper that skips only the mutex, so a guard is on both paths by construction — would delete this whole class of bug rather than assert it away. It is the better fix and it is #702's consolidation territory. This block is what makes waiting for it safe, and it stays useful afterwards as the thing that proves the consolidation kept every guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWp6Z6wvAPDaDCjAFcTSj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWp6Z6wvAPDaDCjAFcTSj6)_