### PR TITLE
Add entitlement approval gate for task classes

### DIFF
--- a/packages/ai/src/task/AiChatWithKbTask.ts
+++ b/packages/ai/src/task/AiChatWithKbTask.ts
@@ -10,10 +10,17 @@ import type {
   CachePolicy,
   IExecuteContext,
   StreamEvent,
+  TaskEntitlements,
   TaskInput,
   Usage,
 } from "@workglow/task-graph";
-import { mergeUsage, TaskConfigSchema, USAGE_OUTPUT_KEY } from "@workglow/task-graph";
+import {
+  Entitlements,
+  TaskConfigSchema,
+  USAGE_OUTPUT_KEY,
+  mergeEntitlements,
+  mergeUsage,
+} from "@workglow/task-graph";
 import type { IHumanRequest } from "@workglow/util";
 import { DEFAULT_LIMITS, resolveHumanConnector } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
@@ -352,6 +359,15 @@ export class AiChatWithKbTask extends StreamingAiTask<
       },
       additionalProperties: false,
     } as const satisfies DataPortSchema;
+  }
+
+  /** Reaches a knowledge base on top of the inference its base class declares. */
+  public static override entitlements(): TaskEntitlements {
+    return mergeEntitlements(super.entitlements(), {
+      entitlements: [
+        { id: Entitlements.STORAGE_READ, reason: "Reads chunks from a knowledge base for context" },
+      ],
+    });
   }
 
   public static override inputSchema(): DataPortSchema {

--- a/packages/ai/src/task/ChunkRetrievalTask.ts
+++ b/packages/ai/src/task/ChunkRetrievalTask.ts
@@ -6,8 +6,13 @@
 
 import type { ChunkRecord, ChunkSearchResult, KnowledgeBase } from "@workglow/knowledge-base";
 import { TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
+import type {
+  IExecuteContext,
+  IRunConfig,
+  TaskConfig,
+  TaskEntitlements,
+} from "@workglow/task-graph";
+import { CreateWorkflow, Entitlements, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, TypedArray } from "@workglow/util/schema";
 import { isTypedArray, TypedArraySchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -233,6 +238,20 @@ export class ChunkRetrievalTask extends Task<
   public static override description =
     "End-to-end retrieval: embed query (if string) and search the knowledge base. Supports similarity and hybrid methods.";
   public static override cacheable = true;
+
+  /** Declared so a host can ask what this reaches before running it. */
+  public static override entitlements(): TaskEntitlements {
+    return {
+      entitlements: [
+        { id: Entitlements.STORAGE_READ, reason: "Searches chunks in a knowledge base" },
+        { id: Entitlements.STORAGE_WRITE, reason: "Installs a text index on first hybrid search" },
+        {
+          id: Entitlements.AI_INFERENCE,
+          reason: "Embeds the query through an owned embedding task",
+        },
+      ],
+    };
+  }
 
   public static override inputSchema(): DataPortSchema {
     return ChunkRetrievalInputSchema as DataPortSchema;

--- a/packages/ai/src/task/ChunkRetrievalTask.ts
+++ b/packages/ai/src/task/ChunkRetrievalTask.ts
@@ -244,7 +244,6 @@ export class ChunkRetrievalTask extends Task<
     return {
       entitlements: [
         { id: Entitlements.STORAGE_READ, reason: "Searches chunks in a knowledge base" },
-        { id: Entitlements.STORAGE_WRITE, reason: "Installs a text index on first hybrid search" },
         {
           id: Entitlements.AI_INFERENCE,
           reason: "Embeds the query through an owned embedding task",

--- a/packages/ai/src/task/ChunkVectorUpsertTask.ts
+++ b/packages/ai/src/task/ChunkVectorUpsertTask.ts
@@ -6,8 +6,14 @@
 
 import type { ChunkRecord, KnowledgeBase } from "@workglow/knowledge-base";
 import { ChunkRecordArraySchema, TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { CachePolicy, IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
+import type {
+  CachePolicy,
+  IExecuteContext,
+  IRunConfig,
+  TaskConfig,
+  TaskEntitlements,
+} from "@workglow/task-graph";
+import { CreateWorkflow, Entitlements, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, TypedArray } from "@workglow/util/schema";
 import { TypedArraySchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -101,6 +107,15 @@ export class ChunkVectorUpsertTask extends Task<
   public static override description =
     "Store chunks + their embeddings in a knowledge base (1:1 aligned)";
   public static override cachePolicy: CachePolicy = { kind: "none" }; // Has side effects
+
+  /** Declared so a host can ask what this reaches before running it. */
+  public static override entitlements(): TaskEntitlements {
+    return {
+      entitlements: [
+        { id: Entitlements.STORAGE_WRITE, reason: "Writes chunk vectors into a knowledge base" },
+      ],
+    };
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/DocumentUpsertTask.ts
+++ b/packages/ai/src/task/DocumentUpsertTask.ts
@@ -6,8 +6,14 @@
 
 import type { DocumentMetadata, DocumentNode, KnowledgeBase } from "@workglow/knowledge-base";
 import { Document, DocumentMetadataSchema, TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { CachePolicy, IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
+import type {
+  CachePolicy,
+  IExecuteContext,
+  IRunConfig,
+  TaskConfig,
+  TaskEntitlements,
+} from "@workglow/task-graph";
+import { CreateWorkflow, Entitlements, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 
@@ -104,6 +110,15 @@ export class DocumentUpsertTask extends Task<
   public static override title = "Add Document";
   public static override description = "Persist a parsed document tree to a knowledge base";
   public static override cachePolicy: CachePolicy = { kind: "none" }; // Has side effects
+
+  /** Declared so a host can ask what this reaches before running it. */
+  public static override entitlements(): TaskEntitlements {
+    return {
+      entitlements: [
+        { id: Entitlements.STORAGE_WRITE, reason: "Writes a document into a knowledge base" },
+      ],
+    };
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/HierarchyJoinTask.ts
+++ b/packages/ai/src/task/HierarchyJoinTask.ts
@@ -7,8 +7,14 @@
 import { ChunkRecordArraySchema, TypeKnowledgeBase } from "@workglow/knowledge-base";
 
 import type { ChunkRecord, KnowledgeBase } from "@workglow/knowledge-base";
-import type { CachePolicy, IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
+import type {
+  CachePolicy,
+  IExecuteContext,
+  IRunConfig,
+  TaskConfig,
+  TaskEntitlements,
+} from "@workglow/task-graph";
+import { CreateWorkflow, Entitlements, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 
@@ -151,6 +157,15 @@ export class HierarchyJoinTask extends Task<
   public static override title = "Hierarchy Join";
   public static override description = "Enrich retrieval metadata with document hierarchy context";
   public static override cachePolicy: CachePolicy = { kind: "none" }; // Has external dependency
+
+  /** Declared so a host can ask what this reaches before running it. */
+  public static override entitlements(): TaskEntitlements {
+    return {
+      entitlements: [
+        { id: Entitlements.STORAGE_READ, reason: "Reads ancestor chunks from a knowledge base" },
+      ],
+    };
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/KbAddDocumentTask.ts
+++ b/packages/ai/src/task/KbAddDocumentTask.ts
@@ -6,8 +6,14 @@
 
 import type { Document, KnowledgeBase } from "@workglow/knowledge-base";
 import { TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { CachePolicy, IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
+import type {
+  CachePolicy,
+  IExecuteContext,
+  IRunConfig,
+  TaskConfig,
+  TaskEntitlements,
+} from "@workglow/task-graph";
+import { CreateWorkflow, Entitlements, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 
@@ -66,6 +72,18 @@ export class KbAddDocumentTask extends Task<
   public static override description =
     "Ingest a document into a knowledge base: chunk, embed, and store via the KB's installed strategy.";
   public static override cachePolicy: CachePolicy = { kind: "none" };
+
+  /** Declared so a host can ask what this reaches before running it. */
+  public static override entitlements(): TaskEntitlements {
+    return {
+      entitlements: [
+        {
+          id: Entitlements.STORAGE_WRITE,
+          reason: "Writes a document and its chunks into a knowledge base",
+        },
+      ],
+    };
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/KbDeleteTask.ts
+++ b/packages/ai/src/task/KbDeleteTask.ts
@@ -6,8 +6,14 @@
 
 import type { KnowledgeBase } from "@workglow/knowledge-base";
 import { TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { CachePolicy, IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
+import type {
+  CachePolicy,
+  IExecuteContext,
+  IRunConfig,
+  TaskConfig,
+  TaskEntitlements,
+} from "@workglow/task-graph";
+import { CreateWorkflow, Entitlements, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 
@@ -57,6 +63,18 @@ export class KbDeleteTask extends Task<KbDeleteTaskInput, KbDeleteTaskOutput, Kb
   public static override title = "KB Delete Document";
   public static override description = "Delete a document and its chunks from a knowledge base.";
   public static override cachePolicy: CachePolicy = { kind: "none" };
+
+  /** Declared so a host can ask what this reaches before running it. */
+  public static override entitlements(): TaskEntitlements {
+    return {
+      entitlements: [
+        {
+          id: Entitlements.STORAGE_WRITE,
+          reason: "Deletes a document and its chunks from a knowledge base",
+        },
+      ],
+    };
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/KbReindexTask.ts
+++ b/packages/ai/src/task/KbReindexTask.ts
@@ -6,8 +6,14 @@
 
 import type { KnowledgeBase } from "@workglow/knowledge-base";
 import { TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { CachePolicy, IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
+import type {
+  CachePolicy,
+  IExecuteContext,
+  IRunConfig,
+  TaskConfig,
+  TaskEntitlements,
+} from "@workglow/task-graph";
+import { CreateWorkflow, Entitlements, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 
@@ -57,6 +63,16 @@ export class KbReindexTask extends Task<
     "Re-chunk and re-embed every document in a knowledge base using its configured models.";
   public static readonly requires: readonly Capability[] = [] as const satisfies Capability[];
   public static override cachePolicy: CachePolicy = { kind: "none" };
+
+  /** Declared so a host can ask what this reaches before running it. */
+  public static override entitlements(): TaskEntitlements {
+    return {
+      entitlements: [
+        { id: Entitlements.STORAGE_READ, reason: "Reads every chunk in a knowledge base" },
+        { id: Entitlements.STORAGE_WRITE, reason: "Rewrites a knowledge base's index" },
+      ],
+    };
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/KbSearchTask.ts
+++ b/packages/ai/src/task/KbSearchTask.ts
@@ -6,8 +6,13 @@
 
 import type { ChunkSearchResult, KnowledgeBase } from "@workglow/knowledge-base";
 import { chunkText, TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
+import type {
+  IExecuteContext,
+  IRunConfig,
+  TaskConfig,
+  TaskEntitlements,
+} from "@workglow/task-graph";
+import { CreateWorkflow, Entitlements, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 
@@ -123,6 +128,15 @@ export class KbSearchTask extends Task<KbSearchTaskInput, KbSearchTaskOutput, Kb
   public static override description =
     "Search a knowledge base. The KB owns its embedding/reranker models and search mode internally.";
   public static override cacheable = true;
+
+  /** Declared so a host can ask what this reaches before running it. */
+  public static override entitlements(): TaskEntitlements {
+    return {
+      entitlements: [
+        { id: Entitlements.STORAGE_READ, reason: "Reads chunks from a knowledge base" },
+      ],
+    };
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/KbToDocumentsTask.ts
+++ b/packages/ai/src/task/KbToDocumentsTask.ts
@@ -6,8 +6,14 @@
 
 import type { DocumentNode, KnowledgeBase } from "@workglow/knowledge-base";
 import { TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { CachePolicy, IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
+import type {
+  CachePolicy,
+  IExecuteContext,
+  IRunConfig,
+  TaskConfig,
+  TaskEntitlements,
+} from "@workglow/task-graph";
+import { CreateWorkflow, Entitlements, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 
@@ -80,6 +86,18 @@ export class KbToDocumentsTask extends Task<
   public static override description =
     "List documents from a knowledge base, optionally filtering to only those that need embedding";
   public static override cachePolicy: CachePolicy = { kind: "none" }; // Depends on external state
+
+  /** Declared so a host can ask what this reaches before running it. */
+  public static override entitlements(): TaskEntitlements {
+    return {
+      entitlements: [
+        {
+          id: Entitlements.STORAGE_READ,
+          reason: "Lists and reads documents from a knowledge base",
+        },
+      ],
+    };
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/TextRerankerTask.ts
+++ b/packages/ai/src/task/TextRerankerTask.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, Workflow } from "@workglow/task-graph";
+import type { TaskConfig, TaskEntitlements } from "@workglow/task-graph";
+import { CreateWorkflow, Entitlements, Workflow, mergeEntitlements } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 import type { ModelConfig } from "../model/ModelSchema";
@@ -108,6 +108,15 @@ export class TextRerankerTask extends AiTask<
   public static override description =
     "Score documents against a query using a cross-encoder reranker model";
   public static override readonly requires = ["text.reranking"] as const satisfies Capability[];
+
+  /** Reaches a knowledge base on top of the inference its base class declares. */
+  public static override entitlements(): TaskEntitlements {
+    return mergeEntitlements(super.entitlements(), {
+      entitlements: [
+        { id: Entitlements.STORAGE_READ, reason: "Reads chunks from a knowledge base" },
+      ],
+    });
+  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/TextRerankerTask.ts
+++ b/packages/ai/src/task/TextRerankerTask.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig, TaskEntitlements } from "@workglow/task-graph";
-import { CreateWorkflow, Entitlements, Workflow, mergeEntitlements } from "@workglow/task-graph";
+import type { TaskConfig } from "@workglow/task-graph";
+import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
 import type { ModelConfig } from "../model/ModelSchema";
@@ -108,15 +108,6 @@ export class TextRerankerTask extends AiTask<
   public static override description =
     "Score documents against a query using a cross-encoder reranker model";
   public static override readonly requires = ["text.reranking"] as const satisfies Capability[];
-
-  /** Reaches a knowledge base on top of the inference its base class declares. */
-  public static override entitlements(): TaskEntitlements {
-    return mergeEntitlements(super.entitlements(), {
-      entitlements: [
-        { id: Entitlements.STORAGE_READ, reason: "Reads chunks from a knowledge base" },
-      ],
-    });
-  }
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/VectorSimilarityTask.ts
+++ b/packages/ai/src/task/VectorSimilarityTask.ts
@@ -103,6 +103,14 @@ export class VectorSimilarityTask extends GraphAsTask<
   static override readonly type = "VectorSimilarityTask";
   /** Pure-compute vector similarity — no provider capability required. */
   public static readonly requires: readonly Capability[] = [] as const satisfies Capability[];
+  /**
+   * Extends {@link GraphAsTask} for its runner and config shape only — {@link execute}
+   * computes the similarities in process and never runs a subgraph, so the inherited
+   * "my reach lives in my children" answer is wrong here. Left inherited, a caller asking
+   * whether this class needs approval is told its reach is undeclared, and the prompt it
+   * draws describes tasks that do not exist.
+   */
+  public static override entitlementsFromChildren: boolean = false;
   static override readonly category = "Vector";
   static override readonly title = "Vector Similarity";
   public static override description =

--- a/packages/ai/src/task/VectorSimilarityTask.ts
+++ b/packages/ai/src/task/VectorSimilarityTask.ts
@@ -5,7 +5,7 @@
  */
 
 import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
-import { CreateWorkflow, GraphAsTask, Workflow } from "@workglow/task-graph";
+import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema, TypedArraySchemaOptions } from "@workglow/util/schema";
 import {
   cosineSimilarity,
@@ -95,7 +95,7 @@ export type VectorSimilarityTaskOutput = FromSchema<
 >;
 export type VectorSimilarityTaskConfig = TaskConfig<VectorSimilarityTaskInput>;
 
-export class VectorSimilarityTask extends GraphAsTask<
+export class VectorSimilarityTask extends Task<
   VectorSimilarityTaskInput,
   VectorSimilarityTaskOutput,
   VectorSimilarityTaskConfig
@@ -103,14 +103,6 @@ export class VectorSimilarityTask extends GraphAsTask<
   static override readonly type = "VectorSimilarityTask";
   /** Pure-compute vector similarity — no provider capability required. */
   public static readonly requires: readonly Capability[] = [] as const satisfies Capability[];
-  /**
-   * Extends {@link GraphAsTask} for its runner and config shape only — {@link execute}
-   * computes the similarities in process and never runs a subgraph, so the inherited
-   * "my reach lives in my children" answer is wrong here. Left inherited, a caller asking
-   * whether this class needs approval is told its reach is undeclared, and the prompt it
-   * draws describes tasks that do not exist.
-   */
-  public static override entitlementsFromChildren: boolean = false;
   static override readonly category = "Vector";
   static override readonly title = "Vector Similarity";
   public static override description =

--- a/packages/ai/src/task/__tests__/KnowledgeBaseEntitlements.test.ts
+++ b/packages/ai/src/task/__tests__/KnowledgeBaseEntitlements.test.ts
@@ -37,8 +37,8 @@ const READS = [
   ["KbSearchTask", KbSearchTask],
   ["KbToDocumentsTask", KbToDocumentsTask],
   ["HierarchyJoinTask", HierarchyJoinTask],
-  ["TextRerankerTask", TextRerankerTask],
   ["AiChatWithKbTask", AiChatWithKbTask],
+  ["ChunkRetrievalTask", ChunkRetrievalTask],
 ] as const satisfies readonly (readonly [string, EntitlementDeclaringTaskClass])[];
 
 const WRITES = [
@@ -47,7 +47,6 @@ const WRITES = [
   ["DocumentUpsertTask", DocumentUpsertTask],
   ["ChunkVectorUpsertTask", ChunkVectorUpsertTask],
   ["KbReindexTask", KbReindexTask],
-  ["ChunkRetrievalTask", ChunkRetrievalTask],
 ] as const satisfies readonly (readonly [string, EntitlementDeclaringTaskClass])[];
 
 describe("knowledge-base tasks declare the storage they reach", () => {
@@ -72,15 +71,27 @@ describe("knowledge-base tasks declare the storage they reach", () => {
   it("keeps the inference its AI base class declares when adding storage", () => {
     // `entitlements()` REPLACES the inherited declaration, so a subclass that
     // returns only its own storage silently drops what its base said it does.
-    const ids = TextRerankerTask.entitlements().entitlements.map((e) => e.id);
+    const ids = AiChatWithKbTask.entitlements().entitlements.map((e) => e.id);
     expect(ids).toContain(Entitlements.AI_INFERENCE);
     expect(ids).toContain(Entitlements.STORAGE_READ);
   });
 
-  it("declares the write ChunkRetrievalTask performs on its first hybrid search", () => {
-    // `installTextIndex` writes an index; reporting only storage:read would
-    // understate it by exactly the operation a reader would want to approve.
+  it("leaves a pure reranker ungated — it takes documents, not a knowledge base", () => {
+    // Its input ports are query/documents/topK/model. The only `kb.` in the file
+    // is a comment saying a KB invokes THIS task; the dependency runs the other
+    // way, and gating it would put a click in front of ordinary scoring.
+    expect(taskClassNeedsApproval(TextRerankerTask)).toBe(false);
+    expect(taskClassReach(TextRerankerTask)).toEqual([]);
+  });
+
+  it("does not claim ChunkRetrievalTask writes, because it only searches", () => {
+    // It names `installTextIndex` in an error message telling the caller how to
+    // fix a missing index, and never calls it — and that method assigns a field
+    // rather than touching storage anyway. `hybridSearch` throws without an
+    // index rather than installing one. Over-declaring reach costs the same as
+    // under-declaring it: a prompt that overstates is a prompt people stop reading.
     const ids = taskClassReach(ChunkRetrievalTask).map((e) => e.id);
-    expect(ids).toContain(Entitlements.STORAGE_WRITE);
+    expect(ids).not.toContain(Entitlements.STORAGE_WRITE);
+    expect(ids).toContain(Entitlements.STORAGE_READ);
   });
 });

--- a/packages/ai/src/task/__tests__/KnowledgeBaseEntitlements.test.ts
+++ b/packages/ai/src/task/__tests__/KnowledgeBaseEntitlements.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  AiChatWithKbTask,
+  ChunkRetrievalTask,
+  ChunkVectorUpsertTask,
+  DocumentUpsertTask,
+  HierarchyJoinTask,
+  KbAddDocumentTask,
+  KbDeleteTask,
+  KbReindexTask,
+  KbSearchTask,
+  KbToDocumentsTask,
+  TextRerankerTask,
+} from "@workglow/ai";
+import type { EntitlementDeclaringTaskClass } from "@workglow/task-graph";
+import {
+  describeTaskClassReach,
+  Entitlements,
+  taskClassNeedsApproval,
+  taskClassReach,
+} from "@workglow/task-graph";
+import { describe, expect, it } from "vitest";
+
+/**
+ * A knowledge base is durable state a caller does not otherwise reach, so a task
+ * touching one has to say so: the approval gate reads the class, and a class that
+ * declares nothing is indistinguishable from one that reaches nothing. Deleting a
+ * document behind a card reading "(nothing beyond running a model)" is the case
+ * these pin.
+ */
+const READS = [
+  ["KbSearchTask", KbSearchTask],
+  ["KbToDocumentsTask", KbToDocumentsTask],
+  ["HierarchyJoinTask", HierarchyJoinTask],
+  ["TextRerankerTask", TextRerankerTask],
+  ["AiChatWithKbTask", AiChatWithKbTask],
+] as const satisfies readonly (readonly [string, EntitlementDeclaringTaskClass])[];
+
+const WRITES = [
+  ["KbDeleteTask", KbDeleteTask],
+  ["KbAddDocumentTask", KbAddDocumentTask],
+  ["DocumentUpsertTask", DocumentUpsertTask],
+  ["ChunkVectorUpsertTask", ChunkVectorUpsertTask],
+  ["KbReindexTask", KbReindexTask],
+  ["ChunkRetrievalTask", ChunkRetrievalTask],
+] as const satisfies readonly (readonly [string, EntitlementDeclaringTaskClass])[];
+
+describe("knowledge-base tasks declare the storage they reach", () => {
+  it.each(READS)("%s declares storage:read", (_name, cls) => {
+    const ids = taskClassReach(cls).map((e) => e.id);
+    expect(ids).toContain(Entitlements.STORAGE_READ);
+  });
+
+  it.each(WRITES)("%s declares storage:write", (_name, cls) => {
+    const ids = taskClassReach(cls).map((e) => e.id);
+    expect(ids).toContain(Entitlements.STORAGE_WRITE);
+  });
+
+  it.each([...READS, ...WRITES])("%s needs approval before it runs", (_name, cls) => {
+    expect(taskClassNeedsApproval(cls)).toBe(true);
+  });
+
+  it.each([...READS, ...WRITES])("%s never describes itself as reaching nothing", (_name, cls) => {
+    expect(describeTaskClassReach(cls)).not.toBe("(nothing beyond running a model)");
+  });
+
+  it("keeps the inference its AI base class declares when adding storage", () => {
+    // `entitlements()` REPLACES the inherited declaration, so a subclass that
+    // returns only its own storage silently drops what its base said it does.
+    const ids = TextRerankerTask.entitlements().entitlements.map((e) => e.id);
+    expect(ids).toContain(Entitlements.AI_INFERENCE);
+    expect(ids).toContain(Entitlements.STORAGE_READ);
+  });
+
+  it("declares the write ChunkRetrievalTask performs on its first hybrid search", () => {
+    // `installTextIndex` writes an index; reporting only storage:read would
+    // understate it by exactly the operation a reader would want to approve.
+    const ids = taskClassReach(ChunkRetrievalTask).map((e) => e.id);
+    expect(ids).toContain(Entitlements.STORAGE_WRITE);
+  });
+});

--- a/packages/task-graph/src/task/EntitlementApproval.ts
+++ b/packages/task-graph/src/task/EntitlementApproval.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { EntitlementId, TaskEntitlement, TaskEntitlements } from "./TaskEntitlements";
+import { Entitlements } from "./TaskEntitlements";
+
+/**
+ * The two statics this rule reads.
+ *
+ * Deliberately narrower than `ITaskConstructor`: a host that holds a task's
+ * class metadata — a catalog entry, a registry lookup — can ask the question
+ * without satisfying the whole task interface.
+ */
+export interface EntitlementDeclaringTaskClass {
+  /**
+   * Whether this class's entitlements come from tasks it contains. Absent is
+   * read as false — see {@link taskClassNeedsApproval} for who owns the gap.
+   */
+  readonly entitlementsFromChildren?: boolean | undefined;
+  entitlements(): TaskEntitlements;
+}
+
+/**
+ * Entitlements a caller that is already running a model necessarily holds.
+ *
+ * The default ambient set for the approval rule below. Running inference is
+ * what such a caller is *for*, so a task that only runs a model reaches nothing
+ * the caller did not already reach, and asking a human to approve it would put
+ * a click in front of ordinary work. Everything else is reach the caller does
+ * not otherwise have: a host and a request body, a path on disk, code, an MCP
+ * server, a browser, stored data, a credential.
+ */
+export const INFERENCE_ENTITLEMENTS: ReadonlySet<EntitlementId> = new Set<EntitlementId>([
+  Entitlements.AI,
+  Entitlements.AI_MODEL,
+  Entitlements.AI_INFERENCE,
+]);
+
+/**
+ * The declared entitlements that fall outside `ambient`.
+ *
+ * Membership is exact, and matching is deliberately NOT hierarchical even
+ * though {@link entitlementCovers} sits next door and would look like the
+ * natural choice. An ambient `ai` must not silently cover an `ai:*` id minted
+ * later: the allowlist is the whole rule, so an entitlement added to the
+ * taxonomy gates the tasks declaring it instead of inheriting a pass from its
+ * parent. Fail-closed on a new capability is the property this exists for; a
+ * caller that genuinely wants a broader pass names the id in `ambient`.
+ */
+export function entitlementsBeyond(
+  declared: readonly TaskEntitlement[],
+  ambient: ReadonlySet<EntitlementId> = INFERENCE_ENTITLEMENTS
+): readonly TaskEntitlement[] {
+  return declared.filter((entitlement) => !ambient.has(entitlement.id));
+}
+
+/**
+ * What running this task class reaches, beyond what the caller already holds.
+ *
+ * Read from the CLASS, so it is answerable before anything is instantiated or
+ * run. A task whose reach widens at run time (`hasDynamicEntitlements`) only
+ * ever widens within a family its static declaration already names — a URL
+ * fetcher adds `network:private` on top of `network:http`, an AI task adds
+ * `ai:model` scoped to the model it resolved — so the static answer is coarser
+ * than the truth but never more permissive than it.
+ */
+export function taskClassReach(
+  taskClass: EntitlementDeclaringTaskClass,
+  ambient: ReadonlySet<EntitlementId> = INFERENCE_ENTITLEMENTS
+): readonly TaskEntitlement[] {
+  return entitlementsBeyond(taskClass.entitlements().entitlements, ambient);
+}
+
+/**
+ * Whether a human should approve before this task class runs.
+ *
+ * Two questions, in order:
+ *
+ * 1. Does the static declaration name reach beyond `ambient`? Then yes.
+ * 2. It does not — but is that empty answer about this task at all? Not when
+ *    the reach lives in tasks it contains.
+ *
+ * The second is the one that is easy to miss. A composed task computes its
+ * aggregate on the INSTANCE, so the static declaration of a graph wrapping a
+ * URL fetcher is empty and a class-only check certifies it as pure.
+ *
+ * `hasDynamicEntitlements` is deliberately NOT what this turns on, though it
+ * looks like the same question. A task is dynamic when it refines what it
+ * already declares, and every AI task is dynamic for exactly that reason —
+ * it attaches the resolved model id to `ai:model`. Gating on the flag would put
+ * an approval in front of running a model at all, which is the one thing a
+ * caller in {@link INFERENCE_ENTITLEMENTS} was always going to do.
+ *
+ * A class that composes without inheriting the marker — one a host synthesized
+ * around saved content, say — reads as false here. That gap belongs to the
+ * host: only it knows which of its classes it wrote.
+ */
+export function taskClassNeedsApproval(
+  taskClass: EntitlementDeclaringTaskClass,
+  ambient: ReadonlySet<EntitlementId> = INFERENCE_ENTITLEMENTS
+): boolean {
+  if (taskClassReach(taskClass, ambient).length > 0) return true;
+  return taskClass.entitlementsFromChildren === true;
+}
+
+function describeEntitlement(entitlement: TaskEntitlement): string {
+  const scope = entitlement.resources?.length ? ` → ${entitlement.resources.join(", ")}` : "";
+  return entitlement.reason
+    ? `${entitlement.id} (${entitlement.reason})${scope}`
+    : `${entitlement.id}${scope}`;
+}
+
+/**
+ * `network:http (Fetches data from URLs via HTTP/HTTPS)` — one line an approval
+ * prompt can show for why this task is being confirmed at all.
+ *
+ * A class gated only by rule 2 above reports that its reach is undeclared
+ * rather than reporting the empty static set as "reaches nothing", which is the
+ * one reading that would make the prompt actively misleading.
+ */
+export function describeTaskClassReach(
+  taskClass: EntitlementDeclaringTaskClass,
+  ambient: ReadonlySet<EntitlementId> = INFERENCE_ENTITLEMENTS
+): string {
+  const reach = taskClassReach(taskClass, ambient);
+  if (reach.length > 0) return reach.map(describeEntitlement).join("; ");
+  if (taskClass.entitlementsFromChildren === true) {
+    return "not declared up front — it depends on the tasks this one runs";
+  }
+  return "(nothing beyond running a model)";
+}

--- a/packages/task-graph/src/task/EntitlementApproval.ts
+++ b/packages/task-graph/src/task/EntitlementApproval.ts
@@ -113,22 +113,30 @@ function describeEntitlement(entitlement: TaskEntitlement): string {
     : `${entitlement.id}${scope}`;
 }
 
+/** What a composed class's reach amounts to, whatever else it declares. */
+const UNDECLARED_REACH = "not declared up front — it depends on the tasks this one runs";
+
 /**
  * `network:http (Fetches data from URLs via HTTP/HTTPS)` — one line an approval
  * prompt can show for why this task is being confirmed at all.
  *
- * A class gated only by rule 2 above reports that its reach is undeclared
- * rather than reporting the empty static set as "reaches nothing", which is the
- * one reading that would make the prompt actively misleading.
+ * Three answers, and the third is why the caveat is appended rather than chosen
+ * between. A class declaring nothing and composing nothing says so plainly. A
+ * class gated only by rule 2 above reports that its reach is undeclared rather
+ * than reporting the empty static set as "reaches nothing", which is the one
+ * reading that would make the prompt actively misleading. A composed class that
+ * ALSO declares reach statically declares only its wrapper's share, so it gets
+ * both — printing just that list is the same misleading reading in a second
+ * spelling.
  */
 export function describeTaskClassReach(
   taskClass: EntitlementDeclaringTaskClass,
   ambient: ReadonlySet<EntitlementId> = INFERENCE_ENTITLEMENTS
 ): string {
   const reach = taskClassReach(taskClass, ambient);
-  if (reach.length > 0) return reach.map(describeEntitlement).join("; ");
-  if (taskClass.entitlementsFromChildren === true) {
-    return "not declared up front — it depends on the tasks this one runs";
+  const declared = reach.map(describeEntitlement).join("; ");
+  if (taskClass.entitlementsFromChildren !== true) {
+    return reach.length > 0 ? declared : "(nothing beyond running a model)";
   }
-  return "(nothing beyond running a model)";
+  return reach.length > 0 ? `${declared}; plus more ${UNDECLARED_REACH}` : UNDECLARED_REACH;
 }

--- a/packages/task-graph/src/task/EntitlementApproval.ts
+++ b/packages/task-graph/src/task/EntitlementApproval.ts
@@ -20,7 +20,13 @@ export interface EntitlementDeclaringTaskClass {
    * read as false — see {@link taskClassNeedsApproval} for who owns the gap.
    */
   readonly entitlementsFromChildren?: boolean | undefined;
-  entitlements(): TaskEntitlements;
+  /**
+   * Optional because `TaskDefinition`-style catalogs are populated by cast, so
+   * a class reaching this rule without the static is reachable in practice.
+   * A class that cannot be asked is treated as unknown, never as empty — see
+   * {@link readDeclaration}.
+   */
+  entitlements?: (() => TaskEntitlements) | undefined;
 }
 
 /**
@@ -33,11 +39,34 @@ export interface EntitlementDeclaringTaskClass {
  * not otherwise have: a host and a request body, a path on disk, code, an MCP
  * server, a browser, stored data, a credential.
  */
-export const INFERENCE_ENTITLEMENTS: ReadonlySet<EntitlementId> = new Set<EntitlementId>([
+export const INFERENCE_ENTITLEMENTS: readonly EntitlementId[] = Object.freeze([
   Entitlements.AI,
   Entitlements.AI_MODEL,
   Entitlements.AI_INFERENCE,
 ]);
+
+/**
+ * Reads a class's declaration, distinguishing "declares nothing" from "cannot
+ * be asked".
+ *
+ * `entitlements` is typed as required on `ITaskStaticProperties`, but catalogs
+ * populate `taskClass` by cast, so a class arriving here without the static is
+ * reachable. Calling it unguarded throws inside the approval path — a gate that
+ * crashes rather than fails closed — and defaulting to an empty list is worse
+ * still: it is indistinguishable from a task that genuinely reaches nothing,
+ * which is the exact reading this module exists to prevent.
+ */
+function readDeclaration(taskClass: EntitlementDeclaringTaskClass): {
+  readonly known: boolean;
+  readonly entitlements: readonly TaskEntitlement[];
+} {
+  if (typeof taskClass.entitlements !== "function") return { known: false, entitlements: [] };
+  try {
+    return { known: true, entitlements: taskClass.entitlements().entitlements ?? [] };
+  } catch {
+    return { known: false, entitlements: [] };
+  }
+}
 
 /**
  * The declared entitlements that fall outside `ambient`.
@@ -49,12 +78,20 @@ export const INFERENCE_ENTITLEMENTS: ReadonlySet<EntitlementId> = new Set<Entitl
  * taxonomy gates the tasks declaring it instead of inheriting a pass from its
  * parent. Fail-closed on a new capability is the property this exists for; a
  * caller that genuinely wants a broader pass names the id in `ambient`.
+ *
+ * An `optional` entitlement is kept rather than skipped, which is where this
+ * parts company with {@link evaluatePolicy} deliberately. That function decides
+ * whether to ALLOW a run and may reasonably ignore reach a task degrades
+ * gracefully without; this one decides what to TELL a person before they
+ * approve, and "might use the network" is exactly what they are being asked
+ * about. The two answer different questions and are not interchangeable.
  */
 export function entitlementsBeyond(
   declared: readonly TaskEntitlement[],
-  ambient: ReadonlySet<EntitlementId> = INFERENCE_ENTITLEMENTS
+  ambient: Iterable<EntitlementId> = INFERENCE_ENTITLEMENTS
 ): readonly TaskEntitlement[] {
-  return declared.filter((entitlement) => !ambient.has(entitlement.id));
+  const held = ambient instanceof Set ? ambient : new Set(ambient);
+  return declared.filter((entitlement) => !held.has(entitlement.id));
 }
 
 /**
@@ -69,9 +106,9 @@ export function entitlementsBeyond(
  */
 export function taskClassReach(
   taskClass: EntitlementDeclaringTaskClass,
-  ambient: ReadonlySet<EntitlementId> = INFERENCE_ENTITLEMENTS
+  ambient: Iterable<EntitlementId> = INFERENCE_ENTITLEMENTS
 ): readonly TaskEntitlement[] {
-  return entitlementsBeyond(taskClass.entitlements().entitlements, ambient);
+  return entitlementsBeyond(readDeclaration(taskClass).entitlements, ambient);
 }
 
 /**
@@ -100,21 +137,33 @@ export function taskClassReach(
  */
 export function taskClassNeedsApproval(
   taskClass: EntitlementDeclaringTaskClass,
-  ambient: ReadonlySet<EntitlementId> = INFERENCE_ENTITLEMENTS
+  ambient: Iterable<EntitlementId> = INFERENCE_ENTITLEMENTS
 ): boolean {
-  if (taskClassReach(taskClass, ambient).length > 0) return true;
+  const declaration = readDeclaration(taskClass);
+  if (!declaration.known) return true;
+  if (entitlementsBeyond(declaration.entitlements, ambient).length > 0) return true;
   return taskClass.entitlementsFromChildren === true;
 }
 
 function describeEntitlement(entitlement: TaskEntitlement): string {
+  // An optional entitlement is reach the task may take, so the card says "may
+  // use" rather than dropping it — see `entitlementsBeyond` on why it is kept.
+  const verb = entitlement.optional ? "may use " : "";
   const scope = entitlement.resources?.length ? ` → ${entitlement.resources.join(", ")}` : "";
   return entitlement.reason
-    ? `${entitlement.id} (${entitlement.reason})${scope}`
-    : `${entitlement.id}${scope}`;
+    ? `${verb}${entitlement.id} (${entitlement.reason})${scope}`
+    : `${verb}${entitlement.id}${scope}`;
 }
 
 /** What a composed class's reach amounts to, whatever else it declares. */
 const UNDECLARED_REACH = "not declared up front — it depends on the tasks this one runs";
+
+/**
+ * Phrased against `ambient` rather than against inference specifically: the set
+ * is a parameter, so a batch runner or CLI passing its own would otherwise be
+ * told a class that runs no model "reaches nothing beyond running a model".
+ */
+const NOTHING_BEYOND_AMBIENT = "(nothing beyond what the caller already holds)";
 
 /**
  * `network:http (Fetches data from URLs via HTTP/HTTPS)` — one line an approval
@@ -131,12 +180,14 @@ const UNDECLARED_REACH = "not declared up front — it depends on the tasks this
  */
 export function describeTaskClassReach(
   taskClass: EntitlementDeclaringTaskClass,
-  ambient: ReadonlySet<EntitlementId> = INFERENCE_ENTITLEMENTS
+  ambient: Iterable<EntitlementId> = INFERENCE_ENTITLEMENTS
 ): string {
-  const reach = taskClassReach(taskClass, ambient);
+  const declaration = readDeclaration(taskClass);
+  const reach = entitlementsBeyond(declaration.entitlements, ambient);
   const declared = reach.map(describeEntitlement).join("; ");
-  if (taskClass.entitlementsFromChildren !== true) {
-    return reach.length > 0 ? declared : "(nothing beyond running a model)";
-  }
+  // Unknown and composed are the same answer to a reader: the list, if any, is
+  // not the whole of it.
+  const undeclared = !declaration.known || taskClass.entitlementsFromChildren === true;
+  if (!undeclared) return reach.length > 0 ? declared : NOTHING_BEYOND_AMBIENT;
   return reach.length > 0 ? `${declared}; plus more ${UNDECLARED_REACH}` : UNDECLARED_REACH;
 }

--- a/packages/task-graph/src/task/GraphAsTask.ts
+++ b/packages/task-graph/src/task/GraphAsTask.ts
@@ -65,6 +65,13 @@ export class GraphAsTask<
   /** Entitlements are always dynamic — they depend on child tasks in the subgraph */
   public static override hasDynamicEntitlements: boolean = true;
 
+  /**
+   * The subgraph is where the reach lives, so this class declares none of it.
+   * Every composed task inherits this, which is what stops a caller reading the
+   * empty static declaration as "reaches nothing".
+   */
+  public static override entitlementsFromChildren: boolean = true;
+
   // ========================================================================
   // Constructor
   // ========================================================================

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -376,6 +376,8 @@ export interface ITaskStaticProperties {
   readonly cachePolicy?: CachePolicy;
   readonly hasDynamicSchemas: boolean;
   readonly hasDynamicEntitlements: boolean;
+  /** Whether entitlements come from contained tasks rather than this class's declaration. */
+  readonly entitlementsFromChildren?: boolean | undefined;
   readonly passthroughInputsToOutputs?: boolean;
   readonly isGraphOutput?: boolean;
   readonly isPassthrough?: boolean;

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -129,6 +129,13 @@ export class Task<
    * representative. A task whose entitlements come from children declares
    * NOTHING statically while its instance may reach anywhere, so the static
    * answer is not merely coarse, it is empty and misleading.
+   *
+   * "Children" means tasks NOT KNOWN UNTIL RUN TIME — the subgraph a
+   * `GraphAsTask` is handed. A task that owns a fixed, hard-coded child in
+   * `execute()` is not this: its reach is knowable from its own source, so it
+   * declares the union its children need and leaves this false. Setting it
+   * there would tell a reader the reach is undeclared when it is merely
+   * inherited — the same misleading prompt in the other direction.
    */
   public static entitlementsFromChildren: boolean = false;
 

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -118,6 +118,21 @@ export class Task<
   public static hasDynamicEntitlements: boolean = false;
 
   /**
+   * Whether this task's entitlements come from tasks it CONTAINS rather than
+   * from its own declaration.
+   *
+   * Distinct from {@link hasDynamicEntitlements}, and the two must not be
+   * conflated by anything deciding whether a static declaration can be
+   * trusted. A task is dynamic when it refines what it already declares —
+   * an AI task declares `ai:inference` statically and adds `ai:model` scoped
+   * to the resolved model id at run time — and there the static answer is
+   * representative. A task whose entitlements come from children declares
+   * NOTHING statically while its instance may reach anywhere, so the static
+   * answer is not merely coarse, it is empty and misleading.
+   */
+  public static entitlementsFromChildren: boolean = false;
+
+  /**
    * Entitlements required by this task class.
    * Subclasses override to declare their permission requirements.
    */

--- a/packages/task-graph/src/task/__tests__/EntitlementApproval.test.ts
+++ b/packages/task-graph/src/task/__tests__/EntitlementApproval.test.ts
@@ -34,6 +34,8 @@ function taskClass(
 describe("INFERENCE_ENTITLEMENTS", () => {
   it("is exactly the three ids a running model already implies", () => {
     expect([...INFERENCE_ENTITLEMENTS].sort()).toEqual(["ai", "ai:inference", "ai:model"]);
+    // Frozen: the gate must not be widenable by a stray push at run time.
+    expect(Object.isFrozen(INFERENCE_ENTITLEMENTS)).toBe(true);
   });
 });
 
@@ -60,7 +62,7 @@ describe("entitlementsBeyond", () => {
   it("honours a caller-supplied ambient set", () => {
     const beyond = entitlementsBeyond(
       [{ id: Entitlements.NETWORK_HTTP }, { id: Entitlements.STORAGE_READ }],
-      new Set([Entitlements.NETWORK_HTTP])
+      [Entitlements.NETWORK_HTTP]
     );
     expect(beyond.map((e) => e.id)).toEqual(["storage:read"]);
   });
@@ -117,6 +119,23 @@ describe("taskClassNeedsApproval", () => {
     expect(taskClassNeedsApproval(refinesOwnFamily)).toBe(false);
   });
 
+  it("gates a class that cannot be asked what it declares", () => {
+    // Catalogs populate `taskClass` by cast, so a class without the static is
+    // reachable here. Reading that as an empty declaration is indistinguishable
+    // from a task that genuinely reaches nothing — the reading this prevents.
+    expect(taskClassNeedsApproval({} as EntitlementDeclaringTaskClass)).toBe(true);
+  });
+
+  it("gates a class whose declaration throws rather than letting the gate crash", () => {
+    const throws: EntitlementDeclaringTaskClass = {
+      entitlements: () => {
+        throw new Error("registry lookup failed");
+      },
+    };
+    expect(() => taskClassNeedsApproval(throws)).not.toThrow();
+    expect(taskClassNeedsApproval(throws)).toBe(true);
+  });
+
   it("gates GraphAsTask, whose reach is only knowable from its subgraph", () => {
     expect(GraphAsTask.entitlements().entitlements).toEqual([]);
     expect(GraphAsTask.entitlementsFromChildren).toBe(true);
@@ -144,15 +163,30 @@ describe("describeTaskClassReach", () => {
     );
   });
 
+  it("marks an optional entitlement as one the task may take", () => {
+    // Kept rather than skipped (unlike evaluatePolicy, which is deciding
+    // whether to allow a run, not what to tell a person before they approve).
+    const described = describeTaskClassReach(
+      taskClass([{ id: Entitlements.NETWORK_HTTP, optional: true }])
+    );
+    expect(described).toBe("may use network:http");
+  });
+
+  it("does not claim a class reaches nothing when it cannot be asked", () => {
+    expect(describeTaskClassReach({} as EntitlementDeclaringTaskClass)).toContain(
+      "not declared up front"
+    );
+  });
+
   it("says so plainly when nothing is reached beyond a model", () => {
     expect(describeTaskClassReach(taskClass([{ id: Entitlements.AI_MODEL }]))).toBe(
-      "(nothing beyond running a model)"
+      "(nothing beyond what the caller already holds)"
     );
   });
 
   it("does not report a composed class as reaching nothing", () => {
     const described = describeTaskClassReach(taskClass([], true));
-    expect(described).not.toBe("(nothing beyond running a model)");
+    expect(described).not.toBe("(nothing beyond what the caller already holds)");
     expect(described).toContain("not declared up front");
   });
 

--- a/packages/task-graph/src/task/__tests__/EntitlementApproval.test.ts
+++ b/packages/task-graph/src/task/__tests__/EntitlementApproval.test.ts
@@ -155,4 +155,15 @@ describe("describeTaskClassReach", () => {
     expect(described).not.toBe("(nothing beyond running a model)");
     expect(described).toContain("not declared up front");
   });
+
+  it("keeps the caveat when a composed class ALSO declares reach statically", () => {
+    // What such a class declares is its wrapper's share, not the whole answer,
+    // so printing only the list is the same misleading reading as reporting the
+    // empty set — the caveat is appended rather than chosen between.
+    const described = describeTaskClassReach(
+      taskClass([{ id: Entitlements.NETWORK_HTTP, reason: "Fetches data from URLs" }], true)
+    );
+    expect(described).toContain("network:http (Fetches data from URLs)");
+    expect(described).toContain("not declared up front");
+  });
 });

--- a/packages/task-graph/src/task/__tests__/EntitlementApproval.test.ts
+++ b/packages/task-graph/src/task/__tests__/EntitlementApproval.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describeTaskClassReach,
+  entitlementsBeyond,
+  Entitlements,
+  GraphAsTask,
+  INFERENCE_ENTITLEMENTS,
+  MapTask,
+  Task,
+  taskClassNeedsApproval,
+  taskClassReach,
+  type EntitlementDeclaringTaskClass,
+  type TaskEntitlement,
+  type TaskEntitlements,
+} from "@workglow/task-graph";
+import { describe, expect, it } from "vitest";
+
+/** Minimal stand-in for a task class; only the statics the rule reads. */
+function taskClass(
+  entitlements: readonly TaskEntitlement[],
+  entitlementsFromChildren = false
+): EntitlementDeclaringTaskClass {
+  return {
+    entitlementsFromChildren,
+    entitlements: (): TaskEntitlements => ({ entitlements }),
+  };
+}
+
+describe("INFERENCE_ENTITLEMENTS", () => {
+  it("is exactly the three ids a running model already implies", () => {
+    expect([...INFERENCE_ENTITLEMENTS].sort()).toEqual(["ai", "ai:inference", "ai:model"]);
+  });
+});
+
+describe("entitlementsBeyond", () => {
+  it("drops the ambient ids and keeps everything else", () => {
+    const beyond = entitlementsBeyond([
+      { id: Entitlements.AI },
+      { id: Entitlements.AI_MODEL },
+      { id: Entitlements.AI_INFERENCE },
+      { id: Entitlements.NETWORK_HTTP },
+    ]);
+    expect(beyond.map((e) => e.id)).toEqual(["network:http"]);
+  });
+
+  it("keeps an id the ambient set does not name, even under an ambient prefix", () => {
+    // The allowlist is the whole rule and matching is exact, NOT hierarchical:
+    // an entitlement added to the taxonomy later must gate the tasks declaring
+    // it rather than inherit a pass from its parent. This is the property the
+    // whole gate exists for, so it is asserted directly.
+    const beyond = entitlementsBeyond([{ id: "ai:autonomous-egress" }]);
+    expect(beyond.map((e) => e.id)).toEqual(["ai:autonomous-egress"]);
+  });
+
+  it("honours a caller-supplied ambient set", () => {
+    const beyond = entitlementsBeyond(
+      [{ id: Entitlements.NETWORK_HTTP }, { id: Entitlements.STORAGE_READ }],
+      new Set([Entitlements.NETWORK_HTTP])
+    );
+    expect(beyond.map((e) => e.id)).toEqual(["storage:read"]);
+  });
+
+  it("returns an empty list for an empty declaration", () => {
+    expect(entitlementsBeyond([])).toEqual([]);
+  });
+});
+
+describe("taskClassReach", () => {
+  it("reports the declared entitlements that are not ambient", () => {
+    const cls = taskClass([
+      { id: Entitlements.AI_INFERENCE },
+      { id: Entitlements.NETWORK_HTTP, reason: "Fetches data from URLs" },
+    ]);
+    expect(taskClassReach(cls).map((e) => e.id)).toEqual(["network:http"]);
+  });
+
+  it("is empty for a class declaring nothing", () => {
+    expect(taskClassReach(taskClass([]))).toEqual([]);
+  });
+});
+
+describe("taskClassNeedsApproval", () => {
+  it("gates a class that reaches past the ambient set", () => {
+    expect(taskClassNeedsApproval(taskClass([{ id: Entitlements.NETWORK_HTTP }]))).toBe(true);
+  });
+
+  it("clears a class that declares nothing and cannot widen", () => {
+    expect(taskClassNeedsApproval(taskClass([]))).toBe(false);
+  });
+
+  it("clears a class that only runs a model", () => {
+    expect(taskClassNeedsApproval(taskClass([{ id: Entitlements.AI_INFERENCE }]))).toBe(false);
+  });
+
+  it("gates an empty declaration whose reach lives in contained tasks", () => {
+    // The hole this closes: a composed task's reach lives in its children, so
+    // its own static declaration is empty and would otherwise certify as pure.
+    expect(taskClassNeedsApproval(taskClass([], true))).toBe(true);
+  });
+
+  it("does NOT gate a task that merely refines what it already declares", () => {
+    // Every AI task sets `hasDynamicEntitlements` so it can attach the resolved
+    // model id to `ai:model`. Reading that flag as "the declaration cannot be
+    // trusted" would put an approval in front of running a model at all — the
+    // one thing a caller holding INFERENCE_ENTITLEMENTS was always going to do.
+    const refinesOwnFamily: EntitlementDeclaringTaskClass = {
+      hasDynamicEntitlements: true,
+      entitlements: (): TaskEntitlements => ({
+        entitlements: [{ id: Entitlements.AI_INFERENCE }],
+      }),
+    } as EntitlementDeclaringTaskClass & { hasDynamicEntitlements: boolean };
+    expect(taskClassNeedsApproval(refinesOwnFamily)).toBe(false);
+  });
+
+  it("gates GraphAsTask, whose reach is only knowable from its subgraph", () => {
+    expect(GraphAsTask.entitlements().entitlements).toEqual([]);
+    expect(GraphAsTask.entitlementsFromChildren).toBe(true);
+    expect(taskClassNeedsApproval(GraphAsTask)).toBe(true);
+  });
+
+  it("gates MapTask, which inherits that shape", () => {
+    expect(taskClassNeedsApproval(MapTask)).toBe(true);
+  });
+
+  it("clears a plain task, which inherits the safe default", () => {
+    expect(Task.entitlementsFromChildren).toBe(false);
+    expect(taskClassNeedsApproval(Task)).toBe(false);
+  });
+});
+
+describe("describeTaskClassReach", () => {
+  it("names each entitlement with its reason and resources", () => {
+    const cls = taskClass([
+      { id: Entitlements.NETWORK_HTTP, reason: "Fetches data from URLs" },
+      { id: Entitlements.FILESYSTEM_READ, resources: ["/tmp/*"] },
+    ]);
+    expect(describeTaskClassReach(cls)).toBe(
+      "network:http (Fetches data from URLs); filesystem:read → /tmp/*"
+    );
+  });
+
+  it("says so plainly when nothing is reached beyond a model", () => {
+    expect(describeTaskClassReach(taskClass([{ id: Entitlements.AI_MODEL }]))).toBe(
+      "(nothing beyond running a model)"
+    );
+  });
+
+  it("does not report a composed class as reaching nothing", () => {
+    const described = describeTaskClassReach(taskClass([], true));
+    expect(described).not.toBe("(nothing beyond running a model)");
+    expect(described).toContain("not declared up front");
+  });
+});

--- a/packages/task-graph/src/task/index.ts
+++ b/packages/task-graph/src/task/index.ts
@@ -8,6 +8,7 @@
 
 export * from "./ConditionalTask";
 export * from "./ConditionUtils";
+export * from "./EntitlementApproval";
 export * from "./EntitlementEnforcer";
 export * from "./EntitlementPolicy";
 export * from "./EntitlementProfile";


### PR DESCRIPTION
Introduces a static approval rule for task classes, and makes this package's RAG tasks declare the knowledge base they reach so the rule has something to read.

## Why here rather than downstream

The entitlement taxonomy says what a task reaches. It has never answered the question a host actually asks it — *given this class, must a person approve before it runs* — so every host wanting a gate writes its own, downstream, against a taxonomy that grows here. An id added here inherits a pass from a list nobody downstream remembers to widen. That direction is the bug.

## The rule

`EntitlementApproval.ts` exports `INFERENCE_ENTITLEMENTS`, `entitlementsBeyond`, `taskClassReach`, `taskClassNeedsApproval` and `describeTaskClassReach`.

- Matching is **exact, not hierarchical**, even though `entitlementCovers` sits next door and looks like the natural choice. An `ai:autonomous-egress` id minted later must gate the tasks declaring it rather than inherit a pass from an ambient `ai`. Fail-closed on a new capability is the point.
- A class that **cannot be asked** for its declaration reads as unknown and gates. Catalogs populate `taskClass` by cast, so one without the static is reachable; calling through unguarded crashed inside the approval path, and defaulting to an empty list is worse — indistinguishable from a task that genuinely reaches nothing.
- An **optional** entitlement is kept and rendered `may use network:http`. This parts company with `evaluatePolicy` deliberately: that decides whether to *allow* a run and may ignore reach a task degrades without; this decides what to *tell a person* before they approve.

### `entitlementsFromChildren`, and what it is not

New static on `Task` (false) / `GraphAsTask` (true). It means **reach not knowable until run time** — the subgraph a `GraphAsTask` is handed.

It is deliberately **not** `hasDynamicEntitlements`, which reads like the same question. A task is dynamic when it *refines what it already declares* — `AiTask` sets it to attach the resolved model id to `ai:model`. **43 tasks in builder's catalog set that flag**, every AI task among them; gating on it puts an approval in front of running a model at all.

It is also **not** set on the five run-time composers in this package (`AiChatWithKbTask`, `ChunkRetrievalTask`, `ContextBuilderTask`, `DocumentEnricherTask`, `HierarchicalChunkerTask`). They own fixed, hard-coded children — a `TextEmbeddingTask`, a `CountTokensTask` — so their reach *is* knowable from their own source. Flagging them would print "not declared up front" about a known child set, which is the same misleading prompt in the other direction. They declare the union instead.

## The case that motivated it

In the first consumer (workglow-dev/builder#461), six tasks in the system catalog are composed — `GraphAsTask`, `FallbackTask`, `MapTask`, `WhileTask`, `ReduceTask` — and each declared nothing statically, so a downstream gate read the empty set as "reaches nothing". A `MapTask` skill ran whatever subgraph an LLM handed it without asking.

Then the same question turned on this package and found the mirror image: `AiTask` was the only class in `packages/ai/src/task/` overriding `entitlements()`, and **no task anywhere in the repo declared `storage:*`** — the taxonomy had it, `EntitlementProfiles` granted it, nothing asked for it. `taskClassNeedsApproval(KbDeleteTask)` returned `false`, and `describeTaskClassReach` said "reaches nothing", for a task whose `execute()` calls `kb.delete()`.

Ten classes now declare what they touch, pinned by tests.

## Correction, kept visible

Two of those declarations were wrong in an earlier commit on this branch and are fixed in `f2b9ebc`. Both came from sweeping for `kb.<method>(` and matching call-shaped text that was not a call:

- **`ChunkRetrievalTask`** was given `storage:write` for "installing a text index on first hybrid search". It does not. It names `installTextIndex` inside an *error message* and never calls it; that method assigns a field rather than touching storage; and `hybridSearch` throws without an index rather than installing one. It declares `storage:read`.
- **`TextRerankerTask`** was given `storage:read`. It reaches no knowledge base at all — its ports are `query`, `documents`, `topK`, `model`, and the only `kb.` in the file is a comment noting a KB invokes *this* task. Its override is removed and it is ungated.

Over-declaring costs what under-declaring costs: a prompt saying a reranker touches storage is one people learn to click through, and then the `KbDeleteTask` prompt stops nobody either. Every remaining declaration was re-checked against an awaited call.

`VectorSimilarityTask` also now extends `Task`. It used nothing from `GraphAsTask` and an earlier commit *overrode* the inherited composed answer to correct it; reparenting makes the wrong answer unrepresentable and drops two more inherited claims (`hasDynamicSchemas`, `hasDynamicEntitlements`) equally untrue of it.

## Downstream

workglow-dev/builder#461 consumes these exports and is **red until this merges and a release ships** — its catalog pins `=0.4.8`. Merge here → release → bump the pin there.

## Verification

- `bun scripts/test.ts ai rag task-graph entitlement unit vitest` — 176 files, **1,743 passed**, 0 failed
- `bun run lint` (type-aware, `--deny-warnings`) and `bun run format-check` — clean
- `bun scripts/test.ts --check-sections` — new test files reachable by section+kind selection

Run on Node 22.22.2, one below the repo's declared floor of 24; storage-backed sections were left unrun for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEFYAGb9D3mWfyhYkmeAvN