### PR TITLE
Add the IVectorStorage contract suite, and run it on six implementations

### DIFF
--- a/packages/knowledge-base/src/knowledge-base/ScopedVectorStorage.ts
+++ b/packages/knowledge-base/src/knowledge-base/ScopedVectorStorage.ts
@@ -71,6 +71,20 @@ export class ScopedVectorStorage<
       topK: overfetchLimit,
     } as any);
 
-    return this.filterAndStrip(results, options?.topK, overfetchLimit);
+    const scoped = this.filterAndStrip(results, options?.topK, overfetchLimit);
+
+    // On this wrapper's own emitter, and with the rows the caller is handed —
+    // as every inherited event here already does. The inner store's event fires
+    // with the overfetched, unfiltered, unstripped set, so a listener that took
+    // it would see another knowledge base's rows and a count nobody received.
+    // The emitter is typed to the tabular event names; this is the one the
+    // vector interface adds.
+    (
+      this.events as unknown as {
+        emit: (name: string, query: TypedArray, results: unknown[]) => void;
+      }
+    ).emit("similaritySearch", query, scoped);
+
+    return scoped;
   }
 }

--- a/packages/test/src/contract/README.md
+++ b/packages/test/src/contract/README.md
@@ -111,6 +111,7 @@ Capability flags:
 | `IMigrationRunner`                      | `contract/storage-migrations/runMigrationRunnerContract`        | Postgres, SQLite, IndexedDB                                                |
 | `IQueueStorage` + `IRateLimiterStorage` | `test/job-queue/genericJobQueueTests`                           | InMemory, IndexedDB, Postgres, SQLite, Supabase                            |
 | `ITabularStorage`                       | `test/storage-tabular/genericTabularStorageTests`               | InMemory, IndexedDB, Postgres, SQLite, Supabase, FsFolder, HuggingFace     |
+| `IVectorStorage`                        | `contract/vector-storage/runVectorStorageContract`              | InMemory, SQLite, Postgres, IndexedDB, Scoped, Telemetry                   |
 | `IEntitlementProfile`                   | `contract/entitlement-profile/runEntitlementProfileConformance` | Browser, Desktop, Server, Custom                                           |
 | `IBrowserContext`                       | `contract/browser-context/runIBrowserContextConformance`        | Mock, Playwright, BunWebView, Electron                                     |
 | `IHumanConnector`                       | `contract/human-connector/runHumanConnectorConformance`         | MockHumanConnector, McpElicitationConnector                                |

--- a/packages/test/src/contract/vector-storage/assertions/dimensionValidation.ts
+++ b/packages/test/src/contract/vector-storage/assertions/dimensionValidation.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AnyVectorStorage } from "@workglow/storage";
+import { StorageValidationError } from "@workglow/storage";
+import { afterEach, beforeEach, describe, expect } from "vitest";
+import type { VectorStorageContractOpts } from "../types";
+import { EAST, VECTOR_DIMENSIONS } from "../types";
+import { itFor } from "./shared";
+
+const SHORT = new Float32Array([1, 2, 3]);
+const LONG = new Float32Array([1, 2, 3, 4, 5]);
+
+/**
+ * A vector of the wrong width is refused, and refused BEFORE the row lands.
+ *
+ * The store's width is fixed at construction and every row has to have it, so a
+ * row of another width is not a bad read waiting to happen — it is a bad read
+ * arbitrarily far away, surfacing in whichever query first reaches it, with
+ * nothing left to say where it came from. Rejecting late is barely better than
+ * not rejecting: the assertion below reads the table back, because a throw
+ * after the insert satisfies `rejects` and still leaves the row.
+ */
+export function dimensionValidationBlock(opts: VectorStorageContractOpts): void {
+  describe.skipIf(!opts.capabilities.supportsDimensionValidation)("dimensionValidation", () => {
+    const itImpl = itFor(opts, "dimensionValidation");
+    let storage: AnyVectorStorage;
+
+    beforeEach(async () => {
+      storage = await opts.createStorage();
+      await storage.setupDatabase?.();
+    });
+
+    afterEach(async () => {
+      await storage.deleteAll();
+      storage.destroy?.();
+      await opts.releaseStorage?.(storage);
+    });
+
+    itImpl(
+      "declares the width it was built with",
+      async () => {
+        expect(storage.getVectorDimensions()).toBe(VECTOR_DIMENSIONS);
+      },
+      opts.timeout
+    );
+
+    for (const [label, vector] of [
+      ["one entry short", SHORT],
+      ["one entry long", LONG],
+    ] as const) {
+      itImpl(
+        `refuses a put whose vector is ${label}, and writes nothing`,
+        async () => {
+          await expect(storage.put({ id: "x", vector, metadata: {} })).rejects.toBeInstanceOf(
+            StorageValidationError
+          );
+          expect((await storage.getAll()) ?? []).toHaveLength(0);
+        },
+        opts.timeout
+      );
+
+      itImpl(
+        `refuses a search whose query vector is ${label}`,
+        async () => {
+          // The query side is the same rule and a different code path: a
+          // wrong-width query either throws or is quietly coerced by the
+          // engine into a search that returns confident nonsense.
+          await expect(storage.similaritySearch(vector)).rejects.toBeInstanceOf(
+            StorageValidationError
+          );
+        },
+        opts.timeout
+      );
+
+      itImpl(
+        `refuses a putBulk containing a vector that is ${label}, and writes nothing`,
+        async () => {
+          // Not even the good row: a bulk write that half-lands leaves the
+          // caller with no way to know which half.
+          await expect(
+            storage.putBulk([
+              { id: "good", vector: EAST, metadata: {} },
+              { id: "bad", vector, metadata: {} },
+            ])
+          ).rejects.toBeInstanceOf(StorageValidationError);
+          expect((await storage.getAll()) ?? []).toHaveLength(0);
+        },
+        opts.timeout
+      );
+    }
+  });
+}

--- a/packages/test/src/contract/vector-storage/assertions/legacyEncoding.ts
+++ b/packages/test/src/contract/vector-storage/assertions/legacyEncoding.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from "vitest";
+import type { VectorStorageContractOpts } from "../types";
+import { NORTH } from "../types";
+import type { Hit } from "./shared";
+import { itFor, seededStore } from "./shared";
+
+/**
+ * A row written in the column's stored form — by an older release, or by
+ * anything that is not this class's writer — is still searchable.
+ *
+ * This is the other half of the decode that broke: a search path may not assume
+ * every row it reads was encoded by the writer it ships with. Only a backend
+ * that has a stored form to write can be asked, so the block is skipped where
+ * the adapter supplies no `writeRawRow`.
+ */
+export function legacyEncodingBlock(opts: VectorStorageContractOpts): void {
+  describe.skipIf(opts.writeRawRow === undefined)("legacyEncoding", () => {
+    const store = seededStore(opts);
+
+    itFor(opts, "legacyEncoding")(
+      "searches a row that never round-tripped through this writer",
+      async () => {
+        await opts.writeRawRow?.(store(), {
+          id: "legacy",
+          vector: [...NORTH],
+          metadata: { region: "legacy" },
+        });
+
+        const hits = (await store().similaritySearch(NORTH, { topK: 2 })) as Hit[];
+
+        expect(hits.map((hit) => hit.id)).toContain("legacy");
+        // And it decodes to the same thing a written row does, rather than
+        // merely not throwing.
+        const legacy = hits.find((hit) => hit.id === "legacy");
+        expect([...(legacy!.vector as Float32Array)]).toEqual([...NORTH]);
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/vector-storage/assertions/metadataFilter.ts
+++ b/packages/test/src/contract/vector-storage/assertions/metadataFilter.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from "vitest";
+import type { VectorStorageContractOpts } from "../types";
+import { EAST } from "../types";
+import type { Hit } from "./shared";
+import { itFor, seededStore } from "./shared";
+
+/**
+ * A metadata filter narrows the search, and narrows it to what matches rather
+ * than to what happens to be near.
+ *
+ * The case worth stating is the second one: filtering to a row that is NOT the
+ * nearest. A backend that takes the top `k` and then filters returns nothing
+ * there, while one that filters and then ranks returns the row — and the first
+ * behaviour is a silently empty result for every scoped RAG query.
+ */
+export function metadataFilterBlock(opts: VectorStorageContractOpts): void {
+  describe.skipIf(!opts.capabilities.supportsMetadataFilter)("metadataFilter", () => {
+    const store = seededStore(opts);
+    const itImpl = itFor(opts, "metadataFilter");
+
+    itImpl(
+      "returns only the rows the filter matches",
+      async () => {
+        const hits = (await store().similaritySearch(EAST, { filter: { region: "n" } })) as Hit[];
+        expect(hits.map((hit) => hit.id)).toEqual(["north"]);
+      },
+      opts.timeout
+    );
+
+    itImpl(
+      "finds a match the ranking would not have reached",
+      async () => {
+        // `north` is the LAST of the three by similarity to EAST. Asking for it
+        // with topK 1 separates "filter, then rank" from "rank, then filter".
+        const hits = (await store().similaritySearch(EAST, {
+          filter: { region: "n" },
+          topK: 1,
+        })) as Hit[];
+        expect(hits.map((hit) => hit.id)).toEqual(["north"]);
+      },
+      opts.timeout
+    );
+
+    itImpl(
+      "returns nothing when the filter matches nothing",
+      async () => {
+        expect(
+          await store().similaritySearch(EAST, { filter: { region: "nowhere" } })
+        ).toHaveLength(0);
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/vector-storage/assertions/searchOptions.ts
+++ b/packages/test/src/contract/vector-storage/assertions/searchOptions.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from "vitest";
+import type { VectorStorageContractOpts } from "../types";
+import { EAST } from "../types";
+import type { Hit } from "./shared";
+import { itFor, seededStore } from "./shared";
+
+/**
+ * `topK` truncates and `scoreThreshold` filters — and they mean the same thing
+ * on a backend that computes the scores in SQL as on one that scans in memory.
+ *
+ * That parity is not free: it has already had to be fixed once, when the two
+ * paths disagreed about which side of the threshold an exact match fell on.
+ * Stating it here is what makes the next backend inherit the answer instead of
+ * rediscovering the question.
+ */
+export function searchOptionsBlock(opts: VectorStorageContractOpts): void {
+  describe("searchOptions", () => {
+    const store = seededStore(opts);
+    const itImpl = itFor(opts, "searchOptions");
+
+    itImpl(
+      "truncates to topK, keeping the most similar",
+      async () => {
+        const hits = (await store().similaritySearch(EAST, { topK: 2 })) as Hit[];
+        expect(hits.map((hit) => hit.id)).toEqual(["east", "northeast"]);
+      },
+      opts.timeout
+    );
+
+    itImpl(
+      "returns everything when topK exceeds the row count",
+      async () => {
+        // A backend that pushes `topK` into a `LIMIT` and one that slices an
+        // array agree here; one that treats it as an exact count does not.
+        expect(await store().similaritySearch(EAST, { topK: 10 })).toHaveLength(3);
+      },
+      opts.timeout
+    );
+
+    describe.skipIf(!opts.capabilities.supportsScoreThreshold)("scoreThreshold", () => {
+      itImpl(
+        "drops rows scoring below the threshold",
+        async () => {
+          const hits = (await store().similaritySearch(EAST, { scoreThreshold: 0.9 })) as Hit[];
+          expect(hits.map((hit) => hit.id)).toEqual(["east"]);
+        },
+        opts.timeout
+      );
+
+      itImpl(
+        "keeps a row scoring exactly the threshold",
+        async () => {
+          // Zero, because it is the one boundary every backend can hit
+          // exactly: `north` is orthogonal to `EAST`, so its score is 0 in
+          // float32 and in float64 alike. `Math.SQRT1_2` is not — it rounds
+          // down through a Float32Array, so a threshold set to it sits just
+          // above the score the store can produce, and the test would be
+          // measuring the rounding rather than the comparison.
+          //
+          // The boundary is where the SQL and in-memory paths drifted apart
+          // before, and either answer is defensible until one is written down.
+          const hits = (await store().similaritySearch(EAST, { scoreThreshold: 0 })) as Hit[];
+          expect(hits.map((hit) => hit.id)).toEqual(["east", "northeast", "north"]);
+        },
+        opts.timeout
+      );
+    });
+  });
+}

--- a/packages/test/src/contract/vector-storage/assertions/shared.ts
+++ b/packages/test/src/contract/vector-storage/assertions/shared.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AnyVectorStorage } from "@workglow/storage";
+import { afterEach, beforeEach, it } from "vitest";
+import { itExpectFail } from "../../itExpectFail";
+import type { VectorStorageContractAssertion, VectorStorageContractOpts } from "../types";
+import { EAST, NORTH, NORTHEAST } from "../types";
+
+/** A hit, as much of one as every assertion here needs to read. */
+export interface Hit {
+  readonly id: string;
+  readonly score: number;
+  readonly vector: unknown;
+}
+
+export function itFor(
+  opts: VectorStorageContractOpts,
+  assertion: VectorStorageContractAssertion
+): typeof it {
+  return new Set(opts.expectedFailures ?? []).has(assertion) ? (itExpectFail as typeof it) : it;
+}
+
+/**
+ * The three-row fixture every block searches over: two axis-aligned unit
+ * vectors and the bisector between them, so a cosine search from `EAST` has one
+ * exact match, one at `SQRT1_2` and one orthogonal — three distinct scores in a
+ * known order, which is what makes "ranked by similarity" checkable rather than
+ * merely non-empty.
+ */
+export function seededStore(opts: VectorStorageContractOpts): () => AnyVectorStorage {
+  let storage: AnyVectorStorage;
+
+  beforeEach(async () => {
+    storage = await opts.createStorage();
+    await storage.setupDatabase?.();
+    await storage.putBulk([
+      { id: "east", vector: EAST, metadata: { region: "e" } },
+      { id: "north", vector: NORTH, metadata: { region: "n" } },
+      { id: "northeast", vector: NORTHEAST, metadata: { region: "ne" } },
+    ]);
+  });
+
+  afterEach(async () => {
+    await storage.deleteAll();
+    storage.destroy?.();
+    await opts.releaseStorage?.(storage);
+  });
+
+  return () => storage;
+}

--- a/packages/test/src/contract/vector-storage/assertions/similarityRanking.ts
+++ b/packages/test/src/contract/vector-storage/assertions/similarityRanking.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from "vitest";
+import type { VectorStorageContractOpts } from "../types";
+import { EAST } from "../types";
+import type { Hit } from "./shared";
+import { itFor, seededStore } from "./shared";
+
+/**
+ * A search returns the rows, most similar first.
+ *
+ * This is the assertion the tree did not have, and the one that cost: a release
+ * shipped in which `similaritySearch` re-decoded a vector column the inherited
+ * tabular read had already turned into a `Float32Array`, so `JSON.parse` threw
+ * on the first row of every search. Writes, dimension validation and `getAll`
+ * were all fine — a store that accepts writes and fails every query looks
+ * healthy from anywhere except a query, and only one backend had a test that
+ * issued one.
+ */
+export function similarityRankingBlock(opts: VectorStorageContractOpts): void {
+  describe("similarityRanking", () => {
+    const store = seededStore(opts);
+
+    itFor(opts, "similarityRanking")(
+      "returns the stored rows ranked by similarity, with the scores that ordered them",
+      async () => {
+        const hits = (await store().similaritySearch(EAST)) as Hit[];
+
+        expect(hits.map((hit) => hit.id)).toEqual(["east", "northeast", "north"]);
+        // The order alone would hold for a backend that returned them in
+        // insertion order by luck. The scores are what say it measured.
+        expect(hits[0]!.score).toBeCloseTo(1, 5);
+        expect(hits[1]!.score).toBeCloseTo(Math.SQRT1_2, 5);
+        expect(hits[2]!.score).toBeCloseTo(0, 5);
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/vector-storage/assertions/similaritySearchEvent.ts
+++ b/packages/test/src/contract/vector-storage/assertions/similaritySearchEvent.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from "vitest";
+import type { VectorStorageContractOpts } from "../types";
+import { EAST } from "../types";
+import type { Hit } from "./shared";
+import { itFor, seededStore } from "./shared";
+
+/**
+ * The `similaritySearch` event is the one thing `IVectorStorage` adds to the
+ * tabular event surface, and it carries the results — not a count, and not the
+ * rows before the options were applied.
+ *
+ * Telemetry and cache layers wrap these stores and read that payload as the
+ * answer the caller got. An event that fires with the unfiltered set reports
+ * work nobody received.
+ */
+export function similaritySearchEventBlock(opts: VectorStorageContractOpts): void {
+  describe("similaritySearchEvent", () => {
+    const store = seededStore(opts);
+
+    itFor(opts, "similaritySearchEvent")(
+      "fires with the results the caller was handed",
+      async () => {
+        let seen: Hit[] | undefined;
+        // The vector extension of the event surface; the inherited `on` is
+        // typed to the tabular names, so the cast is at the call site.
+        (
+          store() as unknown as {
+            on: (name: string, fn: (query: unknown, results: Hit[]) => void) => void;
+          }
+        ).on("similaritySearch", (_query, results) => {
+          seen = results;
+        });
+
+        await store().similaritySearch(EAST, { topK: 1 });
+
+        expect(seen?.map((hit) => hit.id)).toEqual(["east"]);
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/vector-storage/assertions/vectorRoundTrip.ts
+++ b/packages/test/src/contract/vector-storage/assertions/vectorRoundTrip.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from "vitest";
+import type { VectorStorageContractOpts } from "../types";
+import { EAST } from "../types";
+import type { Hit } from "./shared";
+import { itFor, seededStore } from "./shared";
+
+/**
+ * A hit's vector comes back as the declared `TypedArray`, not as whatever the
+ * column stores.
+ *
+ * The stored form is a backend's own business — JSON text, a native vector
+ * type, a blob — and every one of them has a decode step on the search path
+ * that the tabular read does not exercise. Handing back a string or a plain
+ * array is a break for every caller doing arithmetic on the result, and it is
+ * invisible to a test that only reads `id` and `score`.
+ */
+export function vectorRoundTripBlock(opts: VectorStorageContractOpts): void {
+  describe("vectorRoundTrip", () => {
+    const store = seededStore(opts);
+
+    itFor(opts, "vectorRoundTrip")(
+      "hands back the vector as a TypedArray with the values that were written",
+      async () => {
+        const [hit] = (await store().similaritySearch(EAST, { topK: 1 })) as Hit[];
+
+        expect(ArrayBuffer.isView(hit!.vector)).toBe(true);
+        expect([...(hit!.vector as Float32Array)]).toEqual([...EAST]);
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/vector-storage/runVectorStorageContract.ts
+++ b/packages/test/src/contract/vector-storage/runVectorStorageContract.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe } from "vitest";
+import { dimensionValidationBlock } from "./assertions/dimensionValidation";
+import { legacyEncodingBlock } from "./assertions/legacyEncoding";
+import { metadataFilterBlock } from "./assertions/metadataFilter";
+import { searchOptionsBlock } from "./assertions/searchOptions";
+import { similarityRankingBlock } from "./assertions/similarityRanking";
+import { similaritySearchEventBlock } from "./assertions/similaritySearchEvent";
+import { vectorRoundTripBlock } from "./assertions/vectorRoundTrip";
+import type { VectorStorageContractOpts } from "./types";
+
+/**
+ * The conformance suite for {@link IVectorStorage}, in the shape
+ * `runTabularStorageContract` already has.
+ *
+ * Eight classes implement the interface and each had its own hand-written file,
+ * no two checking the same things — which is how a release shipped in which
+ * every single query failed on one backend: its sibling suite only ever wrote
+ * and read back, so nothing there issued a search. The fix added seven cases,
+ * all against that one backend, and the other seven implementations gained
+ * nothing.
+ */
+export function runVectorStorageContract(opts: VectorStorageContractOpts): void {
+  describe.skipIf(opts.skip)(`Vector storage contract: ${opts.name}`, () => {
+    similarityRankingBlock(opts);
+    vectorRoundTripBlock(opts);
+    searchOptionsBlock(opts);
+    metadataFilterBlock(opts);
+    similaritySearchEventBlock(opts);
+    legacyEncodingBlock(opts);
+    dimensionValidationBlock(opts);
+  });
+}
+
+export {
+  EAST,
+  NORTH,
+  NORTHEAST,
+  VECTOR_DIMENSIONS,
+  VectorItemPrimaryKeyNames,
+  VectorItemSchema,
+} from "./types";
+export type {
+  VectorStorageCapabilities,
+  VectorStorageContractAssertion,
+  VectorStorageContractOpts,
+} from "./types";

--- a/packages/test/src/contract/vector-storage/types.ts
+++ b/packages/test/src/contract/vector-storage/types.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AnyVectorStorage } from "@workglow/storage";
+import type { DataPortSchemaObject } from "@workglow/util/schema";
+import { TypedArraySchema } from "@workglow/util/schema";
+
+/**
+ * The schema every backend's own vector suite already declares, hoisted here so
+ * they stop declaring it separately. An `id`, the embedding, and a `metadata`
+ * object — the shape a filter is applied to.
+ */
+export const VectorItemSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    vector: TypedArraySchema(),
+    metadata: { type: "object", format: "metadata", additionalProperties: true },
+  },
+  required: ["id", "vector", "metadata"],
+  additionalProperties: false,
+} as const satisfies DataPortSchemaObject;
+
+export const VectorItemPrimaryKeyNames = ["id"] as const;
+
+/** Four, so a unit vector's cosine score is exactly the coordinate it points along. */
+export const VECTOR_DIMENSIONS = 4;
+
+export const EAST = new Float32Array([1, 0, 0, 0]);
+export const NORTH = new Float32Array([0, 1, 0, 0]);
+export const NORTHEAST = new Float32Array([Math.SQRT1_2, Math.SQRT1_2, 0, 0]);
+
+/**
+ * Closed union of vector-storage contract assertions an adapter can mark as
+ * known failing. A typo in `expectedFailures` becomes a TS error rather than a
+ * silently-ignored entry.
+ */
+export type VectorStorageContractAssertion =
+  | "similarityRanking"
+  | "vectorRoundTrip"
+  | "searchOptions"
+  | "metadataFilter"
+  | "similaritySearchEvent"
+  | "legacyEncoding"
+  | "dimensionValidation";
+
+export interface VectorStorageCapabilities {
+  /** Whether `options.filter` narrows by metadata. */
+  readonly supportsMetadataFilter: boolean;
+  /** Whether `options.scoreThreshold` drops rows below the score. */
+  readonly supportsScoreThreshold: boolean;
+  /**
+   * Whether a write whose vector is the wrong length is refused.
+   *
+   * A backend that stores the vector opaquely cannot check it, and one that
+   * declares this must refuse BEFORE writing — a row of the wrong width that
+   * lands is worse than one that never validates, because the search that
+   * trips over it is arbitrarily far away.
+   */
+  readonly supportsDimensionValidation: boolean;
+}
+
+export interface VectorStorageContractOpts {
+  readonly name: string;
+  readonly skip?: boolean;
+  readonly timeout?: number;
+  readonly capabilities: VectorStorageCapabilities;
+  /** A fresh, empty store of {@link VectorItemSchema} at {@link VECTOR_DIMENSIONS}. */
+  readonly createStorage: () => Promise<AnyVectorStorage>;
+  /**
+   * Releases whatever the factory allocated that the storage does not own —
+   * typically a connection handle. Called from every `afterEach`, passed the
+   * instance the factory returned.
+   */
+  readonly releaseStorage?: (storage: AnyVectorStorage) => void | Promise<void>;
+  /**
+   * Writes a row past this class's writer, in the column's stored form.
+   *
+   * Only a backend that has a stored form to write can supply it, and it is
+   * what the {@link VectorStorageContractAssertion} `legacyEncoding` block
+   * needs: the decode has to accept a row that never round-tripped through the
+   * current writer, and a test that inserts through the writer cannot ask that.
+   */
+  readonly writeRawRow?: (
+    storage: AnyVectorStorage,
+    row: { readonly id: string; readonly vector: readonly number[]; readonly metadata: unknown }
+  ) => Promise<void> | void;
+  readonly expectedFailures?: ReadonlyArray<VectorStorageContractAssertion>;
+}

--- a/packages/test/src/test/vector/InMemoryVectorStorage.test.ts
+++ b/packages/test/src/test/vector/InMemoryVectorStorage.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AnyVectorStorage } from "@workglow/storage";
+import { InMemoryVectorStorage } from "@workglow/storage";
+import { runVectorStorageContract } from "../../contract/vector-storage/runVectorStorageContract";
+import {
+  VECTOR_DIMENSIONS,
+  VectorItemPrimaryKeyNames,
+  VectorItemSchema,
+} from "../../contract/vector-storage/types";
+
+/**
+ * The reference implementation, and the only one that had no vector test at
+ * all — the RAG suites exercised it incidentally, which is how a store's own
+ * contract goes unstated. It costs nothing to run and it is what the SQL
+ * backends' answers are compared against.
+ */
+runVectorStorageContract({
+  name: "InMemoryVectorStorage",
+  capabilities: {
+    supportsMetadataFilter: true,
+    supportsScoreThreshold: true,
+    supportsDimensionValidation: true,
+  },
+  createStorage: async (): Promise<AnyVectorStorage> =>
+    new InMemoryVectorStorage(
+      VectorItemSchema,
+      VectorItemPrimaryKeyNames,
+      [],
+      VECTOR_DIMENSIONS
+    ) as unknown as AnyVectorStorage,
+});

--- a/packages/test/src/test/vector/IndexedDbVectorStorage.search.test.ts
+++ b/packages/test/src/test/vector/IndexedDbVectorStorage.search.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "fake-indexeddb/auto";
+
+import { IndexedDbVectorStorage } from "@workglow/indexeddb/storage";
+import type { AnyVectorStorage } from "@workglow/storage";
+import { uuid4 } from "@workglow/util";
+import { runVectorStorageContract } from "../../contract/vector-storage/runVectorStorageContract";
+import {
+  VECTOR_DIMENSIONS,
+  VectorItemPrimaryKeyNames,
+  VectorItemSchema,
+} from "../../contract/vector-storage/types";
+
+/**
+ * The shared contract on IndexedDB.
+ *
+ * Its three existing files cover atomicity, validation and a search of its own
+ * with a fixture nothing else uses, so no two backends were answering the same
+ * question. These are that question, asked here in the same words.
+ */
+runVectorStorageContract({
+  name: "IndexedDbVectorStorage",
+  capabilities: {
+    supportsMetadataFilter: true,
+    supportsScoreThreshold: true,
+    supportsDimensionValidation: true,
+  },
+  createStorage: async (): Promise<AnyVectorStorage> =>
+    new IndexedDbVectorStorage(
+      `vec_contract_${uuid4().replace(/-/g, "_")}`,
+      VectorItemSchema,
+      VectorItemPrimaryKeyNames,
+      [],
+      VECTOR_DIMENSIONS,
+      Float32Array
+    ) as unknown as AnyVectorStorage,
+});

--- a/packages/test/src/test/vector/PostgresVectorStorage.search.test.ts
+++ b/packages/test/src/test/vector/PostgresVectorStorage.search.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { PostgresVectorStorage } from "@workglow/postgres/storage";
+import type { AnyVectorStorage } from "@workglow/storage";
+import { uuid4 } from "@workglow/util";
+import type { Pool } from "pg";
+import { afterAll } from "vitest";
+import { runVectorStorageContract } from "../../contract/vector-storage/runVectorStorageContract";
+import {
+  VECTOR_DIMENSIONS,
+  VectorItemPrimaryKeyNames,
+  VectorItemSchema,
+} from "../../contract/vector-storage/types";
+
+// Its own instance rather than the validation suite's: that file closes its
+// handle in an `afterAll`, which fires before a second top-level describe in
+// the same file would run.
+const db = new PGlite() as unknown as Pool;
+
+afterAll(async () => {
+  await (db as unknown as PGlite).close();
+});
+
+/**
+ * The search half of this backend's contract. Its sibling
+ * `PostgresVectorStorage.validation.test.ts` keeps what is specific to it — the
+ * finite-number checks on a vector's individual components, which are about the
+ * values rather than about what a search does with them.
+ *
+ * Nothing here was checked on this backend before. The seven cases that found
+ * the equivalent break on SQLite were written against SQLite alone.
+ */
+runVectorStorageContract({
+  name: "PostgresVectorStorage",
+  capabilities: {
+    supportsMetadataFilter: true,
+    supportsScoreThreshold: true,
+    supportsDimensionValidation: true,
+  },
+  createStorage: async (): Promise<AnyVectorStorage> =>
+    new PostgresVectorStorage(
+      db,
+      `vec_contract_${uuid4().replace(/-/g, "_")}`,
+      VectorItemSchema,
+      VectorItemPrimaryKeyNames,
+      [],
+      VECTOR_DIMENSIONS
+    ) as unknown as AnyVectorStorage,
+});

--- a/packages/test/src/test/vector/ScopedVectorStorage.contract.test.ts
+++ b/packages/test/src/test/vector/ScopedVectorStorage.contract.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ScopedVectorStorage } from "@workglow/knowledge-base";
+import type { AnyVectorStorage } from "@workglow/storage";
+import { InMemoryVectorStorage } from "@workglow/storage";
+import type { DataPortSchemaObject } from "@workglow/util/schema";
+import { TypedArraySchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+import { runVectorStorageContract } from "../../contract/vector-storage/runVectorStorageContract";
+import { EAST, NORTH, VECTOR_DIMENSIONS } from "../../contract/vector-storage/types";
+
+/**
+ * The inner schema, which carries the `kb_id` this class injects on write and
+ * strips on read. It must be in the inner primary key — the class refuses an
+ * inner store whose key omits it, because the injection would then not
+ * distinguish two knowledge bases' rows.
+ */
+const ScopedInnerSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    kb_id: { type: "string" },
+    vector: TypedArraySchema(),
+    metadata: { type: "object", format: "metadata", additionalProperties: true },
+  },
+  required: ["id", "kb_id", "vector", "metadata"],
+  additionalProperties: false,
+} as const satisfies DataPortSchemaObject;
+
+const ScopedInnerPrimaryKey = ["kb_id", "id"] as const;
+
+function scopedStore(kbId: string): AnyVectorStorage {
+  const inner = new InMemoryVectorStorage(
+    ScopedInnerSchema,
+    ScopedInnerPrimaryKey,
+    [],
+    VECTOR_DIMENSIONS
+  ) as unknown as AnyVectorStorage;
+  return new ScopedVectorStorage(inner, kbId) as unknown as AnyVectorStorage;
+}
+
+/**
+ * The wrapper the whole RAG path runs through, against the shared contract.
+ *
+ * It had no vector test of its own — what coverage it has comes incidentally
+ * through the RAG suites, which are about what a knowledge base does rather
+ * than about what a vector store owes its caller. The contract's outer surface
+ * is exactly this class's: `kb_id` is injected on write and stripped on read,
+ * so a caller sees the same rows it put in.
+ */
+runVectorStorageContract({
+  name: "ScopedVectorStorage",
+  capabilities: {
+    supportsMetadataFilter: true,
+    supportsScoreThreshold: true,
+    supportsDimensionValidation: true,
+  },
+  createStorage: async (): Promise<AnyVectorStorage> => scopedStore("kb-under-test"),
+});
+
+/**
+ * And the one thing the contract cannot ask, because it is what this class adds
+ * rather than what the interface promises: two scopes over one inner store do
+ * not see each other's rows.
+ */
+describe("ScopedVectorStorage scoping", () => {
+  it("keeps two knowledge bases' rows apart in one inner store", async () => {
+    const inner = new InMemoryVectorStorage(
+      ScopedInnerSchema,
+      ScopedInnerPrimaryKey,
+      [],
+      VECTOR_DIMENSIONS
+    ) as unknown as AnyVectorStorage;
+    const a = new ScopedVectorStorage(inner, "kb-a") as unknown as AnyVectorStorage;
+    const b = new ScopedVectorStorage(inner, "kb-b") as unknown as AnyVectorStorage;
+
+    // The same id in both scopes, which is the case the inner primary key has
+    // to include `kb_id` for: one row would otherwise overwrite the other.
+    await a.put({ id: "shared", vector: EAST, metadata: { owner: "a" } });
+    await b.put({ id: "shared", vector: NORTH, metadata: { owner: "b" } });
+
+    const fromA = (await a.similaritySearch(EAST)) as { id: string; metadata: unknown }[];
+    const fromB = (await b.similaritySearch(EAST)) as { id: string; metadata: unknown }[];
+
+    expect(fromA).toHaveLength(1);
+    expect(fromA[0]!.metadata).toEqual({ owner: "a" });
+    expect(fromB).toHaveLength(1);
+    expect(fromB[0]!.metadata).toEqual({ owner: "b" });
+  });
+});

--- a/packages/test/src/test/vector/SqliteVectorStorage.search.test.ts
+++ b/packages/test/src/test/vector/SqliteVectorStorage.search.test.ts
@@ -4,118 +4,62 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { AnyVectorStorage } from "@workglow/storage";
 import { Sqlite, SqliteVectorStorage } from "@workglow/sqlite/storage";
-import type { DataPortSchemaObject } from "@workglow/util/schema";
-import { TypedArraySchema } from "@workglow/util/schema";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runVectorStorageContract } from "../../contract/vector-storage/runVectorStorageContract";
+import {
+  VECTOR_DIMENSIONS,
+  VectorItemPrimaryKeyNames,
+  VectorItemSchema,
+} from "../../contract/vector-storage/types";
 
-const VecSchema = {
-  type: "object",
-  properties: {
-    id: { type: "string" },
-    vector: TypedArraySchema(),
-    metadata: { type: "object", format: "metadata", additionalProperties: true },
-  },
-  required: ["id", "vector", "metadata"],
-  additionalProperties: false,
-} as const satisfies DataPortSchemaObject;
+const TABLE = "vec_search";
 
-const VecPK = ["id"] as const;
-const DIM = 4;
+await Sqlite.init();
 
-/** Unit vectors, so a cosine score is exactly the coordinate it points along. */
-const EAST = new Float32Array([1, 0, 0, 0]);
-const NORTH = new Float32Array([0, 1, 0, 0]);
-const NORTHEAST = new Float32Array([Math.SQRT1_2, Math.SQRT1_2, 0, 0]);
+/**
+ * Each store gets its own `:memory:` database, so the handle has to be closed
+ * with the store rather than at the end of the file.
+ */
+const handles = new WeakMap<object, InstanceType<typeof Sqlite.Database>>();
 
 /**
  * `similaritySearch` end to end on a real SQLite database.
  *
- * The sibling validation suite only ever wrote and read back, which is why this
- * shipped broken: `similaritySearch` re-decoded a vector column the inherited
- * tabular read had already turned into a `Float32Array`, so `JSON.parse` threw
- * on the first row of every search. A store that accepts writes and fails every
- * query looks healthy from anywhere except a query.
+ * This file used to hold seven hand-written cases, added when a release shipped
+ * in which every search on this backend threw: it re-decoded a vector column
+ * the inherited tabular read had already turned into a `Float32Array`, and its
+ * sibling suite only ever wrote and read back. They are the contract now, so
+ * the other seven implementations get them too.
  */
-describe("SqliteVectorStorage similarity search", async () => {
-  await Sqlite.init();
-
-  let db: InstanceType<typeof Sqlite.Database>;
-  let storage: SqliteVectorStorage<typeof VecSchema, typeof VecPK>;
-
-  beforeEach(async () => {
-    db = new Sqlite.Database(":memory:");
-    storage = new SqliteVectorStorage(db, "vec_search", VecSchema, VecPK, [], DIM);
-    await storage.setupDatabase();
-    await storage.putBulk([
-      { id: "east", vector: EAST, metadata: { region: "e" } },
-      { id: "north", vector: NORTH, metadata: { region: "n" } },
-      { id: "northeast", vector: NORTHEAST, metadata: { region: "ne" } },
-    ] as never);
-  });
-
-  afterEach(async () => {
-    await storage.deleteAll();
-    db.close();
-  });
-
-  it("returns the stored rows, ranked by cosine similarity", async () => {
-    const hits = await storage.similaritySearch(EAST);
-    expect(hits.map((hit) => hit.id)).toEqual(["east", "northeast", "north"]);
-    expect(hits[0]!.score).toBeCloseTo(1, 5);
-    expect(hits[1]!.score).toBeCloseTo(Math.SQRT1_2, 5);
-    expect(hits[2]!.score).toBeCloseTo(0, 5);
-  });
-
-  it("hands back the vector as a TypedArray, not the stored JSON", async () => {
-    const [hit] = await storage.similaritySearch(EAST, { topK: 1 });
-    expect(hit!.vector).toBeInstanceOf(Float32Array);
-    expect([...(hit!.vector as Float32Array)]).toEqual([...EAST]);
-  });
-
-  it("honours topK", async () => {
-    expect(await storage.similaritySearch(EAST, { topK: 2 })).toHaveLength(2);
-  });
-
-  it("honours scoreThreshold", async () => {
-    const hits = await storage.similaritySearch(EAST, { scoreThreshold: 0.9 });
-    expect(hits.map((hit) => hit.id)).toEqual(["east"]);
-  });
-
-  it("honours a metadata filter", async () => {
-    const hits = await storage.similaritySearch(EAST, { filter: { region: "n" } });
-    expect(hits.map((hit) => hit.id)).toEqual(["north"]);
-  });
-
-  it("searches rows written as raw JSON by an older release", async () => {
-    // The column's stored form. A row that never round-tripped through this
-    // class's writer must still be searchable, which is the other half of why
-    // the decode accepts both shapes.
-    db.prepare(`INSERT INTO vec_search (id, vector, metadata) VALUES (?, ?, ?)`).run(
-      "legacy",
-      JSON.stringify([...NORTH]),
-      JSON.stringify({ region: "legacy" })
-    );
-
-    const hits = await storage.similaritySearch(NORTH, { topK: 2 });
-    expect(hits.map((hit) => hit.id)).toContain("legacy");
-  });
-
-  it("emits the similaritySearch event with the results", async () => {
-    let seen: readonly { id: string }[] | undefined;
-    // The event belongs to the vector extension of the event surface; the
-    // inherited `on` is typed to the tabular names, so cast at the call site.
-    (
-      storage as unknown as {
-        on: (
-          name: string,
-          fn: (query: unknown, results: readonly { id: string }[]) => void
-        ) => void;
-      }
-    ).on("similaritySearch", (_query, results) => {
-      seen = results;
-    });
-    await storage.similaritySearch(EAST, { topK: 1 });
-    expect(seen?.map((hit) => hit.id)).toEqual(["east"]);
-  });
+runVectorStorageContract({
+  name: "SqliteVectorStorage",
+  capabilities: {
+    supportsMetadataFilter: true,
+    supportsScoreThreshold: true,
+    supportsDimensionValidation: true,
+  },
+  createStorage: async (): Promise<AnyVectorStorage> => {
+    const db = new Sqlite.Database(":memory:");
+    const storage = new SqliteVectorStorage(
+      db,
+      TABLE,
+      VectorItemSchema,
+      VectorItemPrimaryKeyNames,
+      [],
+      VECTOR_DIMENSIONS
+    ) as unknown as AnyVectorStorage;
+    handles.set(storage, db);
+    return storage;
+  },
+  releaseStorage: (storage) => {
+    handles.get(storage)?.close();
+  },
+  writeRawRow: (storage, row) => {
+    // The column's stored form, written past this class's writer.
+    handles
+      .get(storage)
+      ?.prepare(`INSERT INTO ${TABLE} (id, vector, metadata) VALUES (?, ?, ?)`)
+      .run(row.id, JSON.stringify(row.vector), JSON.stringify(row.metadata));
+  },
 });

--- a/packages/test/src/test/vector/TelemetryVectorStorage.contract.test.ts
+++ b/packages/test/src/test/vector/TelemetryVectorStorage.contract.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AnyVectorStorage } from "@workglow/storage";
+import { InMemoryVectorStorage, TelemetryVectorStorage } from "@workglow/storage";
+import { runVectorStorageContract } from "../../contract/vector-storage/runVectorStorageContract";
+import {
+  VECTOR_DIMENSIONS,
+  VectorItemPrimaryKeyNames,
+  VectorItemSchema,
+} from "../../contract/vector-storage/types";
+
+/**
+ * The measuring wrapper, against the contract it must not change.
+ *
+ * A decorator's whole promise is that the thing it wraps behaves the same, and
+ * the way that promise breaks is by forgetting a method: an override that
+ * drops an option, or an inherited one that reaches the wrong `inner`. Running
+ * the same suite through it is how that is noticed.
+ */
+runVectorStorageContract({
+  name: "TelemetryVectorStorage",
+  capabilities: {
+    supportsMetadataFilter: true,
+    supportsScoreThreshold: true,
+    supportsDimensionValidation: true,
+  },
+  createStorage: async (): Promise<AnyVectorStorage> =>
+    new TelemetryVectorStorage(
+      "contract",
+      new InMemoryVectorStorage(
+        VectorItemSchema,
+        VectorItemPrimaryKeyNames,
+        [],
+        VECTOR_DIMENSIONS
+      ) as never
+    ) as unknown as AnyVectorStorage,
+});


### PR DESCRIPTION
Closes #904.

Eight classes implement `IVectorStorage`; each had its own hand-written file and no two checked the same things. That is how #889 shipped: `similaritySearch` re-decoded a vector column the inherited tabular read had already turned into a `Float32Array`, so `JSON.parse` threw on the **first row of every search**. Writes, dimension validation and `getAll` were all fine — a store that accepts writes and fails every query looks healthy from anywhere except a query, and its sibling suite only ever wrote and read back.

The fix added seven cases against that one backend. The other seven implementations gained nothing, and `ScopedVectorStorage` — which the whole RAG path runs through — had no vector test at all.

## The suite

`contract/vector-storage/runVectorStorageContract`, in the shape `runTabularStorageContract` already has: seven capability-discriminated blocks, each nameable in `expectedFailures` through a closed string union.

Those seven cases generalised, joined by the ones they implied:

| block | what it adds beyond #889's version |
| --- | --- |
| `similarityRanking` | asserts the **scores**, not just the order — an order alone holds for a backend that returned insertion order by luck |
| `vectorRoundTrip` | plus the values, so a `Float32Array` of the wrong contents fails |
| `searchOptions` | `topK` beyond the row count; an exactly-representable `scoreThreshold` boundary |
| `metadataFilter` | a filter matching a row the ranking would **not** have reached, and an empty result |
| `similaritySearchEvent` | the payload is what the caller got |
| `legacyEncoding` | plus: it decodes to the same thing a written row does |
| `dimensionValidation` | short **and** long; the query side too; `putBulk` must land *none* of its rows |

Two of those are worth naming. **The filter case that separates "filter then rank" from "rank then filter"**: `north` is the *last* of the three by similarity, so asking for it with `topK: 1` is the difference between a scoped RAG query working and returning nothing. And **`putBulk` writes nothing on a bad row** — half a batch leaves the caller with no way to know which half.

Wired to six: **InMemory** (the reference, and the only one with no vector test at all), **SQLite**, **Postgres**, **IndexedDB**, **Scoped** and **Telemetry**. The last two because a wrapper's whole promise is that the thing it wraps behaves the same, and the way that breaks is forgetting a method.

## Which is what happened

Running it found that **`ScopedVectorStorage` never emitted `similaritySearch`**. It post-filters the inner store's results, so the only event a listener could see was the inner one — firing with the overfetched, unfiltered, unstripped set: another knowledge base's rows, and a count nobody received. Every other event on that class is already emitted on its own emitter with the stripped payload; this one is now too.

That is a one-method fix in `packages/knowledge-base`, and it is the only production change in the PR.

## One correction to my own first draft

The exact-threshold case originally used `Math.SQRT1_2`, and InMemory failed it. That was the test, not the implementation: `Math.SQRT1_2` rounds **down** through a `Float32Array`, so the threshold sat just above the score the store can produce and the case was measuring the rounding. It uses `0` now — `north` is orthogonal to `EAST`, so its score is exactly 0 in float32 and float64 alike, and the comparison is what gets measured.

## Verified

Reintroducing the original bug — narrowing `toVector` back to `JSON.parse` alone — turns **ten** cases red on SQLite. They would now go red on the other five too, which is the entire point.

Green as it stands: `packages/test/src/test/vector/` is 12 files, 174 passed / 5 skipped; the `rag` suites (the consumers of the Scoped change) 399 passed / 5 skipped; `packages/knowledge-base` 248 passed. `format-check`, `lint` (type-aware), `typecheck:tests` and `--check-sections` all clean.

## Not done here

`SqliteAiVectorStorage` and `SupabaseVectorStorage` are not wired. Both need a live dependency their existing files already gate on (a downloaded embedding model; Supabase credentials), so wiring them adds a suite that skips everywhere it would run today. They are the obvious follow-up once the fixtures are cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWp6Z6wvAPDaDCjAFcTSj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWp6Z6wvAPDaDCjAFcTSj6)_