### PR TITLE
A tool call's whole life on the wire

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -215,10 +215,15 @@ tool is backed by a registered task (looked up by `taskType`, else `name`) or by
 `ToolDefinition.execute` function, which is handed a `ToolExecuteContext` — the tool-use id
 its answer belongs to, and the run's signal — and may throw a `ToolCallError` to report a
 failure in its own words rather than wrapped. The turn also emits a `snapshot` of `messages`
-after every message it records, so a host can draw a tool card from the moment the model asks
-for it; a `snapshot` rather than an object-delta because an array delta is folded as an upsert
+after every message it records, so a host can mirror the conversation while the turn is still
+running; a `snapshot` rather than an object-delta because an array delta is folded as an upsert
 list and successive whole-list snapshots would append into a transcript several times its
-length. A tool reaching beyond `INFERENCE_ENTITLEMENTS` is put to
+length. **A tool card reads `tool-call` events, not those snapshots** — one per call per state
+(`pending` → `running` → `completed | failed`), so a card has its whole life on the wire
+instead of being reconstructed by diffing transcripts, which reports outcomes only as one
+batch after the last call and never says which call is running. Every call passes all three
+states, the ones nothing executes for included (unknown tool, rejected arguments, refused
+approval), so a host draws one lifecycle rather than one per way a call can end. A tool reaching beyond `INFERENCE_ENTITLEMENTS` is put to
 `IHumanConnector` as a `confirm` first: `requiresApproval` overrides that per tool,
 `approval: "never"` turns it off for a headless run, and with no connector registered such a
 call is refused rather than run.

--- a/packages/ai/src/task/AgentTask.ts
+++ b/packages/ai/src/task/AgentTask.ts
@@ -186,6 +186,11 @@ function assistantMessage(text: string, calls: readonly ToolCall[]): ChatMessage
   return { role: "assistant", content };
 }
 
+/** The text of a settled call, as the model will read it. */
+function toolResultText(result: ContentBlockToolResult): string {
+  return result.content.map((block) => (block.type === "text" ? block.text : "")).join("");
+}
+
 /**
  * Every path into a `tool_result` is bounded by the same budget, not just the
  * one carrying a tool's output. "Unknown tool X. Available: …" names every tool
@@ -193,11 +198,6 @@ function assistantMessage(text: string, calls: readonly ToolCall[]): ChatMessage
  * context window as a fetched page — and it would then do it on every round the
  * model keeps guessing.
  */
-/** The text of a settled call, as the model will read it. */
-function toolResultText(result: ContentBlockToolResult): string {
-  return result.content.map((block) => (block.type === "text" ? block.text : "")).join("");
-}
-
 function toolResult(
   call: ToolCall,
   text: string,

--- a/packages/ai/src/task/AgentTask.ts
+++ b/packages/ai/src/task/AgentTask.ts
@@ -193,6 +193,11 @@ function assistantMessage(text: string, calls: readonly ToolCall[]): ChatMessage
  * context window as a fetched page — and it would then do it on every round the
  * model keeps guessing.
  */
+/** The text of a settled call, as the model will read it. */
+function toolResultText(result: ContentBlockToolResult): string {
+  return result.content.map((block) => (block.type === "text" ? block.text : "")).join("");
+}
+
 function toolResult(
   call: ToolCall,
   text: string,
@@ -337,16 +342,40 @@ export class AgentTask extends Task<AgentTaskInput, AgentTaskOutput, AgentTaskCo
         return;
       }
 
+      // Every call the model asked for, announced before any of them runs: it
+      // asked for them together, and a host laying out cards can draw the whole
+      // set rather than watching them appear one at a time in an order that is
+      // this loop's business and not the model's.
+      for (const call of calls) {
+        yield {
+          type: "tool-call",
+          status: "pending",
+          toolCallId: call.id,
+          name: call.name,
+          input: call.input,
+        };
+      }
+
       const results: ContentBlockToolResult[] = [];
       for (const call of calls) {
         context.signal.throwIfAborted();
         await context.updateProgress(undefined, `Running ${call.name}`);
-        results.push(
-          await this.runCall(call, byName, validators, context, {
-            approval,
-            maxResultChars: maxToolResultChars,
-          })
-        );
+        yield { type: "tool-call", status: "running", toolCallId: call.id, name: call.name };
+        const result = await this.runCall(call, byName, validators, context, {
+          approval,
+          maxResultChars: maxToolResultChars,
+        });
+        results.push(result);
+        // Read back off the block rather than from a second copy of the text:
+        // what the card says the call produced is then the same string the
+        // model is about to read, clamp included.
+        yield {
+          type: "tool-call",
+          status: result.is_error === true ? "failed" : "completed",
+          toolCallId: call.id,
+          name: call.name,
+          result: toolResultText(result),
+        };
       }
       messages.push({ role: "tool", content: results });
       yield transcript();

--- a/packages/task-graph/src/task-graph/StreamPump.ts
+++ b/packages/task-graph/src/task-graph/StreamPump.ts
@@ -18,6 +18,7 @@ import {
   getOutputStreamMode,
   getPortStreamMode,
   getStreamingPorts,
+  isDataflowExcluded,
   isDeltaStreamMode,
   isStreamConsumer,
   isTaskStreamable,
@@ -836,10 +837,11 @@ export class StreamPump {
             if (portId !== undefined && StreamPump.isPortDelta(event) && event.port !== portId) {
               return;
             }
-            // Phase events are not accumulated into dataflow edges per the
-            // StreamTypes contract, so they must not be enqueued onto edge
-            // streams; drop them here.
-            if (event.type === "phase") {
+            // A task's own reporting is not content on a port, so it never
+            // reaches an edge. The port filter above cannot decide this: it
+            // recognises only the three delta types, so an event carrying no
+            // `port` passes it by construction.
+            if (isDataflowExcluded(event)) {
               return;
             }
             // Tap: on snapshot events, write per-port data into each edge's

--- a/packages/task-graph/src/task-graph/__tests__/DataflowExcludedEvents.test.ts
+++ b/packages/task-graph/src/task-graph/__tests__/DataflowExcludedEvents.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Which stream events are a task's own reporting rather than content on a port.
+ *
+ * `StreamPump` asks this before enqueueing onto a dataflow edge. The port filter
+ * beside it cannot answer: it recognises only the three delta types, so an event
+ * carrying no `port` passes it by construction and would reach an edge unless
+ * named here. Two things go wrong when one does — a nested graph re-yields it
+ * under a second task id, reporting the same thing twice under different names,
+ * and `streamEventCost` charges it nothing, so an event carrying a whole tool
+ * result passes the backpressure gate uncounted.
+ */
+
+import type { StreamEvent } from "@workglow/task-graph";
+import { isDataflowExcluded, streamEventCost } from "@workglow/task-graph";
+import { describe, expect, it } from "vitest";
+
+describe("isDataflowExcluded", () => {
+  it("excludes a task's own reporting", () => {
+    expect(isDataflowExcluded({ type: "phase", message: "Thinking", progress: undefined })).toBe(
+      true
+    );
+    for (const event of [
+      { type: "tool-call", status: "pending", toolCallId: "c1", name: "t", input: {} },
+      { type: "tool-call", status: "running", toolCallId: "c1", name: "t" },
+      { type: "tool-call", status: "completed", toolCallId: "c1", name: "t", result: "ok" },
+      { type: "tool-call", status: "failed", toolCallId: "c1", name: "t", result: "no" },
+    ] as StreamEvent[]) {
+      expect(isDataflowExcluded(event)).toBe(true);
+    }
+  });
+
+  it("passes content and the control events a downstream consumer reads", () => {
+    for (const event of [
+      { type: "text-delta", port: "text", textDelta: "hi" },
+      { type: "object-delta", port: "o", objectDelta: { a: 1 } },
+      { type: "binary-delta", port: "b", binaryDelta: new Uint8Array([1]) },
+      { type: "snapshot", data: {} },
+      { type: "finish", data: {} },
+      { type: "error", error: new Error("x") },
+    ] as StreamEvent[]) {
+      expect(isDataflowExcluded(event)).toBe(false);
+    }
+  });
+
+  it("excludes exactly the events the backpressure gate cannot price", () => {
+    // The two rules have to agree: an event the gate charges nothing for and
+    // that still reached an edge would accumulate without the gate closing.
+    // Every zero-cost event here is either excluded or bounded in size.
+    const settled: StreamEvent = {
+      type: "tool-call",
+      status: "completed",
+      toolCallId: "c1",
+      name: "t",
+      result: "x".repeat(20_000),
+    };
+    expect(streamEventCost(settled)).toBe(0);
+    expect(isDataflowExcluded(settled)).toBe(true);
+  });
+});

--- a/packages/task-graph/src/task/StreamProcessor.ts
+++ b/packages/task-graph/src/task/StreamProcessor.ts
@@ -360,6 +360,13 @@ export class StreamProcessor<Input extends TaskInput, Output extends TaskOutput>
             this.task.emit("stream_chunk", event as StreamEvent);
             break;
           }
+          case "tool-call": {
+            // Where one tool call has got to. Metadata only, like `phase`: no
+            // accumulator, no runOutputData, no status flip — a task is not
+            // streaming its output because something it called started.
+            this.task.emit("stream_chunk", event as StreamEvent);
+            break;
+          }
           case "finish": {
             sawFinish = true;
             // finish supersedes the snapshots it summarizes; `?? liveUsage`

--- a/packages/task-graph/src/task/StreamTypes.ts
+++ b/packages/task-graph/src/task/StreamTypes.ts
@@ -328,6 +328,13 @@ export type StreamPhase = {
  *  - `completed` / `failed` — settled, carrying the text the model reads
  *    back. `failed` is the call's own outcome — it threw, its arguments were
  *    rejected, nobody approved it — and not an error that ends the run.
+ *
+ * The two settled states are separate members carrying identical fields rather
+ * than one member with `status: "completed" | "failed"`. A shared member makes
+ * `status` no discriminant at all: `Extract<StreamEvent, { type: "tool-call";
+ * status: "completed" }>` is then `never`, because no member is assignable to a
+ * constraint narrower than its own union, and a consumer wanting the settled
+ * shape has to key on whichever property happens to be unique to it.
  */
 export type StreamToolCall =
   | {
@@ -345,7 +352,15 @@ export type StreamToolCall =
     }
   | {
       type: "tool-call";
-      status: "completed" | "failed";
+      status: "completed";
+      toolCallId: string;
+      name: string;
+      /** What the model reads back, after the same clamp the result carries. */
+      result: string;
+    }
+  | {
+      type: "tool-call";
+      status: "failed";
       toolCallId: string;
       name: string;
       /** What the model reads back, after the same clamp the result carries. */
@@ -630,6 +645,26 @@ export const DEFAULT_STREAM_GATE_WATCHDOG_MS = 60_000;
  * deterministic per event, so charge and credit sites can each compute it
  * independently and always agree.
  */
+/**
+ * Whether an event is the task's own reporting rather than content on a port,
+ * and so must not be enqueued onto a dataflow edge.
+ *
+ * These are the events {@link StreamPhase} and {@link StreamToolCall} document
+ * as metadata: a downstream task is not a subscriber to how its producer got
+ * on, and forwarding them onto an edge has two consequences beyond the wrong
+ * audience. A nested graph re-yields them under a second task id, so one tool
+ * call is reported twice under different names; and {@link streamEventCost}
+ * charges them nothing, so an event carrying a settled call's whole result text
+ * passes the backpressure gate uncounted and a slow consumer accumulates one
+ * per call without the gate ever closing.
+ *
+ * The port filter cannot do this job: it only recognises the three delta types,
+ * so anything without a `port` passes it by construction.
+ */
+export function isDataflowExcluded(event: StreamEvent): boolean {
+  return event.type === "phase" || event.type === "tool-call";
+}
+
 export function streamEventCost(event: StreamEvent): number {
   switch (event.type) {
     case "text-delta":

--- a/packages/task-graph/src/task/StreamTypes.ts
+++ b/packages/task-graph/src/task/StreamTypes.ts
@@ -299,6 +299,60 @@ export type StreamPhase = {
 };
 
 /**
+ * How far one tool call a task is running on a model's behalf has got.
+ *
+ * Emitted per call, so a host drawing a card for one has the card's whole
+ * life on the wire. Without it the only account of a tool call is the
+ * conversation the task publishes, and a card has to be reconstructed by
+ * diffing successive copies of that: the ask appears when the assistant
+ * message lands, and the outcome when the results land — as one batch, after
+ * the last of them, with nothing in between and no way to tell which call is
+ * running now. A host owning its own tools can fill that in from inside them,
+ * which is why this was not missed earlier; a host whose tools are task types
+ * it named cannot, and neither can one relaying to a protocol.
+ *
+ * Metadata, not data, on the same terms as {@link StreamPhase}: emitted on
+ * `stream_chunk`, never accumulated into a port, never part of a `finish`
+ * payload, and no status flip. A task that reports these still reports its
+ * conversation — this says where a call has got to, not what was said.
+ *
+ * `status` discriminates what else is known, rather than every field being
+ * optional on one shape:
+ *  - `pending` — the model asked for it; nothing has run. Carries `input`.
+ *  - `running` — the task has taken the call up. Every call passes through
+ *    this, including the ones nothing ever executes for: a tool that does not
+ *    exist, arguments its schema rejects, a call nobody approves. A host then
+ *    draws one lifecycle rather than one per way a call can go, and `running`
+ *    covers waiting on a person for the same reason — an approval is part of
+ *    making the call, and a host drawing its own approval knows it asked.
+ *  - `completed` / `failed` — settled, carrying the text the model reads
+ *    back. `failed` is the call's own outcome — it threw, its arguments were
+ *    rejected, nobody approved it — and not an error that ends the run.
+ */
+export type StreamToolCall =
+  | {
+      type: "tool-call";
+      status: "pending";
+      toolCallId: string;
+      name: string;
+      input: Record<string, unknown>;
+    }
+  | {
+      type: "tool-call";
+      status: "running";
+      toolCallId: string;
+      name: string;
+    }
+  | {
+      type: "tool-call";
+      status: "completed" | "failed";
+      toolCallId: string;
+      name: string;
+      /** What the model reads back, after the same clamp the result carries. */
+      result: string;
+    };
+
+/**
  * Discriminated union of all stream event types.
  * Used as the element type for `AsyncIterable<StreamEvent>` streams
  * flowing through the DAG.
@@ -312,7 +366,8 @@ export type StreamEvent<Output = Record<string, any>> =
   | StreamError
   | StreamRefusal
   | StreamUsage
-  | StreamPhase;
+  | StreamPhase
+  | StreamToolCall;
 
 // ========================================================================
 // Port-level stream helpers

--- a/packages/test/src/test/ai/AgentTask.test.ts
+++ b/packages/test/src/test/ai/AgentTask.test.ts
@@ -865,11 +865,13 @@ describe("AgentTask", () => {
     }
 
     /**
-     * The settled member, picked out by the field only it carries. Extracting
-     * on `status: "completed"` yields `never` instead — that member's status is
-     * the wider `"completed" | "failed"`, which no narrower constraint matches.
+     * Each settled state on its own, which is what `status` being a real
+     * discriminant buys a consumer. Extracting one terminal status works only
+     * because they are separate members: were they one member carrying
+     * `"completed" | "failed"`, both of these would be `never`.
      */
-    type SettledToolCall = Extract<StreamEvent, { type: "tool-call"; result: string }>;
+    type CompletedToolCall = Extract<StreamEvent, { type: "tool-call"; status: "completed" }>;
+    type FailedToolCall = Extract<StreamEvent, { type: "tool-call"; status: "failed" }>;
 
     /** `status:id` for each event — the whole sequence in one readable line. */
     function trace(seen: ReadonlyArray<Extract<StreamEvent, { type: "tool-call" }>>): string[] {
@@ -895,7 +897,7 @@ describe("AgentTask", () => {
 
       // The settled text IS the string the model reads back, not a second copy
       // of it that could drift from the result or miss its clamp.
-      const settled = seen[2] as SettledToolCall;
+      const settled = seen[2] as CompletedToolCall;
       const block = toolResults(output.messages)[0] as {
         readonly content: ReadonlyArray<{ readonly text?: string }>;
       };
@@ -999,7 +1001,7 @@ describe("AgentTask", () => {
       // Every call passes the same three states, the ones this loop answers
       // itself included: a host draws one card lifecycle, not two.
       expect(trace(seen)).toEqual(["pending:c1", "running:c1", "failed:c1"]);
-      expect((seen[2] as SettledToolCall).result).toContain("Unknown tool");
+      expect((seen[2] as FailedToolCall).result).toContain("Unknown tool");
     });
   });
 });

--- a/packages/test/src/test/ai/AgentTask.test.ts
+++ b/packages/test/src/test/ai/AgentTask.test.ts
@@ -14,7 +14,7 @@ import {
   setAiProviderRegistry,
   ToolCallError,
 } from "@workglow/ai";
-import type { TaskEntitlements, TaskGraphJson } from "@workglow/task-graph";
+import type { StreamEvent, TaskEntitlements, TaskGraphJson } from "@workglow/task-graph";
 import { createGraphFromGraphJSON, Entitlements, Task, TaskRegistry } from "@workglow/task-graph";
 import { HumanInputTask } from "@workglow/tasks";
 import type { IHumanConnector, IHumanRequest, IHumanResponse } from "@workglow/util";
@@ -848,5 +848,158 @@ describe("AgentTask", () => {
 
     expect(seen).toEqual({ a: 2, b: 3 });
     expect(JSON.stringify(toolResults(output.messages)[0])).toContain("5");
+  });
+
+  // ======================================================================
+  // Per-tool lifecycle events
+  // ======================================================================
+
+  describe("tool-call events", () => {
+    /** Collects the lifecycle events a run reports, in the order they arrive. */
+    function lifecycle(task: AgentTask): Array<Extract<StreamEvent, { type: "tool-call" }>> {
+      const seen: Array<Extract<StreamEvent, { type: "tool-call" }>> = [];
+      task.subscribe("stream_chunk", (event) => {
+        if (event.type === "tool-call") seen.push(event);
+      });
+      return seen;
+    }
+
+    /**
+     * The settled member, picked out by the field only it carries. Extracting
+     * on `status: "completed"` yields `never` instead — that member's status is
+     * the wider `"completed" | "failed"`, which no narrower constraint matches.
+     */
+    type SettledToolCall = Extract<StreamEvent, { type: "tool-call"; result: string }>;
+
+    /** `status:id` for each event — the whole sequence in one readable line. */
+    function trace(seen: ReadonlyArray<Extract<StreamEvent, { type: "tool-call" }>>): string[] {
+      return seen.map((event) => `${event.status}:${event.toolCallId}`);
+    }
+
+    it("reports a call pending, then running, then completed", async () => {
+      scriptModel([
+        { calls: [{ id: "c1", name: "AgentTest_EchoTask", input: { text: "hi" } }] },
+        { text: "It said HI." },
+      ]);
+      const task = new AgentTask();
+      const seen = lifecycle(task);
+
+      const output = await task.run(
+        { model: MODEL, prompt: "echo hi", tools: [ECHO_TOOL], approval: "never" },
+        { registry }
+      );
+
+      expect(trace(seen)).toEqual(["pending:c1", "running:c1", "completed:c1"]);
+      expect(seen.every((event) => event.name === "AgentTest_EchoTask")).toBe(true);
+      expect(seen[0]).toMatchObject({ status: "pending", input: { text: "hi" } });
+
+      // The settled text IS the string the model reads back, not a second copy
+      // of it that could drift from the result or miss its clamp.
+      const settled = seen[2] as SettledToolCall;
+      const block = toolResults(output.messages)[0] as {
+        readonly content: ReadonlyArray<{ readonly text?: string }>;
+      };
+      expect(block.content[0]?.text).toBe(settled.result);
+      expect(settled.result).toContain("HI");
+    });
+
+    it("announces every call the model asked for before running any of them", async () => {
+      scriptModel([
+        {
+          calls: [
+            { id: "c1", name: "AgentTest_EchoTask", input: { text: "a" } },
+            { id: "c2", name: "AgentTest_EchoTask", input: { text: "b" } },
+          ],
+        },
+        { text: "done" },
+      ]);
+      const task = new AgentTask();
+      const seen = lifecycle(task);
+
+      await task.run(
+        { model: MODEL, prompt: "echo twice", tools: [ECHO_TOOL], approval: "never" },
+        { registry }
+      );
+
+      // The model asked for both at once, so both cards can be drawn at once;
+      // the calls then run one at a time, each settling before the next starts.
+      expect(trace(seen)).toEqual([
+        "pending:c1",
+        "pending:c2",
+        "running:c1",
+        "completed:c1",
+        "running:c2",
+        "completed:c2",
+      ]);
+    });
+
+    it("settles a call the tool refused as failed, in the tool's own words", async () => {
+      scriptModel([{ calls: [{ id: "c1", name: "decline", input: {} }] }, { text: "ok" }]);
+      const task = new AgentTask();
+      const seen = lifecycle(task);
+
+      await task.run(
+        {
+          model: MODEL,
+          prompt: "go",
+          approval: "never",
+          tools: [
+            {
+              name: "decline",
+              description: "Declines",
+              inputSchema: { type: "object", properties: {} },
+              execute: async () => {
+                throw new ToolCallError("Not this time.");
+              },
+            },
+          ],
+        },
+        { registry }
+      );
+
+      expect(trace(seen)).toEqual(["pending:c1", "running:c1", "failed:c1"]);
+      expect(seen[2]).toMatchObject({ status: "failed", result: "Not this time." });
+    });
+
+    it("settles a call nobody approved as failed, without running it", async () => {
+      scriptModel([
+        {
+          calls: [
+            { id: "c1", name: "AgentTest_FetchTask", input: { url: "https://example.test" } },
+          ],
+        },
+        { text: "ok" },
+      ]);
+      const human = connector((request) => ({
+        requestId: request.requestId,
+        action: "decline",
+        content: undefined,
+        done: true,
+      }));
+      registry.registerInstance(HUMAN_CONNECTOR, human.connector);
+      const task = new AgentTask();
+      const seen = lifecycle(task);
+
+      await task.run({ model: MODEL, prompt: "fetch", tools: [FETCH_TOOL] }, { registry });
+
+      expect(trace(seen)).toEqual(["pending:c1", "running:c1", "failed:c1"]);
+      expect(fetchRuns).toBe(0);
+    });
+
+    it("settles a call for a tool that does not exist", async () => {
+      scriptModel([{ calls: [{ id: "c1", name: "nope", input: {} }] }, { text: "ok" }]);
+      const task = new AgentTask();
+      const seen = lifecycle(task);
+
+      await task.run(
+        { model: MODEL, prompt: "go", tools: [ECHO_TOOL], approval: "never" },
+        { registry }
+      );
+
+      // Every call passes the same three states, the ones this loop answers
+      // itself included: a host draws one card lifecycle, not two.
+      expect(trace(seen)).toEqual(["pending:c1", "running:c1", "failed:c1"]);
+      expect((seen[2] as SettledToolCall).result).toContain("Unknown tool");
+    });
   });
 });


### PR DESCRIPTION
A host drawing a card for one tool call could only reconstruct it by diffing successive copies of the conversation `AgentTask` publishes. The ask appears when the assistant message lands, and the outcome when the results land — **as one batch, after the last of them**, with nothing in between and no way to tell which call is running now.

Each call now reports where it has got to, as a `tool-call` stream event:

| | |
| --- | --- |
| `pending` | the model asked for it, carrying the arguments |
| `running` | the loop took the call up |
| `completed` / `failed` | settled, carrying the text the model reads back |

## Why this was not missed earlier

Builder's tools are closures it owns, so its adapter fills the card in from inside the tool. That works exactly as far as the host owning every tool it passes. A host whose tools are **task types it named** has nothing to fill a card in from, and neither does one relaying a turn to a protocol — where a per-call lifecycle is the shape on the other side of the wire, not an extra.

## Three decisions worth a reviewer's attention

**The settled text is read back off the result block**, not built a second time. What the card says the call produced is then the same string the model is about to read, clamp included, and cannot drift from it. Rebuilding it instead fails three tests.

**Every call passes all three states — including the ones nothing executes for.** An unknown tool, arguments its schema rejects, a call nobody approves: all of them go `pending → running → failed`. A host then draws one lifecycle rather than one per way a call can end. `running` covers waiting on a person for the same reason: an approval is part of making the call, and a host drawing its own approval already knows it asked.

**Metadata, on `phase`'s exact terms** — emitted on `stream_chunk`, never accumulated into a port, absent from `finish`, no status flip. A task is not streaming its output because something it called started. `StreamEvent` gains a variant; nothing switches exhaustively over that union, so the change is additive.

All of a round's calls are announced before any of them runs, since the model asked for them together and a host can lay out the whole set rather than watching cards appear in an order that is the loop's business rather than the model's.

## Verification

- `bun run build:types` — 43/43
- `bun run lint` (`--type-aware --deny-warnings`), `bun run format-check` — clean
- `packages/test/src/test/ai` + `packages/ai/src` — **1,808 passed**
- `packages/test/src/test/graph` + `packages/task-graph/src` — **1,036 passed** (this touches core stream types, so that section ran too)
- `AgentTask.test.ts` — 30 passed (25 existing, 5 new)

Each new test fails when the code it covers is broken, and only those — checked by breaking each in turn: disabling the `StreamProcessor` case fails 5, collapsing `failed` into `completed` fails 3, moving the `pending` emission inside the run loop fails exactly the ordering test, and rebuilding the result text instead of reading the block back fails 3.

One trap found on the way, left commented at the site: `Extract<StreamEvent, { status: "completed" }>` silently yields `never`, because the settled member's status is the wider `"completed" | "failed"` and no narrower constraint matches it. The extraction keys on `result` instead.

## Related

- workglow-dev/builder#468 — builder's cards move onto these events.
- The libs `CLAUDE.md` paragraph that told readers to draw tool cards from the `messages` snapshots is corrected; snapshots stay what they were for, mirroring the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEFYAGb9D3mWfyhYkmeAvN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEFYAGb9D3mWfyhYkmeAvN)_