### PR TITLE
fix(pricing): stop reporting an unpriced rate as free

### DIFF
--- a/packages/ai/src/model/ModelPricing.ts
+++ b/packages/ai/src/model/ModelPricing.ts
@@ -123,7 +123,9 @@ const KEY_SUFFIX_BOUNDARY = new Set(["-", "_", ":", "/", "@"]);
  * fabricated unit, and `undefined` is the honest answer. It is consulted only
  * after the exact lookups, so a table that deliberately prices an image model
  * still wins. Providers should pass the SAME matcher their effort policy uses
- * rather than a second copy of it.
+ * rather than a second copy of it — which is why it is asked about the same
+ * prefix-stripped, lower-cased id the walk matches, so a matcher anchored at
+ * `^` fires on `models/…` and `google/…` as it does on the bare id.
  */
 export function resolveModelPricingFromTable(
   table: Readonly<Record<string, ModelPricing>>,
@@ -149,7 +151,7 @@ export function resolveModelPricingFromTable(
   // id has deliberately priced it — Gemini prices several image models — and
   // that is a stronger statement than any matcher. What the guard blocks is the
   // walk BORROWING a sibling's card for an id the table never named.
-  if (notTokenBilled?.(modelId) === true) return undefined;
+  if (notTokenBilled?.(id) === true) return undefined;
 
   let best: string | undefined;
   for (const key of Object.keys(table)) {

--- a/packages/ai/src/model/__tests__/ModelPricing.test.ts
+++ b/packages/ai/src/model/__tests__/ModelPricing.test.ts
@@ -115,6 +115,23 @@ describe("resolveModelPricingFromTable", () => {
       );
     });
 
+    it("sees the same id the walk does, prefix stripped and lower-cased", () => {
+      // A provider writes the matcher for the bare id its table is keyed on, so
+      // an anchored one only fires if the guard is asked about the stripped
+      // form. Asked about the raw id, `models/gpt-4o-image` walks straight past
+      // it and takes `gpt-4o`'s per-token card for a model billed per image.
+      const anchoredImage = (id: string): boolean => /^gpt-.*-image(?:-|$)/i.test(id);
+      expect(
+        resolveModelPricingFromTable(table, "gpt-4o-image", [], anchoredImage)
+      ).toBeUndefined();
+      expect(
+        resolveModelPricingFromTable(table, "models/gpt-4o-image", ["models/"], anchoredImage)
+      ).toBeUndefined();
+      expect(
+        resolveModelPricingFromTable(table, "OpenAI/GPT-4o-Image", ["openai/"], anchoredImage)
+      ).toBeUndefined();
+    });
+
     it("leaves a text id alone, and is optional", () => {
       expect(resolveModelPricingFromTable(table, "gpt-4o", [], isImage)).toBe(table["gpt-4o"]);
       expect(resolveModelPricingFromTable(table, "gpt-4o-2024-08-06", [], isImage)).toBe(

--- a/packages/test/src/test/ai-provider-api/ModelSearchPricing.test.ts
+++ b/packages/test/src/test/ai-provider-api/ModelSearchPricing.test.ts
@@ -154,4 +154,16 @@ describe("a rate card must match the model's billing unit", () => {
     expect(getGeminiModelPricing("gemini-2.5-flash-image-preview")).toBeUndefined();
     expect(getGeminiModelPricing("gemini-2.5-flash")).toBeDefined();
   });
+
+  it("refuses an unnamed image id carrying one of the prefixes it strips", () => {
+    // `models/…` is the shape Gemini's ListModels returns, which is why the
+    // prefix is declared at all. Gemini's image matchers are anchored, so the
+    // guard has to be asked about the stripped id or a prefixed image model
+    // resolves the text sibling's per-1M-token card.
+    expect(getGeminiModelPricing("models/gemini-2.5-flash-image-preview")).toBeUndefined();
+    expect(getGeminiModelPricing("google/gemini-2.5-flash-image-preview")).toBeUndefined();
+    expect(getGeminiModelPricing("google-gemini/gemini-2.5-flash-image-preview")).toBeUndefined();
+    // The prefixed text sibling still resolves; only the borrowing is blocked.
+    expect(getGeminiModelPricing("models/gemini-2.5-flash")).toBeDefined();
+  });
 });

--- a/packages/test/src/test/ai-provider-api/OpenRouterPricing.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouterPricing.test.ts
@@ -48,6 +48,26 @@ describe("OpenRouter prices from the rate it quoted", () => {
     expect(priceOf({ prompt: "-1", completion: "-1" })).toBeUndefined();
   });
 
+  it("leaves an unpriced completion rate unpriced rather than free", () => {
+    // A router entry quotes a prompt rate and `-1` for completion when the
+    // output rate varies by upstream, and a partial card omits the field
+    // outright. Read as zero, the estimate renders as a confident figure that
+    // omits the side of the bill most of the spend sits on; left unset, the
+    // counter is reported unpriced and the total carries its `~`.
+    expect(priceOf({ prompt: "0.000003", completion: "-1" })).toEqual({
+      currency: "USD",
+      input: 3,
+      output: undefined,
+      cached: undefined,
+    });
+    expect(priceOf({ prompt: "0.000003" })).toEqual({
+      currency: "USD",
+      input: 3,
+      output: undefined,
+      cached: undefined,
+    });
+  });
+
   it("reports no card when the record carries no quote at all", () => {
     expect(priceOf(undefined)).toBeUndefined();
     expect(priceOf(null)).toBeUndefined();

--- a/providers/openrouter/src/ai/OpenRouterQueuedProvider.ts
+++ b/providers/openrouter/src/ai/OpenRouterQueuedProvider.ts
@@ -64,7 +64,7 @@ export class OpenRouterQueuedProvider extends createCloudProviderClass<OpenRoute
     return {
       currency: "USD",
       input,
-      output: perMillion(quoted.completion) ?? 0,
+      output: perMillion(quoted.completion),
       cached: perMillion(quoted.input_cache_read),
     };
   }


### PR DESCRIPTION
Two independent ways a cost estimate turned "nobody declared this rate" into a confident dollar figure. Same theme, so they travel together.

## 1. OpenRouter priced an unquoted completion rate at zero

`OpenRouterQueuedProvider.modelPricing` built its card as:

```ts
input,                                        // bails the whole card when undefined
output: perMillion(quoted.completion) ?? 0,
cached: perMillion(quoted.input_cache_read),  // stays undefined
```

`perMillion()` deliberately returns `undefined` for a non-numeric or negative quote — the JSDoc right above it says `"-1"` "means the rate varies by upstream, which is unpriced rather than negative" — and the module's stated rule is that an unset rate means "not declared here", never zero. The `?? 0` undid that for `output` alone.

**Concrete failure:** a router entry such as `openrouter/auto` quotes `{ prompt: "0.000003", completion: "-1" }` (a partial card omitting `completion` behaves the same). `modelPricing` returned `{ input: 3, output: 0 }`, so `estimateCost` priced a 10k-output-token call at exactly the input cost, set `priced = true`, left `unpriced` empty, and `formatCost` rendered a confident `$0.0300` with no `~` marker — silently dropping the side of the bill most of the spend sits on.

**Change:** drop the `?? 0`. `output` now behaves like `cached`: unset, so `estimateCost` lists it in `unpriced` and the total renders approximate. The card is still returned (the `input` rate is real), which is the same trade `cached` already makes.

## 2. The `notTokenBilled` guard was asked about the wrong id

`resolveModelPricingFromTable` strips vendor prefixes and lower-cases the id into `id`, runs the substring walk against `id` — but called the guard with the raw `modelId`.

Gemini's matchers are `^`-anchored (`[/^imagen-/i, /^gemini-.*-image(?:-|$)/i]`), so any id carrying one of the three prefixes the function itself declares walked straight past the guard. Reproduced against the shipped Gemini table before the fix:

```
gemini-2.5-flash-image-preview          => undefined            (guard fires)
models/gemini-2.5-flash-image-preview   => {input:0.3,output:2.5}  (guard bypassed)
google/gemini-2.5-flash-image-preview   => {input:0.3,output:2.5}  (guard bypassed)
```

`models/…` is literally the shape Gemini's ListModels returns, which is why `Gemini_ModelSearch` strips it. The result is the exact "fabricated unit" the guard exists to prevent: a per-image model resolving `gemini-2.5-flash`'s per-1M-token card, and the run reporting a confident wrong-unit figure. (xAI was unaffected only by luck — its matcher is unanchored.)

**Change:** pass the normalized `id`, and say so in the JSDoc, since providers are told to pass the same matcher their effort policy uses.

## Tests

- `packages/test/.../OpenRouterPricing.test.ts` — quoted prompt with `completion: "-1"`, and a card omitting `completion`, must leave `output` unset.
- `packages/ai/.../ModelPricing.test.ts` — the `notTokenBilled` block previously only exercised the no-prefix path; a table-driven case now pairs `vendorPrefixes` with an anchored matcher, including a mixed-case prefixed id.
- `packages/test/.../ModelSearchPricing.test.ts` — the prefixed Gemini forms against the real shipped table, plus the prefixed text sibling still resolving.

## Verified

- All three new cases run **red against the unfixed code** and green after (both confirmed by running them).
- `bunx vitest run packages/test/src/test/ai-provider-api packages/ai/src examples/cli/src/test/lookupModelPricing.test.ts` — 87 files, 985 tests, all pass.
- `bunx turbo run build-types --filter=@workglow/ai --filter=@workglow/openrouter` — clean (9 tasks, includes the dependency chain).
- `bunx oxfmt --check` and `bunx oxlint` over the touched trees — clean.

**Not verified here:** the full repo test suite and the full `bun run lint` / `bun run build`. Only the slices above were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8DU24G9GWuRUJncc5TJFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8DU24G9GWuRUJncc5TJFZ)_