### PR TITLE
Add `all` command annotation to mark sibling execution order

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -290,7 +290,11 @@ terminal runs. Three load-bearing properties:
   ship, no plugin loader. Annotation patterns match a command path (`"*"` = one segment,
   trailing `"**"` = the rest); the more literal pattern wins per key. A field widget's
   `search` receives the rest of the form (`WebFieldWidgetContext`), which is what makes a
-  scoped picker possible. `PanelData` covers `table` (with per-row tones), `kv`, `stats`,
+  scoped picker possible. A command annotation also states what an `all`-style command
+  **runs** — its siblings, in order — and `annotateCommandTree` stamps both sides of that
+  from the one declaration: each member's step, and the siblings the `all` leaves out,
+  since `all` is a name that routinely covers less than the group it sits in.
+  `PanelData` covers `table` (with per-row tones), `kv`, `stats`,
   `timeline`, `markdown`, `empty` and `error`; a status widget contributes meters **or** text
   lines, since most of what an operator checks has no denominator to draw a bar against.
 

--- a/examples/cli/src/lib.ts
+++ b/examples/cli/src/lib.ts
@@ -39,6 +39,7 @@ export {
   type WebCommandAnnotation,
   type WebCommandBadge,
   type WebFieldAnnotation,
+  type WebRunsMember,
   type WebTone,
 } from "./web/annotations";
 export type { WebInvocation } from "./web/argv";
@@ -48,7 +49,13 @@ export {
   type CommandSchemaProvider,
   type WebField,
 } from "./web/commandFields";
-export { buildCommandTree, findCommandNode, type WebCommandNode } from "./web/commandTree";
+export {
+  buildCommandTree,
+  findCommandNode,
+  type WebCommandNode,
+  type WebRunsMembership,
+  type WebRunsOrder,
+} from "./web/commandTree";
 export {
   registerWebFieldWidget,
   registerWebPanel,

--- a/examples/cli/src/web/annotations.test.ts
+++ b/examples/cli/src/web/annotations.test.ts
@@ -114,6 +114,128 @@ describe("command annotations", () => {
   });
 });
 
+/** A group whose `all` runs two of the three commands beside it. */
+function syncProgram(): Command {
+  const program = new Command();
+  const sync = program.command("sync");
+  sync.command("all").description("Run every leaf in order");
+  sync.command("submissions").description("EDGAR indexes");
+  sync.command("forms").description("Form sweeps");
+  sync.command("types").description("Ad-hoc form-type sweep");
+  return program;
+}
+
+describe("an `all` that runs its siblings", () => {
+  beforeEach(() => {
+    registerCommandAnnotation({
+      path: ["sync", "all"],
+      source: "sec",
+      runs: [{ name: "submissions" }, { name: "forms", when: "only with --forms" }],
+    });
+  });
+
+  it("tells each member which step of which command runs it", () => {
+    const tree = annotateCommandTree(buildCommandTree(syncProgram()));
+    expect(findCommandNode(tree, ["sync", "submissions"])?.runsIn).toEqual({
+      command: "all",
+      step: 1,
+      of: 2,
+      // One sibling — `types` — is left out, which is what makes marking the
+      // members worth the ink; the client reads this to decide.
+      skipped: 1,
+    });
+    expect(findCommandNode(tree, ["sync", "forms"])?.runsIn).toEqual({
+      command: "all",
+      step: 2,
+      of: 2,
+      skipped: 1,
+      when: "only with --forms",
+    });
+  });
+
+  /**
+   * The half the name argues against, and the reason the marker exists: a
+   * sibling nobody named is one `all` will never run, and only the tree it
+   * sits in can say which those are.
+   */
+  it("names the siblings it does not run", () => {
+    const tree = annotateCommandTree(buildCommandTree(syncProgram()));
+    const order = findCommandNode(tree, ["sync", "all"])?.runsInOrder;
+    expect(order?.members.map((member) => member.name)).toEqual(["submissions", "forms"]);
+    expect(order?.skipped).toEqual(["types"]);
+    expect(findCommandNode(tree, ["sync", "types"])?.runsIn).toBeUndefined();
+  });
+
+  /**
+   * A member is matched by name among the siblings, so a command since renamed
+   * silently marks nothing. It is kept in the order — where it reads as a step
+   * that runs nothing — and named here, which is what a downstream guard test
+   * asserts is empty rather than discovering by looking at the console.
+   */
+  it("reports a member that names no sibling instead of dropping it", () => {
+    registerCommandAnnotation({
+      path: ["sync", "all"],
+      source: "sec",
+      runs: [{ name: "submissions" }, { name: "renamed-away" }],
+    });
+    const order = annotateCommandTree(buildCommandTree(syncProgram()))
+      .flatMap((node) => node.children)
+      .find((node) => node.name === "all")?.runsInOrder;
+    expect(order?.unrunMembers).toEqual(["renamed-away"]);
+    // The position of the members behind it is what the numbering promises.
+    expect(order?.skipped).toEqual(["forms", "types"]);
+  });
+
+  it("stamps a nested order from the sibling set it belongs to", () => {
+    registerCommandAnnotation({
+      path: ["sync", "forms", "all"],
+      source: "sec",
+      runs: [{ name: "portals" }],
+    });
+    const program = syncProgram();
+    const forms = program.commands[0]!.commands.find((command) => command.name() === "forms")!;
+    forms.command("all").description("Every form domain");
+    forms.command("portals").description("CFPORTAL");
+    forms.command("types").description("Ad-hoc");
+
+    const tree = annotateCommandTree(buildCommandTree(program));
+    expect(findCommandNode(tree, ["sync", "forms", "portals"])?.runsIn?.step).toBe(1);
+    expect(findCommandNode(tree, ["sync", "forms", "portals"])?.runsIn?.skipped).toBe(1);
+    expect(findCommandNode(tree, ["sync", "forms", "all"])?.runsInOrder?.skipped).toEqual([
+      "types",
+    ]);
+    // The group is both a member of one order and the runner of another.
+    expect(findCommandNode(tree, ["sync", "forms"])?.runsIn?.command).toBe("all");
+  });
+
+  /**
+   * The other half of the same field: an `all` that runs its whole group has
+   * nothing left over, so its members carry a zero and the console can stop
+   * repeating a chip down every row under a count that already says twelve of
+   * twelve.
+   */
+  it("counts nothing skipped when the order covers the whole group", () => {
+    registerCommandAnnotation({
+      path: ["sync", "all"],
+      source: "sec",
+      runs: [{ name: "submissions" }, { name: "forms" }, { name: "types" }],
+    });
+    const tree = annotateCommandTree(buildCommandTree(syncProgram()));
+    expect(findCommandNode(tree, ["sync", "forms"])?.runsIn?.skipped).toBe(0);
+    expect(findCommandNode(tree, ["sync", "all"])?.runsInOrder?.skipped).toEqual([]);
+  });
+
+  it("leaves a group with no `all` exactly as it was", () => {
+    resetWebAnnotationsForTesting();
+    const tree = annotateCommandTree(buildCommandTree(syncProgram()));
+    for (const name of ["all", "submissions", "forms", "types"]) {
+      const node = findCommandNode(tree, ["sync", name]);
+      expect(node?.runsIn, name).toBeUndefined();
+      expect(node?.runsInOrder, name).toBeUndefined();
+    }
+  });
+});
+
 describe("field annotations", () => {
   it("gives a positional argument a picker the command could not declare", async () => {
     registerCommandFieldAnnotations({

--- a/examples/cli/src/web/annotations.ts
+++ b/examples/cli/src/web/annotations.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { WebCommandNode } from "./commandTree";
+import type { WebCommandNode, WebRunsMembership, WebRunsOrder } from "./commandTree";
 
 /**
  * What a downstream package says ABOUT a command or a field it already has.
@@ -32,6 +32,22 @@ export type WebTone = "ok" | "warn" | "fail" | "info" | "idle";
 export const COMMAND_BADGES = ["ai", "network", "slow", "writes", "destructive"] as const;
 export type WebCommandBadge = (typeof COMMAND_BADGES)[number];
 
+/**
+ * One sibling an `all`-style command runs, in the position it runs it.
+ *
+ * `name` is the sibling's own command name, as the tree shows it — not a path:
+ * an `all` runs what sits beside it, and nothing else can be named here.
+ */
+export interface WebRunsMember {
+  readonly name: string;
+  /**
+   * The condition, in one phrase, when this member does not run every time —
+   * `"only with --download-docs"`, `"unless --skip-ingest"`. Undefined means it
+   * always runs.
+   */
+  readonly when?: string;
+}
+
 export interface WebCommandAnnotation {
   /**
    * Command path to match. A `"*"` segment matches exactly one segment and a
@@ -52,6 +68,20 @@ export interface WebCommandAnnotation {
    * `ai` badge instead; a dialog on every extraction is a dialog nobody reads.
    */
   readonly confirm?: string;
+  /**
+   * The siblings this command runs, in the order it runs them.
+   *
+   * Declared on the `all` itself and stamped onto both sides by
+   * {@link annotateCommandTree}, which is what keeps the two readings of one
+   * fact from drifting: the members are told which step of which `all` they
+   * are, and the `all` is told which siblings it leaves out.
+   *
+   * That last half is the reason this exists. `all` reads as "everything
+   * listed here" and routinely is not — `sync all` skips the ad-hoc sweeper
+   * beside it — and commander carries nothing that says so, so the console
+   * offered a button whose scope could only be learned by reading the source.
+   */
+  readonly runs?: readonly WebRunsMember[];
 }
 
 export interface WebFieldAnnotation {
@@ -137,21 +167,27 @@ export function registerCommandFieldAnnotations(annotations: CommandFieldAnnotat
   else fieldAnnotations.push(annotations);
 }
 
-/** The badges, note and confirmation that apply to one command path. */
+/** The badges, note, confirmation and run order that apply to one command path. */
 export function resolveCommandAnnotation(path: readonly string[]): {
   readonly badges: readonly WebCommandBadge[];
   readonly note: string | undefined;
   readonly confirm: string | undefined;
+  readonly runs: readonly WebRunsMember[] | undefined;
 } {
   const badges = new Set<WebCommandBadge>();
   let note: string | undefined;
   let confirm: string | undefined;
+  // Not unioned the way badges are: an order is one statement about one
+  // command, and merging a group's with a leaf's would invent a sequence
+  // nothing runs. The most specific annotation wins outright.
+  let runs: readonly WebRunsMember[] | undefined;
   for (const annotation of matching(commandAnnotations, path)) {
     for (const badge of annotation.badges ?? []) badges.add(badge);
     if (annotation.note !== undefined) note = annotation.note;
     if (annotation.confirm !== undefined) confirm = annotation.confirm;
+    if (annotation.runs !== undefined) runs = annotation.runs;
   }
-  return { badges: [...badges], note, confirm };
+  return { badges: [...badges], note, confirm, runs };
 }
 
 /** The annotations for one command's fields, keyed by field key. */
@@ -168,19 +204,83 @@ export function resolveFieldAnnotations(
 }
 
 /**
+ * The siblings an `all` runs, and the ones it does not — its own half.
+ *
+ * A member naming no sibling — a command since renamed or removed — stays in
+ * the order, where it reads as a step that runs nothing rather than vanishing,
+ * and is named in `unrunMembers` for a guard test to assert is empty.
+ */
+function runOrderAmong(
+  runner: WebCommandNode,
+  siblings: readonly WebCommandNode[],
+  runs: readonly WebRunsMember[]
+): WebRunsOrder {
+  const named = new Set(runs.map((member) => member.name));
+  return {
+    members: runs,
+    skipped: siblings
+      .filter((sibling) => sibling.name !== runner.name && !named.has(sibling.name))
+      .map((sibling) => sibling.name),
+    unrunMembers: runs
+      .filter((member) => !siblings.some((sibling) => sibling.name === member.name))
+      .map((member) => member.name),
+  };
+}
+
+/**
+ * What each command in one sibling set is told about the `all` that runs it.
+ *
+ * Read off the same declaration the `all` carries, so what a member says and
+ * what the `all` counts cannot disagree — `skipped` travels with each member
+ * for that reason: whether membership is worth marking at all depends on
+ * whether anything beside it is left out, which no member can see for itself.
+ */
+function membershipsAmong(
+  siblings: readonly WebCommandNode[]
+): ReadonlyMap<string, WebRunsMembership> {
+  const memberships = new Map<string, WebRunsMembership>();
+  const names = new Set(siblings.map((sibling) => sibling.name));
+  for (const runner of siblings) {
+    const { runs } = resolveCommandAnnotation(runner.path);
+    if (runs === undefined) continue;
+    const skipped = runOrderAmong(runner, siblings, runs).skipped.length;
+    runs.forEach((member, index) => {
+      // Numbered from the declaration, so a member that names nothing still
+      // costs its position rather than renumbering the ones behind it.
+      if (!names.has(member.name) || member.name === runner.name) return;
+      memberships.set(member.name, {
+        command: runner.name,
+        step: index + 1,
+        of: runs.length,
+        skipped,
+        ...(member.when !== undefined ? { when: member.when } : {}),
+      });
+    });
+  }
+  return memberships;
+}
+
+/**
  * Decorates a command tree with its annotations, in place of the caller
  * walking it. Applied where the tree is served rather than where it is built,
  * so `buildCommandTree` stays a pure reading of the commander program.
  */
 export function annotateCommandTree(nodes: readonly WebCommandNode[]): readonly WebCommandNode[] {
+  // One sibling set at a time, because an `all` is a statement about the
+  // commands beside it: the member rows are stamped from the runner's own
+  // declaration, which no per-node walk could reach.
+  const memberships = membershipsAmong(nodes);
   return nodes.map((node) => {
-    const { badges, note, confirm } = resolveCommandAnnotation(node.path);
+    const { badges, note, confirm, runs } = resolveCommandAnnotation(node.path);
+    const membership = memberships.get(node.name);
     return {
       ...node,
       children: annotateCommandTree(node.children),
       ...(badges.length > 0 ? { badges } : {}),
       ...(note !== undefined ? { note } : {}),
       ...(confirm !== undefined ? { confirm } : {}),
+      ...(runs !== undefined ? { runsInOrder: runOrderAmong(node, nodes, runs) } : {}),
+      ...(membership !== undefined ? { runsIn: membership } : {}),
     };
   });
 }

--- a/examples/cli/src/web/client/app.css
+++ b/examples/cli/src/web/client/app.css
@@ -385,6 +385,11 @@ textarea {
 .grp-h:hover {
   color: var(--ink-2);
 }
+/* A group heading is selectable too — it opens the group's own page — so it
+   says when it is the thing on screen, in the accent the rows use. */
+.grp-h[aria-current="true"] {
+  color: var(--accent-2);
+}
 .caret {
   font-family: var(--mono);
   font-size: 9px;
@@ -725,6 +730,21 @@ h2.sec:first-child {
    does not need the full inter-section gap on top of the lede's own. */
 .lede + h2.sec {
   margin-top: 0;
+}
+
+/* A group's page lists its commands with the descriptions the rail has no room
+   for: the pane has the width, so a line wraps here instead of ellipsizing —
+   which is the whole reason the rail gave it up. The names take a common
+   minimum so the second column starts in one place. */
+.grouplist {
+  padding: 4px;
+}
+.grouplist .cmd-n {
+  min-width: 14ch;
+}
+.grouplist .cmd-d {
+  white-space: normal;
+  overflow: visible;
 }
 
 /* ---------- form ---------- */

--- a/examples/cli/src/web/client/app.css
+++ b/examples/cli/src/web/client/app.css
@@ -1612,6 +1612,61 @@ pre.json .n {
   background: color-mix(in srgb, var(--fail) 10%, transparent);
   font-weight: 700;
 }
+/* Membership in an `all`, not a cost: outlined rather than filled, so it reads
+   beside the cost badges without competing with them. `partial` is the one an
+   operator has to look twice at — an `all` that leaves siblings out. */
+.cb-all {
+  color: var(--ink-2);
+  border-color: var(--line-2);
+  white-space: nowrap;
+}
+.cb-all.partial {
+  color: var(--run);
+  border-color: color-mix(in srgb, var(--run) 40%, transparent);
+}
+
+/* The order behind that marker, spelled out where the Run button is. */
+.plan {
+  margin-bottom: 14px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: var(--sunk);
+  font-size: var(--fs-12);
+  color: var(--ink-2);
+}
+/* Not the uppercase rail heading: it names commands, and a command spelled in
+   capitals is not the command anyone types. */
+.plan h3 {
+  margin: 0;
+  font-size: var(--fs-12);
+  font-weight: 600;
+  color: var(--ink-2);
+}
+.plan ol {
+  margin: 6px 0 0;
+  padding-left: 20px;
+}
+.plan li {
+  margin: 1px 0;
+}
+.plan code {
+  font-family: var(--mono);
+  font-size: var(--fs-11);
+  color: var(--ink);
+}
+.plan .when {
+  margin-left: 6px;
+  color: var(--ink-3);
+  font-size: var(--fs-11);
+}
+.plan .skipped {
+  margin: 6px 0 0;
+  color: var(--ink-3);
+}
+.plan .skipped code {
+  color: var(--ink-2);
+}
 
 .cnote {
   display: flex;

--- a/examples/cli/src/web/client/app.css
+++ b/examples/cli/src/web/client/app.css
@@ -345,8 +345,10 @@ textarea {
   color: var(--accent-2);
   font-weight: 600;
 }
-/* The name is the thing being chosen: it never wraps or truncates. The
-   description is the concession — it takes what is left and ellipsizes. */
+/* The name is the whole row in the rail: it never wraps or truncates, and the
+   badges take the space after it. `.cmd-d` is the second column the same row
+   shape gets in a picker's result list, where the detail beside a label is the
+   point — it takes what is left and ellipsizes. */
 .cmd-n {
   font-family: var(--mono);
   font-size: var(--fs-12);
@@ -365,6 +367,13 @@ textarea {
 .cmd .badges {
   flex: none;
   margin-left: auto;
+}
+/* The `all` marker and the cost badges are two groups on one row, and two auto
+   margins split the free space between them — which staggers the marker down
+   the rail. Only the first takes the space; the rest close up behind it, so
+   every chip on every row lands in one right-hand cluster. */
+.cmd .badges ~ .badges {
+  margin-left: 0;
 }
 .grp-h {
   background: none;

--- a/examples/cli/src/web/client/main.tsx
+++ b/examples/cli/src/web/client/main.tsx
@@ -52,6 +52,7 @@ import {
   type StackedPane,
 } from "./state";
 import { CommandTree } from "./views/CommandTree";
+import { GroupView } from "./views/GroupView";
 import { HumanPrompt } from "./views/HumanPrompt";
 import { OptionsForm } from "./views/OptionsForm";
 import { RailResizer } from "./views/RailResizer";
@@ -223,6 +224,13 @@ function App(): JSX.Element {
       setPane(stackedPane("select"));
       setTab("options");
       setOpen((current) => new Set([...current, ...openPathsFor(next.path)]));
+      // A group has no action, so there is no form to ask the CLI for — and
+      // the previous command's fields must not survive behind its page.
+      if (next.children.length > 0) {
+        setFields([]);
+        setValues({});
+        return;
+      }
       void getFields(next.path, [])
         .then((result) => {
           setFields(result.fields);
@@ -231,6 +239,22 @@ function App(): JSX.Element {
         .catch((cause: Error) => setError(cause.message));
     },
     [detachRun, node]
+  );
+
+  /**
+   * Selecting from a group's page rather than the rail. Same selection, plus
+   * the rail opens the subtree it just moved into — clicked in the rail that
+   * is what the row's own caret did, and following a link should not leave the
+   * tree pointing somewhere else.
+   */
+  const selectChild = useCallback(
+    (next: WebCommandNode) => {
+      selectNode(next);
+      if (next.children.length > 0) {
+        setOpen((current) => new Set([...current, next.path.join(".")]));
+      }
+    },
+    [selectNode]
   );
 
   /**
@@ -344,7 +368,9 @@ function App(): JSX.Element {
 
   const onRun = useCallback(
     (dryRun: boolean) => {
-      if (!node) return;
+      // A group is selectable — it is a page — but it has no action behind it,
+      // and the Enter shortcut reaches it with no button to have said so.
+      if (!node || node.children.length > 0) return;
       // Guarded here as well as on the button: Run also has a keyboard path,
       // and a request to a dead CLI fails as an unexplained network error.
       if (!cli.online) return;
@@ -600,7 +626,14 @@ function App(): JSX.Element {
               }}
             />
           ) : null}
-          {tab === "options" && node ? (
+          {tab === "options" && node && node.children.length > 0 ? (
+            // Read back off the full tree, not the selected object: the rail
+            // hands over the node it drew, and while a filter is on that node
+            // is pruned to the matches — a group's page lists what is under
+            // the group, not what someone last typed in the box.
+            <GroupView node={findCommandNode(commands, node.path) ?? node} onSelect={selectChild} />
+          ) : null}
+          {tab === "options" && node && node.children.length === 0 ? (
             <OptionsForm
               binaryName={binaryName}
               path={node.path}

--- a/examples/cli/src/web/client/main.tsx
+++ b/examples/cli/src/web/client/main.tsx
@@ -610,6 +610,8 @@ function App(): JSX.Element {
               errors={errors}
               badges={node.badges}
               note={node.note}
+              runsInOrder={node.runsInOrder}
+              runsIn={node.runsIn}
               onChange={onFieldChange}
               onRun={onRun}
               canRun={cli.online}

--- a/examples/cli/src/web/client/views/CommandTree.tsx
+++ b/examples/cli/src/web/client/views/CommandTree.tsx
@@ -96,6 +96,15 @@ export function CommandBadges({
   );
 }
 
+/**
+ * One row: the command, and what it costs to run.
+ *
+ * The rail carries the NAME and nothing else. A description clipped to what a
+ * 266px rail has left over is a sentence nobody can read and a column that
+ * pushes the badges — the part that has to be legible before you click — into
+ * whatever is left; the full line reads in the options pane, and on the row's
+ * tooltip.
+ */
 function NodeRow({
   node,
   depth,
@@ -117,9 +126,13 @@ function NodeRow({
   if (node.children.length === 0) {
     const current = selectedPath.join(".") === key;
     return (
-      <button className="cmd" aria-current={current} onClick={() => onSelect(node)}>
+      <button
+        className="cmd"
+        aria-current={current}
+        title={node.description}
+        onClick={() => onSelect(node)}
+      >
         <span className="cmd-n">{node.name}</span>
-        <span className="cmd-d">{node.description}</span>
         <RunsMarker node={node} />
         <CommandBadges badges={node.badges} />
       </button>
@@ -153,10 +166,14 @@ function NodeRow({
           <span>{node.name}</span>
         </button>
       ) : (
-        <button className="cmd sub" aria-expanded={isOpen} onClick={() => onToggle(key)}>
+        <button
+          className="cmd sub"
+          aria-expanded={isOpen}
+          title={node.description}
+          onClick={() => onToggle(key)}
+        >
           <span className="caret">{isOpen ? "▾" : "▸"}</span>
           <span className="cmd-n">{node.name}</span>
-          <span className="cmd-d">{node.description}</span>
           {/* A sub-group can itself be a member — `sync forms` is one step of
               `sync all` — and the marker has to survive the row being closed,
               which is exactly when nobody can see its `all` beneath it. */}

--- a/examples/cli/src/web/client/views/CommandTree.tsx
+++ b/examples/cli/src/web/client/views/CommandTree.tsx
@@ -105,6 +105,29 @@ export function CommandBadges({
  * whatever is left; the full line reads in the options pane, and on the row's
  * tooltip.
  */
+/**
+ * The badges-and-note strip a command carries above whatever it is about to do.
+ *
+ * Shared by the form and the group page rather than written twice: both are
+ * the same claim — what this costs, and what to know before pressing Run — and
+ * two copies would have drifted the first time either grew a field.
+ */
+export function CommandNote({
+  badges,
+  note,
+}: {
+  badges: readonly WebCommandBadge[] | undefined;
+  note: string | undefined;
+}): JSX.Element | null {
+  if ((badges === undefined || badges.length === 0) && note === undefined) return null;
+  return (
+    <div className={`cnote${badges?.includes("destructive") ? " danger" : ""}`}>
+      <CommandBadges badges={badges} />
+      {note ? <span>{note}</span> : null}
+    </div>
+  );
+}
+
 function NodeRow({
   node,
   depth,
@@ -161,7 +184,15 @@ function NodeRow({
   return (
     <>
       {depth === 0 ? (
-        <button className="grp-h" onClick={() => onToggle(key)}>
+        <button
+          className="grp-h"
+          aria-current={selectedPath.join(".") === key}
+          title={node.description}
+          onClick={() => {
+            onToggle(key);
+            onSelect(node);
+          }}
+        >
           <span className="caret">{isOpen ? "▾" : "▸"}</span>
           <span>{node.name}</span>
         </button>
@@ -169,8 +200,15 @@ function NodeRow({
         <button
           className="cmd sub"
           aria-expanded={isOpen}
+          aria-current={selectedPath.join(".") === key}
           title={node.description}
-          onClick={() => onToggle(key)}
+          // Opens the subtree AND selects the group, because a group is a page
+          // now: it has no action to run, but it is where its own description
+          // and its children's read at a width that fits them.
+          onClick={() => {
+            onToggle(key);
+            onSelect(node);
+          }}
         >
           <span className="caret">{isOpen ? "▾" : "▸"}</span>
           <span className="cmd-n">{node.name}</span>

--- a/examples/cli/src/web/client/views/CommandTree.tsx
+++ b/examples/cli/src/web/client/views/CommandTree.tsx
@@ -25,6 +25,58 @@ const BADGE_GLYPH: Readonly<Record<WebCommandBadge, string>> = {
   destructive: "!",
 };
 
+/**
+ * The `all` marker, on both sides of an order.
+ *
+ * On the `all` itself it is a count, because the name is the thing that
+ * misleads: `4/5` says four of the five commands beside it, and the one it
+ * leaves out is named in the tooltip and in the form.
+ *
+ * A member is marked only where that count leaves the question open — where
+ * the `all` skips something, so which rows it covers is a real question, or
+ * where this member runs only under a flag. An `all` that runs its whole group
+ * has already said so on its own row, and a chip repeated down every row under
+ * it is one nobody reads.
+ */
+export function RunsMarker({ node }: { node: WebCommandNode }): JSX.Element | null {
+  const group = node.path.slice(0, -1).join(" ");
+  if (node.runsInOrder) {
+    const { members, skipped } = node.runsInOrder;
+    const of = members.length + skipped.length;
+    return (
+      <span className="badges">
+        <span
+          className={`cb cb-all${skipped.length > 0 ? " partial" : ""}`}
+          title={
+            `Runs ${members.length} of the ${of} commands under \`${group}\`, in order: ` +
+            `${members.map((member) => member.name).join(" → ")}` +
+            (skipped.length > 0 ? `. Not run: ${skipped.join(", ")}` : "")
+          }
+        >
+          ALL {members.length}/{of}
+        </span>
+      </span>
+    );
+  }
+  if (node.runsIn && (node.runsIn.skipped > 0 || node.runsIn.when !== undefined)) {
+    const { command, step, of, when } = node.runsIn;
+    return (
+      <span className="badges">
+        <span
+          className="cb cb-all"
+          title={
+            `Step ${step} of ${of} of \`${[group, command].filter(Boolean).join(" ")}\`` +
+            (when ? ` — ${when}` : "")
+          }
+        >
+          {when ? "ALL?" : "ALL"}
+        </span>
+      </span>
+    );
+  }
+  return null;
+}
+
 export function CommandBadges({
   badges,
   className = "",
@@ -68,6 +120,7 @@ function NodeRow({
       <button className="cmd" aria-current={current} onClick={() => onSelect(node)}>
         <span className="cmd-n">{node.name}</span>
         <span className="cmd-d">{node.description}</span>
+        <RunsMarker node={node} />
         <CommandBadges badges={node.badges} />
       </button>
     );
@@ -104,6 +157,10 @@ function NodeRow({
           <span className="caret">{isOpen ? "▾" : "▸"}</span>
           <span className="cmd-n">{node.name}</span>
           <span className="cmd-d">{node.description}</span>
+          {/* A sub-group can itself be a member — `sync forms` is one step of
+              `sync all` — and the marker has to survive the row being closed,
+              which is exactly when nobody can see its `all` beneath it. */}
+          <RunsMarker node={node} />
         </button>
       )}
       {children}

--- a/examples/cli/src/web/client/views/GroupView.tsx
+++ b/examples/cli/src/web/client/views/GroupView.tsx
@@ -1,0 +1,47 @@
+/** @jsxImportSource preact */
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { JSX } from "preact";
+import type { WebCommandNode } from "../../commandTree";
+import { CommandBadges, CommandNote, RunsMarker } from "./CommandTree";
+
+/**
+ * A group's own page: what it is, and what is under it.
+ *
+ * A group has no action — there is nothing to run and no form to fill — but it
+ * is still a command with a description, and the rail is 266px wide and spends
+ * that on names. Here every line reads at the width it was written for: the
+ * group's own, and one per child, which is what the rail gave up to keep its
+ * names legible.
+ */
+export function GroupView({
+  node,
+  onSelect,
+}: {
+  node: WebCommandNode;
+  onSelect: (node: WebCommandNode) => void;
+}): JSX.Element {
+  return (
+    <div className="wrap">
+      {node.description ? <p className="lede">{node.description}</p> : null}
+      <CommandNote badges={node.badges} note={node.note} />
+      <h2 className="sec">
+        {node.children.length} {node.children.length === 1 ? "command" : "commands"}
+      </h2>
+      <div className="card grouplist">
+        {node.children.map((child) => (
+          <button key={child.path.join(".")} className="cmd" onClick={() => onSelect(child)}>
+            <span className="cmd-n">{child.name}</span>
+            <span className="cmd-d">{child.description}</span>
+            <RunsMarker node={child} />
+            <CommandBadges badges={child.badges} />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/examples/cli/src/web/client/views/OptionsForm.tsx
+++ b/examples/cli/src/web/client/views/OptionsForm.tsx
@@ -8,6 +8,7 @@
 import type { JSX } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import type { WebCommandBadge } from "../../annotations";
+import type { WebRunsMembership, WebRunsOrder } from "../../commandTree";
 import { renderCliLine } from "../../argv";
 import type { WebField } from "../../commandFields";
 import { searchWidget } from "../api";
@@ -192,6 +193,78 @@ function FieldRows({
   );
 }
 
+/**
+ * What an `all` actually runs, written out where the Run button is.
+ *
+ * The rail's marker is a count; this is the list behind it, because "runs 4 of
+ * 5" is only useful once you can see WHICH four and in what order. The skipped
+ * siblings are named in the same block rather than left implicit — an operator
+ * who runs `all` nightly needs to know what it never covers, and absence is
+ * not something a form can show.
+ */
+function RunPlan({
+  path,
+  order,
+  membership,
+}: {
+  path: readonly string[];
+  order: WebRunsOrder | undefined;
+  membership: WebRunsMembership | undefined;
+}): JSX.Element | null {
+  // The group these commands sit in, named the way the operator would type it.
+  const group = path.slice(0, -1).join(" ");
+  if (order) {
+    const of = order.members.length + order.skipped.length;
+    return (
+      <div className="plan">
+        <h3>
+          Runs {order.members.length} of the {of} commands
+          {group ? (
+            <>
+              {" "}
+              under <code>{group}</code>
+            </>
+          ) : (
+            " beside it"
+          )}
+          , in order
+        </h3>
+        <ol>
+          {order.members.map((member) => (
+            <li key={member.name}>
+              <code>{member.name}</code>
+              {member.when ? <span className="when">{member.when}</span> : null}
+            </li>
+          ))}
+        </ol>
+        {order.skipped.length > 0 ? (
+          <p className="skipped">
+            Not run by this command:{" "}
+            {order.skipped.map((name, index) => (
+              <span key={name}>
+                {index > 0 ? ", " : ""}
+                <code>{name}</code>
+              </span>
+            ))}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+  if (membership) {
+    return (
+      <div className="plan">
+        <h3>
+          Runs as step {membership.step} of {membership.of} of{" "}
+          <code>{[group, membership.command].filter(Boolean).join(" ")}</code>
+        </h3>
+        {membership.when ? <p className="skipped">There, it runs {membership.when}.</p> : null}
+      </div>
+    );
+  }
+  return null;
+}
+
 export function OptionsForm({
   binaryName,
   path,
@@ -201,6 +274,8 @@ export function OptionsForm({
   errors,
   badges,
   note,
+  runsInOrder,
+  runsIn,
   onChange,
   onRun,
   canRun = true,
@@ -218,6 +293,10 @@ export function OptionsForm({
   errors: readonly string[];
   badges?: readonly WebCommandBadge[];
   note?: string;
+  /** Set when this command runs its siblings in order — an `all`. */
+  runsInOrder?: WebRunsOrder;
+  /** Set when a sibling `all` runs this command. */
+  runsIn?: WebRunsMembership;
   onChange: (key: string, value: string | boolean) => void;
   onRun: (dryRun: boolean) => void;
   /** False while the CLI is not answering its heartbeat; running would just fail. */
@@ -247,6 +326,7 @@ export function OptionsForm({
           {note ? <span>{note}</span> : null}
         </div>
       ) : null}
+      <RunPlan path={path} order={runsInOrder} membership={runsIn} />
       {args.length > 0 ? (
         <>
           <h2 className="sec">Arguments</h2>

--- a/examples/cli/src/web/client/views/OptionsForm.tsx
+++ b/examples/cli/src/web/client/views/OptionsForm.tsx
@@ -20,7 +20,7 @@ import {
   type FormValues,
   type WidgetScope,
 } from "../formModel";
-import { CommandBadges } from "./CommandTree";
+import { CommandNote } from "./CommandTree";
 
 type FieldWithWidget = WebField & { widget?: string };
 
@@ -315,17 +315,10 @@ export function OptionsForm({
   // the button exists only where `--dry-run` is real.
   const hasDryRun = fields.some((field) => field.key === "dry-run" && field.source === "option");
 
-  const hasBadges = badges !== undefined && badges.length > 0;
-
   return (
     <div className="wrap">
       {description ? <p className="lede">{description}</p> : null}
-      {hasBadges || note ? (
-        <div className={`cnote${badges?.includes("destructive") ? " danger" : ""}`}>
-          <CommandBadges badges={badges} />
-          {note ? <span>{note}</span> : null}
-        </div>
-      ) : null}
+      <CommandNote badges={badges} note={note} />
       <RunPlan path={path} order={runsInOrder} membership={runsIn} />
       {args.length > 0 ? (
         <>

--- a/examples/cli/src/web/commandTree.ts
+++ b/examples/cli/src/web/commandTree.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Command, Option } from "commander";
-import type { WebCommandBadge } from "./annotations";
+import type { WebCommandBadge, WebRunsMember } from "./annotations";
 
 export interface WebCommandOption {
   /** Long flag without dashes, which is also how an invocation names it. */
@@ -26,6 +26,39 @@ export interface WebCommandArgument {
   readonly choices: readonly string[] | undefined;
 }
 
+/**
+ * A command's place in a sibling `all`'s order, stamped by
+ * `annotateCommandTree` on each command that `all` runs.
+ */
+export interface WebRunsMembership {
+  /** The sibling that runs it, by name — `all` wherever anyone has one. */
+  readonly command: string;
+  /** 1-based position in that order, so a row can say where in the run it is. */
+  readonly step: number;
+  readonly of: number;
+  /**
+   * How many siblings that command leaves out. Zero means it runs the whole
+   * group, which is where marking each member says nothing the `all`'s own
+   * count does not already say.
+   */
+  readonly skipped: number;
+  /** The condition, when this member does not run on every invocation. */
+  readonly when?: string;
+}
+
+/** What an `all`-style command runs, and what it leaves to be run by hand. */
+export interface WebRunsOrder {
+  /** The members, in the order they run — the declaration, verbatim. */
+  readonly members: readonly WebRunsMember[];
+  /** Siblings this command does not run. The half its name argues against. */
+  readonly skipped: readonly string[];
+  /**
+   * Members naming no sibling — a command renamed or dropped since the order
+   * was declared. Rendered as nothing, kept here so a guard test can name it.
+   */
+  readonly unrunMembers: readonly string[];
+}
+
 export interface WebCommandNode {
   readonly path: readonly string[];
   readonly name: string;
@@ -41,6 +74,10 @@ export interface WebCommandNode {
   readonly badges?: readonly WebCommandBadge[];
   readonly note?: string;
   readonly confirm?: string;
+  /** Set by `annotateCommandTree` on a command that runs its siblings in order. */
+  readonly runsInOrder?: WebRunsOrder;
+  /** Set by `annotateCommandTree` on each command such a sibling runs. */
+  readonly runsIn?: WebRunsMembership;
 }
 
 /** Flags that exist to print text, which is not a thing this surface can run. */


### PR DESCRIPTION
## Summary

Adds support for annotating commands that run their siblings in a specific order (like `sync all` running `submissions` then `forms`). The annotation system now tracks which siblings an `all`-style command executes, marks each member with its position in that order, and identifies siblings that are skipped.

## Key Changes

- **Annotation types** (`annotations.ts`):
  - Added `WebRunsMember` interface to describe a sibling command and optional execution condition
  - Added `runs` field to `WebCommandAnnotation` to declare the ordered list of siblings
  - Updated `resolveCommandAnnotation()` to return the `runs` declaration

- **Command tree decoration** (`annotations.ts`):
  - Added `runOrderAmong()` to compute which siblings are skipped by an `all` command
  - Added `membershipsAmong()` to stamp each sibling with its position in the `all`'s order
  - Updated `annotateCommandTree()` to decorate nodes with `runsInOrder` (on the `all`) and `runsIn` (on each member)

- **Type definitions** (`commandTree.ts`):
  - Added `WebRunsMembership` interface: tracks step number, total steps, skipped count, and optional condition
  - Added `WebRunsOrder` interface: lists members in order, skipped siblings, and unrun members (for guard tests)
  - Extended `WebCommandNode` with optional `runsInOrder` and `runsIn` fields

- **UI components** (`CommandTree.tsx`):
  - Added `RunsMarker` component to display `ALL 4/5` on the `all` command and `ALL` or `ALL?` on members
  - Updated `NodeRow` to show the marker instead of description in the rail (description moves to tooltip)
  - Updated group headers to be selectable and show markers when they're members of an `all`

- **Group view** (`GroupView.tsx`, new file):
  - New component to display a group's full description and list all children with their descriptions at readable width
  - Shows `RunsMarker` for each child to indicate membership in a parent `all`

- **Form display** (`OptionsForm.tsx`):
  - Added `RunPlan` component to spell out which siblings an `all` runs, in order, with conditions
  - Shows skipped siblings so operators know what the command never covers
  - Extracted `CommandNote` component for reuse across form and group view

- **Styling** (`app.css`):
  - Added `.cb-all` and `.cb-all.partial` styles for the membership marker
  - Added `.plan` styles for the run order display
  - Added `.grouplist` styles for the group view's command list
  - Updated badge layout to prevent staggering when multiple badge groups appear

- **Tests** (`annotations.test.ts`):
  - Comprehensive test suite covering partial runs, skipped siblings, unrun members, nested orders, and full coverage cases

## Implementation Details

- Members are matched by name among siblings, so renamed commands silently mark nothing but stay in the order (reads as a step that runs nothing)
- The `skipped` count travels with each member so the UI can decide whether marking is worth showing
- An `all` that runs the whole group has `skipped: 0`, allowing the UI to omit redundant chips
- Nested `all` commands work correctly: a group can be both a member of one order and the runner of another
- Group pages are now selectable destinations with their own descriptions and child listings

https://claude.ai/code/session_012LvqkGGMaP4HYcKEacCxpA