### PR TITLE
fix(web-search): reduce domain entries on every route, not just site:

### DIFF
--- a/packages/web-search/src/WebSearchTask.ts
+++ b/packages/web-search/src/WebSearchTask.ts
@@ -9,7 +9,7 @@ import { Task, TaskConfigurationError } from "@workglow/task-graph";
 import { FetchUrlTask, fetchUrlEntitlementsFor } from "@workglow/tasks";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { unhonorableOptions } from "./capabilityCheck";
-import { unusableDomainEntries } from "./domainInput";
+import { normalizeDomains, unusableDomainEntries } from "./domainInput";
 import type {
   IWebSearchProvider,
   SearchResult,
@@ -350,6 +350,13 @@ export class WebSearchTask extends Task<WebSearchTaskInput, WebSearchTaskOutput>
    * includes and `"query-operator"` excludes pass routing and then receive an
    * `excludeDomains` list it has no native way to send — a restriction silently
    * dropped on a request the task reported as honored.
+   *
+   * Domains are reduced to bare hosts here, before either direction is decided,
+   * so the list a native adapter forwards and the list the `site:` translation
+   * reads are the same value. Reducing them only on the way into an operator
+   * left `"https://arxiv.org/"` restricting one route and reaching a vendor API
+   * as a scheme-bearing entry on the other, where it matches nothing or is
+   * skipped — and with `"auto"` the caller cannot tell which route ran.
    */
   private adaptRequest(provider: IWebSearchProvider, request: WebSearchRequest): WebSearchRequest {
     const capabilities = provider.capabilities;
@@ -358,23 +365,25 @@ export class WebSearchTask extends Task<WebSearchTaskInput, WebSearchTaskOutput>
       cap !== undefined && request.maxResults !== undefined
         ? Math.min(request.maxResults, cap)
         : request.maxResults;
+    const includeDomains = normalizeDomains(request.includeDomains);
+    const excludeDomains = normalizeDomains(request.excludeDomains);
 
     const excludeSupport = capabilities.excludeDomainFilter ?? capabilities.domainFilter;
     const translateIncludes = capabilities.domainFilter === "query-operator";
     const translateExcludes = excludeSupport === "query-operator";
     if (!translateIncludes && !translateExcludes) {
-      return { ...request, maxResults };
+      return { ...request, maxResults, includeDomains, excludeDomains };
     }
     return {
       ...request,
       maxResults,
       query: applyDomainOperators(
         request.query,
-        translateIncludes ? request.includeDomains : undefined,
-        translateExcludes ? request.excludeDomains : undefined
+        translateIncludes ? includeDomains : undefined,
+        translateExcludes ? excludeDomains : undefined
       ),
-      includeDomains: translateIncludes ? undefined : request.includeDomains,
-      excludeDomains: translateExcludes ? undefined : request.excludeDomains,
+      includeDomains: translateIncludes ? undefined : includeDomains,
+      excludeDomains: translateExcludes ? undefined : excludeDomains,
     };
   }
 }

--- a/packages/web-search/src/__tests__/WebSearchTask.test.ts
+++ b/packages/web-search/src/__tests__/WebSearchTask.test.ts
@@ -116,7 +116,7 @@ describe("WebSearchTask", () => {
     expect(request.excludeDomains).toBeUndefined();
   });
 
-  it("passes domain lists through untouched to a native provider", async () => {
+  it("passes domain lists to a native provider rather than into the query", async () => {
     const seen = vi.fn();
     WebSearchProviderRegistry.register(fake("tavily", { domainFilter: "native" }, seen));
     await new WebSearchTask().run({
@@ -127,6 +127,50 @@ describe("WebSearchTask", () => {
     const request = seen.mock.calls[0][0] as WebSearchRequest;
     expect(request.query).toBe("cats");
     expect(request.includeDomains).toEqual(["arxiv.org"]);
+  });
+
+  it("hands a native provider the same reduction the site: translation applies", async () => {
+    // The vendor APIs behind `domainFilter: "native"` all document bare hosts,
+    // so a scheme, a `www.` or a trailing slash is at best matched by nothing
+    // and at worst skipped as unparseable — an unrestricted search reported as
+    // successful with nothing saying the filter was dropped. Under `"auto"` the
+    // caller cannot even predict which route ran, so the reduction has to be the
+    // same on both.
+    const native = vi.fn();
+    const operator = vi.fn();
+    WebSearchProviderRegistry.register(fake("tavily", { domainFilter: "native" }, native));
+    WebSearchProviderRegistry.register(fake("brave", { domainFilter: "query-operator" }, operator));
+
+    const domains = {
+      includeDomains: ["https://ArXiv.org/"],
+      excludeDomains: ["www.spam.example"],
+    };
+    await new WebSearchTask().run({ query: "cats", provider: "tavily", ...domains });
+    await new WebSearchTask().run({ query: "cats", provider: "brave", ...domains });
+
+    const nativeRequest = native.mock.calls[0][0] as WebSearchRequest;
+    expect(nativeRequest.includeDomains).toEqual(["arxiv.org"]);
+    expect(nativeRequest.excludeDomains).toEqual(["spam.example"]);
+    const operatorRequest = operator.mock.calls[0][0] as WebSearchRequest;
+    expect(operatorRequest.query).toBe("cats site:arxiv.org -site:spam.example");
+  });
+
+  it("normalizes the direction a split provider filters natively", async () => {
+    // `excludeDomainFilter` is decided separately from `domainFilter`, so the
+    // list left for the adapter to send must be reduced whichever side it is on.
+    const seen = vi.fn();
+    WebSearchProviderRegistry.register(
+      fake("split", { domainFilter: "native", excludeDomainFilter: "query-operator" }, seen)
+    );
+    await new WebSearchTask().run({
+      query: "cats",
+      provider: "split",
+      includeDomains: ["https://arxiv.org/"],
+      excludeDomains: ["https://spam.example/"],
+    });
+    const request = seen.mock.calls[0][0] as WebSearchRequest;
+    expect(request.includeDomains).toEqual(["arxiv.org"]);
+    expect(request.query).toBe("cats -site:spam.example");
   });
 
   it("clamps maxResults to the provider cap instead of refusing", async () => {

--- a/packages/web-search/src/common.ts
+++ b/packages/web-search/src/common.ts
@@ -15,6 +15,7 @@ import { WebSearchProviderRegistry } from "./WebSearchProviderRegistry";
 import { WebSearchTask } from "./WebSearchTask";
 
 export * from "./capabilityCheck";
+export * from "./domainInput";
 export * from "./IWebSearchProvider";
 export * from "./limitResults";
 export * from "./providers/BraveWebSearchProvider";

--- a/packages/web-search/src/domainInput.ts
+++ b/packages/web-search/src/domainInput.ts
@@ -32,6 +32,21 @@ export function normalizeDomain(domain: string): string {
 }
 
 /**
+ * {@link normalizeDomain} over a whole list, preserving an absent one.
+ *
+ * Applied to every route rather than only the `site:` translation: the vendor
+ * APIs behind a native domain filter document bare hosts, so an entry the
+ * operator route reduces and the native route forwards raw is the same request
+ * filtered two different ways — and a vendor that skips an entry it cannot parse
+ * runs the search unrestricted and reports it as honored.
+ */
+export function normalizeDomains(
+  domains: readonly string[] | undefined
+): readonly string[] | undefined {
+  return domains?.map(normalizeDomain);
+}
+
+/**
  * Whether a domain survives normalization as something a filter can express.
  *
  * Judged on the NORMALIZED value, not the raw entry: `" https://a.com/ "` is a


### PR DESCRIPTION
## What was wrong

`normalizeDomain` — which strips a scheme, a `www.` prefix and trailing slashes — was applied in exactly one place: `normalizeAll` inside `queryOperators.ts`, on the way into a `site:` operator. A provider declaring `domainFilter: "native"` received the caller's entry verbatim.

`unusableDomainEntries` validates against the *normalized* form on purpose (`" https://a.com/ "` is a perfectly good domain), so a scheme-bearing, `www.`-prefixed or trailing-slash entry passes validation on every route and is then reduced on one route only. The raw value is forwarded to `body.include_domains` (Tavily), `tool.filters.allowed_domains` (OpenAI), `tool.allowed_domains` / `blocked_domains` (Anthropic) and `plugin.include_domains` (OpenRouter) — all of which document bare hosts.

## The concrete failure

`{ provider: "auto", includeDomains: ["https://arxiv.org/"] }`:

- routed to Brave/SearXNG, the query becomes `cats site:arxiv.org` and the restriction holds;
- routed to Tavily/OpenAI/Anthropic/OpenRouter, the vendor is handed `"https://arxiv.org/"` — either zero results for a filter that should have matched, or, for a vendor that skips an entry it cannot parse, **an unrestricted web search reported as successful**, with `provider` set and nothing saying the filter was discarded.

That is the trade this package refuses everywhere else — the date-filter rule and the empty-entry refusal both say a bound reported as honored on a search that ran unfiltered is worse than a refused request. It is also not reproducible from the caller's side, because `"auto"` picks the route at run time.

## What changed

- `adaptRequest` reduces `includeDomains` / `excludeDomains` **once, before either direction is decided**, and both the native pass-through and the `site:` translation read that same value. The two directions stay decided separately, so a split provider (`domainFilter: "native"`, `excludeDomainFilter: "query-operator"`) gets a reduced native include list and a reduced `-site:` clause.
- Refusal behaviour is untouched: `assertUsableDomains` still runs first, for every provider, and an entry that names no domain is still an error rather than a silent drop. `normalizeAll`'s filter stays in `queryOperators` as the structural backstop it was added to be — nothing spliced into a query can restructure it whether or not a call site validated first.
- `domainInput` is now exported from `common.ts`, so a host writing its own native provider can apply the same reduction instead of re-deriving it.

No new refusals and no new normalization rule — the same reduction, on both routes.

## Tests

Two new cases in `WebSearchTask.test.ts`, both **run red against the unfixed code** and green after (confirmed by running them):

- a native provider and a query-operator provider given the identical `includeDomains: ["https://ArXiv.org/"]` / `excludeDomains: ["www.spam.example"]`, asserting the native adapter sees `["arxiv.org"]` / `["spam.example"]` and the operator route builds `cats site:arxiv.org -site:spam.example`;
- a split provider, asserting the natively-filtered direction is reduced too.

One existing test was renamed from "passes domain lists through untouched to a native provider" to "…rather than into the query" — its assertion is unchanged, but "untouched" now contradicts the contract.

## Verified

- `bunx vitest run packages/web-search/src` — 15 files, 137 tests, all pass (includes the existing "domain entries that name no domain" refusal block).
- `bunx vitest run` over the four vendor `*WebSearchProvider.test.ts` suites (gemini, anthropic, openai, openrouter) — 50 tests, all pass.
- `bunx turbo run build-types` for `@workglow/web-search` and the four vendor packages — clean.
- `bunx oxfmt --check packages/web-search/src` and `bunx oxlint packages/web-search/src` — clean.

**Not verified here:** the full repo test suite, `bun run lint` across the whole tree, and the SearXNG integration test (it is skipped without `WEB_SEARCH_SEARXNG_URL`). No live vendor API was called — the adapter assertions are on the request objects, as the existing suites already are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8DU24G9GWuRUJncc5TJFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8DU24G9GWuRUJncc5TJFZ)_