### PR TITLE
fix(storage): decide the join pushdown on enlistment, not the instance flag

### DIFF
--- a/packages/storage/src/tabular/BaseSqlTabularStorage.ts
+++ b/packages/storage/src/tabular/BaseSqlTabularStorage.ts
@@ -186,6 +186,30 @@ export abstract class BaseSqlTabularStorage<
   }
 
   /**
+   * Whether a connection-scoped transaction this instance is enlisted in is
+   * open in the current async context.
+   *
+   * {@link inTransaction} does not answer this on every backend. It is an
+   * instance flag, and a pooled backend deliberately sets it on nobody: its
+   * transaction runs on one checked-out client while the same instances keep
+   * serving unrelated callers off the pool, so enlistment is a property of the
+   * async context rather than of the instance. Such a backend overrides this
+   * with the context question; the default is `false`, which is right for the
+   * single-session arm, where every participant carries the flag instead.
+   *
+   * The two answers are unioned wherever the question is "is this instance
+   * inside an open transaction", so neither arm has to be special-cased twice.
+   */
+  protected isEnlistedInConnectionTransaction(): boolean {
+    return false;
+  }
+
+  /** Either way an instance can be inside an open transaction. */
+  private insideOpenTransaction(): boolean {
+    return this.inTransaction || this.isEnlistedInConnectionTransaction();
+  }
+
+  /**
    * Per-instance promise-chain mutex. On a backend that runs every statement
    * on one shared connection, all public read/write methods queue behind the
    * previous holder, and `withTransaction` holds the lock for the duration of
@@ -747,9 +771,14 @@ export abstract class BaseSqlTabularStorage<
     // the right side is enlisted on and miss its uncommitted rows entirely.
     // The hash fallback goes through `right.query()`, which does serialize on
     // the right's own lock and does resolve its enlisted client, so hand this
-    // case to it. `this.inTransaction` means the join is already inside that
-    // transaction, where reading its own uncommitted rows is correct.
-    if (right.inTransaction && !this.inTransaction) return null;
+    // case to it. The left side being inside that same transaction is the
+    // exception: reading its own uncommitted rows there is correct.
+    //
+    // Asked through {@link insideOpenTransaction} rather than the
+    // `inTransaction` flag alone, because the pooled arm — the one whose
+    // uncommitted rows sit on another client entirely — sets that flag on
+    // nobody.
+    if (right.insideOpenTransaction() && !this.insideOpenTransaction()) return null;
     return { right, dialect: mine.dialect };
   }
 

--- a/packages/test/src/test/storage-tabular/PostgresPooledJoinTransaction.test.ts
+++ b/packages/test/src/test/storage-tabular/PostgresPooledJoinTransaction.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { PostgresTabularStorage } from "@workglow/postgres/storage";
+import { withConnectionTransaction } from "@workglow/storage";
+import type { Pool } from "pg";
+import { describe, expect, it } from "vitest";
+
+const RowSchema = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    tag: { type: "string" },
+  },
+  required: ["name", "tag"],
+  additionalProperties: false,
+} as const;
+
+const RowPrimaryKeyNames = ["name"] as const;
+
+type RowStorage = PostgresTabularStorage<typeof RowSchema, typeof RowPrimaryKeyNames>;
+
+/**
+ * A `pg.Pool`-shaped facade over one PGlite session.
+ *
+ * `PostgresTabularStorage` decides which arm it is on by whether the db it was
+ * given has `connect()`, so this puts it on the POOLED arm — the one whose
+ * connection transaction checks out its own client and therefore flags no
+ * participant with `inTransaction`. Every statement still runs on the single
+ * PGlite session underneath, which is what makes the arm reachable without a
+ * live Postgres: what is under test is which join strategy gets chosen from
+ * that state, not the isolation a real pool would then impose.
+ */
+function pooledFacade(db: PGlite): Pool {
+  const query = db.query.bind(db);
+  return {
+    query,
+    connect: async () => ({ query, release: (): void => {} }),
+  } as unknown as Pool;
+}
+
+/**
+ * Counts calls to `query` on one storage without a spy, so this file needs
+ * nothing from Vitest's module registry and runs unchanged under either runner.
+ */
+function countQueries(storage: RowStorage): () => number {
+  let calls = 0;
+  const original = storage.query.bind(storage);
+  (storage as { query: RowStorage["query"] }).query = ((...args: Parameters<typeof original>) => {
+    calls += 1;
+    return original(...args);
+  }) as RowStorage["query"];
+  return () => calls;
+}
+
+describe("join pushdown against a pooled connection transaction", () => {
+  it("hands the join to the hash fallback when only the right side is enlisted", async () => {
+    // The pushdown reads the right table while holding only the left's lock, so
+    // on a real pool it runs on a different client from the one the right side
+    // is enlisted on and cannot see that transaction's uncommitted rows — an
+    // inner join returning zero rows where the hash fallback returns the row.
+    // The fallback goes through `right.query()`, which resolves the enlisted
+    // client, so the strategy chosen is the whole question here. Only the
+    // right side is a participant; a join is a read, so nothing else refuses it.
+    const db = new PGlite();
+    const pool = pooledFacade(db);
+    const left: RowStorage = new PostgresTabularStorage(
+      pool,
+      "pooled_join_left",
+      RowSchema,
+      RowPrimaryKeyNames
+    );
+    const right: RowStorage = new PostgresTabularStorage(
+      pool,
+      "pooled_join_right",
+      RowSchema,
+      RowPrimaryKeyNames
+    );
+    await left.setupDatabase();
+    await right.setupDatabase();
+    await left.put({ name: "a", tag: "left-row" });
+
+    const rightQueries = countQueries(right);
+
+    await withConnectionTransaction([right], async () => {
+      await right.put({ name: "a", tag: "uncommitted" });
+
+      const rows = await left.join(
+        {
+          type: "inner",
+          on: [{ left: "name", right: "name" }],
+          orderBy: [{ side: "left", column: "name", direction: "ASC" }],
+        },
+        right
+      );
+
+      expect(rows.map((row) => `${row.left.tag}:${row.right.tag}`)).toEqual([
+        "left-row:uncommitted",
+      ]);
+    });
+
+    expect(rightQueries()).toBeGreaterThan(0);
+  });
+
+  it("still pushes down when neither side is in a transaction", async () => {
+    const db = new PGlite();
+    const pool = pooledFacade(db);
+    const left: RowStorage = new PostgresTabularStorage(
+      pool,
+      "pooled_plain_left",
+      RowSchema,
+      RowPrimaryKeyNames
+    );
+    const right: RowStorage = new PostgresTabularStorage(
+      pool,
+      "pooled_plain_right",
+      RowSchema,
+      RowPrimaryKeyNames
+    );
+    await left.setupDatabase();
+    await right.setupDatabase();
+    await left.put({ name: "a", tag: "left-row" });
+    await right.put({ name: "a", tag: "right-row" });
+
+    const rightQueries = countQueries(right);
+    const rows = await left.join(
+      {
+        type: "inner",
+        on: [{ left: "name", right: "name" }],
+        orderBy: [{ side: "left", column: "name", direction: "ASC" }],
+      },
+      right
+    );
+
+    expect(rows.map((row) => `${row.left.tag}:${row.right.tag}`)).toEqual(["left-row:right-row"]);
+    expect(rightQueries()).toBe(0);
+  });
+});

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -1046,6 +1046,17 @@ export class PostgresTabularStorage<
   }
 
   /**
+   * The real-pool arm sets `inTransaction` on nobody — its transaction runs on
+   * a checked-out client while these instances keep serving other callers off
+   * the pool — so the async context is the only thing that can say whether this
+   * instance is enlisted. The same question `_putBulkInternal` and
+   * `withTransaction` already ask on this path.
+   */
+  protected override isEnlistedInConnectionTransaction(): boolean {
+    return isEnlistedInConnectionTx(this);
+  }
+
+  /**
    * A real `pg.Pool` isolates per checked-out client, so serializing through
    * the base's per-instance chain would turn the pool's main benefit into a
    * per-instance bottleneck for no safety gained. Isolation there comes from


### PR DESCRIPTION
## What was wrong

`BaseSqlTabularStorage.planSqlJoin` guards against pushing a join down while the right-hand storage sits inside a connection transaction the left side is not enlisted in. Its own comment names the pooled-Postgres case explicitly — *"on a real pool it would run on a different client from the one the right side is enlisted on and miss its uncommitted rows entirely… hand this case to it."* — but the test it used was:

```ts
if (right.inTransaction && !this.inTransaction) return null;
```

`inTransaction` is an instance field written only by `setConnectionTransactionActive`, which only `runSingleSessionConnectionTransaction` calls — the SQLite / DuckDB / PGlite arm. `PostgresTabularStorage.runConnectionTransaction`'s pooled branch calls `runNativeConnectionTransaction` directly with `ownsSession: false` and flags no participant, deliberately: the transaction runs on one checked-out client while the same instances keep serving unrelated callers off the pool, so enlistment there is a property of the async context, not of the instance. `withTransaction` on that arm says the same thing in a comment ("We deliberately do NOT set `this.inTransaction` here"), and `_putBulkInternal` already asks the right question — `this.inTransaction || isEnlistedInConnectionTx(this)`.

So on a real `pg.Pool` the guard was dead.

## The concrete failure

1. Pooled Postgres, storages `A` and `B` on the same `Pool`.
2. `withConnectionTransaction([B], async () => { await B.put(row); … })`.
3. Inside the body, something calls `A.join(spec, B)` — `A` is not a participant. A join is a read, so `assertNotForeignConnectionTx` (write-only) raises nothing.
4. `planSqlJoin`: same dialect, same shared handle (both the pool), `B.inTransaction === false` → pushdown chosen.
5. `runSqlJoin` executes through `A.db`; `connectionTxQuery(A)` is `undefined`, so a fresh pooled client runs the JOIN.
6. `row` is invisible. The inner join returns zero rows where the same call on SQLite — or through the hash fallback, which goes via `B.query()` and resolves the enlisted client — returns it.

A wrong answer with no error, differing between backends and between the two join strategies for identical inputs.

## What changed

- `BaseSqlTabularStorage` gains `protected isEnlistedInConnectionTransaction()`, defaulting to `false`, plus a private `insideOpenTransaction()` that unions it with the `inTransaction` flag. The base class cannot import the connection-transaction module itself — that module is instantiated once per runtime entry (`NativeConnectionTransaction.server` / `.browser`), and pulling either in would drag `node:async_hooks` into the browser build — so the seam is a virtual method, in the same shape as the existing `setConnectionTransactionActive` / `sharedConnectionHandle` hooks.
- `PostgresTabularStorage` overrides it with `isEnlistedInConnectionTx(this)` — the predicate its pooled write path and `connectionTxQuery` already use.
- The guard becomes `if (right.insideOpenTransaction() && !this.insideOpenTransaction()) return null;`. The `inTransaction` half is kept, so the `tx`-proxy case (where `createTxView`'s `extras` sets `inTransaction: true` on a pooled backend whose instance flag stays `false`) is unchanged; the proxy binds methods to the receiver, so the union reads the override.

No behavior change on the single-session arm, where the flag is set on every participant and the union is already `true`.

## Test

`packages/test/src/test/storage-tabular/PostgresPooledJoinTransaction.test.ts` builds two `PostgresTabularStorage` instances over a `pg.Pool`-shaped facade around one PGlite session. The facade exposes `connect()`, which is exactly how `PostgresTabularStorage` decides it is on the **pooled** arm — so `runConnectionTransaction` takes the pooled branch and flags no participant, reproducing the state that made the guard dead. It then enlists only the right side and joins from the un-enlisted left, asserting the hash fallback ran (the right side's `query` was called). A second case asserts the pushdown is still chosen when neither side is in a transaction.

**Run against the unfixed source first: the first case failed (`expected 0 to be greater than 0`).** With the fix, both pass.

## What could not be exercised here

There is no live Postgres in this environment, so the test cannot demonstrate the *visibility* half — under one PGlite session the pushdown sees the uncommitted row anyway, and the row assertion passes on both paths. What it pins is the routing decision, made from the same pooled state a real `pg.Pool` produces; the "different client, invisible rows" consequence of that decision is `pg.Pool` behavior, not something this repo implements. The existing `PostgresTabularStorage.integration.test.ts` (real server, skipped without one) was not run.

## Verified

Run in a clean worktree after `bun install`, with `bun run use-dist` (real `dist`) for the type checks:

- `bunx vitest run packages/test/src/test/storage-tabular/PostgresPooledJoinTransaction.test.ts` — 2 passed; 1 failed before the fix.
- `bun scripts/test.ts storage unit vitest` — 61 passed, 2 skipped (63 files, 1178 tests).
- `bun scripts/test.ts storage unit bun` — 1182 pass, 100 skip, 0 fail (same 63 files).
- `bun scripts/test.ts --check-sections` — every test file discoverable; `bunx vitest run scripts/testDiscovery.test.ts` — 11 passed.
- `bunx tsc --noEmit` in `packages/storage`, `providers/postgres`, `packages/test` — clean.
- `bunx oxlint --type-aware` over the three touched trees — clean.
- `bunx oxfmt --check` on the touched trees — clean. (`packages/storage/src/vector/README.md` reports a pre-existing issue on `main`; untouched here.)

## Not verified here

- Integration suites needing a live Postgres, and the full repo test/lint/typecheck, were not run.
- DuckDB and the other single-session backends were not re-run beyond the `storage` unit section above; they take the default `false` override and their behavior is unchanged by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8DU24G9GWuRUJncc5TJFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8DU24G9GWuRUJncc5TJFZ)_