### PR TITLE
fix(postgres): give a vector storage a real pgvector column

### DIFF
--- a/packages/storage/src/sql/mapPostgresType.ts
+++ b/packages/storage/src/sql/mapPostgresType.ts
@@ -17,8 +17,8 @@ export interface PostgresTypeMapOptions {
   readonly getNonNullType: (typeDef: JsonSchema) => JsonSchema;
   /**
    * Optional hook for the pgvector extension: given the resolved non-null
-   * type of a `string` column, return a `vector(N)` column type, or undefined
-   * to fall through to the normal string handling. Backends without pgvector
+   * type of a column, return a `vector(N)` column type, or undefined to fall
+   * through to the normal handling for that type. Backends without pgvector
    * (e.g. Supabase via PostgREST) omit this.
    */
   readonly vectorTypeFor?: (actualType: Exclude<JsonSchema, boolean>) => string | undefined;
@@ -40,6 +40,15 @@ export function mapPostgresType(typeDef: JsonSchema, options: PostgresTypeMapOpt
   // Handle BLOB type
   if (actualType.contentEncoding === "blob") return "BYTEA";
 
+  // Backend-specific vector column (pgvector), when supported. Consulted
+  // before the switch because the embedding schema this repo writes is
+  // `{ type: "array", format: "TypedArray" }` — gating the hook on
+  // `type: "string"` sent every such column to `JSONB /* generic array */`,
+  // which no `vector_*_ops` operator class accepts, so the index was never
+  // built and every search fell back to scanning the table in memory.
+  const vectorType = options.vectorTypeFor?.(actualType);
+  if (vectorType) return vectorType;
+
   switch (actualType.type) {
     case "string": {
       // Handle special string formats that map to a dedicated column type
@@ -47,16 +56,12 @@ export function mapPostgresType(typeDef: JsonSchema, options: PostgresTypeMapOpt
       if (actualType.format === "date") return "DATE";
       if (actualType.format === "uuid") return "UUID";
 
-      // Formats carrying an implied width (`email`, `uri`) resolve before the
-      // pgvector hook. Read from the shared table so the width this DDL
-      // declares is the width `varcharWidth` reports to the schemaless
-      // backends — the two cannot drift apart.
+      // Formats carrying an implied width (`email`, `uri`). Read from the
+      // shared table so the width this DDL declares is the width
+      // `varcharWidth` reports to the schemaless backends — the two cannot
+      // drift apart.
       const formatWidth = varcharWidthForFormat(actualType.format);
       if (formatWidth !== undefined) return `VARCHAR(${formatWidth})`;
-
-      // Backend-specific vector column (pgvector), when supported.
-      const vectorType = options.vectorTypeFor?.(actualType);
-      if (vectorType) return vectorType;
 
       // Use a VARCHAR with maxLength if specified
       if (typeof actualType.maxLength === "number") {

--- a/packages/storage/src/util/__tests__/sqlTypeMapping.test.ts
+++ b/packages/storage/src/util/__tests__/sqlTypeMapping.test.ts
@@ -51,6 +51,36 @@ describe("mapPostgresType integer range selection", () => {
   });
 });
 
+describe("mapPostgresType pgvector hook", () => {
+  // What a backend that knows the width supplies; `undefined` is the base
+  // class, which has no dimension to declare.
+  const withVector = {
+    ...options,
+    vectorTypeFor: (t: Exclude<JsonSchema, boolean>) =>
+      t.format === "TypedArray" ? "vector(4)" : undefined,
+  };
+
+  it("maps a TypedArray property to a vector column", () => {
+    // The embedding schema every vector storage here is built on is an
+    // *array*, not a string. While the hook was only consulted for
+    // `type: "string"` these columns became `JSONB /* generic array */`, no
+    // `vector_*_ops` index could be built over them, and every similarity
+    // search fell back to scanning the table in memory.
+    expect(mapPostgresType({ type: "array", format: "TypedArray" }, withVector)).toBe("vector(4)");
+  });
+
+  it("leaves the column JSONB when the backend declares no width", () => {
+    expect(mapPostgresType({ type: "array", format: "TypedArray" }, options)).toBe(
+      "JSONB /* generic array */"
+    );
+  });
+
+  it("does not divert a column the hook declines", () => {
+    expect(mapPostgresType({ type: "string" }, withVector)).toBe("TEXT");
+    expect(mapPostgresType({ type: "object" }, withVector)).toBe("JSONB /* object */");
+  });
+});
+
 describe("TYPED_ARRAY_CTORS", () => {
   it("includes Float16Array so documented quantized vectors decode", () => {
     // The util schema layer polyfills globalThis.Float16Array on older runtimes,

--- a/packages/test/src/test/vector/PostgresVectorStorage.search.test.ts
+++ b/packages/test/src/test/vector/PostgresVectorStorage.search.test.ts
@@ -5,11 +5,12 @@
  */
 
 import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite-pgvector";
 import { PostgresVectorStorage } from "@workglow/postgres/storage";
 import type { AnyVectorStorage } from "@workglow/storage";
 import { uuid4 } from "@workglow/util";
 import type { Pool } from "pg";
-import { afterAll } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { runVectorStorageContract } from "../../contract/vector-storage/runVectorStorageContract";
 import {
   VECTOR_DIMENSIONS,
@@ -20,7 +21,14 @@ import {
 // Its own instance rather than the validation suite's: that file closes its
 // handle in an `afterAll`, which fires before a second top-level describe in
 // the same file would run.
-const db = new PGlite() as unknown as Pool;
+//
+// PGlite ships pgvector as a loadable extension, and without it every case
+// below passed through the in-memory fallback in `similaritySearch` — so the
+// SQL this class actually issues in production (the distance operator, the
+// score expression, the metadata predicate, ORDER BY/LIMIT) was never run by
+// any test. The `PostgresVectorStorage DDL` block below is what keeps it that
+// way.
+const db = new PGlite({ extensions: { vector } }) as unknown as Pool;
 
 afterAll(async () => {
   await (db as unknown as PGlite).close();
@@ -51,4 +59,38 @@ runVectorStorageContract({
       [],
       VECTOR_DIMENSIONS
     ) as unknown as AnyVectorStorage,
+});
+
+describe("PostgresVectorStorage DDL", () => {
+  it("declares a real vector column and indexes it", async () => {
+    const table = `vec_ddl_${uuid4().replace(/-/g, "_")}`;
+    const storage = new PostgresVectorStorage(
+      db,
+      table,
+      VectorItemSchema,
+      VectorItemPrimaryKeyNames,
+      [],
+      VECTOR_DIMENSIONS
+    );
+    await storage.setupDatabase();
+
+    // A JSONB column here would not fail the contract above: the search would
+    // simply throw inside `similaritySearch`, get swallowed by its fallback,
+    // and be answered from memory with the right values and none of the SQL.
+    const columns = await db.query<{ udt_name: string }>(
+      `SELECT udt_name FROM information_schema.columns
+        WHERE table_name = $1 AND column_name = 'vector'`,
+      [table]
+    );
+    expect(columns.rows[0]?.udt_name).toBe("vector");
+
+    // And the index the column exists for: `vector_cosine_ops` rejects any
+    // other column type, so this fails on the same regression from the far
+    // side — creation is best-effort and only warns.
+    const indexes = await db.query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes WHERE tablename = $1`,
+      [table]
+    );
+    expect(indexes.rows.map((r) => r.indexname)).toContain(`${table}_vector_hnsw_idx`);
+  });
 });

--- a/packages/test/src/test/vector/PostgresVectorStorage.validation.test.ts
+++ b/packages/test/src/test/vector/PostgresVectorStorage.validation.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite-pgvector";
 import { PostgresVectorStorage } from "@workglow/postgres/storage";
 import { StorageValidationError } from "@workglow/storage";
 import { setLogger, uuid4 } from "@workglow/util";
@@ -28,7 +29,7 @@ const VecSchema = {
 const VecPK = ["id"] as const;
 const DIM = 4;
 
-const db = new PGlite() as unknown as Pool;
+const db = new PGlite({ extensions: { vector } }) as unknown as Pool;
 
 describe("PostgresVectorStorage validation", () => {
   const logger = getTestingLogger();

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -244,6 +244,11 @@ export class PostgresTabularStorage<
    * can call it conditionally on a fresh DB.
    */
   private async createTableAndIndexes(): Promise<void> {
+    // Before the DDL, not after it: `CREATE TABLE ... vector(N)` fails with
+    // `type "vector" does not exist` unless the extension is already there.
+    if (this.getVectorColumns().length > 0) {
+      await this.ensureVectorExtension();
+    }
     const sql = `
       CREATE TABLE IF NOT EXISTS "${this.table}" (
         ${this.constructPrimaryKeyColumns('"')} ${this.constructValueColumns('"')},
@@ -354,9 +359,11 @@ export class PostgresTabularStorage<
   protected mapTypeToSQL(typeDef: JsonSchema): string {
     return mapPostgresType(typeDef, {
       getNonNullType: (t) => this.getNonNullType(t),
-      // pgvector column for vector-format strings with a known dimension.
+      // pgvector column for a TypedArray property with a known dimension.
+      // Only a subclass that knows its width (PostgresVectorStorage) returns
+      // one; the base class has no dimension, so the column stays JSONB.
       vectorTypeFor: (actualType) => {
-        if (this.isVectorFormat(actualType.format)) {
+        if (this.pgvectorAvailable && this.isVectorFormat(actualType.format)) {
           const dimension = this.getVectorDimensions(actualType);
           if (typeof dimension === "number") {
             return `vector(${dimension})`;
@@ -439,6 +446,38 @@ export class PostgresTabularStorage<
    * serialization before binding.
    */
   private jsonbColumns: Set<string> | undefined;
+
+  /**
+   * Whether `CREATE EXTENSION vector` succeeded on this connection, or
+   * `undefined` before {@link ensureVectorExtension} has asked. Unasked reads
+   * as unavailable, so a storage that never probes declares JSONB columns
+   * rather than DDL naming a type the database may not have.
+   */
+  private pgvectorAvailable: boolean | undefined;
+
+  /**
+   * Enables pgvector, once per instance, and reports whether it is usable.
+   *
+   * The answer decides the column type {@link mapTypeToSQL} emits, so it has
+   * to be settled before any DDL is generated — hence the cached
+   * {@link jsonbColumns} set is dropped here rather than left holding the
+   * pre-probe answer.
+   */
+  private async ensureVectorExtension(): Promise<boolean> {
+    if (this.pgvectorAvailable !== undefined) return this.pgvectorAvailable;
+    try {
+      await this.db.query("CREATE EXTENSION IF NOT EXISTS vector");
+      this.pgvectorAvailable = true;
+    } catch (error) {
+      console.warn(
+        "pgvector extension not available, vector columns will use the JSONB fallback:",
+        error
+      );
+      this.pgvectorAvailable = false;
+    }
+    this.jsonbColumns = undefined;
+    return this.pgvectorAvailable;
+  }
 
   private isJsonbColumn(column: string): boolean {
     if (!this.jsonbColumns) {
@@ -567,10 +606,19 @@ export class PostgresTabularStorage<
   }
 
   /**
+   * Memo for {@link getVectorColumns}. The schema is fixed at construction and
+   * both the CREATE TABLE and the index pass ask, so without this the warning
+   * below repeats once per caller for the same column.
+   */
+  private vectorColumnsCache: Array<{ column: string; dimension: number }> | undefined;
+
+  /**
    * Gets information about vector columns in the schema
    * @returns Array of objects with column name and dimension
    */
   protected getVectorColumns(): Array<{ column: string; dimension: number }> {
+    if (this.vectorColumnsCache) return this.vectorColumnsCache;
+
     const vectorColumns: Array<{ column: string; dimension: number }> = [];
 
     // Check all properties in the schema
@@ -586,6 +634,7 @@ export class PostgresTabularStorage<
       }
     }
 
+    this.vectorColumnsCache = vectorColumns;
     return vectorColumns;
   }
 
@@ -628,16 +677,10 @@ export class PostgresTabularStorage<
     assertPositiveInt(opts.ivfflat?.lists, "ivfflat.lists");
     assertPositiveInt(opts.ivfflat?.probes, "ivfflat.probes");
 
-    // Try to enable pgvector extension
-    try {
-      await this.db.query("CREATE EXTENSION IF NOT EXISTS vector");
-    } catch (error) {
-      console.warn(
-        "pgvector extension not available, vector columns will use TEXT fallback:",
-        error
-      );
-      return;
-    }
+    // Memoized, and the table DDL above already asked — so this normally
+    // issues no SQL, and only reports what that answer was: without pgvector
+    // the columns are JSONB and no `vector_*_ops` index applies to them.
+    if (!(await this.ensureVectorExtension())) return;
 
     const distance = opts.distance ?? "cosine";
     const opClass =


### PR DESCRIPTION
## Summary

`PostgresVectorStorage` has never used pgvector. Every instance declared its embedding column as `JSONB`, no `vector_*_ops` index could be built over it, and `similaritySearch` threw on `$1::vector` and was answered by the in-memory fallback in its `catch` — for every row, on every search, on real Postgres as much as in the tests.

Nothing failed, which is why this survived: the fallback returns the same values, so the vector-storage contract suite passed over SQL it never ran. An `l2` or `ip` storage was worse off, since that fallback refuses any metric but cosine and threw outright.

The CI stderr that surfaced it — `pgvector extension not available` out of PGlite — was the visible end of that path, not the cause.

## Two independent defects

**1. The type-mapping gate.** `mapPostgresType` only consulted its `vectorTypeFor` hook inside `case "string"`, but the embedding schema every vector storage here is built on is `{ type: "array", format: "TypedArray" }` — `getVectorProperty` requires exactly that shape. So the column fell through to `JSONB /* generic array */`. This alone accounts for the JSONB column; no DDL failed.

**2. A latent ordering bug behind it.** `CREATE EXTENSION vector` ran *after* the `CREATE TABLE`, alongside index creation. Since the mapper never emitted `vector(N)`, the DDL never named the type and the ordering never mattered. Fixing (1) alone surfaces it immediately as `type "vector" does not exist`.

## Changes

- `mapPostgresType` consults `vectorTypeFor` before the type switch, so an array-typed vector column reaches it.
- `createTableAndIndexes` enables the extension before generating DDL. The probe is memoized and its answer decides the column type, so a database without pgvector still declares `JSONB` and skips the index — the documented fallback, now reached deliberately rather than by accident.
- `getVectorColumns` is memoized: both the CREATE TABLE and the index pass ask, and without it the "invalid vector format" warning repeats per caller.

## Tests

Both PGlite suites now load `@electric-sql/pglite-pgvector` — already a workspace dependency, already used by `SupabaseMockClient`. That is what makes them run the class's own SQL: the distance operator, the score expression, the metadata predicate, `ORDER BY`/`LIMIT`.

Two guards, because this regression does not fail the contract:

- `mapPostgresType pgvector hook` in `sqlTypeMapping.test.ts` pins the array case at the mapper.
- A `PostgresVectorStorage DDL` block asserts `udt_name = 'vector'` and that the HNSW index exists. Verified against the bug: with the hook disabled the contract still reports 17 passed while this one fails.

**Verified:** the two vector suites 26 passed / 1 skipped with no pgvector warnings; `bun scripts/test.ts vitest unit --changed origin/main` 7687 passed / 1 failed, that one being `workspaceSource.test.ts > leaves a real bundle on its built file`, which reads `packages/ai/dist/node.js` and fails only on a `use-source` tree (CI downloads real bundles). `oxlint` and `oxfmt --check` clean.

## Not covered

`CREATE TABLE IF NOT EXISTS` does not migrate an already-deployed table whose vector column is JSONB. Those keep today's behaviour — index creation warns, searches fall back — so no regression, but they need an explicit column migration to benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgtH91VUnT4HJxS8Fyc9VW